### PR TITLE
Fix bug depositing at LUP when LUP != HUP

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -616,7 +616,7 @@ contract ERC20Pool is IPool, Clone {
             ,
             ,
             ,
-            uint256 quote,
+            uint256 onDeposit,
             uint256 debt,
             ,
             uint256 lpOutstanding,
@@ -627,7 +627,7 @@ contract ERC20Pool is IPool, Clone {
         uint256 lenderShare = PRBMathUD60x18.div(_lpTokens, lpOutstanding);
 
         collateralTokens = PRBMathUD60x18.mul(bucketCollateral, lenderShare);
-        quoteTokens = PRBMathUD60x18.mul(quote + debt, lenderShare);
+        quoteTokens = PRBMathUD60x18.mul(onDeposit + debt, lenderShare);
     }
 
     // -------------------- Bucket related functions --------------------
@@ -643,7 +643,7 @@ contract ERC20Pool is IPool, Clone {
             uint256 price,
             uint256 up,
             uint256 down,
-            uint256 amount,
+            uint256 onDeposit,
             uint256 debt,
             uint256 bucketInflator,
             uint256 lpOutstanding,
@@ -669,9 +669,9 @@ contract ERC20Pool is IPool, Clone {
     function getHup() public view returns (uint256) {
         uint256 curPrice = lup;
         while (true) {
-            (uint256 price, , uint256 down, uint256 amount, , , , ) = _buckets
+            (uint256 price, , uint256 down, uint256 onDeposit, , , , ) = _buckets
                 .bucketAt(curPrice);
-            if (price == down || amount != 0) {
+            if (price == down || onDeposit != 0) {
                 break;
             }
 

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -177,7 +177,7 @@ contract ERC20Pool is IPool, Clone {
 
         // deposit amount with RAD precision
         _amount = Maths.wadToRad(_amount);
-        bool reallocate = (totalDebt != 0 && _price >= lup);
+        bool reallocate = (totalDebt != 0 && _price > lup);
         (uint256 newLup, uint256 lpTokens) = _buckets.addQuoteToken(
             _price,
             _amount,

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.11;
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 import {UserWithCollateral, UserWithQuoteToken} from "./utils/Users.sol";
 import {CollateralToken, QuoteToken} from "./utils/Tokens.sol";
+import "../libraries/BucketMath.sol";
 
 import {ERC20Pool} from "../ERC20Pool.sol";
 import {ERC20PoolFactory} from "../ERC20PoolFactory.sol";
@@ -253,6 +254,140 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             pool.lpBalance(address(lender), 5_007.644384905151472283 * 1e18),
             40_000 * 1e27
         );
+    }
+
+    function testDepositQuoteTokenWithReallocation() public {
+        // Lender deposits into three buckets
+        lender.addQuoteToken(
+            pool,
+            address(lender),
+            1_000 * 1e18,
+            4_000.927678580567537368 * 1e18
+        );
+        lender.addQuoteToken(
+            pool,
+            address(lender),
+            1_000 * 1e18,
+            3_010.892022197881557845 * 1e18
+        );
+        lender.addQuoteToken(
+            pool,
+            address(lender),
+            1_000 * 1e18,
+            2_000.221618840727700609 * 1e18
+        );
+
+        // Borrower draws debt from all three
+        borrower.addCollateral(pool, 10 * 1e18);
+        borrower.borrow(pool, 2_400 * 1e18, 0);
+        (, , , uint256 deposit, uint256 debt, , , ) = pool.bucketAt(
+            4_000.927678580567537368 * 1e18
+        );
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            3_010.892022197881557845 * 1e18
+        );
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            2_000.221618840727700609 * 1e18
+        );
+        assertEq(deposit, 600 * 1e45);
+        assertEq(debt, 400 * 1e45);
+
+        // Lender deposits more into the middle bucket, causing reallocation
+        lender.addQuoteToken(
+            pool,
+            address(lender),
+            2_000 * 1e18,
+            3_010.892022197881557845 * 1e18
+        );
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            4_000.927678580567537368 * 1e18
+        );
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            3_010.892022197881557845 * 1e18
+        );
+        assertEq(deposit, 1_600 * 1e45);
+        assertEq(debt, 1_400 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            2_000.221618840727700609 * 1e18
+        );
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+
+        // Lender deposits in the top bucket, causing another reallocation
+        lender.addQuoteToken(
+            pool,
+            address(lender),
+            3_000 * 1e18,
+            4_000.927678580567537368 * 1e18
+        );
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            4_000.927678580567537368 * 1e18
+        );
+        assertEq(deposit, 1600 * 1e45);
+        assertEq(debt, 2_400 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            3_010.892022197881557845 * 1e18
+        );
+        assertEq(deposit, 3_000 * 1e45);
+        assertEq(debt, 0);
+        (, , , deposit, debt, , , ) = pool.bucketAt(
+            2_000.221618840727700609 * 1e18
+        );
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+    }
+
+    function testDepositQuoteTokenAtLup() public {
+        // Adjacent prices
+        uint256 p2850 = 2850.155149230026939621 * 1e18;  // index 1595
+        uint256 p2835 = 2835.975272865698470386 * 1e18;  // index 1594
+        uint256 p2821 = 2821.865943149948749647 * 1e18;  // index 1593
+        uint256 p2807 = 2807.826809104426639178 * 1e18;  // index 1592
+
+        // Lender deposits 1000 in each bucket
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2850);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2835);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2821);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2807);
+
+        // Borrower draws 2000 debt fully utilizing the LUP
+        borrower.addCollateral(pool, 10 * 1e18);
+        borrower.borrow(pool, 2_000 * 1e18, 0);
+        (, , , uint256 deposit, uint256 debt, , , ) = pool.bucketAt(p2850);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2835);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2821);
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2807);
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+        assertEq(pool.lup(), p2835);
+
+        // Lender deposits 1400 at LUP
+        lender.addQuoteToken(pool, address(lender1), 1_400 * 1e18, p2835);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2850);
+        assertEq(deposit, 0);             // FIXME: shows  400
+        assertEq(debt, 1_000 * 1e45);     // FIXME: shows  600
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2835);
+        assertEq(deposit, 1_400 * 1e45);  // FIXME: shows 1000
+        assertEq(debt, 1_000 * 1e45);     // FIXME: shows  400
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2821);
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2807);
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+        assertEq(pool.lup(), p2835);      // FIXME: shows LUP is p2850
     }
 
     function testRemoveQuoteTokenNoLoan() public {

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -376,18 +376,18 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // Lender deposits 1400 at LUP
         lender.addQuoteToken(pool, address(lender1), 1_400 * 1e18, p2835);
         (, , , deposit, debt, , , ) = pool.bucketAt(p2850);
-        assertEq(deposit, 0);             // FIXME: shows  400
-        assertEq(debt, 1_000 * 1e45);     // FIXME: shows  600
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
         (, , , deposit, debt, , , ) = pool.bucketAt(p2835);
-        assertEq(deposit, 1_400 * 1e45);  // FIXME: shows 1000
-        assertEq(debt, 1_000 * 1e45);     // FIXME: shows  400
+        assertEq(deposit, 1_400 * 1e45);
+        assertEq(debt, 1_000 * 1e45);
         (, , , deposit, debt, , , ) = pool.bucketAt(p2821);
         assertEq(deposit, 1_000 * 1e45);
         assertEq(debt, 0);
         (, , , deposit, debt, , , ) = pool.bucketAt(p2807);
         assertEq(deposit, 1_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(pool.lup(), p2835);      // FIXME: shows LUP is p2850
+        assertEq(pool.lup(), p2835);
     }
 
     function testRemoveQuoteTokenNoLoan() public {

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -401,7 +401,7 @@ library Buckets {
             uint256 price,
             uint256 up,
             uint256 down,
-            uint256 amount,
+            uint256 onDeposit,
             uint256 debt,
             uint256 inflatorSnapshot,
             uint256 lpOutstanding,
@@ -413,7 +413,7 @@ library Buckets {
         price = bucket.price;
         up = bucket.up;
         down = bucket.down;
-        amount = bucket.onDeposit;
+        onDeposit = bucket.onDeposit;
         debt = bucket.debt;
         inflatorSnapshot = bucket.inflatorSnapshot;
         lpOutstanding = bucket.lpOutstanding;

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -214,6 +214,7 @@ def repay(borrower, borrower_index, pool):
             )
 
 
+@pytest.mark.skip
 def test_stable_volatile_one(
     pool1, dai, weth, lenders, borrowers, bucket_math, test_utils, chain
 ):


### PR DESCRIPTION
Real-world testing revealed the following issue:

Assume the LUP bucket has been fully utilized, such that HUP != LUP:
```
       2878.728                         0.000      60000.000          0.000      60000.000          1.000
       2864.406            LUP          0.000      60000.000          0.000      60000.000          1.000
       2850.155                    274500.000          0.000          0.000     274500.000          1.000
```
When a lender arrives and deposits at the LUP, it was inappropriately attempting to reallocate from itself, and pushed the LUP upwards:
```
       2878.728            LUP      34499.898      25500.203          0.000      60000.000          1.000
       2864.406                     60000.102      34499.898          0.000     154499.840          1.000
       2850.155                    274500.000          0.000          0.000     274500.000          1.000
```

This put the book in an invalid state with multiple partially-utilized buckets.

Fix is identified in comments.  Added another unit test I wrote during debugging which was not broken but I thought worth keeping.

Unrelated:  
- Updated `bucketAt` calls to use the name `onDeposit` instead of `amount`, consistent with the field name in `Bucket`.
- Skipped the real-world-test, which is burning through our GitHub actions credits and delaying tests with an insufficient benefit.