### PR TITLE
Possible LP Token balance bug

### DIFF
--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -388,7 +388,14 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             4_000.927678580567537368 * 1e18
         );
         assertEq(quote.balanceOf(address(lender)), 190_000 * 1e18);
+        (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, ) = pool.bucketAt(
+            4_000.927678580567537368 * 1e18
+        );
+        assertEq(deposit, 10_000 * 1e18);
+        assertEq(debt, 0);
+        assertEq(lpOutstanding, 10_000 * 1e18);
 
+        // another lender deposits 10000 DAI at the same price
         lender2.addQuoteToken(
             pool,
             address(lender2),
@@ -396,12 +403,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             4_000.927678580567537368 * 1e18
         );
         assertEq(quote.balanceOf(address(lender2)), 190_000 * 1e18);
-
-        (, , , uint256 deposit, uint256 debt, , , ) = pool.bucketAt(
+        (, , , deposit, debt, , lpOutstanding, ) = pool.bucketAt(
             4_000.927678580567537368 * 1e18
         );
         assertEq(deposit, 20_000 * 1e18);
         assertEq(debt, 0);
+        assertEq(lpOutstanding, 20_000 * 1e18);
 
         skip(8200);
 
@@ -423,6 +430,11 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         assertEq(quote.balanceOf(address(lender)), 200_000 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 10_000 * 1e18);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            4_000.927678580567537368 * 1e18
+        );
+        assertEq(deposit, 10_000 * 1e18);
+        assertEq(debt, 0);
 
         lender2.removeQuoteToken(
             pool,

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -422,7 +422,7 @@ library Buckets {
         uint256 size = bucket.onDeposit +
             bucket.debt +
             Maths.wmul(bucket.collateral, bucket.price);
-        if (size > 0 && bucket.lpOutstanding > 0) {
+        if (size != 0 && bucket.lpOutstanding != 0) {
             return Maths.wdiv(size, bucket.lpOutstanding);
         }
         return Maths.ONE_WAD;


### PR DESCRIPTION
I could be wrong but I may have discovered a bug that impacts lender's `_lpBalance`... I believe it could be either:
* The formula for initially distributing `lpTokens` to the first lender (when `bucket.lpOutstanding = 0`) is not calculated correctly -> might need to modify `lpTokens = Maths.wdiv(_amount, getExchangeRate(bucket));` https://github.com/ajna-finance/contracts/blob/630792fa709b38720888e9978c4cec0dc88c1c09/src/libraries/Buckets.sol#L37
* The formula in `getExchangeRate()` https://github.com/ajna-finance/contracts/blob/630792fa709b38720888e9978c4cec0dc88c1c09/src/libraries/Buckets.sol#L406 does not properly calculate what the exchange rate for lpTokens -> quoteTokens that the lender is owed.

This draft includes an updated test where two lenders deposit 10K DAI each and should therefore be able to call `remoteQuoteToken`, each asking for the appropriate amount they are owed 10K DAI.

The first lender is able to withdraw however the second lender is not. I believe the intended functionality is that both should be able to fully retrieve their respective 10K DAI deposit leaving the pool with a 0 DAI balance.

To run the test pull down the draft and run `forge clean && forge test -vvv --match-test testRemoveQuoteTokenPaidLoan`. The error that I get is `ajna/amount-greater-than-claimable` when the second lender attempts to run `removeQuoteToken`.

I'm happy to take a stab at a solution if you all agree this is incorrect behavior... it may also be better to have @EdNoepel mess around with the guts of the exchange rate as he is a bit more familiar with the math relationships in the protocol.

PS: I checked the sim and it looks like it is implemented the same. I assume that if this is a bug here we may need to update the sim as well.