### PR TITLE
Encumbered collateral should be calculated as RAY to maintain precision

### DIFF
--- a/src/_test/ERC20PoolBid.t.sol
+++ b/src/_test/ERC20PoolBid.t.sol
@@ -60,7 +60,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 4_000 * 1e18, 3_000 * 1e18);
         assertEq(_pool.lup(), 3_010.892022197881557845 * 1e18);
-        assertEq(_pool.getPoolCollateralization(), 75.272300554947038956 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 75.272300554947038946 * 1e18);
 
         // should revert if invalid price
         vm.expectRevert("BM:PTI:OOB");
@@ -81,7 +81,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),        5_000 * 1e18);
         assertEq(_pool.totalQuoteToken(),                 5_000 * 1e18);
         assertEq(_pool.totalCollateral(),                 100 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),        75.272300554947038956 * 1e18);
+        assertEq(_pool.getPoolCollateralization(),        75.272300554947038946 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),        0.444444444444444444 * 1e18);
 
         // check 4_000.927678580567537368 bucket balance before purchase bid
@@ -105,7 +105,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         _bidder.purchaseBid(_pool, 2_000 * 1e18, _p4000);
 
         assertEq(_pool.lup(), _p1004);
-        assertEq(_pool.getPoolCollateralization(), 25.124741560729269374 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 25.124741560729269377 * 1e18);
         // check 4_000.927678580567537368 bucket balance after purchase bid
         (, , , deposit, debt, , , bucketCollateral) = _pool.bucketAt(_p4000);
         assertEq(deposit,          0);
@@ -131,7 +131,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),        3_000 * 1e18);
         assertEq(_pool.totalQuoteToken(),                 3_000 * 1e18);
         assertEq(_pool.totalCollateral(),                 100 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),        25.124741560729269374 * 1e18);
+        assertEq(_pool.getPoolCollateralization(),        25.124741560729269377 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),        0.571428571428571429 * 1e18);
     }
 
@@ -156,7 +156,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_collateral.balanceOf(address(_pool)),   100 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),        5_000 * 1e18);
         assertEq(_pool.totalCollateral(),                 100 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),        150.544601109894077798 * 1e18);
+        assertEq(_pool.getPoolCollateralization(),        150.544601109894077892 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),        0.285714285714285714 * 1e18);
 
         assertEq(_pool.hpb(), _p4000);
@@ -216,7 +216,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_collateral.balanceOf(address(_pool)),   100.249942033532277153 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),        4_000 * 1e18);
         assertEq(_pool.totalCollateral(),                 100 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),        100.011080942036385043 * 1e18);
+        assertEq(_pool.getPoolCollateralization(),        100.011080942036385030 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),        0.333333333333333333 * 1e18);
 
     }

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -95,8 +95,8 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _borrower.borrow(_pool, 20_000 * 1e18, 2500 * 1e18);
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,                        70 * 1e18);
-        assertEq(borrowerEncumbered,               3.993893827662208276 * 1e18);
-        assertEq(borrowerCollateralization,        17.526755347168030152 * 1e18);
+        assertEq(borrowerEncumbered,               3.993893827662208275880152017 * 1e27);
+        assertEq(borrowerCollateralization,        17.526755347168030153 * 1e18);
         assertEq(_pool.getPoolCollateralization(), borrowerCollateralization);
 
         // check pool state after loan
@@ -114,7 +114,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _borrower.addCollateral(_pool, 30 * 1e18);
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,          100 * 1e18);
-        assertEq(borrowerEncumbered, 3.993893827662208276 * 1e18);
+        assertEq(borrowerEncumbered, 3.993893827662208275880152017 * 1e27);
         // ensure collateralization increased and target utilization decreased
         assertLt(collateralization, _pool.getPoolCollateralization());
         assertGt(targetUtilization, _pool.getPoolTargetUtilization());
@@ -129,7 +129,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _borrower.removeCollateral(_pool, 20 * 1e18);
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,                 80 * 1e18);
-        assertEq(borrowerEncumbered,        3.993893827662208276 * 1e18);
+        assertEq(borrowerEncumbered,        3.993893827662208275880152017 * 1e27);
         assertEq(borrowerCollateralization, 20.030577539620605889 * 1e18);
 
         assertEq(_pool.getPoolCollateralization(), borrowerCollateralization);
