### PR TITLE
Fix issue with bucket inflator initialization, improve test coverage

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -798,17 +798,11 @@ contract ERC20Pool is IPool, Clone {
         )
     {
         BorrowerInfo memory borrower = borrowers[_borrower];
-        uint256 borrowerDebt = borrower.debt;
         uint256 borrowerPendingDebt = borrower.debt;
         uint256 collateralEncumbered;
         uint256 collateralization = Maths.ONE_RAY;
 
         if (borrower.debt > 0 && borrower.inflatorSnapshot != 0) {
-            borrowerDebt += getPendingInterest(
-                borrower.debt,
-                inflatorSnapshot,
-                borrower.inflatorSnapshot
-            );
             borrowerPendingDebt += getPendingInterest(
                 borrower.debt,
                 getPendingInflator(),
@@ -819,7 +813,7 @@ contract ERC20Pool is IPool, Clone {
         }
 
         return (
-            borrowerDebt,
+            borrower.debt,
             borrowerPendingDebt,
             borrower.collateralDeposited,
             collateralEncumbered,

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -156,6 +156,13 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         quote.mint(address(borrower), 5_000 * 1e18);
         borrower.approveToken(quote, address(pool), 5_000 * 1e18);
         borrower.repay(pool, 5_000 * 1e18);
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = pool.getBorrowerInfo(
+            address(borrower)
+        );
+        assertEq(deposited, 80 * 1e27);
+        assertEq(borrowerEncumbered, 2.995420370746656206910114013 * 1e27);
+        assertEq(borrowerCollateralization, 26.707436719494141185509333334 * 1e27);
+        assertEq(pool.getPoolCollateralization(), borrowerCollateralization);
         // collateralization should increase, decreasing target utilization
         assertLt(collateralization, pool.getPoolCollateralization());
         assertGt(actualUtilization, pool.getPoolActualUtilization());

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -75,20 +75,20 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(collateral.balanceOf(address(borrower)), 100 * 1e18);
         assertEq(collateral.balanceOf(address(pool)), 0);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(borrower), address(pool), 100 * 1e18);
+        emit Transfer(address(borrower), address(pool), 70 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateral(address(borrower), 100 * 1e27);
-        borrower.addCollateral(pool, 100 * 1e18);
+        emit AddCollateral(address(borrower), 70 * 1e27);
+        borrower.addCollateral(pool, 70 * 1e18);
 
         // check balances
-        assertEq(collateral.balanceOf(address(borrower)), 0);
-        assertEq(collateral.balanceOf(address(pool)), 100 * 1e18);
-        assertEq(pool.totalCollateral(), 100 * 1e27);
+        assertEq(collateral.balanceOf(address(borrower)), 30 * 1e18);
+        assertEq(collateral.balanceOf(address(pool)), 70 * 1e18);
+        assertEq(pool.totalCollateral(), 70 * 1e27);
 
         // check borrower
         (, , uint256 deposited, uint256 borrowerEncumbered, uint256 borrowerCollateralization, ,)
             = pool.getBorrowerInfo(address(borrower));
-        assertEq(deposited, 100 * 1e27);
+        assertEq(deposited, 70 * 1e27);
         assertEq(borrowerEncumbered, 0);
         assertEq(borrowerCollateralization, Maths.ONE_RAY);
 
@@ -97,10 +97,11 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = pool.getBorrowerInfo(
             address(borrower)
         );
-        assertEq(deposited, 100 * 1e27);
+        assertEq(deposited, 70 * 1e27);
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
-        assertEq(borrowerCollateralization, 25.038221924525757361415000003 * 1e27);
-        assertEq(pool.getPoolCollateralization(), borrowerCollateralization);
+        assertEq(borrowerCollateralization, 17.526755347168030152990500002 * 1e27);
+        collateralization = pool.getPoolCollateralization();
+        assertEq(collateralization, borrowerCollateralization);
 
         // check pool state after loan
         poolEncumbered = pool.getEncumberedCollateral(pool.totalDebt());
@@ -108,6 +109,23 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         actualUtilization = pool.getPoolActualUtilization();
         assertEq(poolEncumbered, borrowerEncumbered);
         assertGt(actualUtilization, targetUtilization);
+
+        // add some collateral
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(borrower), address(pool), 30 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit AddCollateral(address(borrower), 30 * 1e27);
+        borrower.addCollateral(pool, 30 * 1e18);
+        (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = pool.getBorrowerInfo(
+            address(borrower)
+        );
+        assertEq(deposited, 100 * 1e27);
+        assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
+        // ensure collateralization increased and target utilization decreased
+        assertLt(collateralization, pool.getPoolCollateralization());
+        assertGt(targetUtilization, pool.getPoolTargetUtilization());
+        collateralization = pool.getPoolCollateralization();
+        targetUtilization = pool.getPoolTargetUtilization();
 
         // should revert if trying to remove all collateral deposited
         vm.expectRevert(
@@ -127,6 +145,9 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
         assertEq(borrowerCollateralization, 20.030577539620605889132000002 * 1e27);
         assertEq(pool.getPoolCollateralization(), borrowerCollateralization);
+        // ensure collateralization decreased and target utilization increased
+        assertGt(collateralization, pool.getPoolCollateralization());
+        assertLt(targetUtilization, pool.getPoolTargetUtilization());
 
         // borrower pays back entire loan and accumulated debt
         quote.mint(address(borrower), 20_001 * 1e18);

--- a/src/_test/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20PoolLiquidate.t.sol
@@ -335,7 +335,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
             uint256 borrowerInflator,
 
         ) = pool.getBorrowerInfo(address(borrower));
-        assertEq(borrowerDebt, 14_061.7115323370164519872904080 * 1e45);
+        assertEq(borrowerDebt, 12_000 * 1e45);
         assertEq(borrowerPendingDebt, 14_061.7115323370164519872904080 * 1e45);
         assertEq(collateralDeposited, 2 * 1e27);
         assertEq(collateralEncumbered, 140.151297059547691733986086344 * 1e27);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -214,6 +214,10 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(pool.hpb(), p4000);
         assertEq(pool.lup(), p2000);
 
+        uint256 collateralizationBeforeAdd = pool.getPoolCollateralization();
+        uint256 targetUtilizationBeforeAdd = pool.getPoolTargetUtilization();
+        uint256 actualUtilizationBeforeAdd = pool.getPoolActualUtilization();
+
         // Lender deposits more into the middle bucket, causing reallocation
         lender.addQuoteToken(pool, address(lender), 2_000 * 1e18, p3000);
         (, , , deposit, debt, , , ) = pool.bucketAt(p4000);
@@ -227,8 +231,14 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(debt, 0);
         assertEq(pool.hpb(), p4000);
         assertEq(pool.lup(), p3000);
+        assertGt(pool.getPoolCollateralization(), collateralizationBeforeAdd);
+        assertLt(pool.getPoolTargetUtilization(), targetUtilizationBeforeAdd);
+        assertLt(pool.getPoolActualUtilization(), actualUtilizationBeforeAdd);
 
         // Lender deposits in the top bucket, causing another reallocation
+        collateralizationBeforeAdd = pool.getPoolCollateralization();
+        targetUtilizationBeforeAdd = pool.getPoolTargetUtilization();
+        actualUtilizationBeforeAdd = pool.getPoolActualUtilization();
         lender.addQuoteToken(pool, address(lender), 3_000 * 1e18, p4000);
         (, , , deposit, debt, , , ) = pool.bucketAt(p4000);
         assertEq(deposit, 1600 * 1e45);
@@ -241,6 +251,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(debt, 0);
         assertEq(pool.hpb(), p4000);
         assertEq(pool.lup(), p4000);
+        assertGt(pool.getPoolCollateralization(), collateralizationBeforeAdd);
+        assertLt(pool.getPoolTargetUtilization(), targetUtilizationBeforeAdd);
+        assertLt(pool.getPoolActualUtilization(), actualUtilizationBeforeAdd);
     }
 
     // @notice: 1 lender and 1 borrower test adding quote token,

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -89,7 +89,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 0);
         assertEq(deposit, 10_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 0);
+        assertEq(snapshot, Maths.ONE_RAY);
         assertEq(lpOutstanding, 10_000 * 1e27);
         // check lender's LP amount can be redeemed for correct amount of quote token
         assertEq(pool.lpBalance(address(lender), 4_000.927678580567537368 * 1e18), 10_000 * 1e27);
@@ -120,7 +120,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 0);
         assertEq(deposit, 20_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 0);
+        assertEq(snapshot, Maths.ONE_RAY);
         assertEq(lpOutstanding, 20_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 2000.221618840727700609 * 1e18), 20_000 * 1e27);
         // check hpb down price pointer updated
@@ -148,7 +148,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 2_000.221618840727700609 * 1e18);
         assertEq(deposit, 30_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 0);
