### PR TITLE
Fixed bug managing LUP upon quote removal

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -231,8 +231,8 @@ contract ERC20Pool is IPool, Clone {
             inflatorSnapshot
         );
 
-        // move lup down only if removal happened at lup and new lup different than current
-        if (_price == lup && newLup < lup) {
+        // move lup down only if removal happened at or above lup and new lup different than current
+        if (_price >= lup && newLup < lup) {
             lup = newLup;
         }
 

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -771,6 +771,53 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(debt, 4_000.002124558305730000 * 1e45);
     }
 
+    function testRemoveQuoteTokenAboveLup() public {
+        // Adjacent prices
+        uint256 p2850 = 2850.155149230026939621 * 1e18; // index 1595
+        uint256 p2835 = 2835.975272865698470386 * 1e18; // index 1594
+        uint256 p2821 = 2821.865943149948749647 * 1e18; // index 1593
+        uint256 p2807 = 2807.826809104426639178 * 1e18; // index 1592
+
+        // Lender deposits 1000 in each bucket
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2850);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2835);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2821);
+        lender.addQuoteToken(pool, address(lender), 1_000 * 1e18, p2807);
+
+        // Borrower draws 2400 debt partially utilizing the LUP
+        borrower.addCollateral(pool, 10 * 1e18);
+        borrower.borrow(pool, 2_400 * 1e18, 0);
+        (, , , uint256 deposit, uint256 debt, , , ) = pool.bucketAt(p2850);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2835);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2821);
+        assertEq(deposit, 600 * 1e45);
+        assertEq(debt, 400 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2807);
+        assertEq(deposit, 1_000 * 1e45);
+        assertEq(debt, 0);
+        assertEq(pool.lup(), p2821);
+
+        // Lender withdraws above LUP
+        lender.removeQuoteToken(pool, address(lender), 1_000 * 1e18, p2850);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2850);
+        assertEq(deposit, 0);
+        assertEq(debt, 0);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2835);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2821);
+        assertEq(deposit, 0);
+        assertEq(debt, 1_000 * 1e45);
+        (, , , deposit, debt, , , ) = pool.bucketAt(p2807);
+        assertEq(deposit, 600 * 1e45);
+        assertEq(debt, 400 * 1e45);
+        assertEq(pool.lup(), p2807);
+    }
+
     function testRemoveQuoteTokenBelowLup() public {
         // lender deposit 5000 DAI in 3 buckets
         lender.addQuoteToken(


### PR DESCRIPTION
When removing a quote above the LUP, debt gets reallocated to the HUP downward.  As a result, removing liquidity above the LUP can cause a change to the LUP.  Implemented a test to realize this, and then resolved the issue.

Test documented in spreadsheet: https://docs.google.com/spreadsheets/d/1CMbWoTnMvsiFPXoMTMxYbMa488rSPAzarXRgrKRcKfU/edit#gid=1149976765