### PR TITLE
lpBalance testing and wrdivr

### DIFF
--- a/src/_test/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20PoolLiquidate.t.sol
@@ -409,8 +409,8 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(collateralization,    0.014270292476495862 * 1e18);
         assertEq(borrowerInflator,     1 * 1e27);
 
-        // TODO: fix these asserts -> pending debt is not 0
         // check pool and borrowers collateralization after both borrows
+        assertLt(borrowerDebt, borrowerPendingDebt);
         assertEq(_pool.getEncumberedCollateral(borrowerPendingDebt), collateralEncumbered);
         assertEq(_pool.getBorrowerCollateralization(collateralDeposited, borrowerPendingDebt), collateralization);
         assertEq(
@@ -419,7 +419,6 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         );
 
         assertEq(_pool.getPoolCollateralization(), 1.345606594670868806 * 1e18);
-        // assertEq(_pool.getPoolCollateralization(), 1);
         assertEq(_pool.getPoolActualUtilization(), 1 * 1e18);
 
         // liquidate borrower

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -206,41 +206,54 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, _p4000);
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, _p3010);
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, _p2000);
+        skip(3600);
 
-        // Borrower draws debt from all three
+        // Borrower draws 2400 debt, utilizing all three
         _borrower.addCollateral(_pool, 10 * 1e18);
         _borrower.borrow(_pool, 2_400 * 1e18, 0);
-        (, , , uint256 deposit, uint256 debt, , , ) = _pool.bucketAt(_p4000);
-        assertEq(deposit, 0);
-        assertEq(debt,    1_000 * 1e18);
+        skip(3600 * 24 * 7);
+
+        (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, ) = _pool.bucketAt(_p4000);
+        assertEq(deposit,       0);
+        assertEq(debt,          1_000 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p4000));
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p3010);
-        assertEq(deposit, 0);
-        assertEq(debt,    1_000 * 1e18);
+        assertEq(deposit,       0);
+        assertEq(debt,          1_000 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p3010));
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p2000);
-        assertEq(deposit, 600 * 1e18);
-        assertEq(debt,    400 * 1e18);
+        assertEq(deposit,         600 * 1e18);
+        assertEq(debt,            400 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p2000));
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), _p2000);
-
         uint256 collateralizationBeforeAdd = _pool.getPoolCollateralization();
         uint256 targetUtilizationBeforeAdd = _pool.getPoolTargetUtilization();
         uint256 actualUtilizationBeforeAdd = _pool.getPoolActualUtilization();
 
-        // Lender deposits more into the middle bucket, causing reallocation
+        // Lender deposits 2000 more into the middle bucket, causing reallocation
         _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, _p3010);
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p4000);
-        assertEq(deposit, 0);
-        assertEq(debt,    1_000 * 1e18);
+        skip(3600 * 24 * 14);
 
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p3010);
-        assertEq(deposit, 1_600 * 1e18);
-        assertEq(debt,    1_400 * 1e18);
-
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p2000);
-        assertEq(deposit, 1_000 * 1e18);
-        assertEq(debt,    0);
-
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p4000);
+        assertEq(deposit,       0);
+        assertEq(debt,          1_000 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p4000));
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p3010);
+        assertEq(deposit,       1_599.616254398255734490 * 1e18);
+        assertEq(debt,          1_401.343109606104929285 * 1e18);
+        assertEq(lpOutstanding, 2_998.083110985599442734706053425 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p3010));
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p2000);
+        assertEq(deposit,       1_000.383745601744265510 * 1e18);
+        assertEq(debt,          0);
+        assertEq(lpOutstanding, 1_000 * 1e27);
+        assertEq(lpOutstanding, _pool.getLPTokenBalance(address(_lender), _p2000));
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), _p3010);
 
@@ -252,23 +265,23 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         collateralizationBeforeAdd = _pool.getPoolCollateralization();
         targetUtilizationBeforeAdd = _pool.getPoolTargetUtilization();
         actualUtilizationBeforeAdd = _pool.getPoolActualUtilization();
