### PR TITLE
Manipulation mitigations - Deposit penalty:

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -212,7 +212,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     }
 
     function moveQuoteToken(
-        address recipient_, uint256 amount_, uint256 fromPrice_, uint256 toPrice_
+        address recipient_, uint256 maxAmount_, uint256 fromPrice_, uint256 toPrice_
     ) external override {
         require(BucketMath.isValidPrice(toPrice_), "P:MQT:INVALID_TO_PRICE");
         require(fromPrice_ != toPrice_, "P:MQT:SAME_PRICE");
@@ -220,7 +220,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         accumulatePoolInterest();
 
         (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = moveQuoteTokenFromBucket(
-            fromPrice_, toPrice_, amount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], inflatorSnapshot
+            fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], inflatorSnapshot
         );
 
         require(getPoolCollateralization() >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");

--- a/src/_test/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool.t.sol
@@ -462,27 +462,27 @@ contract ERC20PoolTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         vm.expectEmit(true, true, true, true);
-        emit MoveQuoteToken(address(_lender1), priceHigh, priceMed, 500 * 1e18, 0);
-        _lender1.moveQuoteToken(_pool, address(_lender1), 500 * 1e18, priceHigh, priceMed);
+        emit MoveQuoteToken(address(_lender1), priceHigh, priceMed, 500.499262543592459489 * 1e18, 0);
+        _lender1.moveQuoteToken(_pool, address(_lender1), 510 * 1e18, priceHigh, priceMed);
 
         // check buckets
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
         bipCredit = _pool.bipAt(priceMed);
-        assertEq(deposit,       5_000 * 1e18);
-        assertEq(lpOutstanding, 5_000 * 1e27);
+        assertEq(deposit,       5_000.499262543592459489 * 1e18);
+        assertEq(lpOutstanding, 5_000.499262543592459489000000000 * 1e27);
         assertEq(bipCredit,     0);
 
         assertEq(_pool.lpBalance(address(_lender), priceMed),  3_500 * 1e27);
-        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500.499262543592459489000000000 * 1e27);
 
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
         bipCredit = _pool.bipAt(priceHigh);
-        assertEq(deposit,       1_001.497787630777378468 * 1e18);
-        assertEq(lpOutstanding, 1_000.498764514711922023590135240 * 1e27);
+        assertEq(deposit,       1_000.998525087184918979 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
         assertEq(bipCredit,     1.497787630777378468 * 1e18);
 
         assertEq(_pool.lpBalance(address(_lender), priceHigh),  1_000 * 1e27);
-        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0.498764514711922023590135240 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0);
 
         // lender deposit in priceHigh bucket, check penalty applies only if moving from priceHigh bucket
         _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
@@ -493,21 +493,21 @@ contract ERC20PoolTest is DSTestPlus {
 
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
         bipCredit = _pool.bipAt(priceHigh);
-        assertEq(deposit,       1_002.493019587188935394 * 1e18);
-        assertEq(lpOutstanding, 1_000.498764514711922023590135240 * 1e27);
+        assertEq(deposit,       1_001.993757043596475905 * 1e18);
+        assertEq(lpOutstanding, 1_000 * 1e27);
         assertEq(bipCredit,     2.493019587188935394 * 1e18);
 
         assertEq(_pool.lpBalance(address(_lender), priceHigh),  1_000 * 1e27);
-        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0.498764514711922023590135240 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0 * 1e27);
 
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
         bipCredit = _pool.bipAt(priceMed);
-        assertEq(deposit,       6_999.004768043588443074 * 1e18);
-        assertEq(lpOutstanding, 6_999.004768043588443074000000000 * 1e27);
+        assertEq(deposit,       6_999.504030587180902563 * 1e18);
+        assertEq(lpOutstanding, 6_999.504030587180902563000000000 * 1e27);
         assertEq(bipCredit,     0);
 
         assertEq(_pool.lpBalance(address(_lender), priceMed),  5_499.004768043588443074000000000 * 1e27);
-        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500.499262543592459489000000000 * 1e27);
 
         // penalty should not apply if moving from priceMed bucket to priceLow
         vm.expectEmit(true, true, true, true);
