### PR TITLE
Allow removal of all quote token from a bucket, pending interest views, HPB/LUP fixes

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -829,7 +829,7 @@ contract ERC20Pool is IPool, Clone {
         uint256 borrowerDebt = borrower.debt;
         uint256 borrowerPendingDebt = borrower.debt;
         uint256 collateralEncumbered;
-        uint256 collateralization;
+        uint256 collateralization = Maths.ONE_RAY;
 
         if (borrower.debt > 0 && borrower.inflatorSnapshot != 0) {
             borrowerDebt += getPendingInterest(

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -613,13 +613,9 @@ contract ERC20Pool is IPool, Clone {
     /// @notice Calculate unaccrued interest for the pool, which may be added to totalDebt
     /// @notice to discover pending pool debt
     /// @return interest - Unaccumulated pool interest, RAD
-    function getPendingPoolInterest() external view returns (uint256 interest)
-    {
+    function getPendingPoolInterest() external view returns (uint256 interest) {
         if (totalDebt != 0) {
-            return getPendingInterest(
-                totalDebt,
-                getPendingInflator(),
-                inflatorSnapshot);
+            return getPendingInterest(totalDebt, getPendingInflator(), inflatorSnapshot);
         } else {
             return 0;
         }
@@ -629,11 +625,10 @@ contract ERC20Pool is IPool, Clone {
     /// @notice bucket debt to discover pending bucket debt
     /// @param _price The price bucket for which interest should be calculated, WAD
     /// @return interest - Unaccumulated bucket interest, RAD
-    function getPendingBucketInterest(uint256 _price) external view returns (uint256 interest)
-    {
-        (, , , , uint256 debt, uint256 bucketInflator, ,) = bucketAt(_price);
+    function getPendingBucketInterest(uint256 _price) external view returns (uint256 interest) {
+        (, , , , uint256 debt, uint256 bucketInflator, , ) = bucketAt(_price);
         if (debt != 0) {
-            return getPendingInterest(debt,  getPendingInflator(), bucketInflator);
+            return getPendingInterest(debt, getPendingInflator(), bucketInflator);
         } else {
             return 0;
         }
@@ -781,11 +776,7 @@ contract ERC20Pool is IPool, Clone {
     /// @return RAY - The current collateralization of the pool given totalCollateral and totalDebt
     function getPoolCollateralization() public view returns (uint256) {
         if (lup != 0 && totalDebt != 0) {
-            return
-                Maths.rdiv(
-                    totalCollateral,
-                    getEncumberedCollateral(totalDebt)
-                );
+            return Maths.rdiv(totalCollateral, getEncumberedCollateral(totalDebt));
         }
         return Maths.ONE_RAY;
     }

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -418,6 +418,11 @@ contract ERC20Pool is IPool, Clone {
         totalQuoteToken += amount;
         totalDebt -= Maths.min(totalDebt, amount);
 
+        // reset LUP if no debt in pool
+        if (totalDebt == 0) {
+            lup = 0;
+        }
+
         quoteToken().safeTransferFrom(msg.sender, address(this), amount / quoteTokenScale);
         emit Repay(msg.sender, lup, amount);
     }

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -247,8 +247,8 @@ contract ERC20Pool is IPool, Clone {
             lup = newLup;
         }
 
-        // update HPB if removed from current, if no deposit nor debt in current HPB and if LUP not 0
-        if (_price == hpb && bucket.onDeposit == 0 && bucket.debt == 0 && lup != 0) {
+        // update HPB if removed from current, if no deposit nor debt in current HPB
+        if (_price == hpb && bucket.onDeposit == 0 && bucket.debt == 0) {
             hpb = getHpb();
         }
 
@@ -741,7 +741,10 @@ contract ERC20Pool is IPool, Clone {
         uint256 curHpb = hpb;
         while (true) {
             (, , uint256 down, uint256 onDeposit, uint256 debt, , , ) = _buckets.bucketAt(curHpb);
-            if (down == 0 || onDeposit != 0 || debt != 0) {
+            if (onDeposit != 0 || debt != 0) {
+                break;
+            } else if (down == 0) {
+                curHpb = 0;
                 break;
             }
 

--- a/src/_test/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20PoolBorrow.t.sol
@@ -115,7 +115,10 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         // check pool balances
         assertEq(pool.totalQuoteToken(), 29_000 * 1e45);
         assertEq(pool.totalDebt(), 21_000 * 1e45);
-        assertEq(pool.getEncumberedCollateral(pool.totalDebt()), pool.getEncumberedCollateral(borrowerDebt));
+        assertEq(
+            pool.getEncumberedCollateral(pool.totalDebt()),
+            pool.getEncumberedCollateral(borrowerDebt)
+        );
         assertEq(pool.getPoolCollateralization(), 14.337581058085150275452380951 * 1e27);
 
         skip(8200);
@@ -160,11 +163,13 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         // check pool balances
         assertEq(pool.totalQuoteToken(), 20_000 * 1e45);
         assertEq(pool.totalDebt(), 30_000.2730230835484929329412510 * 1e45);
-        assertEq(pool.getEncumberedCollateral(pool.totalDebt()), pool.getEncumberedCollateral(borrowerDebt));
+        assertEq(
+            pool.getEncumberedCollateral(pool.totalDebt()),
+            pool.getEncumberedCollateral(borrowerDebt)
+        );
         assertEq(pool.getPoolCollateralization(), 10.036215403377052296661609493 * 1e27);
 
-        (, borrowerPendingDebt, , , , , )
-            = pool.getBorrowerInfo(address(borrower));
+        (, borrowerPendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower));
         poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         assertEq(borrowerPendingDebt, poolPendingDebt);
 
@@ -173,8 +178,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         assertEq(pool.hpb(), 5_007.644384905151472283 * 1e18);
         assertEq(pool.lup(), 5_007.644384905151472283 * 1e18);
 
-        (, borrowerPendingDebt, , , , , )
-            = pool.getBorrowerInfo(address(borrower));
+        (, borrowerPendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower));
         poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         assertEq(borrowerPendingDebt, poolPendingDebt);
 
@@ -225,8 +229,11 @@ contract ERC20PoolBorrowTest is DSTestPlus {
 
         // check pool collateralization after borrower1 takes loan
         uint256 poolCollateralizationAfterB1Actions = pool.getPoolCollateralization();
-        (uint256 borrower1Debt,,) = pool.borrowers(address(borrower));
-        assertEq(pool.getEncumberedCollateral(pool.totalDebt()), pool.getEncumberedCollateral(borrower1Debt));
+        (uint256 borrower1Debt, , ) = pool.borrowers(address(borrower));
+        assertEq(
+            pool.getEncumberedCollateral(pool.totalDebt()),
+            pool.getEncumberedCollateral(borrower1Debt)
+        );
         assertEq(poolCollateralizationAfterB1Actions, 1.020113025608771127310590000 * 1e27);
 
         // check utilization after borrow - since pool is barely overcollateralized actual < target
@@ -273,8 +280,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         // tie out debt between bucket, borrower, and pool
         (, , , , uint256 debt, , , ) = pool.bucketAt(priceLow);
         uint256 bucketPendingDebt = debt + pool.getPendingBucketInterest(priceLow);
-        (, uint256 borrowerPendingDebt, , , , , )
-            = pool.getBorrowerInfo(address(borrower));
+        (, uint256 borrowerPendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower));
         uint256 poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         assertEq(bucketPendingDebt, borrowerPendingDebt);
         assertEq(bucketPendingDebt, poolPendingDebt);

--- a/src/_test/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20PoolBorrow.t.sol
@@ -63,6 +63,8 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         assertEq(pool.totalQuoteToken(), 50_000 * 1e45);
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.hpb(), priceHighest);
+        assertEq(pool.getPendingPoolInterest(), 0);
+        assertEq(pool.getPendingBucketInterest(priceHighest), 0);
 
         // should revert if borrower wants to borrow a greater amount than in pool
         vm.expectRevert(
@@ -117,6 +119,13 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         assertEq(pool.getPoolCollateralization(), 14.337581058085150275452380951 * 1e27);
 
         skip(8200);
+
+        // tie out borrower and pool debt
+        (, uint256 borrowerPendingDebt, , , uint256 collateralization, , )
+            = pool.getBorrowerInfo(address(borrower));
+        assertGt(collateralization, 10**27);
+        uint256 poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
+        assertEq(borrowerPendingDebt, poolPendingDebt);
 
         // borrow remaining 9_000 DAI from LUP
         vm.expectEmit(true, true, false, true);

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -86,18 +86,20 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(pool.totalCollateral(), 100 * 1e27);
 
         // check borrower
-        (, , uint256 deposited, uint256 borrowerEncumbered, uint256 collateralization, ,)
+        (, , uint256 deposited, uint256 borrowerEncumbered, uint256 borrowerCollateralization, ,)
             = pool.getBorrowerInfo(address(borrower));
         assertEq(deposited, 100 * 1e27);
         assertEq(borrowerEncumbered, 0);
-        assertEq(collateralization, Maths.ONE_RAY);
+        assertEq(borrowerCollateralization, Maths.ONE_RAY);
 
         // get loan of 20_000 DAI, recheck borrower
         borrower.borrow(pool, 20_000 * 1e18, 2500 * 1e18);
-        (, , deposited, borrowerEncumbered, collateralization, , ) = pool.getBorrowerInfo(address(borrower));
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , )
+        = pool.getBorrowerInfo(address(borrower));
         assertEq(deposited, 100 * 1e27);
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
-        assertEq(collateralization, 25.038221924525757361415000003 * 1e27);
+        assertEq(borrowerCollateralization, 25.038221924525757361415000003 * 1e27);
+        assertEq(pool.getPoolCollateralization(), borrowerCollateralization);
 
         // check pool state after loan
         poolEncumbered = pool.getEncumberedCollateral(pool.totalDebt());
@@ -105,9 +107,6 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         actualUtilization = pool.getPoolActualUtilization();
         assertEq(poolEncumbered, borrowerEncumbered);
         assertGt(actualUtilization, targetUtilization);
-
-        collateralization = pool.getPoolCollateralization();
-        assertEq(collateralization, 25.038221924525757361415000003 * 1e27);
 
         // should revert if trying to remove all collateral deposited
         vm.expectRevert(
@@ -120,11 +119,12 @@ contract ERC20PoolCollateralTest is DSTestPlus {
 
         // remove some collateral
         borrower.removeCollateral(pool, 20 * 1e18);
-        (, , deposited, encumbered, collateralization, , ) = pool.getBorrowerInfo(address(borrower));
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , )
+            = pool.getBorrowerInfo(address(borrower));
         assertEq(deposited, 80 * 1e27);
-        assertEq(encumbered, 3.993893827662208275880152017 * 1e27);
-        assertEq(collateralization, 20.030577539620605889132000002 * 1e27);
-        assertEq(pool.getPoolCollateralization(), collateralization);
+        assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
+        assertEq(borrowerCollateralization, 20.030577539620605889132000002 * 1e27);
+        assertEq(pool.getPoolCollateralization(), borrowerCollateralization);
 
         // borrower pays back entire loan and accumulated debt
         quote.mint(address(borrower), 20_001 * 1e18);
@@ -132,7 +132,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         borrower.repay(pool, 20_001 * 1e18);
         assertEq(pool.getPoolCollateralization(), Maths.ONE_RAY);
 
-        // remove collateral
+        // remove remaining collateral
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(pool), address(borrower), 80 * 1e18);
         vm.expectEmit(true, false, false, true);
@@ -155,7 +155,6 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(actualUtilization, 0);
         assertEq(pool.totalCollateral(), 0);
         assertEq(collateral.balanceOf(address(pool)), 0);
-
     }
 
     // @notice: With 2 lenders, 1 borrower and 1 bidder tests adding quote token, adding collateral

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -94,8 +94,9 @@ contract ERC20PoolCollateralTest is DSTestPlus {
 
         // get loan of 20_000 DAI, recheck borrower
         borrower.borrow(pool, 20_000 * 1e18, 2500 * 1e18);
-        (, , deposited, borrowerEncumbered, borrowerCollateralization, , )
-        = pool.getBorrowerInfo(address(borrower));
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = pool.getBorrowerInfo(
+            address(borrower)
+        );
         assertEq(deposited, 100 * 1e27);
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
         assertEq(borrowerCollateralization, 25.038221924525757361415000003 * 1e27);
@@ -119,8 +120,9 @@ contract ERC20PoolCollateralTest is DSTestPlus {
 
         // remove some collateral
         borrower.removeCollateral(pool, 20 * 1e18);
-        (, , deposited, borrowerEncumbered, borrowerCollateralization, , )
-            = pool.getBorrowerInfo(address(borrower));
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = pool.getBorrowerInfo(
+            address(borrower)
+        );
         assertEq(deposited, 80 * 1e27);
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
         assertEq(borrowerCollateralization, 20.030577539620605889132000002 * 1e27);

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -86,15 +86,18 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(pool.totalCollateral(), 100 * 1e27);
 
         // check borrower
-        (, , uint256 deposited, uint256 borrowerEncumbered, , , ) = pool.getBorrowerInfo(address(borrower));
+        (, , uint256 deposited, uint256 borrowerEncumbered, uint256 collateralization, ,)
+            = pool.getBorrowerInfo(address(borrower));
         assertEq(deposited, 100 * 1e27);
         assertEq(borrowerEncumbered, 0);
+        assertEq(collateralization, Maths.ONE_RAY);
 
         // get loan of 20_000 DAI, recheck borrower
         borrower.borrow(pool, 20_000 * 1e18, 2500 * 1e18);
-        (, , deposited, borrowerEncumbered, , , ) = pool.getBorrowerInfo(address(borrower));
+        (, , deposited, borrowerEncumbered, collateralization, , ) = pool.getBorrowerInfo(address(borrower));
         assertEq(deposited, 100 * 1e27);
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
+        assertEq(collateralization, 25.038221924525757361415000003 * 1e27);
 
         // check pool state after loan
         poolEncumbered = pool.getEncumberedCollateral(pool.totalDebt());
@@ -115,17 +118,27 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         );
         borrower.removeCollateral(pool, 100 * 1e18);
 
+        // remove some collateral
+        borrower.removeCollateral(pool, 20 * 1e18);
+        (, , deposited, encumbered, collateralization, , ) = pool.getBorrowerInfo(address(borrower));
+        assertEq(deposited, 80 * 1e27);
+        assertEq(encumbered, 3.993893827662208275880152017 * 1e27);
+        assertEq(collateralization, 20.030577539620605889132000002 * 1e27);
+        assertEq(pool.getPoolCollateralization(), collateralization);
+
         // borrower pays back entire loan and accumulated debt
         quote.mint(address(borrower), 20_001 * 1e18);
         borrower.approveToken(quote, address(pool), 20_001 * 1e18);
         borrower.repay(pool, 20_001 * 1e18);
+        assertEq(pool.getPoolCollateralization(), Maths.ONE_RAY);
 
         // remove collateral
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(pool), address(borrower), 100 * 1e18);
+        emit Transfer(address(pool), address(borrower), 80 * 1e18);
         vm.expectEmit(true, false, false, true);
-        emit RemoveCollateral(address(borrower), 100 * 1e27);
-        borrower.removeCollateral(pool, 100 * 1e18);
+        emit RemoveCollateral(address(borrower), 80 * 1e27);
+        borrower.removeCollateral(pool, 80 * 1e18);
+        assertEq(pool.getPoolCollateralization(), Maths.ONE_RAY);
 
         // check borrower balances
         (, , deposited, borrowerEncumbered, , , ) = pool.getBorrowerInfo(address(borrower));

--- a/src/_test/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20PoolLiquidate.t.sol
@@ -44,7 +44,6 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
     // @notice: is called
     // @notice: lender reverts:
     // @notice:    attempts to call liquidate on borrower that is collateralized
-
     function testLiquidate() public {
         // lender deposit in 3 buckets, price spaced
         uint256 priceHigh = 10_016.501589292607751220 * 1e18;
@@ -163,7 +162,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt, 0);
         assertEq(collateralDeposited, 0.790937395069026649243637516 * 1e27);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization, 0);
+        assertEq(collateralization, Maths.ONE_RAY);
         assertEq(borrowerInflator, 1.000013001099216594901568631 * 1e27);
 
         // check pool balance and that interest accumulated
@@ -282,7 +281,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt, 0);
         assertEq(collateralDeposited, 0.455302902616749045232864441 * 1e27);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization, 0);
+        assertEq(collateralization, Maths.ONE_RAY);
         assertEq(borrowerInflator, 1 * 1e27);
 
         // check pool balance
@@ -383,7 +382,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt, 0);
         assertEq(collateralDeposited, 0.189909584313202057545482525 * 1e27);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization, 0);
+        assertEq(collateralization, Maths.ONE_RAY);
         assertEq(borrowerInflator, 1.171809294361418037665607534 * 1e27);
 
         // check pool balance

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -865,12 +865,16 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // first borrower takes a loan of 12_000 DAI, pushing lup to 8_002.824356287850613262
         borrower.borrow(pool, 12_000 * 1e18, 8_000 * 1e18);
+        assertEq(pool.lup(), p8002);
+        assertEq(pool.getPoolCollateralization(), 134.714209997512151989910333326 * 1e27);
 
         skip(5000);
         pool.updateInterestRate();
         skip(5000);
         // 2nd borrower takes a loan of 1_000 DAI, pushing lup to 100.332368143282009890
         borrower2.borrow(pool, 1_000 * 1e18, 100 * 1e18);
+        assertEq(pool.lup(), p100);
+        assertEq(pool.getPoolCollateralization(), 1.558954565201166119419824603 * 1e27);
 
         skip(5000);
         pool.updateInterestRate();

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -481,7 +481,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(pool.totalQuoteToken(), 0);
         assertEq(quote.balanceOf(address(pool)), 0);
         assertEq(pool.hpb(), 0);
-        assertEq(pool.lup(), 0);  // FIXME: LUP isn't being reset after all debt paid off
+        assertEq(pool.lup(), 0);
         // check lender balance
         assertEq(quote.balanceOf(address(lender)), 200_000 * 1e18);
 
@@ -589,8 +589,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // lender removes entire bid from 4_000.927678580567537368 bucket
         uint256 withdrawalAmount = 3_001 * 1e45;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(pool), address(lender),
-            3_000.006373674954296470 * 1e18);
+        emit Transfer(address(pool), address(lender), 3_000.006373674954296470 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(lender), priceMed,
             3_000.006373674954296470378557 * 1e45, priceLow);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -915,15 +915,6 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertLt(actualUtilizationAfterRepay, actualUtilizationAfterBorrow);
         assertLt(targetUtilizationAfterRepay, targetUtilizationAfterBorrow);
 
-        // should revert if trying to remove more than was lent
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Buckets.AmountExceedsClaimable.selector,
-                1_000.058932266911224024728608 * 1e45
-            )
-        );
-        lender.removeQuoteToken(pool, address(lender), 1_001 * 1e18, p8002);
-
         // lender should be able to remove lent quote tokens + interest
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(pool), address(lender), 1_000.053487614594018248 * 1e18);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -13,8 +13,7 @@ import "../libraries/Maths.sol";
 import "../libraries/Buckets.sol";
 
 contract ERC20PoolQuoteTokenTest is DSTestPlus {
-    uint256 public constant MAX_INT = 2**256 - 1;
-    uint256 public constant LARGEST_AMOUNT = MAX_INT / 10**27;
+    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
 
     ERC20Pool internal pool;
     CollateralToken internal collateral;

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -444,6 +444,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
     // @notice: quote token is removed
     function testRemoveQuoteTokenPaidLoan() public {
         uint256 priceMed = 4_000.927678580567537368 * 1e18;
+
         // lender deposit 10000 DAI at price 4000
         lender.addQuoteToken(pool, address(lender), 10_000 * 1e18, priceMed);
         assertEq(quote.balanceOf(address(lender)), 190_000 * 1e18);
@@ -461,9 +462,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // borrower repay entire loan
         quote.mint(address(borrower), 1 * 1e18);
         borrower.approveToken(quote, address(pool), 100_000 * 1e18);
-
         borrower.repay(pool, 10_001 * 1e18);
-//        assertEq(pool.lup(), 0);  // FIXME: repay isn't updating the LUP
+        assertEq(pool.totalDebt(), 0);
+        assertEq(pool.lup(), 0);  // FIXME: LUP isn't being reset after all debt paid off
 
         skip(8200);
 
@@ -480,7 +481,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(pool.totalQuoteToken(), 0);
         assertEq(quote.balanceOf(address(pool)), 0);
         assertEq(pool.hpb(), 0);
-//        assertEq(pool.lup(), 0);
+        assertEq(pool.lup(), 0);  // FIXME: LUP isn't being reset after all debt paid off
         // check lender balance
         assertEq(quote.balanceOf(address(lender)), 200_000 * 1e18);
 

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -464,7 +464,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         borrower.approveToken(quote, address(pool), 100_000 * 1e18);
         borrower.repay(pool, 10_001 * 1e18);
         assertEq(pool.totalDebt(), 0);
-        assertEq(pool.lup(), 0);  // FIXME: LUP isn't being reset after all debt paid off
+        assertEq(pool.lup(), 0);
 
         skip(8200);
 
@@ -474,7 +474,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(pool), address(lender), 10_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(lender), priceMed, 10_000 * 1e45, priceMed);
+        emit RemoveQuoteToken(address(lender), priceMed, 10_000 * 1e45, 0);
         lender.removeQuoteToken(pool, address(lender), 10_001 * 1e18, priceMed);
 
         // check pool balances and prices

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -575,26 +575,27 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(1340);
 
         // lender removes entire bid from 4_000.927678580567537368 bucket
-        // FIXME: need a way to remove the entire bid
-        // uint256 withdrawalAmount = 3_000.006373674954296470378557 * 1e45;
-        uint256 withdrawalAmount = 3_000 * 1e45;
+        uint256 withdrawalAmount = 3_001 * 1e45;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(pool), address(lender), withdrawalAmount / 1e27);
-        emit RemoveQuoteToken(address(lender), priceMed, withdrawalAmount, priceMed);
+        emit Transfer(address(pool), address(lender),
+            3_000.006373674954296470 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(lender), priceMed,
+            3_000.006373674954296470378557 * 1e45, priceLow);
         lender.removeQuoteToken(pool, address(lender), withdrawalAmount / 1e27, priceMed);
 
         // confirm entire bid was removed
         (, , , deposit, debt, , lpOutstanding, ) = pool.bucketAt(priceMed);
         assertEq(deposit, 0);
-        // assertEq(debt, 0);  // FIXME: debt should be zero here
-        // assertEq(lpOutstanding, 0);
+        assertEq(debt, 0);
+        assertEq(lpOutstanding, 0);
 
         // confirm debt was reallocated
         (, , , deposit, debt, , lpOutstanding, ) = pool.bucketAt(priceLow);
-        assertEq(deposit, 2_000 * 1e45);
+        assertEq(deposit, 1_999.993626325045703529621443 * 1e45);
         // some debt accumulated between loan and reallocation
-        assertEq(debt, 4_000.002124558318098823459519 * 1e45);
-        // assertEq(pool.hbp(), priceLow);  // FIXME: once all debt is reallocated, HPB should move
+        assertEq(debt, 4_000.008498233272395293838076 * 1e45);
+        assertEq(pool.hpb(), priceLow);
         assertEq(pool.lup(), priceLow);
     }
 

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -249,8 +249,8 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(pool.totalQuoteToken(), 28_000.715071443825413103419758346 * 1e45);
         assertEq(pool.totalDebt(), 1_999.635958235022649238933278654 * 1e45);
         (, uint256 borrower2PendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower2));
