### PR TITLE
resolved issue with getLPTokenExchangeValue

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -569,7 +569,7 @@ contract ERC20Pool is IPool, Clone {
             ,
             ,
             uint256 quote,
-            ,
+            uint256 debt,
             ,
             uint256 lpOutstanding,
             uint256 bucketCollateral
@@ -579,7 +579,7 @@ contract ERC20Pool is IPool, Clone {
         uint256 lenderShare = PRBMathUD60x18.div(_lpTokens, lpOutstanding);
 
         collateralTokens = PRBMathUD60x18.mul(bucketCollateral, lenderShare);
-        quoteTokens = PRBMathUD60x18.mul(quote, lenderShare);
+        quoteTokens = PRBMathUD60x18.mul(quote + debt, lenderShare);
     }
 
     // -------------------- Bucket related functions --------------------

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -88,10 +88,17 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(debt, 0);
         assertEq(snapshot, 1 * 1e18);
         assertEq(lpOutstanding, 10_000 * 1e18);
+        // check lender's LP amount can be redeemed for correct amount of quote token
         assertEq(
             pool.lpBalance(address(lender), 4_000.927678580567537368 * 1e18),
             10_000 * 1e18
         );
+        (
+            uint256 collateralTokens,
+            uint256 quoteTokens
+        ) = pool.getLPTokenExchangeValue(10_000 * 1e18, 4_000.927678580567537368 * 1e18);
+        assertEq(collateralTokens, 0);
+        assertEq(quoteTokens, 10_000 * 1e18);
 
         // test 20000 DAI deposit at price of 1 MKR = 2000.221618840727700609 DAI
         vm.expectEmit(true, true, false, true);
@@ -343,6 +350,18 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             10_000 * 1e18,
             4_000.927678580567537368 * 1e18
         );
+
+        // confirm our LP balance still entitles us to our share of the utilized bucket
+        assertEq(
+            pool.lpBalance(address(lender), 4_000.927678580567537368 * 1e18),
+            10_000 * 1e18
+        );
+        (
+            uint256 collateralTokens,
+            uint256 quoteTokens
+        ) = pool.getLPTokenExchangeValue(10_000 * 1e18, 4_000.927678580567537368 * 1e18);
+        assertEq(collateralTokens, 0);
+        assertEq(quoteTokens, 10_000 * 1e18);
 
         // remove 4000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
         vm.expectEmit(true, true, false, true);


### PR DESCRIPTION
I encountered an issue today where a lender had deposited above the LUP, such that debt reallocation immediately utilized their entire deposit.  When attempting to withdraw this deposit, `getLPTokenExchangeValue` showed their LP balance had no value, because `quote` was 0 in the deposit bucket.

Although we cannot predict whether `removeQuoteToken` can reallocate debt to facilitate the withdrawal, `getLPTokenExchangeValue` should not prevent users from attempting to withdraw their entitled amount.