@@ -516,12 +516,12 @@ contract ERC20PoolTest is DSTestPlus {
 
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
         bipCredit = _pool.bipAt(priceMed);
-        assertEq(deposit,       4_999.004768043588443074 * 1e18);
-        assertEq(lpOutstanding, 4_999.004768043588443074000000000 * 1e27);
+        assertEq(deposit,       4_999.504030587180902563 * 1e18);
+        assertEq(lpOutstanding, 4_999.504030587180902563000000000 * 1e27);
         assertEq(bipCredit,     0);
 
         assertEq(_pool.lpBalance(address(_lender), priceMed),  3_499.004768043588443074000000000 * 1e27);
-        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500.499262543592459489000000000 * 1e27);
 
         (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
         bipCredit = _pool.bipAt(priceLow);

--- a/src/_test/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool.t.sol
@@ -151,6 +151,10 @@ contract ERC20PoolTest is DSTestPlus {
 
     }
 
+    /**********************************************************/
+    /*** Manipulation mitigation tests - fees and penalties ***/
+    /**********************************************************/
+
    function testManipulationMitigations() external {
         _lender.addQuoteToken(_pool, address(_lender), 100_000 * 1e18, _p4000);
         _lender1.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, _p3010);
@@ -219,6 +223,314 @@ contract ERC20PoolTest is DSTestPlus {
         _borrower1.repay(_pool, 100 * 1e18);
         assertEq(_pool.getPoolMinDebtAmount(), 0);
         assertEq(_pool.totalBorrowers(),       0);
+   }
+
+   function testRemoveQuoteTokenPenalty() external {
+        uint256 priceHigh = _p2000;
+        uint256 priceMed  = _p1004;
+        uint256 priceLow  = _p502;
+
+        _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
+        _lender.addQuoteToken(_pool, address(_lender), 3_000 * 1e18, priceMed);
+        _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceLow);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   6_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 194_000 * 1e18);
+
+        // check bucket
+        (, , , uint256 deposit, , , uint256 lpOutstanding, ) = _pool.bucketAt(priceHigh);
+        uint256 bipCredit = _pool.bipAt(priceHigh);
+        assertEq(deposit,       2_000 * 1e18);
+        assertEq(lpOutstanding, 2_000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceHigh), 2_000 * 1e27);
+
+        // test remove all amount with penalty from one bucket
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 1_998 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceHigh, 1_998 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   4_002 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 195_998 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
+        bipCredit = _pool.bipAt(priceHigh);
+        assertEq(deposit,       0);
+        assertEq(lpOutstanding, 0);
+        assertEq(bipCredit,     2 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceHigh), 0);
+
+        // test remove entire amount in 2 steps with penalty 
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 499.5 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceMed, 499.5 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 500 * 1e18, priceMed);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   3_502.5 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 196_497.5 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       2_500 * 1e18);
+        assertEq(lpOutstanding, 2_500 * 1e27);
+        assertEq(bipCredit,     0.5 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed), 2_500 * 1e27);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 2_497.5 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceMed, 2_497.5 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 2_500 * 1e18, priceMed);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   1_005 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 198_995 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       0 * 1e18);
+        assertEq(lpOutstanding, 0 * 1e27);
+        assertEq(bipCredit,     3 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed), 0);
+
+        // skip > 24h no penalty should occur
+        skip(3600 * 24 + 1);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 500 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceLow, 500 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 500 * 1e18, priceLow);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   505 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 199_495 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       500 * 1e18);
+        assertEq(lpOutstanding, 500 * 1e27);
+        assertEq(bipCredit,     0 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow), 500 * 1e27);
+
+        // deposit at a different bucket should not impose penalty on current bucket
+        _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 100 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceLow, 100 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 100 * 1e18, priceLow);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   2_405 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 197_595 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       400 * 1e18);
+        assertEq(lpOutstanding, 400 * 1e27);
+        assertEq(bipCredit,     0 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow), 400 * 1e27);
+
+        // deposit in current bucket should reactivate penalty
+        _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceLow);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(_pool), address(_lender), 2_397.6 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit RemoveQuoteToken(address(_lender), priceLow, 2_397.6 * 1e18, 0);
+        _lender.removeQuoteToken(_pool, address(_lender), 2_400 * 1e18, priceLow);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),   2_007.4 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 197_992.6 * 1e18);
+
+        // check bucket
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       0 * 1e18);
+        assertEq(lpOutstanding, 0 * 1e27);
+        assertEq(bipCredit,     2.4 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow), 0 * 1e27);
+    }
+
+   function testMoveQuoteTokenPenalty() external {
+        uint256 priceHigh = _p2000;
+        uint256 priceMed  = _p1004;
+        uint256 priceLow  = _p502;
+
+        _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
+        _lender.addQuoteToken(_pool, address(_lender), 3_000 * 1e18, priceMed);
+        _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceLow);
+
+        _lender1.addQuoteToken(_pool, address(_lender1), 500 * 1e18, priceHigh);
+        _lender1.addQuoteToken(_pool, address(_lender1), 1_000 * 1e18, priceMed);
+        _lender1.addQuoteToken(_pool, address(_lender1), 1_500 * 1e18, priceLow);
+
+        // check balances
+        assertEq(_quote.balanceOf(address(_pool)),    9_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)),  194_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender1)), 197_000 * 1e18);
+
+        // check bucket
+        (, , , uint256 deposit, , , uint256 lpOutstanding, ) = _pool.bucketAt(priceLow);
+        uint256 bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       2_500 * 1e18);
+        assertEq(lpOutstanding, 2_500 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow), 1_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceLow), 1_500 * 1e27);
+
+        // there should be no penalty if moving to a higher bucket
+        vm.expectEmit(true, true, true, true);
+        emit MoveQuoteToken(address(_lender), priceLow, priceMed, 500 * 1e18, 0);
+        _lender.moveQuoteToken(_pool, address(_lender), 500 * 1e18, priceLow, priceMed);
+
+        // check buckets
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       2_000 * 1e18);
+        assertEq(lpOutstanding, 2_000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow),  500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceLow), 1_500 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       4_500 * 1e18);
+        assertEq(lpOutstanding, 4_500 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed),  3_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_000 * 1e27);
+
+        // apply penalty if moving to a lower bucket
+        vm.expectEmit(true, true, true, true);
+        emit MoveQuoteToken(address(_lender), priceHigh, priceLow, 998.502212369222621532 * 1e18, 0);
+        _lender.moveQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceHigh, priceLow);
+
+        // check buckets
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       2_998.502212369222621532 * 1e18);
+        assertEq(lpOutstanding, 2_998.502212369222621532000000000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow),  1_498.502212369222621532000000000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceLow), 1_500 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
+        bipCredit = _pool.bipAt(priceHigh);
+        assertEq(deposit,       1_501.497787630777378468 * 1e18);
+        assertEq(lpOutstanding, 1_500 * 1e27);
+        assertEq(bipCredit,     1.497787630777378468 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceHigh),  1_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 500 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       4_500 * 1e18);
+        assertEq(lpOutstanding, 4_500 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed),  3_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_000 * 1e27);
+
+        // skip > 24h no penalty should occur
+        skip(3600 * 24 + 1);
+
+        vm.expectEmit(true, true, true, true);
+        emit MoveQuoteToken(address(_lender1), priceHigh, priceMed, 500 * 1e18, 0);
+        _lender1.moveQuoteToken(_pool, address(_lender1), 500 * 1e18, priceHigh, priceMed);
+
+        // check buckets
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       5_000 * 1e18);
+        assertEq(lpOutstanding, 5_000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed),  3_500 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
+        bipCredit = _pool.bipAt(priceHigh);
+        assertEq(deposit,       1_001.497787630777378468 * 1e18);
+        assertEq(lpOutstanding, 1_000.498764514711922023590135240 * 1e27);
+        assertEq(bipCredit,     1.497787630777378468 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceHigh),  1_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0.498764514711922023590135240 * 1e27);
+
+        // lender deposit in priceHigh bucket, check penalty applies only if moving from priceHigh bucket
+        _lender.addQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh);
+
+        vm.expectEmit(true, true, true, true);
+        emit MoveQuoteToken(address(_lender), priceHigh, priceMed, 1_999.004768043588443074 * 1e18, 0);
+        _lender.moveQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceHigh, priceMed);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceHigh);
+        bipCredit = _pool.bipAt(priceHigh);
+        assertEq(deposit,       1_002.493019587188935394 * 1e18);
+        assertEq(lpOutstanding, 1_000.498764514711922023590135240 * 1e27);
+        assertEq(bipCredit,     2.493019587188935394 * 1e18);
+
+        assertEq(_pool.lpBalance(address(_lender), priceHigh),  1_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 0.498764514711922023590135240 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       6_999.004768043588443074 * 1e18);
+        assertEq(lpOutstanding, 6_999.004768043588443074000000000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed),  5_499.004768043588443074000000000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+
+        // penalty should not apply if moving from priceMed bucket to priceLow
+        vm.expectEmit(true, true, true, true);
+        emit MoveQuoteToken(address(_lender), priceMed, priceLow, 2_000 * 1e18, 0);
+        _lender.moveQuoteToken(_pool, address(_lender), 2_000 * 1e18, priceMed, priceLow);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceMed);
+        bipCredit = _pool.bipAt(priceMed);
+        assertEq(deposit,       4_999.004768043588443074 * 1e18);
+        assertEq(lpOutstanding, 4_999.004768043588443074000000000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceMed),  3_499.004768043588443074000000000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceMed), 1_500 * 1e27);
+
+        (, , , deposit, , , lpOutstanding, ) = _pool.bucketAt(priceLow);
+        bipCredit = _pool.bipAt(priceLow);
+        assertEq(deposit,       4_998.502212369222621532 * 1e18);
+        assertEq(lpOutstanding, 4_998.502212369222621532000000000 * 1e27);
+        assertEq(bipCredit,     0);
+
+        assertEq(_pool.lpBalance(address(_lender), priceLow),  3_498.502212369222621532000000000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceLow), 1_500 * 1e27);
    }
 
 }