-        // FIXME: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
-        assertEq(pool.totalDebt() + pool.getPendingPoolInterest(), borrower2PendingDebt);
+//        // FIXME: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
+//        assertEq(pool.totalDebt() + pool.getPendingPoolInterest(), borrower2PendingDebt);
         assertEq(pool.lup(), priceHigh);
         assertEq(pool.totalDebt() / pool.lup(), 0.399316685558313112714566594 * 1e27);
         assertEq(quote.balanceOf(address(borrower)), 9_999.284928556174586897 * 1e18);

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -266,9 +266,9 @@ contract ERC20PoolRepayTest is DSTestPlus {
         uint256 poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         (, uint256 borrower2PendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower2));
         // TODO: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
-//        assertEq(bucketPendingDebt, borrower2PendingDebt);
+        //        assertEq(bucketPendingDebt, borrower2PendingDebt);
         assertEq(bucketPendingDebt, poolPendingDebt);
-//        assertEq(borrower2PendingDebt, poolPendingDebt);
+        //        assertEq(borrower2PendingDebt, poolPendingDebt);
 
         assertEq(pool.hpb(), priceHigh);
         assertEq(pool.lup(), priceHigh);
@@ -283,7 +283,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(borrower2), address(pool), 2000.026002198433189803 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(borrower2), 0, 2000.026002198433189803137262 * 1e45);  // FIXME
+        emit Repay(address(borrower2), 0, 2000.026002198433189803137262 * 1e45);
         // repay entire debt
         borrower2.repay(pool, 2_010 * 1e18);
 

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -106,7 +106,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
             address(borrower),
             0,
             15_000.913648922084090343510876438000000000000000000 * 1e45
