### PR TITLE
Change behavior of pool-level quote token accumulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ make test
 brownie test
 ```
 
+#### Debugging Brownie integration tests
+
+To drop into the console upon test failure:
+```bash
+brownie test --interactive
+```
+
+From there, use `chain.undo` to roll back the most recent transaction.
+Copy/paste the failed transaction prefixed with `tx = ` and you can interact 
+with the transaction receipt as desired.
+
 ### ERC20 pool manual test
 
 - Running following command will deploy ERC20 MKR/DAI pool

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -312,11 +312,11 @@ contract ERC20Pool is IPool, Clone {
     }
 
     /// @notice Called by a borrower to repay some amount of their borrowed quote tokens
-    /// @param _amount The amount of quote token to repay
-    function repay(uint256 _amount) external {
+    /// @param _maxAmount The maximum amount of quote token to repay
+    function repay(uint256 _maxAmount) external {
         uint256 availableAmount = quoteToken().balanceOf(msg.sender) *
             quoteTokenScale;
-        require(availableAmount >= _amount, "ajna/no-funds-to-repay");
+        require(availableAmount >= _maxAmount, "ajna/no-funds-to-repay");
 
         BorrowerInfo storage borrower = borrowers[msg.sender];
         require(borrower.debt != 0, "ajna/no-debt-to-repay");
@@ -324,9 +324,9 @@ contract ERC20Pool is IPool, Clone {
         accumulateBorrowerInterest(borrower);
 
         uint256 debtToPay;
-        (lup, debtToPay) = _buckets.repay(_amount, lup, inflatorSnapshot);
+        (lup, debtToPay) = _buckets.repay(_maxAmount, lup, inflatorSnapshot);
 
-        if (debtToPay < borrower.debt && _amount >= borrower.debt) {
+        if (debtToPay < borrower.debt && _maxAmount >= borrower.debt) {
             debtToPay = borrower.debt;
         }
 

--- a/src/_test/ERC20PoolBid.t.sol
+++ b/src/_test/ERC20PoolBid.t.sol
@@ -204,7 +204,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(pool.totalCollateral(), 100 * 1e18);
     }
 
-    function testPurchaseBidNotEnoughLiquidity() public {
+    function testPurchaseBidCannotReallocate() public {
         lender.addQuoteToken(pool, 1_000 * 1e18, 4_000 * 1e18);
         lender.addQuoteToken(pool, 1_000 * 1e18, 3_000 * 1e18);
         lender.addQuoteToken(pool, 500 * 1e18, 2_000 * 1e18);
@@ -217,8 +217,8 @@ contract ERC20PoolBidTest is DSTestPlus {
 
         assertEq(pool.lup(), 3_000 * 1e18);
 
-        // should revert if trying to bid more than available liquidity (1000 vs 500)
-        vm.expectRevert("ajna/not-enough-liquidity");
+        // should revert if debt cannot be reallocated
+        vm.expectRevert("ajna/failed-to-reallocate");
         bidder.purchaseBid(pool, 1_000 * 1e18, 4_000 * 1e18);
     }
 

--- a/src/_test/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20PoolBorrow.t.sol
@@ -89,7 +89,8 @@ contract ERC20PoolBorrowTest is DSTestPlus {
             3_000 * 1e18
         );
         assertEq(deposit - debt, 9_000 * 1e18);
-        // check pool debt
+        // check pool balances
+        assertEq(pool.totalQuoteToken(), 29_000 * 1e18);
         assertEq(pool.totalDebt(), 21_000 * 1e18);
         // check borrower balance
         (uint256 borrowerDebt, uint256 depositedCollateral, ) = pool.borrowers(
@@ -127,7 +128,8 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         (, , , deposit, debt, , , ) = pool.bucketAt(4_000 * 1e18);
         assertEq(debt, 10_000 * 1e18);
         assertEq(deposit, 10_000 * 1e18);
-        // check pool debt
+        // check pool balances
+        assertEq(pool.totalQuoteToken(), 20_000 * 1e18);
         assertEq(pool.totalDebt(), 30_000.273023081959005000 * 1e18);
 
         // check borrower balances
@@ -160,8 +162,8 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         (, , , deposit, debt, , , ) = pool.bucketAt(5_000 * 1e18);
         assertEq(debt, 30000.273023081959005000 * 1e18);
         assertEq(deposit, 40_000 * 1e18);
-        // check pool debt
-        assertEq(pool.totalQuoteToken(), 90_000 * 1e18);
+        // check pool balances
+        assertEq(pool.totalQuoteToken(), 60_000 * 1e18);
         assertEq(pool.totalDebt(), 30000.273023081959005000 * 1e18);
     }
 

--- a/src/_test/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20PoolLiquidate.t.sol
@@ -84,7 +84,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerInflator, 1 * 1e18);
 
         // check pool balance
-        assertEq(pool.totalQuoteToken(), 21_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 9_000 * 1e18);
         assertEq(pool.totalDebt(), 12_000 * 1e18);
         assertEq(pool.totalCollateral(), 202 * 1e18);
         assertEq(pool.lup(), 100 * 1e18);
@@ -150,7 +150,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerInflator, 1.000013001099140905 * 1e18);
 
         // check pool balance and that interest accumulated
-        assertEq(pool.totalQuoteToken(), 10_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 9_000 * 1e18);
         assertEq(pool.totalDebt(), 1000.013001099140905000 * 1e18);
         assertEq(pool.totalCollateral(), 200.888874443223176772 * 1e18);
         assertEq(pool.inflatorSnapshot(), 1.000013001099140905 * 1e18);
@@ -277,7 +277,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerInflator, 1 * 1e18);
 
         // check pool balance
-        assertEq(pool.totalQuoteToken(), 1_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 0);
         assertEq(pool.totalDebt(), 1_000 * 1e18);
         assertEq(pool.totalCollateral(), 200.763888888888888889 * 1e18);
     }
@@ -380,7 +380,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerInflator, 1.171809293279796920 * 1e18);
 
         // check pool balance
-        assertEq(pool.totalQuoteToken(), 1_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 0);
         assertEq(pool.totalDebt(), 1_000 * 1e18);
         assertEq(pool.totalCollateral(), 200.551513512473584363 * 1e18);
     }

--- a/src/_test/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20PoolPrecision.t.sol
@@ -100,7 +100,7 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         );
         borrower.borrow(pool, 10_000 * poolPrecision, 2_000 * poolPrecision);
         // check balances
-        assertEq(pool.totalQuoteToken(), 10_000 * poolPrecision);
+        assertEq(pool.totalQuoteToken(), 0);
         assertEq(pool.totalDebt(), 10_000 * poolPrecision);
         assertEq(pool.totalCollateral(), 100 * poolPrecision);
         assertEq(quote.balanceOf(address(pool)), 0);
@@ -117,7 +117,7 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         emit Transfer(address(borrower), address(pool), 5_000 * quotePrecision);
         borrower.repay(pool, 5_000 * poolPrecision);
         // check balances
-        assertEq(pool.totalQuoteToken(), 10_000 * poolPrecision);
+        assertEq(pool.totalQuoteToken(), 5_000 * poolPrecision);
         assertEq(pool.totalDebt(), 5_000 * poolPrecision);
         assertEq(pool.totalCollateral(), 100 * poolPrecision);
         assertEq(quote.balanceOf(address(pool)), 5_000 * quotePrecision);
@@ -134,7 +134,7 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         emit Transfer(address(pool), address(bidder), 1_000 * quotePrecision);
         bidder.purchaseBid(pool, 1_000 * poolPrecision, 2_000 * poolPrecision);
         // check balances
-        assertEq(pool.totalQuoteToken(), 9_000 * poolPrecision);
+        assertEq(pool.totalQuoteToken(), 4_000 * poolPrecision);
         assertEq(pool.totalDebt(), 5_000 * poolPrecision);
         assertEq(pool.totalCollateral(), 100 * poolPrecision);
         assertEq(quote.balanceOf(address(pool)), 4_000 * quotePrecision);
@@ -164,7 +164,7 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
             2_000 * poolPrecision
         );
         // // check balances
-        assertEq(pool.totalQuoteToken(), 9_000 * poolPrecision);
+        assertEq(pool.totalQuoteToken(), 4_000 * poolPrecision);
         assertEq(pool.totalDebt(), 5_000 * poolPrecision);
         assertEq(pool.totalCollateral(), 100 * poolPrecision);
         assertEq(quote.balanceOf(address(pool)), 4_000 * quotePrecision);
@@ -194,7 +194,7 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         );
         borrower.removeCollateral(pool, 50 * poolPrecision);
         // check balances
-        assertEq(pool.totalQuoteToken(), 9_000 * poolPrecision);
+        assertEq(pool.totalQuoteToken(), 4_000 * poolPrecision);
         assertEq(pool.totalDebt(), 5_000 * poolPrecision);
         assertEq(pool.totalCollateral(), 50 * poolPrecision);
         assertEq(quote.balanceOf(address(pool)), 4_000 * quotePrecision);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -232,8 +232,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         borrower.borrow(pool, 5_000 * 1e18, 4_000 * 1e18);
 
         // should revert if trying to remove entire amount lended
-        vm.expectRevert("ajna/amount-greater-than-claimable");
-        lender.removeQuoteToken(pool, 10_000 * 1e18, 4_000 * 1e18);
+        // FIXME: This should revert because 5_000 debt could not be reallocated
+        // vm.expectRevert("ajna/failed-to-reallocate");
+        // lender.removeQuoteToken(pool, 10_000 * 1e18, 4_000 * 1e18);
 
         // remove 4000 DAI at price of 1 MKR = 4000 DAI
         vm.expectEmit(true, true, false, true);
@@ -247,7 +248,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         lender.removeQuoteToken(pool, 4_000 * 1e18, 4_000 * 1e18);
 
         // check pool balances
-        assertEq(pool.totalQuoteToken(), 6_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 1_000 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 1_000 * 1e18);
         // check lender balance
         assertEq(quote.balanceOf(address(lender)), 194_000 * 1e18);
@@ -320,7 +321,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // check lup moved down to 3000
         assertEq(pool.lup(), 3_000 * 1e18);
         // check pool balances
-        assertEq(pool.totalQuoteToken(), 5_800 * 1e18);
+        assertEq(pool.totalQuoteToken(), 2_800 * 1e18);
         assertEq(pool.totalDebt(), 3_000 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 2_800 * 1e18);
         // check lender balance
@@ -342,7 +343,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(pool.lpBalance(address(lender), 3_000 * 1e18), 3_400 * 1e18);
     }
 
-    function testRemoveQuoteTokenBellowLup() public {
+    function testRemoveQuoteTokenBelowLup() public {
         // lender deposit 5000 DAI in 3 buckets
         lender.addQuoteToken(pool, 5_000 * 1e18, 4_000 * 1e18);
         lender.addQuoteToken(pool, 5_000 * 1e18, 3_000 * 1e18);
@@ -367,7 +368,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // check same lup
         assertEq(pool.lup(), 4_000 * 1e18);
         // check pool balances
-        assertEq(pool.totalQuoteToken(), 14_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 11_000 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 11_000 * 1e18);
 
         // check 4000 bucket balance

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -232,9 +232,8 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         borrower.borrow(pool, 5_000 * 1e18, 4_000 * 1e18);
 
         // should revert if trying to remove entire amount lended
-        // FIXME: This should revert because 5_000 debt could not be reallocated
-        // vm.expectRevert("ajna/failed-to-reallocate");
-        // lender.removeQuoteToken(pool, 10_000 * 1e18, 4_000 * 1e18);
+        vm.expectRevert("ajna/failed-to-reallocate");
+        lender.removeQuoteToken(pool, 10_000 * 1e18, 4_000 * 1e18);
 
         // remove 4000 DAI at price of 1 MKR = 4000 DAI
         vm.expectEmit(true, true, false, true);

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -56,7 +56,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         borrower.borrow(pool, 25_000 * 1e18, 2_500 * 1e18);
 
         // check balances
-        assertEq(pool.totalQuoteToken(), 30_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 5_000 * 1e18);
         assertEq(pool.totalDebt(), 25_000 * 1e18);
         assertEq(pool.lup(), 3_000 * 1e18);
         assertEq(pool.getEncumberedCollateral(), 8.333333333333333333 * 1e18);
@@ -82,7 +82,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         borrower.repay(pool, 10_000 * 1e18);
 
         // check balances
-        assertEq(pool.totalQuoteToken(), 30_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 15_000 * 1e18);
         assertEq(pool.totalDebt(), 15_000.325027478522625000 * 1e18);
         assertEq(pool.lup(), 4_000 * 1e18);
         assertEq(pool.getEncumberedCollateral(), 3.750081256869630656 * 1e18);
@@ -111,7 +111,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         borrower.repay(pool, 16_000 * 1e18);
 
         // check balances
-        assertEq(pool.totalQuoteToken(), 30_000 * 1e18);
+        assertEq(pool.totalQuoteToken(), 30_000.325027478522625000 * 1e18);
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.lup(), 5_000 * 1e18);
         assertEq(pool.getEncumberedCollateral(), 0);

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -260,7 +260,7 @@ library Buckets {
 
                 while (true) {
                     accumulateBucketInterest(toBucket, _inflator);
-
+                    
                     uint256 toBucketOnDeposit;
                     if (toBucket.amount > toBucket.debt) {
                         toBucketOnDeposit = toBucket.amount - toBucket.debt;
@@ -289,6 +289,9 @@ library Buckets {
 
                     toBucket = buckets[toBucket.down];
                 }
+            } else {
+                // lup started at the bottom
+                require(reallocation == 0, "ajna/failed-to-reallocate");
             }
         }
     }

--- a/tests/test_purchase_bid.py
+++ b/tests/test_purchase_bid.py
@@ -305,7 +305,7 @@ def test_purchase_bid_not_enough_liquidity(
     # should fail if trying to bid more than available liquidity (1000 vs 500)
     with pytest.raises(brownie.exceptions.VirtualMachineError) as exc:
         mkr_dai_pool.purchaseBid(1_000 * 1e18, 4000 * 1e18, {"from": bidder})
-    assert exc.value.revert_msg == "ajna/not-enough-liquidity"
+    assert exc.value.revert_msg == "ajna/failed-to-reallocate"
 
 
 def test_purchase_bid_undercollateralized(

--- a/tests/test_quote_removal.py
+++ b/tests/test_quote_removal.py
@@ -141,8 +141,6 @@ def test_quote_removal_loan_paid_back(
 
     dai.transfer(borrower, 1 * 1e18, {"from": lenders[1]})
     mkr_dai_pool.repay(10_001 * 1e18, {"from": borrower})
-    # FIXME: Should expect 10_001 quote token in pool; issue in Buckets.repay
-    assert 10_000 * 1e18 <= mkr_dai_pool.totalQuoteToken() <= 10_001 * 1e18
 
     # forward time so lp tokens to accumulate
     chain.sleep(82000)
@@ -152,8 +150,6 @@ def test_quote_removal_loan_paid_back(
     tx = mkr_dai_pool.removeQuoteToken(10_000 * 1e18, 4000 * 1e18, {"from": lender})
     assert format(dai.balanceOf(mkr_dai_pool) / 1e18, ".3f") == format(0, ".3f")
     assert dai.balanceOf(lender) == 200_000 * 1e18
-    # FIXME: After above error is resolved, 1 quote token should remain.
-    assert 0 <= mkr_dai_pool.totalQuoteToken() <= 1 * 1e18
     # check bucket balance
     (
         _,

--- a/tests/test_quote_removal.py
+++ b/tests/test_quote_removal.py
@@ -150,6 +150,7 @@ def test_quote_removal_loan_paid_back(
     tx = mkr_dai_pool.removeQuoteToken(10_000 * 1e18, 4000 * 1e18, {"from": lender})
     assert format(dai.balanceOf(mkr_dai_pool) / 1e18, ".3f") == format(0, ".3f")
     assert dai.balanceOf(lender) == 200_000 * 1e18
+    assert 0 <= mkr_dai_pool.totalQuoteToken() <= 1 * 1e18
     # check bucket balance
     (
         _,

--- a/tests/test_quote_removal.py
+++ b/tests/test_quote_removal.py
@@ -85,9 +85,10 @@ def test_quote_removal_loan_not_paid_back(
     mkr_dai_pool.borrow(5_000 * 1e18, 4000 * 1e18, {"from": borrower})
 
     # should fail if trying to remove entire amount lended
+    # FIXME: Integer overflows
     with pytest.raises(brownie.exceptions.VirtualMachineError) as exc:
         mkr_dai_pool.removeQuoteToken(10_000 * 1e18, 4000 * 1e18, {"from": lender})
-    assert exc.value.revert_msg == "ajna/amount-greater-than-claimable"
+    assert exc.value.revert_msg == "ajna/failed-to-reallocate"
 
     # remove 4000 DAI at price of 1 MKR = 4000 DAI
     tx = mkr_dai_pool.removeQuoteToken(4_000 * 1e18, 4000 * 1e18, {"from": lender})
@@ -136,9 +137,11 @@ def test_quote_removal_loan_paid_back(
 
     mkr_dai_pool.addCollateral(100 * 1e18, {"from": borrower})
     mkr_dai_pool.borrow(10_000 * 1e18, 4000 * 1e18, {"from": borrower})
+    assert mkr_dai_pool.totalQuoteToken() == 0
 
     dai.transfer(borrower, 1 * 1e18, {"from": lenders[1]})
     mkr_dai_pool.repay(10_001 * 1e18, {"from": borrower})
+    assert mkr_dai_pool.totalQuoteToken() == 10_001 * 1e18
 
     # forward time so lp tokens to accumulate
     chain.sleep(82000)
@@ -148,7 +151,7 @@ def test_quote_removal_loan_paid_back(
     tx = mkr_dai_pool.removeQuoteToken(10_000 * 1e18, 4000 * 1e18, {"from": lender})
     assert format(dai.balanceOf(mkr_dai_pool) / 1e18, ".3f") == format(0, ".3f")
     assert dai.balanceOf(lender) == 200_000 * 1e18
-    assert mkr_dai_pool.totalQuoteToken() == 0
+    assert mkr_dai_pool.totalQuoteToken() == 1 * 1e18
     # check bucket balance
     (
         _,
@@ -202,7 +205,7 @@ def test_quote_removal_from_lup_with_reallocation(
         tx = mkr_dai_pool.removeQuoteToken(1_000 * 1e18, 4000 * 1e18, {"from": lender})
         assert dai.balanceOf(mkr_dai_pool) == 2_800 * 1e18
         assert dai.balanceOf(lender) == 194_200 * 1e18
-        assert mkr_dai_pool.totalQuoteToken() == 5_800 * 1e18
+        assert mkr_dai_pool.totalQuoteToken() == 2_800 * 1e18
 
         # check lup moved down to 3000
         assert mkr_dai_pool.lup() == 3_000 * 1e18
@@ -289,7 +292,7 @@ def test_quote_removal_below_lup(
         # lender removes 1000 DAI
         tx = mkr_dai_pool.removeQuoteToken(1_000 * 1e18, 3000 * 1e18, {"from": lender})
         assert dai.balanceOf(mkr_dai_pool) == 11_000 * 1e18
-        assert mkr_dai_pool.totalQuoteToken() == 14_000 * 1e18
+        assert mkr_dai_pool.totalQuoteToken() == 11_000 * 1e18
 
         # check lup same 4000
         assert mkr_dai_pool.lup() == 4_000 * 1e18


### PR DESCRIPTION
**Changes**
- Removed inappropriate pool-level checks.  (see below)
- Updated `Buckets.reallocateDown` to handle corner case which arose without aforementioned pool-level checks.
- Updated tests with appropriate expectations; commented anywhere those expections were wrong due to issues outside the scope of this PR.
- Documented how to debug unexpected TX failures in brownie tests.

**Notes**
- A lender's claimable amount is determined only by their `lpOutstanding`.  Reverts should not suggest their claim is made invalid because debt could not be reallocated to fund their withdrawal.  We cannot discover whether the withdrawal is possible using a pool-level check, because we won't know if reallocation of debt (and the implicit accrual of interest) would make the pool undercollateralized.
- Similarly, the ability of an actor to purchase a bid off the book cannot be checked using pool-level accumulators.  Success hinges on whether debt can be reallocated without undercollateralizing the pool.

**Out-of-scope**
- There is an issue with the way `Buckets` is tracking the amount of quote token on deposit.  I added `FIXME`s to `tests/test_quote_removal.py` to show where the pool-level quote token accumulator has been updated improperly as a result of this issue.