--- a/src/_test/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20PoolCollateral.t.sol
@@ -240,6 +240,9 @@ contract ERC20PoolCollateralTest is DSTestPlus {
 
         _lender.claimCollateral(_pool, address(_lender), 1 * 1e18, priceHigh);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // borrower takes a loan of 4000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 4_000 * 1e18, 3_000 * 1e18);

--- a/src/_test/ERC20PoolMove.t.sol
+++ b/src/_test/ERC20PoolMove.t.sol
@@ -71,6 +71,9 @@ contract ERC20PoolMoveQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   170_466_756.126702504695020000 * 1e18);
 
+        // skip > 24h to avoid deposit penalty
+        skip(3600 * 24 + 1);
+
         // lender moves 10_000 DAI down
         assertMoveQuoteToken(address(_lender), _p3514, _p2503, 10_000 * 1e18, 0);
 
@@ -125,6 +128,9 @@ contract ERC20PoolMoveQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(), 60_000 * 1e18);
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   170_466_756.126702504695020000 * 1e18);
+
+        // skip > 24h to avoid deposit penalty
+        skip(3600 * 24 + 1);
 
         // lender moves 10_000 DAI up
         assertMoveQuoteToken(address(_lender), _p2503, _p3514, 10_000 * 1e18, 0);

