### PR TITLE
Fix bucket inflator snapshot bug

### DIFF
--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -412,8 +412,8 @@ abstract contract Buckets {
             bucket_.debt += Maths.radToWadTruncate(
                 bucket_.debt * (Maths.rdiv(inflator_, bucket_.inflatorSnapshot) - Maths.ONE_RAY)
             );
-            bucket_.inflatorSnapshot = inflator_;
         }
+        bucket_.inflatorSnapshot = inflator_;
     }
 
     /**


### PR DESCRIPTION
- Update bucket inflator snapshot each time we interact with a bucket (and not only when accumulating debt)
- this guarantees that LP tokens are properly calculated when adding / removing quote tokens