+        assertEq(snapshot, Maths.ONE_RAY);
         assertEq(lpOutstanding, 30_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 3010.892022197881557845 * 1e18), 30_000 * 1e27);
         // check hdp down price pointer updated
@@ -182,7 +182,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 4_000.927678580567537368 * 1e18);
         assertEq(deposit, 40_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 0);
+        assertEq(snapshot, Maths.ONE_RAY);
         assertEq(lpOutstanding, 40_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 5_007.644384905151472283 * 1e18), 40_000 * 1e27);
     }

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -83,14 +83,13 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             uint256 debt,
             uint256 snapshot,
             uint256 lpOutstanding,
-
         ) = pool.bucketAt(4_000.927678580567537368 * 1e18);
         assertEq(price, 4_000.927678580567537368 * 1e18);
         assertEq(upPrice, 4_000.927678580567537368 * 1e18);
         assertEq(downPrice, 0);
         assertEq(deposit, 10_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 1 * 1e18);
+        assertEq(snapshot, 0);
         assertEq(lpOutstanding, 10_000 * 1e27);
         // check lender's LP amount can be redeemed for correct amount of quote token
         assertEq(pool.lpBalance(address(lender), 4_000.927678580567537368 * 1e18), 10_000 * 1e27);
@@ -121,7 +120,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 0);
         assertEq(deposit, 20_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 1 * 1e18);