-        );  // FIXME
+        );
         borrower.repay(pool, 16_000 * 1e18);
 
         // check balances
@@ -115,7 +115,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
             30_000.913648922084090343510876438000000000000000000 * 1e45
         );
         assertEq(pool.totalDebt(), 0);
-        assertEq(pool.lup(), priceHigh);
+        assertEq(pool.lup(), 0);
         // assertEq(pool.getEncumberedCollateral() , 0);
         assertEq(pool.getPendingPoolInterest(), 0);
         assertEq(quote.balanceOf(address(borrower)), 9_999.086351077915909657 * 1e18);
@@ -309,7 +309,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(pool.totalQuoteToken(), 30_000.741073642258602906557020346 * 1e45);
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.getPendingPoolInterest(), 0);
-        assertEq(pool.lup(), priceHigh);
+        assertEq(pool.lup(), 0);
         // assertEq(pool.getEncumberedCollateral() , 0);
         assertEq(quote.balanceOf(address(borrower2)), 9_999.973997801566810197 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 30_000.741073642258602906 * 1e18);

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -104,9 +104,9 @@ contract ERC20PoolRepayTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Repay(
             address(borrower),
-            priceHigh,
+            0,
             15_000.913648922084090343510876438000000000000000000 * 1e45
-        );
+        );  // FIXME
         borrower.repay(pool, 16_000 * 1e18);
 
         // check balances