--- a/src/_test/ERC20PoolMove.t.sol
+++ b/src/_test/ERC20PoolMove.t.sol
@@ -1136,10 +1136,6 @@ contract ERC20PoolMoveQuoteTokenTest is DSTestPlus {
         vm.expectRevert("P:MQT:INVALID_TO_PRICE");
         _lender.moveQuoteToken(_pool, address(_lender), 2_000 * 1e18, _p3010, 3_000 * 1e18);
 
-        // should revert if trying to move more than entitled
-        vm.expectRevert("B:MQT:AMT_GT_CLAIM");
-        _lender.moveQuoteToken(_pool, address(_lender), 10_001 * 1e18, _p3010, _p3514);
-
         assertMoveQuoteToken(address(_lender), _p3010, _p3514, 2_000 * 1e18, 0);
 
         assertEq(_pool.hpb(), _p3514);

--- a/src/_test/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20PoolPrecision.t.sol
@@ -79,6 +79,9 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),   20_000 * _quotePrecision);
         assertEq(_quote.balanceOf(address(_lender)), 180_000 * _quotePrecision);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // remove 10_000 quote token with 6 decimal precision
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 10_000 * _quotePrecision);

--- a/src/_test/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20PoolQuoteToken.t.sol
@@ -494,7 +494,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
     function testRemoveQuoteTokenNoLoan() external {
         // lender deposit 10000 DAI at price 4000
         _lender.addQuoteToken(_pool, address(_lender), 10_000 * 1e18, _p4000);
-        skip(8200);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), 0);
@@ -543,7 +545,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
     function testRemoveQuoteTokenUnpaidLoan() external {
         // lender deposit 10000 DAI at price 4_000.927678580567537368
         _lender.addQuoteToken(_pool, address(_lender), 10_000 * 1e18, _p4000);
-        skip(3600);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), 0);
@@ -629,6 +633,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_lender)),  190_000 * 1e18);
         assertEq(_quote.balanceOf(address(_lender1)), 190_000 * 1e18);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // borrower takes a loan of 10_000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 10_000 * 1e18, 4_000 * 1e18);