+        assertEq(snapshot, 0);
         assertEq(lpOutstanding, 20_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 2000.221618840727700609 * 1e18), 20_000 * 1e27);
         // check hpb down price pointer updated
@@ -149,7 +148,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 2_000.221618840727700609 * 1e18);
         assertEq(deposit, 30_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 1 * 1e18);
+        assertEq(snapshot, 0);
         assertEq(lpOutstanding, 30_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 3010.892022197881557845 * 1e18), 30_000 * 1e27);
         // check hdp down price pointer updated
@@ -183,7 +182,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(downPrice, 4_000.927678580567537368 * 1e18);
         assertEq(deposit, 40_000 * 1e45);
         assertEq(debt, 0);
-        assertEq(snapshot, 1 * 1e18);
+        assertEq(snapshot, 0);
         assertEq(lpOutstanding, 40_000 * 1e27);
         assertEq(pool.lpBalance(address(lender), 5_007.644384905151472283 * 1e18), 40_000 * 1e27);
     }

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -76,7 +76,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
             uint256 borrowerPendingDebt,
             uint256 depositedCollateral,
             , , , ) = pool.getBorrowerInfo(address(borrower));
-        assertEq(borrowerDebt, 25_000 * 1e45);  // FIXME: shows 25_000.002219685535643948678400000000000000000000000
+        assertEq(borrowerDebt, 25_000 * 1e45);
         assertEq(borrowerPendingDebt, 25_000.0022196855356439486784 * 1e45);
         assertEq(depositedCollateral, 100 * 1e27);
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -504,7 +504,7 @@ library Buckets {
     ) public returns (uint256) {
         Bucket storage bucket = buckets[_price];
         bucket.price = _price;
-        bucket.inflatorSnapshot = Maths.ONE_WAD;
+        bucket.inflatorSnapshot;
 
         if (_price > _hpb) {
             bucket.down = _hpb;

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -504,7 +504,7 @@ library Buckets {
     ) public returns (uint256) {
         Bucket storage bucket = buckets[_price];
         bucket.price = _price;
-        bucket.inflatorSnapshot;
+        bucket.inflatorSnapshot = Maths.ONE_RAY;
 
         if (_price > _hpb) {
             bucket.down = _hpb;


### PR DESCRIPTION
**Changes**
- Initialize buckets with inflator at the correct scale
- `getBorrowerInfo` returns unaccumulated debt where expected
- Improve test coverage for collateralization and utilization