@@ -116,7 +116,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         );
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.lup(), priceHigh);
-        assertEq(pool.totalDebt() / pool.lup(), 0);
+        // assertEq(pool.getEncumberedCollateral() , 0);
         assertEq(pool.getPendingPoolInterest(), 0);
         assertEq(quote.balanceOf(address(borrower)), 9_999.086351077915909657 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 30_000.913648922084090343 * 1e18);
@@ -171,6 +171,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         // check balances
         assertEq(pool.totalQuoteToken(), 3_000 * 1e45);
         assertEq(pool.totalDebt(), 27_000 * 1e45);
+        assertEq(pool.hpb(), priceHigh);
         assertEq(pool.lup(), priceLow);
         assertEq(pool.totalDebt() / pool.lup(), 8.967442140382910277403541019 * 1e27);
         assertEq(quote.balanceOf(address(borrower)), 35_000 * 1e18);
@@ -246,11 +247,31 @@ contract ERC20PoolRepayTest is DSTestPlus {
         (, uint256 borrowerPendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower));
         assertEq(borrowerPendingDebt, 0);
 
+        // determine pending debt across all buckets
+        uint256 bucketPendingDebt = 0;
+        (, , , , debt, , , ) = pool.bucketAt(priceHigh);
+        bucketPendingDebt += debt;
+        bucketPendingDebt += pool.getPendingBucketInterest(priceHigh);
+        (, , , , debt, , , ) = pool.bucketAt(priceMid);
+        bucketPendingDebt += debt;
+        bucketPendingDebt += pool.getPendingBucketInterest(priceMid);
+        (, , , , debt, , , ) = pool.bucketAt(priceLow);
+        bucketPendingDebt += debt;
+        bucketPendingDebt += pool.getPendingBucketInterest(priceLow);
+
         assertEq(pool.totalQuoteToken(), 28_000.715071443825413103419758346 * 1e45);
         assertEq(pool.totalDebt(), 1_999.635958235022649238933278654 * 1e45);
