### PR TITLE
Lock initialize method in ERC20Pool clones.

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -122,6 +122,7 @@ contract ERC20Pool is IPool, Clone {
     );
     event Liquidate(address indexed borrower, uint256 debt, uint256 collateral);
 
+    error AlreadyInitialized();
     error InvalidPrice();
     error NoClaimToBucket();
     error NoDebtToRepay();
@@ -137,7 +138,9 @@ contract ERC20Pool is IPool, Clone {
 
     /// @notice Modifier to protect a clone's initialize method from repeated updates
     modifier onlyOnce() {
-        require(poolInitializations == 0, "ajna/already-initialized");
+        if(poolInitializations != 0) {
+            revert AlreadyInitialized();
+        }
         _;
     }
 

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -135,10 +135,9 @@ contract ERC20Pool is IPool, Clone {
     error AmountExceedsTotalClaimableQuoteToken(uint256 totalClaimable);
     error AmountExceedsAvailableCollateral(uint256 availableCollateral);
 
-
-    /// @notice Modifier to protect a clone's initaliz
+    /// @notice Modifier to protect a clone's initialize method from repeated updates
     modifier onlyOnce() {
-        require(poolInitializations == 0);
+        require(poolInitializations == 0, "ajna/already-initialized");
         _;
     }
 

--- a/src/_test/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool.t.sol
@@ -93,7 +93,7 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(pool.lastInflatorSnapshotUpdate(), 8200);
 
         // Attempt to call initialize() to reset global variables and check for revert
-        vm.expectRevert("ajna/already-initialized");
+        vm.expectRevert(ERC20Pool.AlreadyInitialized.selector);
         pool.initialize();
 
         // check that global variables weren't reset

--- a/src/_test/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool.t.sol
@@ -14,21 +14,23 @@ contract ERC20PoolTest is DSTestPlus {
     CollateralToken internal collateral;
     QuoteToken internal quote;
 
-    UserWithCollateral internal alice;
-    UserWithCollateral internal bob;
+    UserWithCollateral internal borrower;
+    UserWithQuoteToken internal lender;
 
     function setUp() public {
-        alice = new UserWithCollateral();
-        bob = new UserWithCollateral();
         collateral = new CollateralToken();
-
-        collateral.mint(address(alice), 100 * 1e18);
-        collateral.mint(address(bob), 100 * 1e18);
-
         quote = new QuoteToken();
 
         ERC20PoolFactory factory = new ERC20PoolFactory();
         pool = factory.deployPool(address(collateral), address(quote));
+
+        lender = new UserWithQuoteToken();
+        quote.mint(address(lender), 200_000 * 1e18);
+        lender.approveToken(quote, address(pool), 200_000 * 1e18);
+
+        borrower = new UserWithCollateral();
+        collateral.mint(address(borrower), 200_000 * 1e18);
+        borrower.approveToken(collateral, address(pool), 200_000 * 1e18);
     }
 
     // @notice:Tests pool factory inputs match the pool created
@@ -69,5 +71,33 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(bucketInflator, 0);
         assertEq(lpOutstanding, 0);
         assertEq(bucketCollateral, 0);
+    }
+
+    // @notice: Check that initialize can only be called once
+    function testInitialize() public {
+        uint256 initialInflator = 1 * 10**27;
+
+        assertEq(pool.inflatorSnapshot(), initialInflator);
+        assertEq(pool.lastInflatorSnapshotUpdate(), 0);
+
+        // Add quote tokens to the pool to allow initial values to change
+        lender.addQuoteToken(pool, address(lender), 10_000 * 1e18, 4_000.927678580567537368 * 1e18);
+
+        // add time to enable the inflator to update
+        skip(8200);
+
+        borrower.addCollateral(pool, 2 * 1e18);
+        borrower.borrow(pool, 1000 * 1e18, 3000 * 1e18);
+
+        assertGt(pool.inflatorSnapshot(), initialInflator);
+        assertEq(pool.lastInflatorSnapshotUpdate(), 8200);
+
+        // Attempt to call initialize() to reset global variables and check for revert
+        vm.expectRevert("ajna/already-initialized");
+        pool.initialize();
+
+        // check that global variables weren't reset
+        assertGt(pool.inflatorSnapshot(), initialInflator);
+        assertEq(pool.lastInflatorSnapshotUpdate(), 8200);
     }
 }

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -4,13 +4,10 @@ pragma solidity 0.8.11;
 import {DSTest} from "@ds-test/test.sol";
 import {ERC20} from "@solmate/tokens/ERC20.sol";
 
-import {stdCheats, stdError} from "@std/stdlib.sol";
+import {Test} from "@std/Test.sol";
 import {Vm} from "@std/Vm.sol";
 
-contract DSTestPlus is DSTest, stdCheats {
-    /// @dev Use forge-std Vm logic
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
+contract DSTestPlus is DSTest, Test {
     // PositionManager events
     event Mint(address lender, address pool, uint256 tokenId);
     event MemorializePosition(address lender, uint256 tokenId);


### PR DESCRIPTION
Prior to this modifier, external callers would have been able to call `initialize` and reset pool state.