@@ -701,6 +708,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(), 6_800 * 1e18);
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   23_840_186.982646726923724200 * 1e18);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // borrower takes a loan of 3000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
@@ -889,6 +899,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.getPoolTargetUtilization(), Maths.ONE_WAD);
 
+        // skip > 24h to avoid deposit penalty
+        skip(3600 * 24 + 1);
+
         // Borrower draws 2400 debt partially utilizing the LUP
         _borrower.addCollateral(_pool, 10 * 1e18);
         _borrower.borrow(_pool, 2_400 * 1e18, 0);
@@ -970,7 +983,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceHigh);
         _lender.addQuoteToken(_pool, address(_lender), 1_000 * 1e18, priceMed);
         _lender.addQuoteToken(_pool, address(_lender), 3_000 * 1e18, priceLow);
-        skip(60);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         assertEq(_pool.hpb(), priceHigh);
         assertEq(_pool.lup(), 0);
@@ -1103,6 +1118,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(collateralization, Maths.ONE_WAD);
         assertEq(actualUtilization, 0);
         assertEq(targetUtilization, Maths.ONE_WAD);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // borrower takes a loan of 3000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
@@ -1259,7 +1277,8 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         (, , , , , , lpOutstanding, ) = _pool.bucketAt(priceLow);
         assertEq(lpOutstanding, 20_000 * 1e27);
 
-        skip(8200);
+        // skip > 24h to avoid deposit penalty
+        skip(3600 * 24 + 1);
 
         _lender.removeQuoteToken(_pool, address(_lender), 10_000 * 1e18, priceLow);
 
@@ -1318,6 +1337,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(), 13_300 * 1e18);
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   117_318_734.038244664909739000 * 1e18);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // borrowers deposit collateral
         _borrower.addCollateral(_pool, 2 * 1e18);
@@ -1442,6 +1464,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   16_003_710.714322270149472000 * 1e18);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // remove max 5000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 4_000 * 1e18);
@@ -1473,6 +1498,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(), 2_000 * 1e18);
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   8_001_855.357161135074736000 * 1e18);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // remove uint256.max at price of 1 MKR = 4_000.927678580567537368 DAI
         vm.expectEmit(true, true, false, true);
@@ -1513,6 +1541,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, address(_lender), 100 * 1e18, priceMed);
         assertEq(_pool.hpb(), priceHigh);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // lender removes from middle bucket
         _lender.removeQuoteToken(_pool, address(_lender), 100 * 1e18, priceMed);
         assertEq(_pool.hpb(), priceHigh);
@@ -1542,6 +1573,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         (, uint256 up, uint256 down, , , , , ) = _pool.bucketAt(_p1004);
         assertEq(up,   _p1004);
         assertEq(down, 0);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // remove tokens from 1_004.989662429170775094, bucket should be deactivated
         _lender.removeQuoteToken(_pool, address(_lender), 10_000 * 1e18, _p1004);