+
+        // tie out pending debt
+        uint256 poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         (, uint256 borrower2PendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower2));
-//        // FIXME: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
-//        assertEq(pool.totalDebt() + pool.getPendingPoolInterest(), borrower2PendingDebt);
+        // TODO: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
+        //  Might be caused by
+//        assertEq(bucketPendingDebt, borrower2PendingDebt);
+        assertEq(bucketPendingDebt, poolPendingDebt);
+//        assertEq(borrower2PendingDebt, poolPendingDebt);
+
+        assertEq(pool.hpb(), priceHigh);
         assertEq(pool.lup(), priceHigh);
         assertEq(pool.totalDebt() / pool.lup(), 0.399316685558313112714566594 * 1e27);
         assertEq(quote.balanceOf(address(borrower)), 9_999.284928556174586897 * 1e18);
@@ -263,7 +284,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(borrower2), address(pool), 2000.026002198433189803 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(borrower2), priceHigh, 2000.026002198433189803137262 * 1e45);
+        emit Repay(address(borrower2), 0, 2000.026002198433189803137262 * 1e45);  // FIXME
         // repay entire debt
         borrower2.repay(pool, 2_010 * 1e18);
 
@@ -289,9 +310,12 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.getPendingPoolInterest(), 0);
         assertEq(pool.lup(), priceHigh);
