### PR TITLE
Pool optimizations

### DIFF
--- a/scripts/erc20setup.py
+++ b/scripts/erc20setup.py
@@ -36,7 +36,7 @@ def main():
         dai_client.approve_max(pool, borrower)
         borrowers.append(borrower)
 
-    for i in range(0, 50):
+    for i in range(0, 5):
         pool.addQuoteToken(
             lenders[0],
             1 * 1e18,

--- a/scripts/erc20setup.py
+++ b/scripts/erc20setup.py
@@ -36,7 +36,7 @@ def main():
         dai_client.approve_max(pool, borrower)
         borrowers.append(borrower)
 
-    for i in range(0, 5):
+    for i in range(0, 50):
         pool.addQuoteToken(
             lenders[0],
             1 * 1e18,

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -69,7 +69,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
     function addCollateral(uint256 amount_) external override {
         // pool level accounting
-        (totalDebt, ) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
+        (totalDebt, )   = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
         totalCollateral += amount_;
 
         // borrower accounting

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -93,12 +93,13 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     function borrow(uint256 amount_, uint256 limitPrice_) external override {
         require(amount_ <= totalQuoteToken, "P:B:INSUF_LIQ");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
         require(amount_ > _poolMinDebtAmount(curDebt, totalBorrowers), "P:B:AMT_LT_AVG_DEBT");
 
         BorrowerInfo memory borrower = borrowers[msg.sender];
@@ -132,12 +133,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
     function removeCollateral(uint256 amount_) external override {
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
         BorrowerInfo memory borrower = borrowers[msg.sender];
         _accumulateBorrowerInterest(borrower, curInflator);
@@ -170,12 +171,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         BorrowerInfo memory borrower = borrowers[msg.sender];
         require(borrower.debt != 0, "P:R:NO_DEBT");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
         _accumulateBorrowerInterest(borrower, curInflator);
 
@@ -214,12 +215,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     ) external override returns (uint256 lpTokens_) {
         require(BucketMath.isValidPrice(price_), "P:AQT:INVALID_PRICE");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
         require(amount_ > _poolMinDebtAmount(curDebt, totalBorrowers), "P:AQT:AMT_LT_AVG_DEBT");
 
         // deposit quote token amount and get awarded LP tokens
@@ -300,12 +301,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     function removeQuoteToken(address recipient_, uint256 maxAmount_, uint256 price_) external override {
         require(BucketMath.isValidPrice(price_), "P:RQT:INVALID_PRICE");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
         // remove quote token amount and get LP tokens burned
         (uint256 amount, uint256 lpTokens) = removeQuoteTokenFromBucket(
@@ -339,12 +340,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         BorrowerInfo memory borrower = borrowers[borrower_];
         require(borrower.debt != 0, "P:L:NO_DEBT");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
         _accumulateBorrowerInterest(borrower, curInflator);
 
@@ -382,12 +383,12 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         uint256 collateralRequired = Maths.wdiv(amount_, price_);
         require(collateral().balanceOf(msg.sender) * collateralScale >= collateralRequired, "P:PB:INSUF_COLLAT");
 
-        uint256 curInflator   = inflatorSnapshot;
-        uint256 curDebt       = totalDebt;
         uint256 elapsed       = block.timestamp - lastInflatorSnapshotUpdate;
         bool shouldAccumulate = elapsed != 0;
-
-        if (shouldAccumulate) (curDebt, curInflator) = _accumulatePoolInterest(curDebt, curInflator, elapsed);
+        (
+            uint256 curDebt,
+            uint256 curInflator
+        ) = shouldAccumulate ? _accumulatePoolInterest(totalDebt, inflatorSnapshot, elapsed) : (totalDebt, inflatorSnapshot);
 
         purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
 

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -220,7 +220,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = moveQuoteTokenFromBucket(
-                fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
+            fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
         );
 
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -92,7 +92,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // borrow amount from buckets with limit price and apply the origination fee
         uint256 fee = Maths.max(Maths.wdiv(previousRate, WAD_WEEKS_PER_YEAR), minFee);
-        borrowFromBucket(amount_, fee, limitPrice_, curInflator);
+        _borrowFromBucket(amount_, fee, limitPrice_, curInflator);
         require(borrower.collateralDeposited > Maths.rayToWad(_encumberedCollateral(borrower.debt + amount_ + fee)), "P:B:INSUF_COLLAT");
         curDebt += amount_ + fee;
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
@@ -147,7 +147,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         require(remainingDebt == 0 || remainingDebt > _poolMinDebtAmount(curDebt, totalBorrowers),"P:R:AMT_LT_AVG_DEBT");
 
         // repay amount to buckets
-        repayBucket(amount, curInflator, amount >= curDebt);
+        _repayBucket(amount, curInflator, amount >= curDebt);
 
         // pool level accounting
         totalQuoteToken += amount;
@@ -176,7 +176,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         require(amount_ > _poolMinDebtAmount(curDebt, totalBorrowers), "P:AQT:AMT_LT_AVG_DEBT");
 
         // deposit quote token amount and get awarded LP tokens
-        lpTokens_ = addQuoteTokenToBucket(price_, amount_, curDebt, curInflator);
+        lpTokens_ = _addQuoteTokenToBucket(price_, amount_, curDebt, curInflator);
 
         // pool level accounting
         totalQuoteToken += amount_;
@@ -198,7 +198,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         require(maxClaim != 0, "P:CC:NO_CLAIM_TO_BUCKET");
 
         // claim collateral and get amount of LP tokens burned for claim
-        uint256 claimedLpTokens = claimCollateralFromBucket(price_, amount_, maxClaim);
+        uint256 claimedLpTokens = _claimCollateralFromBucket(price_, amount_, maxClaim);
 
         // lender accounting
         lpBalance[recipient_][price_] -= claimedLpTokens;
@@ -217,7 +217,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // move quote tokens between buckets and get LP tokens
-        (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = moveQuoteTokenFromBucket(
+        (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = _moveQuoteTokenFromBucket(
             fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
         );
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
@@ -238,7 +238,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // remove quote token amount and get LP tokens burned
-        (uint256 amount, uint256 lpTokens) = removeQuoteTokenFromBucket(
+        (uint256 amount, uint256 lpTokens) = _removeQuoteTokenFromBucket(
             price_, maxAmount_, lpBalance[recipient_][price_], lpTimer[recipient_][price_], curInflator
         );
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
@@ -274,7 +274,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         );
 
         // liquidate borrower and get collateral required to liquidate
-        uint256 requiredCollateral = liquidateAtBucket(debt, borrower.collateralDeposited, curInflator);
+        uint256 requiredCollateral = _liquidateAtBucket(debt, borrower.collateralDeposited, curInflator);
 
         // pool level accounting
         totalCollateral -= requiredCollateral;
@@ -299,7 +299,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // purchase bid from bucket
-        purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
+        _purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
 
         // pool level accounting

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -111,7 +111,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     }
 
     function removeCollateral(uint256 amount_) external override {
-        (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
+        ( , uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         BorrowerInfo memory borrower = borrowers[msg.sender];
         _accumulateBorrowerInterest(borrower, curInflator);
@@ -121,7 +121,6 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // pool level accounting
         totalCollateral -= amount_;
-        totalDebt       = curDebt;
 
         // borrower accounting
         borrower.collateralDeposited -= amount_;        
@@ -220,9 +219,6 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         );
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
 
-        // pool level accounting
-        totalDebt = curDebt;
-
         // lender accounting
         lpBalance[recipient_][fromPrice_] -= fromLpTokens;
         lpBalance[recipient_][toPrice_]   += toLpTokens;
@@ -243,7 +239,6 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // pool level accounting
         totalQuoteToken -= amount;
-        totalDebt       = curDebt;
 
         // lender accounting
         lpBalance[recipient_][price_] -= lpTokens;

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -69,7 +69,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
     function addCollateral(uint256 amount_) external override {
         // pool level accounting
-        (totalDebt, )   = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
+        _accumulatePoolInterest(totalDebt, inflatorSnapshot);
         totalCollateral += amount_;
 
         // borrower accounting
@@ -180,7 +180,6 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // pool level accounting
         totalQuoteToken += amount_;
-        totalDebt       = curDebt;
 
         // lender accounting
         lpBalance[recipient_][price_] += lpTokens_;
@@ -304,7 +303,6 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // pool level accounting
         totalQuoteToken -= amount_;
-        totalDebt       = curDebt;
 
         // move required collateral from sender to pool
         collateral().safeTransferFrom(msg.sender, address(this), collateralRequired / collateralScale);

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -92,10 +92,10 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // borrow amount from buckets with limit price and apply the origination fee
         uint256 fee = Maths.max(Maths.wdiv(previousRate, WAD_WEEKS_PER_YEAR), minFee);
-        uint256 curLup = borrowFromBucket(amount_, fee, limitPrice_, curInflator);
-        require(borrower.collateralDeposited > Maths.rayToWad(_encumberedCollateral(borrower.debt + amount_ + fee, curLup)), "P:B:INSUF_COLLAT");
+        borrowFromBucket(amount_, fee, limitPrice_, curInflator);
+        require(borrower.collateralDeposited > Maths.rayToWad(_encumberedCollateral(borrower.debt + amount_ + fee)), "P:B:INSUF_COLLAT");
         curDebt += amount_ + fee;
-        require(_poolCollateralization(curDebt, curLup) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;
@@ -108,7 +108,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // move borrowed amount from pool to sender
         quoteToken().safeTransfer(msg.sender, amount_ / quoteTokenScale);
-        emit Borrow(msg.sender, curLup, amount_);
+        emit Borrow(msg.sender, lup, amount_);
     }
 
     function removeCollateral(uint256 amount_) external override {
@@ -117,7 +117,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         BorrowerInfo memory borrower = borrowers[msg.sender];
         _accumulateBorrowerInterest(borrower, curInflator);
 
-        uint256 encumberedBorrowerCollateral = Maths.rayToWad(_encumberedCollateral(borrower.debt, lup));
+        uint256 encumberedBorrowerCollateral = Maths.rayToWad(_encumberedCollateral(borrower.debt));
         require(borrower.collateralDeposited - encumberedBorrowerCollateral >= amount_, "P:RC:AMT_GT_AVAIL_COLLAT");
 
         // pool level accounting
@@ -147,7 +147,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         require(remainingDebt == 0 || remainingDebt > _poolMinDebtAmount(curDebt, totalBorrowers),"P:R:AMT_LT_AVG_DEBT");
 
         // repay amount to buckets
-        uint256 curLup = repayBucket(amount, curInflator, amount >= curDebt);
+        repayBucket(amount, curInflator, amount >= curDebt);
 
         // pool level accounting
         totalQuoteToken += amount;
@@ -160,7 +160,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // move amount to repay from sender to pool
         quoteToken().safeTransferFrom(msg.sender, address(this), amount / quoteTokenScale);
-        emit Repay(msg.sender, curLup, amount);
+        emit Repay(msg.sender, lup, amount);
     }
 
     /*********************************/
@@ -176,8 +176,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         require(amount_ > _poolMinDebtAmount(curDebt, totalBorrowers), "P:AQT:AMT_LT_AVG_DEBT");
 
         // deposit quote token amount and get awarded LP tokens
-        uint256 curLup;
-        (lpTokens_, curLup) = addQuoteTokenToBucket(price_, amount_, curDebt, curInflator);
+        lpTokens_ = addQuoteTokenToBucket(price_, amount_, curDebt, curInflator);
 
         // pool level accounting
         totalQuoteToken += amount_;
@@ -189,7 +188,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // move quote token amount from lender to pool
         quoteToken().safeTransferFrom(recipient_, address(this), amount_ / quoteTokenScale);
-        emit AddQuoteToken(recipient_, price_, amount_, curLup);
+        emit AddQuoteToken(recipient_, price_, amount_, lup);
     }
 
     function claimCollateral(address recipient_, uint256 amount_, uint256 price_) external override {
@@ -218,12 +217,10 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // move quote tokens between buckets and get LP tokens
-        uint256 balance =  lpBalance[recipient_][fromPrice_];
-        uint256 timer   =  lpTimer[recipient_][fromPrice_];
-        (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount, uint256 curLup) = moveQuoteTokenFromBucket(
-            fromPrice_, toPrice_, maxAmount_, balance, timer, curInflator
+        (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = moveQuoteTokenFromBucket(
+            fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
         );
-        require(_poolCollateralization(curDebt, curLup) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalDebt = curDebt;
@@ -232,7 +229,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         lpBalance[recipient_][fromPrice_] -= fromLpTokens;
         lpBalance[recipient_][toPrice_]   += toLpTokens;
 
-        emit MoveQuoteToken(recipient_, fromPrice_, toPrice_, movedAmount, curLup);
+        emit MoveQuoteToken(recipient_, fromPrice_, toPrice_, movedAmount, lup);
     }
 
     function removeQuoteToken(address recipient_, uint256 maxAmount_, uint256 price_) external override {
@@ -241,10 +238,10 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // remove quote token amount and get LP tokens burned
-        (uint256 amount, uint256 lpTokens, uint256 curLup) = removeQuoteTokenFromBucket(
+        (uint256 amount, uint256 lpTokens) = removeQuoteTokenFromBucket(
             price_, maxAmount_, lpBalance[recipient_][price_], lpTimer[recipient_][price_], curInflator
         );
-        require(_poolCollateralization(curDebt, curLup) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount;
@@ -255,7 +252,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         // move quote token amount from pool to lender
         quoteToken().safeTransfer(recipient_, amount / quoteTokenScale);
-        emit RemoveQuoteToken(recipient_, price_, amount, curLup);
+        emit RemoveQuoteToken(recipient_, price_, amount, lup);
     }
 
     /*******************************/
@@ -302,8 +299,8 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // purchase bid from bucket
-        uint256 curLup = purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
-        require(_poolCollateralization(curDebt, curLup) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
+        purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -68,12 +68,13 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     /***********************************/
 
     function addCollateral(uint256 amount_) external override {
-        // pool level accounting
-        (totalDebt, ) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
-        totalCollateral += amount_;
 
         // borrower accounting
         borrowers[msg.sender].collateralDeposited += amount_;
+
+        // pool level accounting
+        (totalDebt, ) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
+        totalCollateral += amount_;
 
         // TODO: verify that the pool address is the holder of any token balances - i.e. if any funds are held in an escrow for backup interest purposes
         // move collateral from sender to pool
@@ -93,11 +94,11 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         // borrow amount from buckets with limit price and apply the origination fee
         uint256 fee = Maths.max(Maths.wdiv(previousRate, WAD_WEEKS_PER_YEAR), minFee);
         borrowFromBucket(amount_, fee, limitPrice_, curInflator);
-        require(borrower.collateralDeposited > Maths.rayToWad(_encumberedCollateral(borrower.debt + amount_ + fee)), "P:B:INSUF_COLLAT");
-        curDebt += amount_ + fee;
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
+        require(borrower.collateralDeposited > Maths.rayToWad(getEncumberedCollateral(borrower.debt + amount_ + fee)), "P:B:INSUF_COLLAT");
 
         // pool level accounting
+        curDebt += amount_ + fee;
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
         totalQuoteToken -= amount_;
         totalDebt       = curDebt;
 
@@ -112,12 +113,13 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
     }
 
     function removeCollateral(uint256 amount_) external override {
+
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         BorrowerInfo memory borrower = borrowers[msg.sender];
         _accumulateBorrowerInterest(borrower, curInflator);
 
-        uint256 encumberedBorrowerCollateral = Maths.rayToWad(_encumberedCollateral(borrower.debt));
+        uint256 encumberedBorrowerCollateral = Maths.rayToWad(getEncumberedCollateral(borrower.debt));
         require(borrower.collateralDeposited - encumberedBorrowerCollateral >= amount_, "P:RC:AMT_GT_AVAIL_COLLAT");
 
         // pool level accounting
@@ -142,6 +144,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
         _accumulateBorrowerInterest(borrower, curInflator);
+
         uint256 amount        = Maths.min(maxAmount_, borrower.debt);
         uint256 remainingDebt = borrower.debt - amount;
         require(remainingDebt == 0 || remainingDebt > _poolMinDebtAmount(curDebt, totalBorrowers),"P:R:AMT_LT_AVG_DEBT");
@@ -216,10 +219,10 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
-        // move quote tokens between buckets and get LP tokens
         (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = moveQuoteTokenFromBucket(
             fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
         );
+
         require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
@@ -241,9 +244,9 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 amount, uint256 lpTokens) = removeQuoteTokenFromBucket(
             price_, maxAmount_, lpBalance[recipient_][price_], lpTimer[recipient_][price_], curInflator
         );
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
         totalQuoteToken -= amount;
         totalDebt       = curDebt;
 
@@ -267,6 +270,7 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         _accumulateBorrowerInterest(borrower, curInflator);
+
         uint256 debt = borrower.debt;
         require(
             getBorrowerCollateralization(borrower.collateralDeposited, debt) <= Maths.ONE_WAD,
@@ -298,11 +302,10 @@ contract ERC20Pool is IPool, BorrowerManager, Clone, LenderManager {
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
-        // purchase bid from bucket
         purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
 
         // pool level accounting
+        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
         totalQuoteToken -= amount_;
         totalDebt       = curDebt;
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -42,21 +42,12 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
 
     uint256 public override quoteTokenScale;
 
-    /*****************/
-    /*** Modifiers ***/
-    /*****************/
-
-    /// @notice Modifier to protect a clone's initialize method from repeated updates
-    modifier onlyOnce() {
-        require(_poolInitializations == 0, "P:INITIALIZED");
-        _;
-    }
-
     /*****************************/
     /*** Inititalize Functions ***/
     /*****************************/
 
-    function initialize() external override onlyOnce {
+    function initialize() external override {
+        _onlyOnce();
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
         inflatorSnapshot           = Maths.ONE_RAY;
@@ -68,7 +59,8 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
         _poolInitializations += 1;
     }
 
-    function initializeSubset(uint256[] memory tokenIds_) external override onlyOnce {
+    function initializeSubset(uint256[] memory tokenIds_) external override {
+        _onlyOnce();
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
         inflatorSnapshot           = Maths.ONE_RAY;
@@ -426,6 +418,11 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
     /**************************/
     /*** Internal Functions ***/
     /**************************/
+
+    /** @notice Used to protect a clone's initialize method from repeated updates */
+    function _onlyOnce() internal view {
+        require(_poolInitializations == 0, "P:INITIALIZED");
+    }
 
     function _onlySubset(uint256 tokenId_) internal view {
         if (_tokenIdsAllowed.length() != 0) {

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -172,7 +172,7 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
     }
 
     function removeCollateral(uint256 tokenId_) external override {
-        require(collateral().ownerOf(tokenId_) == address(this), "P:T_NOT_IN_P");
+        _tokenInPool(tokenId_);
 
         ( , uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
@@ -270,7 +270,7 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
     }
 
     function claimCollateral(address recipient_, uint256 tokenId_, uint256 price_) external override {
-        require(collateral().ownerOf(tokenId_) == address(this), "P:T_NOT_IN_P");
+        _tokenInPool(tokenId_);
         require(BucketMath.isValidPrice(price_), "P:CC:INVALID_PRICE");
 
         uint256 maxClaim = lpBalance[recipient_][price_];
@@ -444,10 +444,15 @@ contract ERC721Pool is INFTPool, BorrowerManager, Clone, LenderManager {
         }
     }
 
+    /// @notice Check if token have been deposited into the pool
+    function _tokenInPool(uint256 tokenId_) internal view {
+        require(collateral().ownerOf(tokenId_) == address(this), "P:T_NOT_IN_P");
+    }
+
     /// @notice Check if all tokens in an array have been deposited into the pool
     function _tokensInPool(uint256[] memory tokenIds_) internal view {
         for (uint i; i < tokenIds_.length;) {
-            require(collateral().ownerOf(tokenIds_[i]) == address(this), "P:T_NOT_IN_P");
+            _tokenInPool(tokenIds_[i]);
 
             unchecked {
                 ++i;

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -37,7 +37,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         inflatorSnapshot_         = inflatorSnapshot;
 
         if (debt_ != 0 && borrowerInflatorSnapshot_ != 0) {
-            pendingDebt_          += getPendingInterest(debt_, getPendingInflator(), borrowerInflatorSnapshot_);
+            pendingDebt_          += _pendingInterest(debt_, getPendingInflator(), borrowerInflatorSnapshot_);
             collateralEncumbered_ = getEncumberedCollateral(pendingDebt_);
             collateralization_    = Maths.wrdivw(collateralDeposited_, collateralEncumbered_);
         }

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -16,6 +16,10 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
     // borrowers book: borrower address -> BorrowerInfo
     mapping(address => BorrowerInfo) public override borrowers;
 
+    /**********************/
+    /*** View Functions ***/
+    /**********************/
+
     function getBorrowerInfo(address borrower_)
         public view override returns (
             uint256 debt_,

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -51,7 +51,7 @@ abstract contract Buckets is IBuckets {
         bucket.debt             = accumulateBucketInterest(bucket.debt, bucket.inflatorSnapshot, inflator_);
         bucket.inflatorSnapshot = inflator_;
 
-        lpTokens_ = Maths.rdiv(Maths.wadToRay(amount_), _exchangeRate(bucket));
+        lpTokens_ = Maths.rdiv(Maths.wadToRay(amount_), getExchangeRate(bucket));
 
         // bucket accounting
         bucket.lpOutstanding += lpTokens_;
@@ -126,7 +126,7 @@ abstract contract Buckets is IBuckets {
 
         require(amount_ <= bucket.collateral, "B:CC:AMT_GT_COLLAT");
 
-        lpRedemption_ = Maths.wrdivr(Maths.wmul(amount_, bucket.price), _exchangeRate(bucket));
+        lpRedemption_ = Maths.wrdivr(Maths.wmul(amount_, bucket.price), getExchangeRate(bucket));
 
         require(lpRedemption_ <= lpBalance_, "B:CC:INSUF_LP_BAL");
 
@@ -186,7 +186,7 @@ abstract contract Buckets is IBuckets {
         }
 
         // HPB and LUP management
-        uint256 newHpb = _hpb();
+        uint256 newHpb = getHpb();
         if (hpb != newHpb) hpb = newHpb;
     }
 
@@ -212,7 +212,7 @@ abstract contract Buckets is IBuckets {
         fromBucket.debt             = accumulateBucketInterest(fromBucket.debt, fromBucket.inflatorSnapshot, inflator_);
         fromBucket.inflatorSnapshot = inflator_;
 
-        uint256 exchangeRate = _exchangeRate(fromBucket);                 // RAY
+        uint256 exchangeRate = getExchangeRate(fromBucket);                 // RAY
         uint256 claimable    = Maths.rmul(lpBalance_, exchangeRate);       // RAY
 
         amount_       = Maths.min(Maths.wadToRay(maxAmount_), claimable); // RAY
@@ -230,7 +230,7 @@ abstract contract Buckets is IBuckets {
             _bip[fromBucket.price] += penalty;
         }
 
-        lpAward_ = Maths.rdiv(Maths.wadToRay(amount_), _exchangeRate(toBucket));
+        lpAward_ = Maths.rdiv(Maths.wadToRay(amount_), getExchangeRate(toBucket));
 
         // move LP tokens
         fromBucket.lpOutstanding -= lpRedemption_;
@@ -251,7 +251,7 @@ abstract contract Buckets is IBuckets {
 
         // HPB and LUP management
         if (newLup != lup) lup = newLup;
-        newHpb = (isEmpty && fromBucket.price == newHpb) ? _hpb() : newHpb;
+        newHpb = (isEmpty && fromBucket.price == newHpb) ? getHpb() : newHpb;
         if (newHpb != hpb) hpb = newHpb;
 
         // bucket management
@@ -289,7 +289,7 @@ abstract contract Buckets is IBuckets {
 
         _buckets[price_] = bucket;
 
-        uint256 newHpb = (bucket.onDeposit == 0 && bucket.debt == 0) ? _hpb() : hpb;
+        uint256 newHpb = (bucket.onDeposit == 0 && bucket.debt == 0) ? getHpb() : hpb;
 
         // HPB and LUP management
         if (lup != newLup) lup = newLup;
@@ -315,7 +315,7 @@ abstract contract Buckets is IBuckets {
         bucket.debt             = accumulateBucketInterest(bucket.debt, bucket.inflatorSnapshot, inflator_);
         bucket.inflatorSnapshot = inflator_;
 
-        uint256 exchangeRate = _exchangeRate(bucket);                // RAY
+        uint256 exchangeRate = getExchangeRate(bucket);                // RAY
         uint256 claimable    = Maths.rmul(lpBalance_, exchangeRate);   // RAY
         amount_             = Maths.min(Maths.wadToRay(maxAmount_), claimable); // RAY
         lpTokens_           = Maths.rdiv(amount_, exchangeRate);                // RAY
@@ -343,7 +343,7 @@ abstract contract Buckets is IBuckets {
         _buckets[bucket.price] = bucket;
 
         // HPB and LUP management
-        uint256 newHpb = (isEmpty && bucket.price == hpb) ? _hpb() : hpb;
+        uint256 newHpb = (isEmpty && bucket.price == hpb) ? getHpb() : hpb;
         if (bucket.price >= lup && newLup < lup) lup = newLup; // move lup down only if removal happened at or above lup
         if (newHpb != hpb) hpb = newHpb;
 
@@ -862,7 +862,17 @@ abstract contract Buckets is IBuckets {
     }
 
     function getHpb() public view override returns (uint256 newHpb_) {
-        return _hpb();
+        newHpb_ = hpb;
+        while (true) {
+            (, , uint256 down, uint256 onDeposit, uint256 debt, , , ) = bucketAt(newHpb_);
+            if (onDeposit != 0 || debt != 0) {
+                break;
+            } else if (down == 0) {
+                newHpb_ = 0;
+                break;
+            }
+            newHpb_ = down;
+        }
     }
 
     function getHup() public view override returns (uint256 hup_) {
@@ -894,23 +904,9 @@ abstract contract Buckets is IBuckets {
      *  @dev    Performs calculations in RAY terms and rounds up to determine size to minimize precision loss
      *  @return RAY The current rate at which quote tokens can be exchanged for LP tokens
      */
-    function _exchangeRate(Bucket memory bucket_) internal pure returns (uint256) {
+    function getExchangeRate(Bucket memory bucket_) internal pure returns (uint256) {
         uint256 size = bucket_.onDeposit + bucket_.debt + Maths.wmul(bucket_.collateral, bucket_.price);
         return (size != 0 && bucket_.lpOutstanding != 0) ? Maths.wrdivr(size, bucket_.lpOutstanding) : Maths.ONE_RAY;
-    }
-
-    function _hpb() internal view returns (uint256 newHpb_) {
-        newHpb_ = hpb;
-        while (true) {
-            (, , uint256 down, uint256 onDeposit, uint256 debt, , , ) = bucketAt(newHpb_);
-            if (onDeposit != 0 || debt != 0) {
-                break;
-            } else if (down == 0) {
-                newHpb_ = 0;
-                break;
-            }
-            newHpb_ = down;
-        }
     }
 
 }

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -41,7 +41,7 @@ abstract contract Buckets is IBuckets {
      *  @param  inflator_   The current pool inflator rate.
      *  @return lpTokens_   The amount of lpTokens received by the lender for the added quote tokens.
      */
-    function addQuoteTokenToBucket(
+    function _addQuoteTokenToBucket(
         uint256 price_, uint256 amount_, uint256 totalDebt_, uint256 inflator_
     ) internal returns (uint256 lpTokens_) {
         // initialize bucket if required and get new HPB
@@ -76,7 +76,7 @@ abstract contract Buckets is IBuckets {
      *  @param  limit_    The lowest price desired to borrow at, WAD
      *  @param  inflator_ The current pool inflator rate, RAY
      */
-    function borrowFromBucket(uint256 amount_, uint256 fee_, uint256 limit_, uint256 inflator_) internal {
+    function _borrowFromBucket(uint256 amount_, uint256 fee_, uint256 limit_, uint256 inflator_) internal {
         // if first loan then borrow at HPB price, otherwise at LUP
         uint256 price = lup == 0 ? hpb : lup;
         uint256 curPrice = price;
@@ -119,7 +119,7 @@ abstract contract Buckets is IBuckets {
      *  @param  lpBalance_    The claimers current LP balance, RAY
      *  @return lpRedemption_ The amount of LP tokens that will be redeemed
      */
-    function claimCollateralFromBucket(
+    function _claimCollateralFromBucket(
         uint256 price_, uint256 amount_, uint256 lpBalance_
     ) internal returns (uint256 lpRedemption_) {
         Bucket memory bucket = _buckets[price_];
@@ -151,7 +151,7 @@ abstract contract Buckets is IBuckets {
      *  @param  inflator_           The current pool inflator rate, RAY
      *  @return requiredCollateral_ The amount of collateral to be liquidated
      */
-    function liquidateAtBucket(
+    function _liquidateAtBucket(
         uint256 debt_, uint256 collateral_, uint256 inflator_
     ) internal returns (uint256 requiredCollateral_) {
         uint256 curPrice = hpb;
@@ -202,7 +202,7 @@ abstract contract Buckets is IBuckets {
      *  @return lpAward_      The amount of lpTokens moved to bucket
      *  @return amount_       The amount of quote tokens moved to bucket
      */
-    function moveQuoteTokenFromBucket(
+    function _moveQuoteTokenFromBucket(
         uint256 fromPrice_, uint256 toPrice_, uint256 maxAmount_, uint256 lpBalance_, uint256 lpTimer_, uint256 inflator_
     ) internal returns (uint256 lpRedemption_, uint256 lpAward_, uint256 amount_) {
         uint256 newHpb = !BitMaps.get(_bitmap, toPrice_) ? initializeBucket(hpb, toPrice_) : hpb;
@@ -265,7 +265,7 @@ abstract contract Buckets is IBuckets {
      *  @param  collateral_ The amount of collateral to exchange, WAD
      *  @param  inflator_   The current pool inflator rate, RAY
      */
-    function purchaseBidFromBucket(
+    function _purchaseBidFromBucket(
         uint256 price_, uint256 amount_, uint256 collateral_, uint256 inflator_
     ) internal {
         Bucket memory bucket    = _buckets[price_];
@@ -308,7 +308,7 @@ abstract contract Buckets is IBuckets {
      *  @return amount_    The actual amount being removed
      *  @return lpTokens_  The amount of lpTokens removed equivalent to the quote tokens removed
      */
-    function removeQuoteTokenFromBucket(
+    function _removeQuoteTokenFromBucket(
         uint256 price_, uint256 maxAmount_, uint256 lpBalance_, uint256 lpTimer_, uint256 inflator_
     ) internal returns (uint256 amount_, uint256 lpTokens_) {
         Bucket memory bucket    = _buckets[price_];
@@ -357,7 +357,7 @@ abstract contract Buckets is IBuckets {
      *  @param  inflator_     The current pool inflator rate, RAY
      *  @param  reconcile_    True if all debt in pool is repaid
      */
-    function repayBucket(uint256 amount_, uint256 inflator_, bool reconcile_) internal {
+    function _repayBucket(uint256 amount_, uint256 inflator_, bool reconcile_) internal {
         uint256 curPrice = lup;
         uint256 pdAdd;
 
@@ -896,7 +896,7 @@ abstract contract Buckets is IBuckets {
     }
 
     /*******************************/
-    /*** Internal View Functions ***/
+    /*** Private View Functions ***/
     /*******************************/
 
     /**
@@ -904,7 +904,7 @@ abstract contract Buckets is IBuckets {
      *  @dev    Performs calculations in RAY terms and rounds up to determine size to minimize precision loss
      *  @return RAY The current rate at which quote tokens can be exchanged for LP tokens
      */
-    function getExchangeRate(Bucket memory bucket_) internal pure returns (uint256) {
+    function getExchangeRate(Bucket memory bucket_) private pure returns (uint256) {
         uint256 size = bucket_.onDeposit + bucket_.debt + Maths.wmul(bucket_.collateral, bucket_.price);
         return (size != 0 && bucket_.lpOutstanding != 0) ? Maths.wrdivr(size, bucket_.lpOutstanding) : Maths.ONE_RAY;
     }

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -329,7 +329,7 @@ abstract contract Buckets is IBuckets {
      *  @param  lpBalance_    The claimers current LP balance, RAY
      *  @return lpRedemption_ The amount of LP tokens that will be redeemed
      */
-    function claimNFTCollateralFromBucket(uint256 price_, uint256 tokenId_, uint256 lpBalance_) internal returns (uint256 lpRedemption_) {
+    function _claimNFTCollateralFromBucket(uint256 price_, uint256 tokenId_, uint256 lpBalance_) internal returns (uint256 lpRedemption_) {
         Bucket storage bucket = _buckets[price_];
         NFTBucket storage nftBucket = _nftBuckets[price_];
 

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -40,11 +40,10 @@ abstract contract Buckets is IBuckets {
      *  @param  totalDebt_  The amount of total debt.
      *  @param  inflator_   The current pool inflator rate.
      *  @return lpTokens_   The amount of lpTokens received by the lender for the added quote tokens.
-     *  @return lup_        The current LUP.
      */
     function addQuoteTokenToBucket(
         uint256 price_, uint256 amount_, uint256 totalDebt_, uint256 inflator_
-    ) internal returns (uint256 lpTokens_, uint256 lup_) {
+    ) internal returns (uint256 lpTokens_) {
         // initialize bucket if required and get new HPB
         uint256 newHpb = !BitMaps.get(_bitmap, price_) ? initializeBucket(hpb, price_) : hpb;
 
@@ -60,14 +59,13 @@ abstract contract Buckets is IBuckets {
         pdAccumulator        += Maths.wmul(amount_, price_);
 
         // debt reallocation
-        lup_ = lup;
-        bool reallocate = totalDebt_ != 0 && price_ > lup_;
-        lup_ = reallocate ? reallocateUp(bucket, amount_, inflator_) : lup_;
+        bool reallocate = totalDebt_ != 0 && price_ > lup;
+        uint256 newLup = reallocate ? reallocateUp(bucket, amount_, inflator_) : lup;
 
         _buckets[price_] = bucket;
 
         // HPB and LUP management
-        if (lup != lup_) lup = lup_;
+        if (lup != newLup) lup = newLup;
         if (hpb != newHpb) hpb = newHpb;
     }
 
@@ -77,13 +75,10 @@ abstract contract Buckets is IBuckets {
      *  @param  fee_      The amount of quote tokens to pay as origination fee, WAD
      *  @param  limit_    The lowest price desired to borrow at, WAD
      *  @param  inflator_ The current pool inflator rate, RAY
-     *  @return lup_      The current LUP.
      */
-    function borrowFromBucket(uint256 amount_, uint256 fee_, uint256 limit_, uint256 inflator_
-    ) internal returns (uint256 lup_) {
+    function borrowFromBucket(uint256 amount_, uint256 fee_, uint256 limit_, uint256 inflator_) internal {
         // if first loan then borrow at HPB price, otherwise at LUP
-        lup_ = lup;
-        uint256 price = lup_ == 0 ? hpb : lup_;
+        uint256 price = lup == 0 ? hpb : lup;
         uint256 curPrice = price;
         uint256 pdRemove;
 
@@ -113,8 +108,7 @@ abstract contract Buckets is IBuckets {
         }
 
         // HPB and LUP management
-        lup_ = (price > curPrice|| price == 0) ? curPrice : price;
-        lup = lup_;
+        lup = (price > curPrice|| price == 0) ? curPrice : price;
         pdAccumulator -= pdRemove;
     }
 
@@ -207,13 +201,12 @@ abstract contract Buckets is IBuckets {
      *  @return lpRedemption_ The amount of lpTokens moved from bucket
      *  @return lpAward_      The amount of lpTokens moved to bucket
      *  @return amount_       The amount of quote tokens moved to bucket
-     *  @return lup_          The current LUP.
      */
     function moveQuoteTokenFromBucket(
         uint256 fromPrice_, uint256 toPrice_, uint256 maxAmount_, uint256 lpBalance_, uint256 lpTimer_, uint256 inflator_
-    ) internal returns (uint256 lpRedemption_, uint256 lpAward_, uint256 amount_, uint256 lup_) {
-        uint256 newHpb   = !BitMaps.get(_bitmap, toPrice_) ? initializeBucket(hpb, toPrice_) : hpb;
-        lup_ = lup;
+    ) internal returns (uint256 lpRedemption_, uint256 lpAward_, uint256 amount_) {
+        uint256 newHpb = !BitMaps.get(_bitmap, toPrice_) ? initializeBucket(hpb, toPrice_) : hpb;
+        uint256 newLup = lup;
 
         Bucket memory fromBucket    = _buckets[fromPrice_];
         fromBucket.debt             = accumulateBucketInterest(fromBucket.debt, fromBucket.inflatorSnapshot, inflator_);
@@ -243,11 +236,11 @@ abstract contract Buckets is IBuckets {
         fromBucket.lpOutstanding -= lpRedemption_;
         toBucket.lpOutstanding   += lpAward_;
 
-        bool atLup  = lup_ != 0 && fromBucket.price == lup_;
+        bool atLup  = newLup != 0 && fromBucket.price == newLup;
         if (atLup) {
-            lup_ = moveQuoteTokenAtLup(fromBucket, toBucket, amount_, inflator_);
+            newLup = moveQuoteTokenAtLup(fromBucket, toBucket, amount_, inflator_);
         } else {
-            lup_ = moveQuoteTokenAtPrice(fromBucket, toBucket, amount_, inflator_, lup_);
+            newLup = moveQuoteTokenAtPrice(fromBucket, toBucket, amount_, inflator_, newLup);
         }
 
         bool isEmpty = fromBucket.onDeposit == 0 && fromBucket.debt == 0;
@@ -257,7 +250,7 @@ abstract contract Buckets is IBuckets {
         _buckets[toBucket.price]   = toBucket;
 
         // HPB and LUP management
-        if (lup_ != lup) lup = lup_;
+        if (newLup != lup) lup = newLup;
         newHpb = (isEmpty && fromBucket.price == newHpb) ? getHpb() : newHpb;
         if (newHpb != hpb) hpb = newHpb;
 
@@ -271,11 +264,10 @@ abstract contract Buckets is IBuckets {
      *  @param  amount_     The amount of quote tokens to receive, WAD
      *  @param  collateral_ The amount of collateral to exchange, WAD
      *  @param  inflator_   The current pool inflator rate, RAY
-     *  @return lup_        The current LUP.
      */
     function purchaseBidFromBucket(
         uint256 price_, uint256 amount_, uint256 collateral_, uint256 inflator_
-    ) internal returns (uint256 lup_){
+    ) internal {
         Bucket memory bucket    = _buckets[price_];
         bucket.debt             = accumulateBucketInterest(bucket.debt, bucket.inflatorSnapshot, inflator_);
         bucket.inflatorSnapshot = inflator_;
@@ -293,14 +285,14 @@ abstract contract Buckets is IBuckets {
         bucket.collateral += collateral_;
 
         // debt reallocation
-        lup_ = reallocateDown(bucket, amount_, inflator_);
+        uint256 newLup = reallocateDown(bucket, amount_, inflator_);
 
         _buckets[price_] = bucket;
 
         uint256 newHpb = (bucket.onDeposit == 0 && bucket.debt == 0) ? getHpb() : hpb;
 
         // HPB and LUP management
-        if (lup != lup_)  lup = lup_;
+        if (lup != newLup) lup = newLup;
         if (hpb != newHpb) hpb = newHpb;
 
         pdAccumulator -= Maths.wmul(purchaseFromDeposit, bucket.price);
@@ -315,11 +307,10 @@ abstract contract Buckets is IBuckets {
      *  @param  inflator_  The current pool inflator rate, RAY
      *  @return amount_    The actual amount being removed
      *  @return lpTokens_  The amount of lpTokens removed equivalent to the quote tokens removed
-     *  @return lup_       The current LUP.
      */
     function removeQuoteTokenFromBucket(
         uint256 price_, uint256 maxAmount_, uint256 lpBalance_, uint256 lpTimer_, uint256 inflator_
-    ) internal returns (uint256 amount_, uint256 lpTokens_, uint256 lup_) {
+    ) internal returns (uint256 amount_, uint256 lpTokens_) {
         Bucket memory bucket    = _buckets[price_];
         bucket.debt             = accumulateBucketInterest(bucket.debt, bucket.inflatorSnapshot, inflator_);
         bucket.inflatorSnapshot = inflator_;
@@ -352,10 +343,8 @@ abstract contract Buckets is IBuckets {
         _buckets[bucket.price] = bucket;
 
         // HPB and LUP management
-        lup_ = lup;
-        if (bucket.price >= lup_ && newLup < lup_) lup_ = newLup; // move lup down only if removal happened at or above lup
-        if (lup_ != lup) lup = lup_;
         uint256 newHpb = (isEmpty && bucket.price == hpb) ? getHpb() : hpb;
+        if (bucket.price >= lup && newLup < lup) lup = newLup; // move lup down only if removal happened at or above lup
         if (newHpb != hpb) hpb = newHpb;
 
         // bucket management
@@ -364,14 +353,12 @@ abstract contract Buckets is IBuckets {
 
     /**
      *  @notice Called by a borrower to repay quote tokens as part of reducing their position
-     *  @param  amount_     The amount of quote tokens to repay to the bucket, WAD
-     *  @param  inflator_   The current pool inflator rate, RAY
-     *  @param  reconcile_  True if all debt in pool is repaid
-     *  @return lup_        The current LUP.
+     *  @param  amount_       The amount of quote tokens to repay to the bucket, WAD
+     *  @param  inflator_     The current pool inflator rate, RAY
+     *  @param  reconcile_    True if all debt in pool is repaid
      */
-    function repayBucket(uint256 amount_, uint256 inflator_, bool reconcile_) internal returns (uint256 lup_){
-        lup_ = lup;
-        uint256 curPrice = lup_;
+    function repayBucket(uint256 amount_, uint256 inflator_, bool reconcile_) internal {
+        uint256 curPrice = lup;
         uint256 pdAdd;
 
         while (true) {
@@ -402,9 +389,8 @@ abstract contract Buckets is IBuckets {
         }
 
         // HPB and LUP management
-        if (reconcile_) lup_ = 0;                   // reset LUP if no debt in pool
-        else if (lup_ != curPrice) lup_ = curPrice; // update LUP to current price
-        if (lup_ != lup) lup = lup_;
+        if (reconcile_) lup = 0;                 // reset LUP if no debt in pool
+        else if (lup != curPrice) lup = curPrice; // update LUP to current price
 
         pdAccumulator += pdAdd;
     }

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -37,14 +37,15 @@ abstract contract Interest is IInterest, PoolState {
     function updateInterestRate() external override {
         // RAY
         uint256 curDebt = totalDebt;
-        uint256 actualUtilization = _poolActualUtilization(curDebt);
-        if (actualUtilization != 0 && previousRateUpdate < block.timestamp && _poolCollateralization(curDebt) > Maths.ONE_WAD) {
+        uint256 curLup  = lup;
+        uint256 actualUtilization = _poolActualUtilization(curDebt, curLup);
+        if (actualUtilization != 0 && previousRateUpdate < block.timestamp && _poolCollateralization(curDebt, curLup) > Maths.ONE_WAD) {
             uint256 oldRate = previousRate;
 
             (curDebt, ) = _accumulatePoolInterest(curDebt, inflatorSnapshot);
             totalDebt   = curDebt;
 
-            previousRate       = Maths.wmul(previousRate, (actualUtilization + Maths.ONE_WAD - _poolTargetUtilization(curDebt)));
+            previousRate       = Maths.wmul(previousRate, (actualUtilization + Maths.ONE_WAD - _poolTargetUtilization(curDebt, curLup)));
             previousRateUpdate = block.timestamp;
 
             emit UpdateInterestRate(oldRate, previousRate);

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -78,7 +78,7 @@ abstract contract Interest is IInterest, PoolState {
             curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                 // RAY
             curDebt_     = totalDebt_ + _pendingInterest(totalDebt_, curInflator_, inflator_); // WAD
 
-            inflatorSnapshot           = curInflator_;
+            inflatorSnapshot           = curInflator_; // RAY
             lastInflatorSnapshotUpdate = block.timestamp;
         } else {
             curInflator_ = inflator_;

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -75,7 +75,7 @@ abstract contract Interest is IInterest, PoolState {
     function _accumulatePoolInterest(uint256 totalDebt_, uint256 inflator_) internal returns (uint256 curDebt_, uint256 curInflator_) {
         uint256 elapsed  = block.timestamp - lastInflatorSnapshotUpdate;
         if (elapsed != 0) {
-            curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                 // RAY
+            curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                // RAY
             curDebt_     = totalDebt_ + _pendingInterest(totalDebt_, curInflator_, inflator_); // WAD
 
             inflatorSnapshot           = curInflator_;

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -37,15 +37,14 @@ abstract contract Interest is IInterest, PoolState {
     function updateInterestRate() external override {
         // RAY
         uint256 curDebt = totalDebt;
-        uint256 curLup  = lup;
-        uint256 actualUtilization = _poolActualUtilization(curDebt, curLup);
-        if (actualUtilization != 0 && previousRateUpdate < block.timestamp && _poolCollateralization(curDebt, curLup) > Maths.ONE_WAD) {
+        uint256 actualUtilization = _poolActualUtilization(curDebt);
+        if (actualUtilization != 0 && previousRateUpdate < block.timestamp && _poolCollateralization(curDebt) > Maths.ONE_WAD) {
             uint256 oldRate = previousRate;
 
             (curDebt, ) = _accumulatePoolInterest(curDebt, inflatorSnapshot);
             totalDebt   = curDebt;
 
-            previousRate       = Maths.wmul(previousRate, (actualUtilization + Maths.ONE_WAD - _poolTargetUtilization(curDebt, curLup)));
+            previousRate       = Maths.wmul(previousRate, (actualUtilization + Maths.ONE_WAD - _poolTargetUtilization(curDebt)));
             previousRateUpdate = block.timestamp;
 
             emit UpdateInterestRate(oldRate, previousRate);

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -75,7 +75,7 @@ abstract contract Interest is IInterest, PoolState {
     function _accumulatePoolInterest(uint256 totalDebt_, uint256 inflator_) internal returns (uint256 curDebt_, uint256 curInflator_) {
         uint256 elapsed  = block.timestamp - lastInflatorSnapshotUpdate;
         if (elapsed != 0) {
-            curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                // RAY
+            curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                 // RAY
             curDebt_     = totalDebt_ + _pendingInterest(totalDebt_, curInflator_, inflator_); // WAD
 
             inflatorSnapshot           = curInflator_;

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -41,8 +41,7 @@ abstract contract Interest is IInterest, PoolState {
         if (actualUtilization != 0 && previousRateUpdate < block.timestamp && _poolCollateralization(curDebt) > Maths.ONE_WAD) {
             uint256 oldRate = previousRate;
 
-            (curDebt, ) = _accumulatePoolInterest(curDebt, inflatorSnapshot);
-            totalDebt   = curDebt;
+            (curDebt, ) =  _accumulatePoolInterest(curDebt, inflatorSnapshot);
 
             previousRate       = Maths.wmul(previousRate, (actualUtilization + Maths.ONE_WAD - _poolTargetUtilization(curDebt)));
             previousRateUpdate = block.timestamp;
@@ -78,6 +77,7 @@ abstract contract Interest is IInterest, PoolState {
             curInflator_ = _pendingInflator(previousRate, inflator_, elapsed);                 // RAY
             curDebt_     = totalDebt_ + _pendingInterest(totalDebt_, curInflator_, inflator_); // WAD
 
+            totalDebt                  = curDebt_;
             inflatorSnapshot           = curInflator_; // RAY
             lastInflatorSnapshotUpdate = block.timestamp;
         } else {

--- a/src/base/LenderManager.sol
+++ b/src/base/LenderManager.sol
@@ -22,6 +22,10 @@ abstract contract LenderManager is ILenderManager, Buckets {
      */
     mapping(address => mapping(uint256 => uint256)) public lpTimer;
 
+    /**********************/
+    /*** View Functions ***/
+    /**********************/
+
     function getLPTokenExchangeValue(uint256 lpTokens_, uint256 price_) external view override returns (uint256 collateralTokens_, uint256 quoteTokens_) {
         require(BucketMath.isValidPrice(price_), "P:GLPTEV:INVALID_PRICE");
 

--- a/src/base/Multicall.sol
+++ b/src/base/Multicall.sol
@@ -19,7 +19,7 @@ abstract contract Multicall {
 
             // Process any failing calls and revert the transaction accordingly
             if (!success) {
-                handleRevert(result);
+                _handleRevert(result);
             }
 
             results_[i] = result;
@@ -38,7 +38,7 @@ abstract contract Multicall {
      *  @dev    Based upon Superfluid code: https://github.com/superfluid-finance/protocol-monorepo/blob/dev/packages/ethereum-contracts/contracts/libs/CallUtils.sol
      *  @param  result_ The failing call result to process and bubble up revert from
      */
-    function handleRevert(bytes memory result_) internal pure {
+    function _handleRevert(bytes memory result_) internal pure {
         uint256 len = result_.length;
 
         if (len < 4) {

--- a/src/base/PermitERC721.sol
+++ b/src/base/PermitERC721.sol
@@ -51,7 +51,7 @@ abstract contract PermitERC721 is ERC721, IPermit {
                     0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f,
                     _nameHash,
                     _versionHash,
-                    getChainId(),
+                    _chainId(),
                     address(this)
                 )
             );
@@ -126,7 +126,7 @@ abstract contract PermitERC721 is ERC721, IPermit {
      *  @dev Gets the current chain ID
      *  @return chainId_ The current chain ID
      */
-    function getChainId() internal view returns (uint256 chainId_) {
+    function _chainId() internal view returns (uint256 chainId_) {
         assembly {
             chainId_ := chainid()
         }

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -36,13 +36,13 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
-        if (lup != 0 && totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt_));
+        if (totalDebt_ != 0) {
+            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
         }
         return Maths.ONE_WAD;
     }
 
-    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
+    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal pure returns (uint256) {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -43,7 +43,7 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
-        return totalDebt != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
+        return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
     function _poolTargetUtilization(uint256 totalDebt_) internal view returns (uint256) {

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -36,13 +36,13 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
-        if (totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
+        if (lup != 0 && totalDebt_ != 0) {
+            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt_));
         }
         return Maths.ONE_WAD;
     }
 
-    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal pure returns (uint256) {
+    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -27,22 +27,22 @@ abstract contract PoolState is IPoolState, Buckets {
     /*** Internal Functions ***/
     /**************************/
 
-    function _encumberedCollateral(uint256 debt_) internal view returns (uint256) {
+    function _encumberedCollateral(uint256 debt_, uint256 lup_) internal pure returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
+        return debt_ != 0 ? Maths.wwdivr(debt_, lup_) : 0;
     }
 
-    function _poolActualUtilization(uint256 totalDebt_) internal view returns (uint256) {
+    function _poolActualUtilization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
-            uint256 lupMulDebt = Maths.wmul(lup, totalDebt_);
+            uint256 lupMulDebt = Maths.wmul(lup_, totalDebt_);
             return Maths.wdiv(lupMulDebt, lupMulDebt + pdAccumulator);
         }
         return 0;
     }
 
-    function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
+    function _poolCollateralization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
+            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup_));
         }
         return Maths.ONE_WAD;
     }
@@ -51,8 +51,8 @@ abstract contract PoolState is IPoolState, Buckets {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
-    function _poolTargetUtilization(uint256 totalDebt_) internal view returns (uint256) {
-        return Maths.wdiv(Maths.ONE_WAD, _poolCollateralization(totalDebt_));
+    function _poolTargetUtilization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
+        return Maths.wdiv(Maths.ONE_WAD, _poolCollateralization(totalDebt_, lup_));
     }
 
     /**********************/
@@ -61,7 +61,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return _encumberedCollateral(debt_);
+        return _encumberedCollateral(debt_, lup);
     }
 
     function getMinimumPoolPrice() public view override returns (uint256) {
@@ -69,11 +69,11 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function getPoolActualUtilization() public view override returns (uint256) {
-        return _poolActualUtilization(totalDebt);
+        return _poolActualUtilization(totalDebt, lup);
     }
 
     function getPoolCollateralization() public view override returns (uint256) {
-        return _poolCollateralization(totalDebt);
+        return _poolCollateralization(totalDebt, lup);
     }
 
     function getPoolMinDebtAmount() public view override returns (uint256) {

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -27,11 +27,6 @@ abstract contract PoolState is IPoolState, Buckets {
     /*** Internal Functions ***/
     /**************************/
 
-    function _encumberedCollateral(uint256 debt_) internal view returns (uint256) {
-        // Calculate encumbrance as RAY to maintain precision
-        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
-    }
-
     function _poolActualUtilization(uint256 totalDebt_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
             uint256 lupMulDebt = Maths.wmul(lup, totalDebt_);
@@ -41,13 +36,13 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
-        if (totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
+        if (lup != 0 && totalDebt_ != 0) {
+            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt_));
         }
         return Maths.ONE_WAD;
     }
 
-    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal pure returns (uint256) {
+    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
@@ -61,7 +56,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return _encumberedCollateral(debt_);
+        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
     }
 
     function getMinimumPoolPrice() public view override returns (uint256) {

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -24,7 +24,11 @@ abstract contract PoolState is IPoolState, Buckets {
     uint256 public totalBorrowers;
 
     function getPoolMinDebtAmount() public view override returns (uint256) {
-        return totalDebt != 0 ? Maths.wdiv(totalDebt, Maths.wad(Maths.max(1000, totalBorrowers * 10))) : 0;
+        return _poolMinDebtAmount(totalDebt, totalBorrowers);
+    }
+
+    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
+        return totalDebt != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256) {
@@ -45,8 +49,12 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function getPoolCollateralization() public view override returns (uint256) {
-        if (lup != 0 && totalDebt != 0) {
-            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt));
+        return _poolCollateralization(totalDebt);
+    }
+
+    function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
+        if (lup != 0 && totalDebt_ != 0) {
+            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt_));
         }
         return Maths.ONE_WAD;
     }

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -27,22 +27,22 @@ abstract contract PoolState is IPoolState, Buckets {
     /*** Internal Functions ***/
     /**************************/
 
-    function _encumberedCollateral(uint256 debt_, uint256 lup_) internal pure returns (uint256) {
+    function _encumberedCollateral(uint256 debt_) internal view returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return debt_ != 0 ? Maths.wwdivr(debt_, lup_) : 0;
+        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
     }
 
-    function _poolActualUtilization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
+    function _poolActualUtilization(uint256 totalDebt_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
-            uint256 lupMulDebt = Maths.wmul(lup_, totalDebt_);
+            uint256 lupMulDebt = Maths.wmul(lup, totalDebt_);
             return Maths.wdiv(lupMulDebt, lupMulDebt + pdAccumulator);
         }
         return 0;
     }
 
-    function _poolCollateralization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
+    function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup_));
+            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
         }
         return Maths.ONE_WAD;
     }
@@ -51,8 +51,8 @@ abstract contract PoolState is IPoolState, Buckets {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
-    function _poolTargetUtilization(uint256 totalDebt_, uint256 lup_) internal view returns (uint256) {
-        return Maths.wdiv(Maths.ONE_WAD, _poolCollateralization(totalDebt_, lup_));
+    function _poolTargetUtilization(uint256 totalDebt_) internal view returns (uint256) {
+        return Maths.wdiv(Maths.ONE_WAD, _poolCollateralization(totalDebt_));
     }
 
     /**********************/
@@ -61,7 +61,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return _encumberedCollateral(debt_, lup);
+        return _encumberedCollateral(debt_);
     }
 
     function getMinimumPoolPrice() public view override returns (uint256) {
@@ -69,11 +69,11 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function getPoolActualUtilization() public view override returns (uint256) {
-        return _poolActualUtilization(totalDebt, lup);
+        return _poolActualUtilization(totalDebt);
     }
 
     function getPoolCollateralization() public view override returns (uint256) {
-        return _poolCollateralization(totalDebt, lup);
+        return _poolCollateralization(totalDebt);
     }
 
     function getPoolMinDebtAmount() public view override returns (uint256) {

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -27,6 +27,11 @@ abstract contract PoolState is IPoolState, Buckets {
     /*** Internal Functions ***/
     /**************************/
 
+    function _encumberedCollateral(uint256 debt_) internal view returns (uint256) {
+        // Calculate encumbrance as RAY to maintain precision
+        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
+    }
+
     function _poolActualUtilization(uint256 totalDebt_) internal view returns (uint256) {
         if (totalDebt_ != 0) {
             uint256 lupMulDebt = Maths.wmul(lup, totalDebt_);
@@ -36,13 +41,13 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolCollateralization(uint256 totalDebt_) internal view returns (uint256) {
-        if (lup != 0 && totalDebt_ != 0) {
-            return Maths.wrdivw(totalCollateral, getEncumberedCollateral(totalDebt_));
+        if (totalDebt_ != 0) {
+            return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
         }
         return Maths.ONE_WAD;
     }
 
-    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal view returns (uint256) {
+    function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal pure returns (uint256) {
         return totalDebt_ != 0 ? Maths.wdiv(totalDebt_, Maths.wad(Maths.max(1000, totalBorrowers_ * 10))) : 0;
     }
 
@@ -56,7 +61,7 @@ abstract contract PoolState is IPoolState, Buckets {
 
     function getEncumberedCollateral(uint256 debt_) public view override returns (uint256) {
         // Calculate encumbrance as RAY to maintain precision
-        return debt_ != 0 ? Maths.wwdivr(debt_, lup) : 0;
+        return _encumberedCollateral(debt_);
     }
 
     function getMinimumPoolPrice() public view override returns (uint256) {

--- a/src/base/PositionNFT.sol
+++ b/src/base/PositionNFT.sol
@@ -23,7 +23,7 @@ abstract contract PositionNFT is ERC721, ERC721Enumerable, PermitERC721 {
         string memory _name = string(
             abi.encodePacked("Ajna Token #", Strings.toString(params_.tokenId))
         );
-        string memory image = Base64.encode(bytes(generateSVGofTokenById(params_.tokenId)));
+        string memory image = Base64.encode(bytes(_generateSVGofTokenById(params_.tokenId)));
         string memory description = "Ajna Positions NFT-V1";
 
         // address tokenOwner = ownerOf(params_.tokenId);
@@ -55,11 +55,11 @@ abstract contract PositionNFT is ERC721, ERC721Enumerable, PermitERC721 {
     }
 
     // TODO: finish implementing: https://github.com/scaffold-eth/scaffold-eth/blob/sipping-oe/packages/hardhat/contracts/OldEnglish.sol#L112-L234
-    function generateSVGofTokenById(uint256 tokenId_) internal pure returns (string memory) {
+    function _generateSVGofTokenById(uint256 tokenId_) internal pure returns (string memory) {
         string memory svg = string(
             abi.encodePacked(
                 '<svg xmlns="http://www.w3.org/2000/svg" width="216.18" height="653.57">',
-                renderTokenById(tokenId_),
+                _renderTokenById(tokenId_),
                 "</svg>"
             )
         );
@@ -67,7 +67,7 @@ abstract contract PositionNFT is ERC721, ERC721Enumerable, PermitERC721 {
     }
 
     // TODO: add SVG string for Ajna Logo
-    function renderTokenById(uint256) internal pure returns (string memory) {
+    function _renderTokenById(uint256) internal pure returns (string memory) {
         return string(abi.encodePacked(""));
     }
 

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -200,3 +200,115 @@ interface IPool {
     function liquidate(address borrower_) external;
 
 }
+
+interface INFTPool is IPool {
+
+    /**************/
+    /*** Events ***/
+    /**************/
+
+    /**
+     *  @notice Emitted when borrower locks collateral in the pool.
+     *  @param  borrower_ `msg.sender`.
+     *  @param  tokenId_  Token ID of the collateral locked in the pool.
+     */
+    event AddNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
+
+    /**
+     *  @notice Emitted when borrower locks collateral in the pool.
+     *  @param  borrower_ `msg.sender`.
+     *  @param  tokenIds_ Array of tokenIds to be added to the pool.
+     */
+    event AddNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+
+    /**
+     *  @notice Emitted when lender claims unencumbered collateral.
+     *  @param  claimer_ Recipient that claimed collateral.
+     *  @param  price_   Price at which unencumbered collateral was claimed.
+     *  @param  tokenId_ Token ID of the collateral to be claimed from the pool.
+     *  @param  lps_     The amount of LP tokens burned in the claim.
+     */
+    event ClaimNFTCollateral(address indexed claimer_, uint256 indexed price_, uint256 indexed tokenId_, uint256 lps_);
+
+    /**
+     *  @notice Emitted when lender claims multiple unencumbered NFT collateral.
+     *  @param  claimer_  Recipient that claimed collateral.
+     *  @param  price_    Price at which unencumbered collateral was claimed.
+     *  @param  tokenIds_ Array of unencumbered tokenIds claimed as collateral.
+     *  @param  lps_      The amount of LP tokens burned in the claim.
+     */
+    event ClaimNFTCollateralMultiple(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_, uint256 lps_);
+
+    /**
+     *  @notice Emitted when NFT collateral is exchanged for quote tokens.
+     *  @param  bidder_     `msg.sender`.
+     *  @param  price_      Price at which collateral was exchanged for quote tokens.
+     *  @param  amount_     Amount of quote tokens purchased.
+     *  @param  tokenIds_   Array of tokenIds used as collateral for the exchange.
+     */
+    event PurchaseWithNFTs(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256[] tokenIds_);
+
+    /**
+     *  @notice Emitted when borrower removes collateral from the pool.
+     *  @param  borrower_ `msg.sender`.
+     *  @param  tokenId_  Token ID of the collateral removed from the pool.
+     */
+    event RemoveNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
+
+    /**
+     *  @notice Emitted when borrower removes multiple collateral from the pool.
+     *  @param  borrower_ `msg.sender`.
+     *  @param  tokenIds_ Array of tokenIds removed from the pool.
+     */
+    event RemoveNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+
+    /*****************************/
+    /*** Inititalize Functions ***/
+    /*****************************/
+
+    /**
+     *  @notice Called by deployNFTSubsetPool()
+     *  @dev Used to initialize pools that only support a subset of tokenIds
+     */
+    function initializeSubset(uint256[] memory tokenIds_) external;
+
+    /***********************************/
+    /*** Borrower External Functions ***/
+    /***********************************/
+
+    /**
+     *  @notice Called by borrowers to add multiple NFTs to the pool.
+     *  @param  tokenIds_ NFT token ids to be deposited as collateral in the pool.
+     */
+    function addCollateralMultiple(uint256[] memory tokenIds_) external;
+
+    /**
+     *  @notice Called by borrowers to remove multiple NFTs from the pool.
+     *  @param  tokenIds_ NFT token ids to be removed as collateral from the pool.
+     */
+    function removeCollateralMultiple(uint256[] memory tokenIds_) external;
+
+    /*********************************/
+    /*** Lender External Functions ***/
+    /*********************************/
+
+    /**
+     *  @notice Called by lenders to claim multiple unencumbered collateral from a price bucket.
+     *  @param  recipient_ The recipient claiming collateral.
+     *  @param  tokenIds_  NFT token ids to be claimed from the pool.
+     *  @param  price_     The bucket from which unencumbered collateral will be claimed.
+     */
+    function claimCollateralMultiple(address recipient_, uint256[] memory tokenIds_, uint256 price_) external;
+
+    /*******************************/
+    /*** Pool External Functions ***/
+    /*******************************/
+
+    /**
+     *  @notice Exchanges NFT collateral for quote token.
+     *  @param  amount_   WAD The amount of quote token to purchase.
+     *  @param  price_    The purchasing price of quote token.
+     *  @param  tokenIds_ NFT token ids to be purchased from the pool.
+     */
+    function purchaseBidNFTCollateral(uint256 amount_, uint256 price_, uint256[] memory tokenIds_) external;
+}


### PR DESCRIPTION
ERC20 pool improvements
- read pool state variables only once per function call (e.g. debt, inflator)
- add internal functions for pool related accounting (also more efficient in terms of gas costs). All external functions are calling the internal functions and passing variables read from storage 
- rename all internal function (prefixed with `_`) to make interaction clear

Gas comparison: 
`develop`:
    5 buckets:  borrow: 0.260838 ETH, repay: 0.204805 ETH
    10 buckets: borrow: 0.356331 ETH, repay: 0.308353 ETH
    20 buckets: borrow: 0.546983 ETH, repay: 0.514930 ETH
    30 buckets: borrow: 0.737968 ETH, repay: 0.721680 ETH
    40 buckets: borrow: 0.928624 ETH, repay: 0.928430 ETH
    50 buckets: borrow: 1.120127 ETH, repay: 1.135698 ETH

`pool-optimizations`:
    5 buckets:  borrow: 0.253633 ETH, repay: 0.195550 ETH
    10 buckets: borrow: 0.349142 ETH, repay: 0.298925 ETH
    20 buckets: borrow: 0.539794 ETH, repay: 0.506525 ETH
    30 buckets: borrow: 0.730418 ETH, repay: 0.713275 ETH  
    40 buckets: borrow: 0.921074 ETH, repay: 0.920009 ETH
    50 buckets: borrow: 1.112059 ETH, repay: 1.127120 ETH

TODOs:
- read `lup` and `hpb` only once from storage and use it in pool calculation / events
- compare results