@@ -147,8 +147,8 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _borrower.repay(_pool, 5_000 * 1e18);
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,                 80 * 1e18);
-        assertEq(borrowerEncumbered,        2.995420370746656207 * 1e18);
-        assertEq(borrowerCollateralization, 26.707436719494141185 * 1e18);
+        assertEq(borrowerEncumbered,        2.995420370746656206910114013 * 1e27);
+        assertEq(borrowerCollateralization, 26.707436719494141186 * 1e18);
 
         assertEq(_pool.getPoolCollateralization(), borrowerCollateralization);
         // collateralization should increase, decreasing target utilization

--- a/src/_test/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20PoolLiquidate.t.sol
@@ -88,7 +88,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         uint256 borrower1CollateralEncumbered = collateralEncumbered;
         assertEq(_pool.getEncumberedCollateral(borrowerDebt), borrower1CollateralEncumbered);
         assertEq(_pool.getBorrowerCollateralization(collateralDeposited, borrowerDebt), collateralization);
-        assertEq(_pool.getPoolCollateralization(), 165.648478682707543214 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 165.648478682707543148 * 1e18);
         assertEq(
             _pool.getBorrowerCollateralization(collateralDeposited, borrowerDebt),
             collateralization
@@ -133,7 +133,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerDebt,         11_000 * 1e18);
         assertEq(borrowerPendingDebt,  11_000 * 1e18);
         assertEq(collateralDeposited,  2 * 1e18);
-        assertEq(collateralEncumbered, 109.635606171392167204 * 1e18);
+        assertEq(collateralEncumbered, 109.635606171392167204250999673 * 1e27);
         assertEq(collateralization,    0.018242248753324002 * 1e18);
         assertEq(borrowerInflator,     1 * 1e27);
 
@@ -272,7 +272,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerDebt,         12_000 * 1e18);
         assertEq(borrowerPendingDebt,  12_000 * 1e18);
         assertEq(collateralDeposited,  2 * 1e18);
-        assertEq(collateralEncumbered, 119.602479459700546041 * 1e18);
+        assertEq(collateralEncumbered, 119.602479459700546041001090553 * 1e27);
         assertEq(collateralization,    0.016722061357213668 * 1e18);
         assertEq(borrowerInflator,     1 * 1e27);
 
@@ -397,7 +397,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerDebt,         12_000 * 1e18);
         assertEq(borrowerPendingDebt,  14_061.711532337016451987 * 1e18);
         assertEq(collateralDeposited,  2 * 1e18);
-        assertEq(collateralEncumbered, 140.151297059547691734 * 1e18);
+        assertEq(collateralEncumbered, 140.151297059547691733983191885 * 1e27);
         assertEq(collateralization,    0.014270292476495862 * 1e18);
         assertEq(borrowerInflator,     1 * 1e27);
 

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -579,7 +579,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         uint256 poolCollateralizationAfterBorrow = _pool.getPoolCollateralization();
         uint256 targetUtilizationAfterBorrow     = _pool.getPoolTargetUtilization();
         uint256 actualUtilizationAfterBorrow     = _pool.getPoolActualUtilization();
-        assertEq(poolCollateralizationAfterBorrow, 133.364255952685584575 * 1e18);
+        assertEq(poolCollateralizationAfterBorrow, 133.364255952685584579 * 1e18);
         assertGt(actualUtilizationAfterBorrow,     targetUtilizationAfterBorrow);
 
         // lender removes 1000 DAI from LUP
@@ -742,7 +742,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         uint256 targetUtilizationAfterBorrow      = _pool.getPoolTargetUtilization();
         uint256 actualUtilizationAfterBorrow      = _pool.getPoolActualUtilization();
 
-        assertEq(poolCollateralizationAfterBorrow, 11.757774763124786460 * 1e18);
+        assertEq(poolCollateralizationAfterBorrow, 11.757774763124786457 * 1e18);
         assertGt(actualUtilizationAfterBorrow,     targetUtilizationAfterBorrow);
 
         // Lender withdraws above LUP
@@ -911,7 +911,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // check pool collateralization
         collateralization = _pool.getPoolCollateralization();