-
         _lender.addQuoteToken(_pool, address(_lender), 3_000 * 1e18, _p4000);
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p4000);
-        assertEq(deposit, 1600 * 1e18);
-        assertEq(debt,    2_400 * 1e18);
 
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p3010);
-        assertEq(deposit, 3_000 * 1e18);
-        assertEq(debt,    0);
-
-        (, , , deposit, debt, , , ) = _pool.bucketAt(_p2000);
-        assertEq(deposit, 1_000 * 1e18);
-        assertEq(debt,    0);
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p4000);
+        assertEq(deposit,       1_595.966804352484918343 * 1e18);
+        assertEq(debt,          2_406.914049681454425698 * 1e18);
+        assertEq(lpOutstanding, 3_991.382264336730919556003493759 * 1e27);
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p3010);
+        assertEq(deposit,       3_003.649450045770816147 * 1e18);
+        assertEq(debt,          0);
+        assertEq(lpOutstanding, 2_998.083110985599442734706053425 * 1e27);
+        (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p2000);
+        assertEq(deposit,       1_000.383745601744265510 * 1e18);
+        assertEq(debt,          0);
+        assertEq(lpOutstanding, 1_000 * 1e27);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), _p4000);
-
         assertGt(_pool.getPoolCollateralization(), collateralizationBeforeAdd);
         assertLt(_pool.getPoolTargetUtilization(), targetUtilizationBeforeAdd);
         assertLt(_pool.getPoolActualUtilization(), actualUtilizationBeforeAdd);
@@ -422,6 +435,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
     function testRemoveQuoteTokenUnpaidLoan() external {
         // lender deposit 10000 DAI at price 4_000.927678580567537368
         _lender.addQuoteToken(_pool, address(_lender), 10_000 * 1e18, _p4000);
+        skip(3600);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),          10_000 * 1e18);
@@ -432,6 +446,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // borrower takes a loan of 5_000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 5_000 * 1e18, 4_000 * 1e18);
+        skip(3600);
 
         // should revert if trying to remove entire amount lended
         vm.expectRevert(Buckets.NoDepositToReallocateTo.selector);
@@ -467,10 +482,10 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // check 4000 bucket balance
         (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, ) = _pool.bucketAt(_p4000);
         assertEq(deposit,       1_000 * 1e18);
-        assertEq(debt,          5_000 * 1e18);
-        assertEq(lpOutstanding, 6_000 * 1e27);
+        assertEq(debt,          5_000.028538894209302482 * 1e18);
+        assertEq(lpOutstanding, 6_000.011415525105074661063764799 * 1e27);
 
-        assertEq(_pool.lpBalance(address(_lender), _p4000), 6_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender), _p4000), 6_000.011415525105074661063764799 * 1e27);
     }
 
     // @notice: 1 lender and 1 borrower deposits quote token
@@ -609,37 +624,51 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // lender deposit into 2 buckets
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceMed);
+        skip(3600);
         _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceMed);
-        skip(14);
+        skip(3600);
         _lender.addQuoteToken(_pool, address(_lender), 6_000 * 1e18, priceLow);
-        skip(1340);
+        skip(3600);
 
         // borrower takes a loan of 4000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 4_000 * 1e18, 0);
+        skip(3600);
 
+        uint256 bucketPendingDebt = 0;
         (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, ) = _pool.bucketAt(priceMed);
         assertEq(deposit,       0);
         assertEq(debt,          3_000 * 1e18);
         assertEq(lpOutstanding, 3_000 * 1e27);
+        bucketPendingDebt += debt;
 
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(priceLow);
         assertEq(deposit,       5_000 * 1e18);
         assertEq(debt,          1_000 * 1e18);
         assertEq(lpOutstanding, 6_000 * 1e27);
+        bucketPendingDebt += debt;
 
         assertEq(_pool.hpb(), priceMed);
         assertEq(_pool.lup(), priceLow);
 
-        skip(1340);
+        skip(3600 * 24 * 7);
+
+        // check pending debt
+        bucketPendingDebt += _pool.getPendingBucketInterest(priceMed);
+        bucketPendingDebt += _pool.getPendingBucketInterest(priceLow);
+        uint256 poolPendingDebt = _pool.totalDebt() + _pool.getPendingPoolInterest();
+        (, uint256 borrowerPendingDebt, , , , , ) = _pool.getBorrowerInfo(address(_borrower));
+        assertEq(borrowerPendingDebt, poolPendingDebt);
+        assertLt(wadPercentDifference(bucketPendingDebt, borrowerPendingDebt), 0.000000000000000001 * 1e18);
+        assertLt(wadPercentDifference(bucketPendingDebt, poolPendingDebt),     0.000000000000000001 * 1e18);
 
         // lender removes entire bid from 4_000.927678580567537368 bucket
-        uint256 withdrawalAmount = 3_001 * 1e18;
+        uint256 withdrawalAmount = 3_010 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 3_000.006373674954296470 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 3_002.895231777120270013 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed,
-            3_000.006373674954296470 * 1e18, priceLow);
+            3_002.895231777120270013 * 1e18, priceLow);
         _lender.removeQuoteToken(_pool, address(_lender), withdrawalAmount, priceMed);
 
         // confirm entire bid was removed