-        assertEq(pool.totalDebt() / pool.lup(), 0);
+        // assertEq(pool.getEncumberedCollateral() , 0);
         assertEq(quote.balanceOf(address(borrower2)), 9_999.973997801566810197 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 30_000.741073642258602906 * 1e18);
+
+        assertEq(pool.hpb(), priceHigh);
+        assertEq(pool.lup(), 0);
 
         // remove deposited collateral
         borrower.removeCollateral(pool, 100 * 1e18);

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -116,7 +116,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         );
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.lup(), 0);
-        // assertEq(pool.getEncumberedCollateral() , 0);
+         assertEq(pool.getEncumberedCollateral(pool.totalDebt()) , 0);
         assertEq(pool.getPendingPoolInterest(), 0);
         assertEq(quote.balanceOf(address(borrower)), 9_999.086351077915909657 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 30_000.913648922084090343 * 1e18);
@@ -309,7 +309,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(pool.totalDebt(), 0);
         assertEq(pool.getPendingPoolInterest(), 0);
         assertEq(pool.lup(), 0);
-        // assertEq(pool.getEncumberedCollateral() , 0);
+         assertEq(pool.getEncumberedCollateral(pool.totalDebt()) , 0);
         assertEq(quote.balanceOf(address(borrower2)), 9_999.973997801566810197 * 1e18);
         assertEq(quote.balanceOf(address(pool)), 30_000.741073642258602906 * 1e18);
 

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -266,7 +266,6 @@ contract ERC20PoolRepayTest is DSTestPlus {
         uint256 poolPendingDebt = pool.totalDebt() + pool.getPendingPoolInterest();
         (, uint256 borrower2PendingDebt, , , , , ) = pool.getBorrowerInfo(address(borrower2));
         // TODO: Pending debt should tie within 1 RAY, but it is ~0.4 quote tokens off.
-        //  Might be caused by
 //        assertEq(bucketPendingDebt, borrower2PendingDebt);
         assertEq(bucketPendingDebt, poolPendingDebt);
 //        assertEq(borrower2PendingDebt, poolPendingDebt);

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -210,7 +210,6 @@ library Buckets {
 
             if (curLup.price == curLup.up) {
                 // nowhere to go
-                // FIXME: If there is no debt, should return (0, debtToPay)
                 break;
             }
             // move to upper bucket

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -210,6 +210,7 @@ library Buckets {
 
             if (curLup.price == curLup.up) {
                 // nowhere to go
+                // FIXME: If there is no debt, should return (0, debtToPay)
                 break;
             }
             // move to upper bucket

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -147,8 +147,7 @@ def draw_and_bid(lenders, borrowers, start_from, pool, bucket_math, chain, gas_v
             # Draw debt, repay debt, or do nothing depending on interest rate
             utilization = pool.getPoolActualUtilization() / 10**27
             if interest_rate < 0.10 and utilization < 0.70:
-                target_collateralization = max(1.01, min(1 / pool.getPoolTargetUtilization() * 10**27, 2.5))
-                # target_collateralization = 1/0.6
+                target_collateralization = 1/0.6
                 draw_debt(borrowers[user_index], user_index, pool, gas_validator,
                           collateralization=target_collateralization)
             elif utilization > 0.40:  # start repaying debt if interest grows too high

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -283,7 +283,7 @@ def repay(borrower, borrower_index, pool, gas_validator):
             print(f" borrower {borrower_index} has insufficient funds to repay {pending_debt / 10**18:.1f}")
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, test_utils, chain, tx_validator):
     # Validate test set-up
     assert pool1.collateral() == weth

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -62,7 +62,7 @@ def borrowers(ajna_protocol, pool_client, weth_dai_pool):
 def pool1(pool_client, dai, weth, lenders, borrowers, bucket_math, test_utils):
     # Adds liquidity to an empty pool and draws debt up to a target utilization
     add_initial_liquidity(lenders, pool_client, bucket_math)
-    draw_initial_debt(borrowers, pool_client)
+    draw_initial_debt(borrowers, pool_client, bucket_math, test_utils)
     global last_triggered
     last_triggered = dict.fromkeys(range(0, 100), 0)
     pool = pool_client.get_contract()
@@ -107,7 +107,8 @@ def place_initial_random_bid(lender_index, pool_client, bucket_math):
     pool_client.deposit_quote_token(60_000 * 10**18, price, lender_index)
 
 
-def draw_initial_debt(borrowers, pool_client, target_utilization=0.60, limit_price=2000 * 10**18):
+def draw_initial_debt(borrowers, pool_client, bucket_math, test_utils,
+                      target_utilization=0.60, limit_price=2000 * 10**18):
     pool = pool_client.get_contract()
     weth = pool_client.get_collateral_token().get_contract()
     target_debt = pool.totalQuoteToken() * target_utilization
@@ -123,7 +124,9 @@ def draw_initial_debt(borrowers, pool_client, target_utilization=0.60, limit_pri
         collateral_to_deposit = borrow_amount / pool_price * collateralization_ratio / 10**9
         assert collateral_balance > collateral_to_deposit
         pool_client.deposit_collateral(collateral_to_deposit, borrower_index)
+        # print(f"\nBorrower {borrower_index} drawing {borrow_amount/1e45:.1f} from bucket {pool.lup()/1e18:.1f}")
         pool_client.borrow(borrow_amount / 10**27, borrower_index, limit_price)
+        # test_utils.validate_debt(pool, borrowers, bucket_math, MIN_BUCKET)
 
 
 def get_time_between_interactions(actor_index):
@@ -143,13 +146,12 @@ def draw_and_bid(lenders, borrowers, start_from, pool, bucket_math, chain, gas_v
 
             # Draw debt, repay debt, or do nothing depending on interest rate
             utilization = pool.getPoolActualUtilization() / 10**27
-            collateralization = pool.getPoolCollateralization() / 10**27
-            if interest_rate < 0.10 and utilization < 0.70 and collateralization > 1.1:
+            if interest_rate < 0.10 and utilization < 0.70:
                 target_collateralization = max(1.01, min(1 / pool.getPoolTargetUtilization() * 10**27, 2.5))
-                assert 1 < target_collateralization < 10
+                # target_collateralization = 1/0.6
                 draw_debt(borrowers[user_index], user_index, pool, gas_validator,
                           collateralization=target_collateralization)
-            elif interest_rate > 0.15 and utilization > 0.40:  # start repaying debt if interest grows too high
+            elif utilization > 0.40:  # start repaying debt if interest grows too high
                 repay(borrowers[user_index], user_index, pool, gas_validator)
             chain.sleep(14)
 
@@ -253,8 +255,7 @@ def remove_quote_token(lender, lender_index, price, pool):
     if lp_balance > 0:
         assert lp_outstanding > 0
         (_, claimable_quote) = pool.getLPTokenExchangeValue(lp_balance, price)
-        # FIXME: subtracting dust amount (1 wad) to mitigate rounding error
-        claimable_quote = claimable_quote / 10**27 - 10**18
+        claimable_quote = claimable_quote * 1.1 / 10**27  # include extra for unaccumulated interest
         print(f" lender {lender_index} removing {claimable_quote / 10**18:.1f} at {price / 10**18:.1f}")
         pool.removeQuoteToken(lender, claimable_quote, price, {"from": lender})
     else:
@@ -282,7 +283,7 @@ def repay(borrower, borrower_index, pool, gas_validator):
             print(f" borrower {borrower_index} has insufficient funds to repay {pending_debt / 10**18:.1f}")
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, test_utils, chain, tx_validator):
     # Validate test set-up
     assert pool1.collateral() == weth
@@ -291,6 +292,7 @@ def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, 
     assert len(borrowers) == 100
     assert pool1.totalQuoteToken() > 2_700_000 * 10**18  # 50% utilization
     assert pool1.getPoolActualUtilization() > 0.50 * 10**27
+    # test_utils.validate_debt(pool1, borrowers, bucket_math, MIN_BUCKET)
 
     # Simulate pool activity over a configured time duration
     start_time = chain.time()
@@ -304,12 +306,14 @@ def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, 
             collateralization = pool1.getPoolCollateralization() / 10**27
             print(f"actual utlzn: {utilization:>6.1%}   "
                   f"target utlzn: {target:>6.1%}   "
-                  f"collateralization: {collateralization:>6.1%}")
+                  f"collateralization: {collateralization:>6.1%}   "
+                  f"debt: {pool1.totalDebt()/10**45:>12.1f}")
             # hit the pool an hour at a time, calculating interest and then sending transactions
             actor_id = draw_and_bid(lenders, borrowers, actor_id, pool1, bucket_math, chain, tx_validator, test_utils)
             print(f"days remaining: {(end_time - chain.time()) / 3600 / 24:.3f}")
 
     # Validate test ended with the pool in a meaningful state
+    # test_utils.validate_debt(pool1, borrowers, bucket_math, MIN_BUCKET)
     hpb_index = bucket_math.priceToIndex(pool1.hpb())
     print("After test:\n" + test_utils.dump_book(pool1, bucket_math, MIN_BUCKET, hpb_index))
     utilization = pool1.getPoolActualUtilization() / 10**27


### PR DESCRIPTION
**Changes**
- `removeQuoteToken` now takes it's amount as a max, consistent with `repay`.  No additional conditionals were added to make this work.  This enables removal of all quote token from a bucket, an important feature.
- Implemented `getPendingPoolInterest` and `getPendingBucketInterest` views, which calculate unaccumulated interest.
- Improved test coverage, which is being recorded here: https://docs.google.com/spreadsheets/d/1h7lBLJTUILK-g3eGRG4EqtCI3cppl43KWKACMY56HP0/edit#gid=0 .
- With help of @grandizzy, resolved two price pointer management issues.
- Fixed bug with `getBorrowerInfo` and `getPoolCollateralization` handling the "no debt" use case inconsistently.
- Implemented brownie test util to `validate_debt`, which revealed significant error in pending debt between bucket/borrower/pool.
- Applied some (but not all) lints provided by `make lint`.