-        assertEq(collateralization, 133.364255952685584575 * 1e18);
+        assertEq(collateralization, 133.364255952685584579 * 1e18);
 
         // check pool is still overcollateralized
         targetUtilization = _pool.getPoolTargetUtilization();
@@ -1058,7 +1058,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // first borrower takes a loan of 12_000 DAI, pushing lup to 8_002.824356287850613262
         _borrower.borrow(_pool, 12_000 * 1e18, 8_000 * 1e18);
         assertEq(_pool.lup(),                       _p8002);
-        assertEq(_pool.getPoolCollateralization(), 134.714209997512152015 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 134.714209997512151990 * 1e18);
 
         skip(5000);
         _pool.updateInterestRate();

--- a/src/_test/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20PoolRepay.t.sol
@@ -78,7 +78,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(),                          5_000 * 1e18);
         assertEq(_pool.totalDebt(),                                25_000 * 1e18);
         assertEq(_pool.lup(),                                      priceLow);
-        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 8.303187167021213220 * 1e18);
+        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 8.303187167021213219818093536 * 1e27);
         assertEq(_pool.getPoolCollateralization(),                 12.043568088791526231 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),                 0.833333333333333333 * 1e18);
 
@@ -106,8 +106,8 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(),                          15_000 * 1e18);
         assertEq(_pool.totalDebt(),                                15_000.325027480414872539 * 1e18);
         assertEq(_pool.lup(),                                      priceMid);
-        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 3.749211741013566066 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),                 26.672273242419188877 * 1e18);
+        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 3.749211741013566065511760082 * 1e27);
+        assertEq(_pool.getPoolCollateralization(),                 26.672273242419188880 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),                 0.500005417065983738 * 1e18);
         assertEq(_quote.balanceOf(address(_borrower)),             25_000 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),                 15_000 * 1e18);
@@ -194,8 +194,8 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalDebt(),                                27_000 * 1e18);
         assertEq(_pool.hpb(),                                      priceHigh);
         assertEq(_pool.lup(),                                      priceLow);
-        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 8.967442140382910277 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),                 22.302903868132455985 * 1e18);
+        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 8.967442140382910277403541019 * 1e27);
+        assertEq(_pool.getPoolCollateralization(),                 22.302903868132455984 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),                 0.9 * 1e18);
 
         assertEq(_quote.balanceOf(address(_borrower)),  35_000 * 1e18);
@@ -257,8 +257,8 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(),                          13_000 * 1e18);
         assertEq(_pool.totalDebt(),                                17_000.351029678848062342 * 1e18);
         assertEq(_pool.lup(),                                      priceMid);
-        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 4.249102307120473073 * 1e18);
-        assertEq(_pool.getPoolCollateralization(),                 47.068765481322519067 * 1e18);
+        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 4.249102307120473073413145494 * 1e27);
+        assertEq(_pool.getPoolCollateralization(),                 47.068765481322519063 * 1e18);
         assertEq(_pool.getPoolActualUtilization(),                 0.566671737036032801 * 1e18);
 
         assertEq(_quote.balanceOf(address(_borrower)), 25_000 * 1e18);
@@ -298,7 +298,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
 
         assertEq(_pool.totalQuoteToken(),          28_000.325027480414872539 * 1e18);
         assertEq(_pool.totalDebt(),                2_000.026002198433189803 * 1e18);
-        assertEq(_pool.getPoolCollateralization(), 500.757928087008591313 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 500.757928087008591535 * 1e18);
         assertEq(_pool.getPoolActualUtilization(), 0.066666753339647284 * 1e18);
 
         // first borrower repaid; tie out pending debt second borrower debt to reasonable percentage
@@ -311,7 +311,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
 
         assertEq(_pool.hpb(),                                      priceHigh);
         assertEq(_pool.lup(),                                      priceHigh);
