### PR TITLE
Broke up the brownie tests for gas summaries

### DIFF
--- a/.github/workflows/brownie-tests.yml
+++ b/.github/workflows/brownie-tests.yml
@@ -2,6 +2,10 @@ name: Brownie Tests
 
 on: [push]
 
+env:
+  ETHERSCAN_TOKEN: ${{ secrets.ETHERSCAN_TOKEN }}
+  WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
+
 jobs:
     tests:
         runs-on: ubuntu-latest
@@ -53,8 +57,26 @@ jobs:
             - name: Compile Code
               run: brownie compile --size
 
-            - name: Run Tests
-              env:
-                  ETHERSCAN_TOKEN: ${{ secrets.ETHERSCAN_TOKEN }}
-                  WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
-              run: brownie test --gas
+            - name: Run add remove test
+              run: brownie test tests/test_add_remove_collateral.py --gas
+
+            - name: Run borrow test
+              run: brownie test tests/test_borrow.py --gas
+
+            - name: Run bucket math test
+              run: brownie test tests/test_bucket_math.py --gas
+
+            - name: Run inflator test
+              run: brownie test tests/test_inflator.py --gas
+
+            - name: Run interest rate test
+              run: brownie test tests/test_interest_rate.py --gas
+
+            - name: Run quote deposit test
+              run: brownie test tests/test_quote_deposit.py --gas
+
+            - name: Run quote removal test
+              run: brownie test tests/test_quote_removal.py --gas
+
+            - name: Run repay test
+              run: brownie test tests/test_repay.py --gas


### PR DESCRIPTION
This was done in order to see the avg, low and high summaries per test. I will investigate an alternative approach - interacting with the brownie's `TxHistory` object from the test itself - since this process of creating a command and separate file for each brownie test we want summaries for doesn't seem like a scalable solution.