### PR TITLE
Ensure LUP updates to the deposit bucket when reallocating upward

### DIFF
--- a/src/_test/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20PoolBorrow.t.sol
@@ -234,7 +234,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         (, , , deposit, debt, , , ) = pool.bucketAt(
             5_007.644384905151472283 * 1e18
         );
-        assertEq(debt, 30000.663059605786311304455309928599525 * 1e45);
+        assertEq(debt, 30000.273023081959005000 * 1e45);
         assertEq(deposit, 9999.726976918040995000 * 1e45);
         // check pool balances
         assertEq(pool.totalQuoteToken(), 60_000 * 1e45);

--- a/src/_test/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20PoolBorrow.t.sol
@@ -203,6 +203,8 @@ contract ERC20PoolBorrowTest is DSTestPlus {
             40_000 * 1e18,
             5_007.644384905151472283 * 1e18
         );
+        assertEq(pool.hdp(), 5_007.644384905151472283 * 1e18);
+        assertEq(pool.lup(), 5_007.644384905151472283 * 1e18);
 
         // check bucket debt at 2_503.519024294695168295
         (, , , deposit, debt, , , ) = pool.bucketAt(
@@ -232,7 +234,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         (, , , deposit, debt, , , ) = pool.bucketAt(
             5_007.644384905151472283 * 1e18
         );
-        assertEq(debt, 30000.273023081959005000 * 1e45);
+        assertEq(debt, 30000.663059605786311304455309928599525 * 1e45);
         assertEq(deposit, 9999.726976918040995000 * 1e45);
         // check pool balances
         assertEq(pool.totalQuoteToken(), 60_000 * 1e45);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -48,6 +48,8 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         lender1.approveToken(quote, address(pool), 200_000 * 1e18);
     }
 
+    // TODO: Review each test and validate HPB and LUP are correct where appropriate.
+
     function testDepositQuoteToken() public {
         // should revert when depositing at invalid price
         vm.expectRevert(ERC20Pool.InvalidPrice.selector);

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -324,6 +324,11 @@ library Buckets {
             // accumulate bucket interest
             accumulateBucketInterest(curLup, _inflator);
 
+            if (curLup.price == _bucket.price) {
+                // reached deposit bucket; nowhere to go
+                break;
+            }
+
             curLupDebt = curLup.debt;
 
             if (_amount > curLupDebt) {
@@ -333,7 +338,7 @@ library Buckets {
                 curLup.debt = 0;
                 curLup.onDeposit += curLupDebt;
                 if (curLup.price == curLup.up) {
-                    // nowhere to go
+                    // reached top-of-book; nowhere to go
                     break;
                 }
             } else {
@@ -341,11 +346,6 @@ library Buckets {
                 _bucket.onDeposit -= _amount;
                 curLup.debt -= _amount;
                 curLup.onDeposit += _amount;
-                break;
-            }
-
-            if (curLup.up == _bucket.price) {
-                // nowhere to go
                 break;
             }
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -321,13 +321,13 @@ library Buckets {
         uint256 curLupDebt;
 
         while (true) {
-            // accumulate bucket interest
-            accumulateBucketInterest(curLup, _inflator);
-
             if (curLup.price == _bucket.price) {
                 // reached deposit bucket; nowhere to go
                 break;
             }
+
+            // accumulate bucket interest
+            accumulateBucketInterest(curLup, _inflator);
 
             curLupDebt = curLup.debt;
 


### PR DESCRIPTION
Real-world tests revealed a scenario where a user deposited two buckets above the LUP, with a gap in liquidity between.  Upon deposit, debt at the HUP was reallocated into the deposit bucket, yet the LUP failed to update.  Upon analysis, I discovered the problem was reproducible without the liquidity gap.

After adding a test for my use case, I updated a few tests to validate the LUP.