### PR TITLE
Interest rate underflow condition

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -509,10 +509,10 @@ contract ERC20Pool is IPool, Clone {
             previousRate = Maths.wmul(
                 previousRate,
                 (
-                    Maths.max(0, Maths.sub(
+                    Maths.sub(
                         Maths.add(Maths.rayToWad(actualUtilization), Maths.ONE_WAD),
                         Maths.rayToWad(getPoolTargetUtilization())
-                    ))
+                    )
                 )
             );
             previousRateUpdate = block.timestamp;

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -501,17 +501,18 @@ contract ERC20Pool is IPool, Clone {
     function updateInterestRate() external {
         // RAY
         uint256 actualUtilization = getPoolActualUtilization();
-        if (actualUtilization != 0 && previousRateUpdate < block.timestamp) {
+        if (actualUtilization != 0 && previousRateUpdate < block.timestamp
+            && getPoolCollateralization() > Maths.ONE_RAY) {
             uint256 oldRate = previousRate;
             accumulatePoolInterest();
 
             previousRate = Maths.wmul(
                 previousRate,
                 (
-                    Maths.sub(
+                    Maths.max(0, Maths.sub(
                         Maths.add(Maths.rayToWad(actualUtilization), Maths.ONE_WAD),
                         Maths.rayToWad(getPoolTargetUtilization())
-                    )
+                    ))
                 )
             );
             previousRateUpdate = block.timestamp;


### PR DESCRIPTION
When pool is underutilized and undercollateralized, interest rates can go negative, causing an underflow condition.  Although this error prevents rates from being updated, it seems worth spending some gas to explicitly prevent a rate update when the pool becomes undercollateralized.