@@ -1586,6 +1620,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         (, up, down, , , , , ) = _pool.bucketAt(_p2000);
         assertEq(up,   _p2503);
         assertEq(down, 0);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // remove tokens and deactivate middle bucket 3_010.892022197881557845
         _lender.removeQuoteToken(_pool, address(_lender), 10_000 * 1e18, _p3010);

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -287,6 +287,9 @@ contract PositionManagerTest is DSTestPlus {
         // add liquidity that can later be decreased
         increaseLiquidity(tokenId, testAddress, address(_pool), mintAmount, mintPrice);
 
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
+
         // find number of lp tokens received
         uint256 originalLPTokens = _positionManager.getLPTokens(tokenId, mintPrice); // RAY
         assertEq(originalLPTokens, 10_000 * 1e27);
@@ -422,6 +425,9 @@ contract PositionManagerTest is DSTestPlus {
 
         // add liquidity that can later be decreased
         increaseLiquidity(tokenId, testAddress, address(_pool), mintAmount, mintPrice);
+
+        // skip > 24h to avoid deposit removal penalty
+        skip(3600 * 24 + 1);
 
         // construct BurnParams
         IPositionManager.BurnParams memory burnParams = IPositionManager.BurnParams(tokenId, testAddress, mintPrice);

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -214,7 +214,7 @@ abstract contract Buckets is IBuckets {
         // apply bid penalty if deposit happened less than 24h ago
         if (fromBucket.price > toBucket.price && block.timestamp - lpTimer_ < SECONDS_PER_DAY) {
             uint256 penalty        = Maths.wmul(PENALTY_BPS, fromBucket.price - toBucket.price);
-            amount_               -= penalty;
+            amount_                -= penalty;
             _bip[fromBucket.price] += penalty;
         }
 
@@ -295,7 +295,7 @@ abstract contract Buckets is IBuckets {
         Bucket storage bucket = _buckets[price_];
         accumulateBucketInterest(bucket, inflator_);
 
-        uint256 exchangeRate = getExchangeRate(bucket);                 // RAY
+        uint256 exchangeRate = getExchangeRate(bucket);                // RAY
         uint256 claimable    = Maths.rmul(lpBalance_, exchangeRate);   // RAY
         amount_             = Maths.min(Maths.wadToRay(maxAmount_), claimable); // RAY
         lpTokens_           = Maths.rdiv(amount_, exchangeRate);                // RAY
@@ -492,7 +492,7 @@ abstract contract Buckets is IBuckets {
     function moveQuoteTokenAtPrice(
         Bucket storage fromBucket_, Bucket storage toBucket_, uint256 amount_, uint256 inflator_, uint256 lup_
     ) private returns (uint256 newLup_) {
-        newLup_      = lup_;
+        newLup_       = lup_;
         bool moveUp   = fromBucket_.price < toBucket_.price;
         bool aboveLup = newLup_ !=0 && newLup_ < Maths.min(fromBucket_.price, toBucket_.price);
 

--- a/src/base/LenderManager.sol
+++ b/src/base/LenderManager.sol
@@ -17,6 +17,10 @@ abstract contract LenderManager is ILenderManager, Buckets {
      *  @dev lender address -> price bucket [WAD] -> lender lp [RAY]
      */
     mapping(address => mapping(uint256 => uint256)) public lpBalance;
+    /**
+     *  @dev lender address -> price bucket [WAD] -> timer
+     */
+    mapping(address => mapping(uint256 => uint256)) public lpTimer;
 
     function getLPTokenExchangeValue(uint256 lpTokens_, uint256 price_) external view override returns (uint256 collateralTokens_, uint256 quoteTokens_) {
         require(BucketMath.isValidPrice(price_), "P:GLPTEV:INVALID_PRICE");

--- a/src/interfaces/IBuckets.sol
+++ b/src/interfaces/IBuckets.sol
@@ -56,6 +56,13 @@ interface IBuckets {
     /**********************/
 
     /**
+     *  @notice Get the BIP credit for a given price.
+     *  @param  price_     The price of the bucket to retrieve BIP credit for.
+     *  @return bipCredit_ BIP credit of the bucket.
+     */
+    function bipAt(uint256 price_) external view returns (uint256 bipCredit_);
+
+    /**
      *  @notice Get a bucket struct for a given price.
      *  @param  price_            The price of the bucket to retrieve.
      *  @return bucketPrice_      The price of the bucket.

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -176,11 +176,11 @@ interface IPool {
     /**
      *  @notice Called by lenders to move an amount of credit from a specified price bucket to another specified price bucket.
      *  @param  recipient_ The recipient moving quote tokens.
-     *  @param  amount_    The amount of quote token to be moved by a lender.
+     *  @param  maxAmount_ The maximum amount of quote token to be moved by a lender.
      *  @param  fromPrice_ The bucket from which the quote tokens will be removed.
      *  @param  toPrice_   The bucket to which the quote tokens will be added.
      */
-    function moveQuoteToken(address recipient_, uint256 amount_, uint256 fromPrice_, uint256 toPrice_) external;
+    function moveQuoteToken(address recipient_, uint256 maxAmount_, uint256 fromPrice_, uint256 toPrice_) external;
 
     /**
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.


### PR DESCRIPTION
ERC20Pool:
- add new lpTimer address to price mapping to store last time lender made a deposit to specific bucket
- update lender/bucket timer each time quote tokens are deposited to bucket

Buckets:
- add new BIP mapping for storing BIP credit per bucket and function bipAt to retrieve BIP value
- on move quote token - apply penalty if deposit happened less than 24h ago and tokens are moved to a lower price. Add penalty to bucket's bip credit. Broke moveQuoteToken function in moveQuoteTokenAtLup and moveQuoteTokenAtPrice to workaround Solidity stack to deep exception. Return the effective amount that was moved (that is without penalty) in order to be used by MoveQuoteToken event
- on remove quote token apply bid penalty if deposit happened less than 24h ago and add to bucket's bip credit