@@ -650,10 +679,10 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // confirm debt was reallocated
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(priceLow);
-        assertEq(deposit, 1_999.993626325045703530 * 1e18);
+        assertEq(deposit, 1_997.104768222879729987 * 1e18);
 
         // some debt accumulated between loan and reallocation
-        assertEq(debt, 4_000.008498233272395293 * 1e18);
+        assertEq(debt, 4_003.860309036160360017 * 1e18);
 
         assertEq(_pool.hpb(), priceLow);
         assertEq(_pool.lup(), priceLow);

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -39,7 +39,7 @@ contract MathTest is DSTestPlus {
         assertEq(debt * 1e18 / price,     10.98202093218880245 * 1e18);
 
         uint256 exchangeRate = 1.09232010 * 1e27;
-        assertEq(Maths.rdiv(Maths.wadToRay(debt), price), Maths.wrdivr(debt, price));
+        assertEq(Maths.rdiv(Maths.wadToRay(debt), exchangeRate), Maths.wrdivr(debt, exchangeRate));
     }
 
 }

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -37,6 +37,9 @@ contract MathTest is DSTestPlus {
 
         assertEq(Maths.wdiv(debt, price), 10.98202093218880245 * 1e18);
         assertEq(debt * 1e18 / price,     10.98202093218880245 * 1e18);
+
+        uint256 exchangeRate = 1.09232010 * 1e27;
+        assertEq(Maths.rdiv(Maths.wadToRay(debt), price), Maths.wrdivr(debt, price));
     }
 
 }

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -105,7 +105,7 @@ library Buckets {
             revert ClaimExceedsCollateral({collateralAmount: bucket_.collateral});
         }
 
-        lpRedemption_ = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, bucket_.price)), getExchangeRate(bucket_)); // TODO: improve efficiency
+        lpRedemption_ = Maths.wrdivr(Maths.wmul(amount_, bucket_.price), getExchangeRate(bucket_));
 
         if (lpRedemption_ > lpBalance_) {
             revert InsufficientLpBalance({balance: lpBalance_});
@@ -483,7 +483,7 @@ library Buckets {
             bucket_.debt +
             Maths.wmul(bucket_.collateral, bucket_.price);
         if (size != 0 && bucket_.lpOutstanding != 0) {
-            return Maths.rdiv(Maths.wadToRay(size), bucket_.lpOutstanding);
+            return Maths.wrdivr(size, bucket_.lpOutstanding);
         }
         return Maths.ONE_RAY;
     }

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -44,6 +44,11 @@ library Maths {
         z = (x * RAY + y / 2) / y;
     }
 
+    /// @notice Multiplies a WAD by a RAY and returns a RAY
+    function wrdivr(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        return (x * 1e36 + y / 2) / y;
+    }
+
     function rpow(uint256 x, uint256 n) internal pure returns (uint256 z) {
         z = n % 2 != 0 ? x : RAY;
 

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -299,7 +299,7 @@ def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, 
     # Simulate pool activity over a configured time duration
     start_time = chain.time()
     # end_time = start_time + SECONDS_PER_YEAR  # TODO: one year test
-    end_time = start_time + SECONDS_PER_YEAR / 119
+    end_time = start_time + SECONDS_PER_YEAR / 52
     actor_id = 0
     with test_utils.GasWatcher(['addQuoteToken', 'borrow', 'removeQuoteToken', 'repay', 'updateInterestRate']):
         while chain.time() < end_time:


### PR DESCRIPTION
**lpBalance testing**
Assume one lender makes an initial deposit of 1000 quote token into a bucket and has an lpBalance of 1000.  A borrower borrows that bucket.  After time passes, the lender deposits another 1000 into that bucket.  Because the second deposit accumulates debt, bucket "size" becomes slightly bigger, such that the exchange rate only gives them an lpBalance of 1999.999.  As the bucket matures, the relationship to lpBalance and bucket size will diverge.

On the contrary, if the lender does not deposit into a utilized bucket, debt may accumulate as a result of reallocation.  When this happens, the lender's LP balance remains constant and can be redeemed for their deposit plus interest.

Changes to `testDepositQuoteTokenWithReallocation` allow debt to accumulate between operations and confirm `lpBalance` is practical in both scenarios.

**wrdivr**
`Buckets` library has two places where we need to multiply a WAD by a RAY and get the result as a RAY.  The previous implementation includes an unnecessary multiplication.  To simplify, I implemented a new method in `Maths`.