### PR TITLE
Correct MVP interest rate calculation

### DIFF
--- a/src/_test/ERC20PoolInterestRate.t.sol
+++ b/src/_test/ERC20PoolInterestRate.t.sol
@@ -68,10 +68,10 @@ contract ERC20PoolInterestRateTest is DSTestPlus {
         assertEq(_pool.getPoolTargetUtilization(), 0.099859436886217129 * 1e18);
 
         vm.expectEmit(true, true, false, true);
-        emit UpdateInterestRate(0.05 * 1e18, 0.050000000036673630 * 1e18);
+        emit UpdateInterestRate(0.05 * 1e18, 0.086673629908233477 * 1e18);
         _lender.updateInterestRate(_pool);
 
-        assertEq(_pool.previousRate(),               0.050000000036673630 * 1e18);
+        assertEq(_pool.previousRate(),               0.086673629908233477 * 1e18);
         assertEq(_pool.previousRateUpdate(),         8200);
         assertEq(_pool.lastInflatorSnapshotUpdate(), 8200);
     }
@@ -95,9 +95,9 @@ contract ERC20PoolInterestRateTest is DSTestPlus {
         assertLt(_pool.getPoolActualUtilization(), _pool.getPoolTargetUtilization());
 
         vm.expectEmit(true, true, false, true);
-        emit UpdateInterestRate(0.05 * 1e18, 0.049999999959999999 * 1e18);
+        emit UpdateInterestRate(0.05 * 1e18, 0.009999998890157270 * 1e18);
         _lender.updateInterestRate(_pool);
-        assertEq(_pool.previousRate(), 0.049999999959999999 * 1e18);
+        assertEq(_pool.previousRate(), 0.009999998890157270 * 1e18);
     }
 
     /**

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -1066,7 +1066,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // 2nd borrower takes a loan of 1_000 DAI, pushing lup to 100.332368143282009890
         _borrower2.borrow(_pool, 1_000 * 1e18, 100 * 1e18);
         assertEq(_pool.lup(),                      _p100);
-        assertEq(_pool.getPoolCollateralization(), 1.558987827039498473 * 1e18);
+        assertEq(_pool.getPoolCollateralization(), 1.558977381172573759 * 1e18);
 
         skip(5000);
         _pool.updateInterestRate();
@@ -1076,14 +1076,14 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             _pool.lpBalance(address(_lender), _p8002), _p8002
         );
         assertEq(col, 0);
-        assertEq(quoteLPValue, 1_000.015855021676099840 * 1e18);
+        assertEq(quoteLPValue, 1_000.023113960510762449 * 1e18);
 
         // check pool state following borrows
         uint256 poolCollateralizationAfterBorrow = _pool.getPoolCollateralization();
         uint256 targetUtilizationAfterBorrow     = _pool.getPoolTargetUtilization();
         uint256 actualUtilizationAfterBorrow     = _pool.getPoolActualUtilization();
 
-        assertEq(poolCollateralizationAfterBorrow, 1.558975468293558516 * 1e18);
+        assertEq(poolCollateralizationAfterBorrow, 1.558953706339260276 * 1e18);
         assertGt(actualUtilizationAfterBorrow,     targetUtilizationAfterBorrow);
 
         // should revert if not enough funds in pool
@@ -1098,7 +1098,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
             _pool.lpBalance(address(_lender), _p8002), _p8002
         );
         assertEq(col, 0);
-        assertEq(quoteLPValue, 1_000.031710294744013558 * 1e18);
+        assertEq(quoteLPValue, 1_000.058932859846503255 * 1e18);
 
         // check that utilization decreased following repayment
         uint256 poolCollateralizationAfterRepay = _pool.getPoolCollateralization();
@@ -1112,9 +1112,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // lender should be able to remove lent quote tokens + interest
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 1_000.031710294744013558 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 1_000.058932859846503255 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _p8002, 1_000.031710294744013558 * 1e18, _p10016);
+        emit RemoveQuoteToken(address(_lender), _p8002, 1_000.058932859846503255 * 1e18, _p10016);
         _lender.removeQuoteToken(_pool, address(_lender), 1_001 * 1e18, _p8002);
 
         assertEq(_pool.hpb(), _p10016);

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -112,10 +112,7 @@ abstract contract Interest is IInterest, PoolState {
 
             previousRate = Maths.wmul(
                 previousRate,
-                (
-                    Maths.rayToWad(actualUtilization) + Maths.ONE_WAD
-                        - Maths.rayToWad(getPoolTargetUtilization())
-                )
+                (actualUtilization + Maths.ONE_WAD - getPoolTargetUtilization())
             );
             previousRateUpdate = block.timestamp;
             emit UpdateInterestRate(oldRate, previousRate);


### PR DESCRIPTION
Utilization figures are calculated as WADs, but the interest rate calculation was interpreting them as RAYs.  As such, the calculation was producing the wrong numbers.  Verified the rate calculation in `testUpdateInterestRate` by hand.