-        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 0.399394575267212226 * 1e18);
+        assertEq(_pool.getEncumberedCollateral(_pool.totalDebt()), 0.399394575267212225822870931 * 1e27);
 
         assertEq(_quote.balanceOf(address(_borrower)), 9_999.674972519585127461 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),     28_000.325027480414872539 * 1e18);

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -35,8 +35,10 @@ contract MathTest is DSTestPlus {
         uint256 debt  = 11_000.143012091382543917 * 1e18;
         uint256 price = 1_001.6501589292607751220 * 1e18;
 
-        assertEq(Maths.wdiv(debt, price), 10.98202093218880245 * 1e18);
-        assertEq(debt * 1e18 / price,     10.98202093218880245 * 1e18);
+        assertEq(Maths.wdiv(debt, price),   10.98202093218880245 * 1e18);
+        assertEq(debt * 1e18 / price,       10.98202093218880245 * 1e18);
+        assertEq(Maths.wwdivr(debt, price), 10.982020932188802450191601163 * 1e27);
+        assertEq(Maths.wrdivw(20 * 1e18, 10.982020932188802450191601163 * 1e27), 1.821158430082671857 * 1e18);
 
         uint256 exchangeRate = 1.09232010 * 1e27;
         assertEq(Maths.rdiv(Maths.wadToRay(debt), exchangeRate), Maths.wrdivr(debt, exchangeRate));

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -38,6 +38,7 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.wdiv(debt, price),   10.98202093218880245 * 1e18);
         assertEq(debt * 1e18 / price,       10.98202093218880245 * 1e18);
         assertEq(Maths.wwdivr(debt, price), 10.982020932188802450191601163 * 1e27);
+
         assertEq(Maths.wrdivw(20 * 1e18, 10.982020932188802450191601163 * 1e27), 1.821158430082671857 * 1e18);
 
         uint256 exchangeRate = 1.09232010 * 1e27;

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -35,7 +35,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         if (borrower.debt > 0 && borrower.inflatorSnapshot != 0) {
             borrowerPendingDebt  += getPendingInterest(borrower.debt, getPendingInflator(), borrower.inflatorSnapshot);
             collateralEncumbered  = getEncumberedCollateral(borrowerPendingDebt);
-            collateralization     = Maths.wdiv(borrower.collateralDeposited, collateralEncumbered);
+            collateralization     = Maths.wrdivw(borrower.collateralDeposited, collateralEncumbered);
         }
 
         return (

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -51,7 +51,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
 
     function getBorrowerCollateralization(uint256 collateralDeposited_, uint256 debt_) public view override returns (uint256 borrowerCollateralization_) {
         if (lup != 0 && debt_ != 0) {
-            return Maths.wdiv(collateralDeposited_, getEncumberedCollateral(debt_));
+            return Maths.wrdivw(collateralDeposited_, getEncumberedCollateral(debt_));
         }
         return Maths.ONE_WAD;
     }

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -25,7 +25,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256 encumbrance_) {
         // Calculate encumbrance as RAY to maintain precision
-        encumbrance_ = debt_ != 0 ? Maths.wdiv(debt_, lup) : 0;
+        encumbrance_ = debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
     }
 
     function getMinimumPoolPrice() public view override returns (uint256 minPrice_) {

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -41,7 +41,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getPoolCollateralization() public view override returns (uint256 poolCollateralization_) {
         if (lup != 0 && totalDebt != 0) {
-            return Maths.wdiv(totalCollateral, getEncumberedCollateral(totalDebt));
+            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt));
         }
         return Maths.ONE_WAD;
     }

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -44,9 +44,14 @@ library Maths {
         z = (x * RAY + y / 2) / y;
     }
 
-    /** @notice Multiplies a WAD by a RAY and returns a RAY */
+    /** @notice Divides a WAD by a RAY and returns a RAY */
     function wrdivr(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return (x * 1e36 + y / 2) / y;
+    }
+
+    /** @notice Divides a WAD by a WAD and returns a RAY */
+    function wwdivr(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        return (x * 1e27 + y / 2) / y;
     }
 
     function rpow(uint256 x, uint256 n) internal pure returns (uint256 z) {

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -49,6 +49,11 @@ library Maths {
         return (x * 1e36 + y / 2) / y;
     }
 
+    /** @notice Divides a WAD by a RAY and returns a WAD */
+    function wrdivw(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        return (x * 1e27 + y / 2) / y;
+    }
+
     /** @notice Divides a WAD by a WAD and returns a RAY */
     function wwdivr(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return (x * 1e27 + y / 2) / y;


### PR DESCRIPTION
Existing pool methods all interpreted encumbered collateral as a RAY, however the implementation was using a WAD scaling factor for the arithmetic.  Result was that precision was lost.  Corrected this, and updated tests to check encumbered collateral against the appropriate RAY value.