### PR TITLE
Contract size

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -34,7 +34,7 @@ contract ERC20Pool is IFungiblePool, BasePool {
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        inflatorSnapshot           = Maths.ONE_RAY;
+        inflatorSnapshot           = 10**27;
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;
         interestRateUpdate         = block.timestamp;
@@ -78,7 +78,7 @@ contract ERC20Pool is IFungiblePool, BasePool {
         _borrowFromBucket(amount_, fee, limitPrice_, curInflator);
         require(borrower.collateralDeposited > Maths.rayToWad(_encumberedCollateral(borrower.debt + amount_ + fee)), "P:B:INSUF_COLLAT");
         curDebt += amount_ + fee;
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:B:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;
@@ -189,7 +189,7 @@ contract ERC20Pool is IFungiblePool, BasePool {
         _accumulateBorrowerInterest(borrower, curInflator);
         uint256 debt = borrower.debt;
         require(
-            getBorrowerCollateralization(borrower.collateralDeposited, debt) <= Maths.ONE_WAD,
+            getBorrowerCollateralization(borrower.collateralDeposited, debt) <= Maths.WAD,
             "P:L:BORROWER_OK"
         );
 
@@ -222,7 +222,7 @@ contract ERC20Pool is IFungiblePool, BasePool {
 
         // purchase bid from bucket
         _purchaseBidFromBucket(price_, amount_, collateralRequired, curInflator);
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:PB:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -24,23 +24,13 @@ contract ERC20Pool is IFungiblePool, BasePool {
 
     uint256 public override collateralScale;
 
-    /*****************/
-    /*** Modifiers ***/
-    /*****************/
-
-    /**
-     *  @notice Modifier to protect a clone's initialize method from repeated updates.
-     */
-    modifier onlyOnce() {
-        require(_poolInitializations == 0, "P:INITIALIZED");
-        _;
-    }
 
     /*****************************/
     /*** Inititalize Functions ***/
     /*****************************/
 
-    function initialize(uint256 rate_) external override onlyOnce {
+    function initialize(uint256 rate_) external override {
+        require(_poolInitializations == 0, "P:INITIALIZED");
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
@@ -152,7 +142,7 @@ contract ERC20Pool is IFungiblePool, BasePool {
 
         // borrower accounting
         if (remainingDebt == 0) totalBorrowers -= 1;
-        borrower.debt         -= amount;
+        borrower.debt         = remainingDebt;
         borrowers[msg.sender] = borrower; // save borrower to storage
 
         _updateInterestRate(curDebt);

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -45,7 +45,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        inflatorSnapshot           = Maths.ONE_RAY;
+        inflatorSnapshot           = 10**27;
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;
         interestRateUpdate         = block.timestamp;
@@ -83,7 +83,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
             // pool level accounting
             _collateralTokenIdsAdded.add(tokenIds_[i]);
-            totalCollateral += Maths.ONE_WAD;
+            totalCollateral += Maths.WAD;
 
             // borrower accounting
             NFTborrowers[msg.sender].collateralDeposited.add(tokenIds_[i]);
@@ -113,7 +113,7 @@ contract ERC721Pool is INFTPool, BasePool {
         // collateral amounts need to be recorded as WADs to enable like-unit comparisons with quote token precision
         require(Maths.ray(borrower.collateralDeposited.length()) > _encumberedCollateral(borrower.debt + amount_ + fee), "P:B:INSUF_COLLAT");
         curDebt += amount_ + fee;
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:B:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:B:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;
@@ -141,7 +141,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
         // Require overcollateralization to be at a minimum of one RAY to account for indivisible NFTs
         require(
-            Maths.ray(tokenIds_.length) <= unencumberedCollateral || unencumberedCollateral >= Maths.ray(tokenIds_.length) + Maths.ONE_RAY,
+            Maths.ray(tokenIds_.length) <= unencumberedCollateral || unencumberedCollateral >= Maths.ray(tokenIds_.length) + Maths.RAY,
             "P:RC:AMT_GT_AVAIL_COLLAT"
         );
 
@@ -153,7 +153,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
             // pool level accounting
             _collateralTokenIdsAdded.remove(tokenIds_[i]);
-            totalCollateral -= Maths.ONE_WAD;
+            totalCollateral -= Maths.WAD;
 
             // borrower accounting
             borrower.collateralDeposited.remove(tokenIds_[i]);
@@ -196,7 +196,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
             // pool level accounting
             _collateralTokenIdsAdded.remove(tokenIds_[i]);
-            totalCollateral -= Maths.ONE_WAD;
+            totalCollateral -= Maths.WAD;
 
             // move claimed collateral from pool to claimer
             collateral().safeTransferFrom(address(this), recipient_, tokenIds_[i]);
@@ -237,7 +237,7 @@ contract ERC721Pool is INFTPool, BasePool {
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         _purchaseBidFromBucketNFTCollateral(price_, amount_, usedTokens, curInflator);
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:PB:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:PB:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount_;

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -130,33 +130,7 @@ contract ERC721Pool is INFTPool, BasePool {
         emit Borrow(msg.sender, lup, amount_);
     }
 
-    function removeCollateral(uint256 tokenId_) external override {
-        _tokenInPool(tokenId_);
-
-        (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
-
-        NFTBorrowerInfo storage borrower = NFTborrowers[msg.sender];
-        _accumulateNFTBorrowerInterest(borrower, curInflator);
-
-        // Require overcollateralization to be at a minimum of one RAY to account for indivisible NFTs
-        require(Maths.ray(borrower.collateralDeposited.length()) - _encumberedCollateral(borrower.debt) >= Maths.ONE_RAY, "P:RC:AMT_GT_AVAIL_COLLAT");
-
-        // pool level accounting
-        _collateralTokenIdsAdded.remove(tokenId_);
-        totalCollateral = Maths.wad(_collateralTokenIdsAdded.length());
-
-        // borrower accounting
-        borrower.collateralDeposited.remove(tokenId_);
-
-        _updateInterestRate(curDebt);
-
-        // move collateral from pool to sender
-        collateral().safeTransferFrom(address(this), msg.sender, tokenId_);
-        emit RemoveNFTCollateral(msg.sender, tokenId_);
-    }
-
-    function removeCollateralMultiple(uint256[] calldata tokenIds_) external override {
-        _tokensInPool(tokenIds_);
+    function removeCollateral(uint256[] calldata tokenIds_) external override {
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
@@ -175,6 +149,7 @@ contract ERC721Pool is INFTPool, BasePool {
 
         // remove tokenIds from the pool
         for (uint i; i < tokenIds_.length;) {
+            require(collateral().ownerOf(tokenIds_[i]) == address(this), "P:T_NOT_IN_P");
 
             // pool level accounting
             _collateralTokenIdsAdded.remove(tokenIds_[i]);
@@ -190,7 +165,7 @@ contract ERC721Pool is INFTPool, BasePool {
                 ++i;
             }
         }
-        emit RemoveNFTCollateralMultiple(msg.sender, tokenIds_);
+        emit RemoveNFTCollateral(msg.sender, tokenIds_);
     }
 
 
@@ -201,40 +176,14 @@ contract ERC721Pool is INFTPool, BasePool {
     /*** Lender External Functions ***/
     /*********************************/
 
-    function claimCollateral(address recipient_, uint256 tokenId_, uint256 price_) external override {
-        _tokenInPool(tokenId_);
+    function claimCollateral(address recipient_, uint256[] calldata tokenIds_, uint256 price_) external override {
         require(BucketMath.isValidPrice(price_), "P:CC:INVALID_PRICE");
 
         uint256 maxClaim = lpBalance[recipient_][price_];
         require(maxClaim != 0, "P:CC:NO_CLAIM_TO_BUCKET");
 
         // claim collateral and get amount of LP tokens burned for claim
-        uint256 claimedLpTokens = _claimNFTCollateralFromBucket(price_, tokenId_, maxClaim);
-
-        // pool level accounting
-        _collateralTokenIdsAdded.remove(tokenId_);
-        totalCollateral -= Maths.ONE_WAD;
-
-        // lender accounting
-        lpBalance[recipient_][price_] -= claimedLpTokens;
-
-        _updateInterestRate(totalDebt);
-
-        // move claimed collateral from pool to claimer
-        collateral().safeTransferFrom(address(this), recipient_, tokenId_);
-        emit ClaimNFTCollateral(recipient_, price_, tokenId_, claimedLpTokens);
-    }
-
-    function claimCollateralMultiple(address recipient_, uint256[] calldata tokenIds_, uint256 price_) external override {
-        require(BucketMath.isValidPrice(price_), "P:CC:INVALID_PRICE");
-
-        _tokensInPool(tokenIds_);
-
-        uint256 maxClaim = lpBalance[recipient_][price_];
-        require(maxClaim != 0, "P:CC:NO_CLAIM_TO_BUCKET");
-
-        // claim collateral and get amount of LP tokens burned for claim
-        uint256 claimedLpTokens = _claimMultipleNFTCollateralFromBucket(price_, tokenIds_, maxClaim);
+        uint256 claimedLpTokens = _claimNFTCollateralFromBucket(price_, tokenIds_, maxClaim);
 
         // lender accounting
         lpBalance[recipient_][price_] -= claimedLpTokens;
@@ -243,6 +192,8 @@ contract ERC721Pool is INFTPool, BasePool {
 
         // claim tokenIds from the pool
         for (uint i; i < tokenIds_.length;) {
+            require(collateral().ownerOf(tokenIds_[i]) == address(this), "P:T_NOT_IN_P");
+
             // pool level accounting
             _collateralTokenIdsAdded.remove(tokenIds_[i]);
             totalCollateral -= Maths.ONE_WAD;
@@ -253,7 +204,7 @@ contract ERC721Pool is INFTPool, BasePool {
                 ++i;
             }
         }
-        emit ClaimNFTCollateralMultiple(recipient_, price_, tokenIds_, claimedLpTokens);
+        emit ClaimNFTCollateral(recipient_, price_, tokenIds_, claimedLpTokens);
     }
 
     /*******************************/
@@ -263,10 +214,17 @@ contract ERC721Pool is INFTPool, BasePool {
     // TODO: finish implementing
     function liquidate(address borrower_) external override {}
 
-    function purchaseBidNFTCollateral(uint256 amount_, uint256 price_, uint256[] calldata tokenIds_) external override {
+    function purchaseBid(uint256 amount_, uint256 price_, uint256[] calldata tokenIds_) external override {
         require(BucketMath.isValidPrice(price_), "P:PB:INVALID_PRICE");
 
-        _onlySubsetMultiple(tokenIds_);
+        if (_tokenIdsAllowed.length() != 0) {
+            for (uint i; i < tokenIds_.length;) {
+                require(_tokenIdsAllowed.contains(tokenIds_[i]), "P:ONLY_SUBSET");
+                unchecked {
+                    ++i;
+                }
+            }
+        }
 
         // calculate in whole NFTs the amount of collateral required to cover desired quote at desired price
         uint256 collateralRequired = Maths.divRoundingUp(amount_, price_);
@@ -285,6 +243,8 @@ contract ERC721Pool is INFTPool, BasePool {
         totalQuoteToken -= amount_;
         totalCollateral += Maths.wad(usedTokens.length);
 
+        _updateInterestRate(curDebt);
+
         // move required collateral from sender to pool
         for (uint i; i < collateralRequired;) {
             collateral().safeTransferFrom(msg.sender, address(this), usedTokens[i]);
@@ -293,54 +253,11 @@ contract ERC721Pool is INFTPool, BasePool {
             }
         }
 
-        _updateInterestRate(curDebt);
-
         // move quote token amount from pool to sender
         quoteToken().safeTransfer(msg.sender, amount_ / quoteTokenScale);
         emit PurchaseWithNFTs(msg.sender, price_, amount_, usedTokens);
     }
 
-    /**************************/
-    /*** Internal Functions ***/
-    /**************************/
-
-    /** @notice Used to protect a clone's initialize method from repeated updates */
-    function _onlyOnce() internal view {
-        require(_poolInitializations == 0, "P:INITIALIZED");
-    }
-
-    function _onlySubset(uint256 tokenId_) internal view {
-        if (_tokenIdsAllowed.length() != 0) {
-            require(_tokenIdsAllowed.contains(tokenId_), "P:ONLY_SUBSET");
-        }
-    }
-
-    function _onlySubsetMultiple(uint256[] memory tokenIds_) internal view {
-        if (_tokenIdsAllowed.length() != 0) {
-            for (uint i; i < tokenIds_.length;) {
-                require(_tokenIdsAllowed.contains(tokenIds_[i]), "P:ONLY_SUBSET");
-                unchecked {
-                    ++i;
-                }
-            }
-        }
-    }
-
-    /** @notice Check if a token has been deposited into the pool */
-    function _tokenInPool(uint256 tokenId_) internal view {
-        require(collateral().ownerOf(tokenId_) == address(this), "P:T_NOT_IN_P");
-    }
-
-    /** @notice Check if all tokens in an array have been deposited into the pool */
-    function _tokensInPool(uint256[] memory tokenIds_) internal view {
-        for (uint i; i < tokenIds_.length;) {
-            _tokenInPool(tokenIds_[i]);
-
-            unchecked {
-                ++i;
-            }
-        }
-    }
 
     /**********************/
     /*** View Functions ***/
@@ -369,12 +286,7 @@ contract ERC721Pool is INFTPool, BasePool {
     /** @notice Implementing this method allows contracts to receive ERC721 tokens
      *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828
      */    
-    function onERC721Received(
-        address,
-        address,
-        uint256,
-        bytes memory
-    ) external pure returns (bytes4) {
+    function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
         return this.onERC721Received.selector;
     }
 

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -55,12 +55,6 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
         pool.removeQuoteToken(params_.recipient, quoteTokenToRemove, params_.price);
 
-        // enable lenders to remove quote token from a bucket that no debt is added to
-        if (collateralToRemove != 0) {
-            // claim any unencumbered collateral accrued to the price bucket
-            pool.claimCollateral(params_.recipient, Maths.rayToWad(collateralToRemove), params_.price);
-        }
-
         // update position with newly removed lp shares
         positions[params_.tokenId].lpTokens[params_.price] -= params_.lpTokens;
 

--- a/src/_test/ERC20Pool/ERC20PoolBid.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBid.t.sol
@@ -59,7 +59,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_pool.totalQuoteToken(), 9_000 * 1e18);
         assertEq(_pool.pdAccumulator(),   24_050_428.089622859610921000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // borrower takes a loan of 4000 DAI making bucket 4000 to be fully utilized
@@ -166,7 +166,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   17_012_927.794982087598258000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // borrower takes a loan of 1000 DAI from bucket 4000
@@ -268,7 +268,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   8_011_930.510198812945517500 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // borrower takes a loan of 1000 DAI from bucket 4000
@@ -311,7 +311,7 @@ contract ERC20PoolBidTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   7_013_819.700778449095213000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // borrower takes a loan of 1000 DAI from bucket 4000

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -72,7 +72,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 0);
         assertEq(_pool.pdAccumulator(),   150_298_948.393042738130440000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         assertEq(_pool.getPendingPoolInterest(),               0);

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -97,7 +97,7 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         _borrower.addCollateral(_pool, 90 * 1e18);
 
         // get a 21_000 DAI loan from 3 buckets, loan price should be 3000 DAI
-        assertEq(_pool.estimatePriceForLoan(21_000 * 1e18), priceMed);
+        assertEq(_pool.estimatePrice(21_000 * 1e18), priceMed);
 
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_borrower), 21_000 * 1e18);
@@ -264,9 +264,9 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         _lender.addQuoteToken(_pool, address(_lender), 50_000 * 1e18, priceLow);
 
         // borrower1 takes a loan of 100_000 DAI
-        assertEq(_pool.estimatePriceForLoan(75_000 * 1e18),  priceHigh);
-        assertEq(_pool.estimatePriceForLoan(125_000 * 1e18), priceMed);
-        assertEq(_pool.estimatePriceForLoan(175_000 * 1e18), priceLow);
+        assertEq(_pool.estimatePrice(75_000 * 1e18),  priceHigh);
+        assertEq(_pool.estimatePrice(125_000 * 1e18), priceMed);
+        assertEq(_pool.estimatePrice(175_000 * 1e18), priceLow);
         _borrower.addCollateral(_pool, 51 * 1e18);
         _borrower.borrow(_pool, 100_000 * 1e18, 1_000 * 1e18);
 
@@ -285,9 +285,9 @@ contract ERC20PoolBorrowTest is DSTestPlus {
         assertLt(actualUtilizationAfterBorrow, targetUtilizationAfterBorrow);
 
         // borrower2 adds collateral to attempt a borrow
-        assertEq(_pool.estimatePriceForLoan(25_000 * 1e18),  priceMed);
-        assertEq(_pool.estimatePriceForLoan(75_000 * 1e18),  priceLow);
-        assertEq(_pool.estimatePriceForLoan(175_000 * 1e18), 0);
+        assertEq(_pool.estimatePrice(25_000 * 1e18),  priceMed);
+        assertEq(_pool.estimatePrice(75_000 * 1e18),  priceLow);
+        assertEq(_pool.estimatePrice(175_000 * 1e18), 0);
         _borrower2.addCollateral(_pool, 51 * 1e18);
 
         // check collateralization / utilization after borrower adds collateral

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -68,7 +68,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         uint256 targetUtilization = _pool.getPoolTargetUtilization();
         uint256 actualUtilization = _pool.getPoolActualUtilization();
         assertEq(poolEncumbered,    0);
-        assertEq(collateralization, Maths.ONE_WAD);
+        assertEq(collateralization, Maths.WAD);
 
         // test deposit collateral
         assertEq(_collateral.balanceOf(address(_borrower)), 100 * 1e18);
@@ -89,7 +89,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         (, , uint256 deposited, uint256 borrowerEncumbered, uint256 borrowerCollateralization, ,) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,                 70 * 1e18);
         assertEq(borrowerEncumbered,        0);
-        assertEq(borrowerCollateralization, Maths.ONE_WAD);
+        assertEq(borrowerCollateralization, Maths.WAD);
 
         // get loan of 20_000 DAI, recheck borrower
         _borrower.borrow(_pool, 20_000 * 1e18, 2500 * 1e18);
@@ -164,7 +164,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _borrower.approveToken(_quote, address(_pool), 15_001 * 1e18);
         _borrower.repay(_pool, 15_001 * 1e18);
         // since collateralization dropped to 100%, target utilization should increase
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertGt(actualUtilization,                _pool.getPoolActualUtilization());
         assertLt(targetUtilization,                _pool.getPoolTargetUtilization());
 
@@ -177,7 +177,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         vm.expectEmit(true, false, false, true);
         emit RemoveCollateral(address(_borrower), 80 * 1e18);
         _borrower.removeCollateral(_pool, 80 * 1e18);
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(actualUtilization,                _pool.getPoolActualUtilization());
         assertEq(targetUtilization,                _pool.getPoolTargetUtilization());
 
@@ -185,14 +185,14 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         (, , deposited, borrowerEncumbered, borrowerCollateralization, , ) = _pool.getBorrowerInfo(address(_borrower));
         assertEq(deposited,                 0);
         assertEq(borrowerEncumbered,        0);
-        assertEq(borrowerCollateralization, Maths.ONE_WAD);
+        assertEq(borrowerCollateralization, Maths.WAD);
 
         assertEq(_collateral.balanceOf(address(_borrower)), 100 * 1e18);
         // // check pool balances
         poolEncumbered = _pool.getEncumberedCollateral(_pool.totalDebt());
         assertEq(poolEncumbered,                   borrowerEncumbered);
         assertEq(_pool.getPoolCollateralization(), borrowerCollateralization);
-        assertEq(_pool.getPoolTargetUtilization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolTargetUtilization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.totalCollateral(),          0);
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidate.t.sol
@@ -208,7 +208,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt,  0);
         assertEq(collateralDeposited,  0.790937192475694302 * 1e18);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization,    Maths.ONE_WAD);
+        assertEq(collateralization,    Maths.WAD);
         assertEq(borrowerInflator,     1.000013001099216594901568631 * 1e27);
         assertEq(_pool.getEncumberedCollateral(borrowerDebt), collateralEncumbered);
         assertEq(_pool.getBorrowerCollateralization(collateralDeposited, borrowerDebt), collateralization);
@@ -266,7 +266,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(_pool.totalBorrowers(),  0);
         assertEq(_pool.pdAccumulator(),   117_318_734.038244664909739000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // first borrower takes a loan of 12_000 DAI, pushing lup to 8_002.824356287850613262
@@ -363,7 +363,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt,  0);
         assertEq(collateralDeposited,  0.455302579876161169 * 1e18);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization,    Maths.ONE_WAD);
+        assertEq(collateralization,    Maths.WAD);
         assertEq(borrowerInflator,     1 * 1e27);
 
         // check borrower collateralization after liquidation
@@ -405,7 +405,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(_pool.totalBorrowers(),  0);
         assertEq(_pool.pdAccumulator(),   136_701_357.140089103528322500 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
 
         // first borrower takes a loan of 12_000 DAI, pushing lup to 8_000
@@ -505,7 +505,7 @@ contract ERC20PoolLiquidateTest is DSTestPlus {
         assertEq(borrowerPendingDebt,  0);
         assertEq(collateralDeposited,  0);
         assertEq(collateralEncumbered, 0);
-        assertEq(collateralization,    Maths.ONE_WAD);
+        assertEq(collateralization,    Maths.WAD);
         assertEq(borrowerInflator,     1.171809294361418037665607534 * 1e27);
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -901,9 +901,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.pdAccumulator(),   11_315_823.174350100798832000 * 1e18);
 
         // check initial utilization after depositing but not borrowing
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
-        assertEq(_pool.getPoolTargetUtilization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolTargetUtilization(), Maths.WAD);
 
         // skip > 24h to avoid deposit penalty
         skip(3600 * 24 + 1);
@@ -1123,9 +1123,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         uint256 collateralization = _pool.getPoolCollateralization();
         uint256 targetUtilization = _pool.getPoolTargetUtilization();
         uint256 actualUtilization = _pool.getPoolActualUtilization();
-        assertEq(collateralization, Maths.ONE_WAD);
+        assertEq(collateralization, Maths.WAD);
         assertEq(actualUtilization, 0);
-        assertEq(targetUtilization, Maths.ONE_WAD);
+        assertEq(targetUtilization, Maths.WAD);
 
         // skip > 24h to avoid deposit removal penalty
         skip(3600 * 24 + 1);
@@ -1210,7 +1210,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         uint256 targetUtilization = _pool.getPoolTargetUtilization();
         uint256 actualUtilization = _pool.getPoolActualUtilization();
         assertEq(actualUtilization, 0);
-        assertEq(targetUtilization, Maths.ONE_WAD);
+        assertEq(targetUtilization, Maths.WAD);
 
         // borrower takes a loan of 4000 DAI at priceLow
         uint256 borrowAmount = 4_000 * 1e18;
@@ -1353,7 +1353,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // borrowers deposit collateral
         _borrower.addCollateral(_pool, 2 * 1e18);
         _borrower2.addCollateral(_pool, 200 * 1e18);
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
 
         // first borrower takes a loan of 12_000 DAI, pushing lup to 8_002.824356287850613262
         _borrower.borrow(_pool, 12_000 * 1e18, 8_000 * 1e18);

--- a/src/_test/ERC20Pool/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolRepay.t.sol
@@ -71,7 +71,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 100 * 1e18);
         assertEq(_pool.pdAccumulator(),   120_194_640.856836005674960000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.getPendingPoolInterest(),   0);
 
@@ -157,7 +157,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 100 * 1e18);
         assertEq(_pool.pdAccumulator(),   120_196_921.839645522983871485 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.getPendingPoolInterest(),   0);
 
@@ -208,7 +208,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 200 * 1e18);
         assertEq(_pool.pdAccumulator(),   122_001_176.070154734609667000 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.getPendingPoolInterest(),   0);
 
@@ -394,7 +394,7 @@ contract ERC20PoolRepayTest is DSTestPlus {
         assertEq(_pool.totalCollateral(), 200 * 1e18);
         assertEq(_pool.pdAccumulator(),   122_002_650.575083875239252452 * 1e18);
 
-        assertEq(_pool.getPoolCollateralization(), Maths.ONE_WAD);
+        assertEq(_pool.getPoolCollateralization(), Maths.WAD);
         assertEq(_pool.getPoolActualUtilization(), 0);
         assertEq(_pool.getPendingPoolInterest(),   0);
 

--- a/src/_test/ERC721Pool/ERC721PoolBid.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBid.t.sol
@@ -112,23 +112,23 @@ contract ERC721PoolBidTest is DSTestPlus {
 
         // should revert if invalid price
         vm.expectRevert("BM:PTI:OOB");
-        _bidder.purchaseBidNFTCollateral(_NFTSubsetPool, _p1, 1_000, _tokenIds);
+        _bidder.purchaseBid(_NFTSubsetPool, _p1, 1_000, _tokenIds);
 
         // should revert if trying to use collateral not in the allowed subset
         uint256[] memory _invalidTokenIds = new uint256[](2);
         _invalidTokenIds[0] = 61;
         _invalidTokenIds[1] = 62;
         vm.expectRevert("P:ONLY_SUBSET");
-        _bidder.purchaseBidNFTCollateral(_NFTSubsetPool, 5_100 * 1e18, _p8002, _invalidTokenIds);
+        _bidder.purchaseBid(_NFTSubsetPool, 5_100 * 1e18, _p8002, _invalidTokenIds);
 
         // should revert if bidder doesn't have enough collateral
         vm.expectRevert("P:PB:INSUF_COLLAT");
-        _bidder.purchaseBidNFTCollateral(_NFTSubsetPool, 2_000_000 * 1e18, _p4000, _tokenIds);
+        _bidder.purchaseBid(_NFTSubsetPool, 2_000_000 * 1e18, _p4000, _tokenIds);
 
         // should revert if trying to purchase more than on bucket
         vm.expectRevert("B:PB:INSUF_BUCKET_LIQ");
         vm.prank((address(_bidder)));
-        _bidder.purchaseBidNFTCollateral(_NFTSubsetPool, 5_100 * 1e18, _p8002, _tokenIds);
+        _bidder.purchaseBid(_NFTSubsetPool, 5_100 * 1e18, _p8002, _tokenIds);
 
         // check 4_000.927678580567537368 bucket balance before purchase bid
         (, , , uint256 deposit, uint256 debt, , , uint256 bucketCollateral) = _NFTSubsetPool.bucketAt(_p4000);
@@ -142,7 +142,7 @@ contract ERC721PoolBidTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit PurchaseWithNFTs(address(_bidder), _p4000, 4_000 * 1e18, _tokenIds);
         vm.prank((address(_bidder)));
-        _bidder.purchaseBidNFTCollateral(_NFTSubsetPool, 4_000 * 1e18, _p4000, _tokenIds);
+        _bidder.purchaseBid(_NFTSubsetPool, 4_000 * 1e18, _p4000, _tokenIds);
 
         // check 4_000.927678580567537368 bucket balance after purchase bid
         (, , , deposit, debt, , , bucketCollateral) = _NFTSubsetPool.bucketAt(_p4000);

--- a/src/_test/ERC721Pool/ERC721PoolBid.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBid.t.sol
@@ -148,7 +148,7 @@ contract ERC721PoolBidTest is DSTestPlus {
         (, , , deposit, debt, , , bucketCollateral) = _NFTSubsetPool.bucketAt(_p4000);
         assertEq(deposit,          1_000 * 1e18);
         assertEq(debt,             5_000.000961538461538462 * 1e18);
-        assertEq(bucketCollateral, Maths.ONE_WAD);
+        assertEq(bucketCollateral, Maths.WAD);
 
         // check  3_010.892022197881557845 bucket balance after purchase bid
         (, , , deposit, debt, , , bucketCollateral) = _NFTSubsetPool.bucketAt(_p3010);

--- a/src/_test/ERC721Pool/ERC721PoolBid.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBid.t.sol
@@ -77,11 +77,17 @@ contract ERC721PoolBidTest is DSTestPlus {
 
         // add iniitial collateral to pool
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(1);
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = 1;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(5);
+        tokens = new uint[](1);
+        tokens[0] = 5;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(50);
+        tokens = new uint[](1);
+        tokens[0] = 50;
+        _NFTSubsetPool.addCollateral(tokens);
         assertEq(_NFTSubsetPool.getCollateralDeposited().length, 3);
 
         // borrow from pool

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -86,11 +86,17 @@ contract ERC721PoolBorrowTest is DSTestPlus {
 
         // add iniitial collateral to pool
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(1);
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = 1;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(5);
+        tokens = new uint[](1);
+        tokens[0] = 5;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(50);
+        tokens = new uint[](1);
+        tokens[0] = 50;
+        _NFTSubsetPool.addCollateral(tokens);
         assertEq(_NFTSubsetPool.getCollateralDeposited().length, 3);
 
         // should revert if borrower wants to borrow a greater amount than in pool

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -80,8 +80,10 @@ contract ERC721PoolCollateralTest is DSTestPlus {
     function testAddRemoveCollateralNFTSubset() external {
         // should revert if attempt to add collateral from a tokenId outside of allowed subset
         vm.prank((address(_borrower)));
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = 2;
         vm.expectRevert("P:ONLY_SUBSET");
-        _NFTSubsetPool.addCollateral(2);
+        _NFTSubsetPool.addCollateral(tokens);
 
         // should revert if attempting to remove collateral that is not in the pool
         vm.prank((address(_borrower)));
@@ -105,16 +107,22 @@ contract ERC721PoolCollateralTest is DSTestPlus {
 
         // add iniitial collateral to pool
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(1);
+        tokens = new uint[](1);
+        tokens[0] = 1;
+        _NFTSubsetPool.addCollateral(tokens);
+        tokens = new uint[](1);
+        tokens[0] = 5;
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(5);
+        _NFTSubsetPool.addCollateral(tokens);
 
         vm.prank((address(_borrower)));
         // vm.expectEmit(true, true, false, true);
         // emit Transfer(address(_borrower), address(_NFTSubsetPool), 50);
         vm.expectEmit(true, true, false, true);
-        emit AddNFTCollateral(address(_borrower), 50);
-        _NFTSubsetPool.addCollateral(50);
+        tokens = new uint[](1);
+        tokens[0] = 50;
+        emit AddNFTCollateral(address(_borrower), tokens);
+        _NFTSubsetPool.addCollateral(tokens);
 
         // check collateral balances
         assertEq(_collateral.balanceOf(address(_borrower)),      57);
@@ -186,7 +194,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         invalidTokenIds[2] = 3;
         vm.prank((address(_borrower)));
         vm.expectRevert("P:ONLY_SUBSET");
-        _NFTSubsetPool.addCollateralMultiple(invalidTokenIds);
+        _NFTSubsetPool.addCollateral(invalidTokenIds);
 
         // should revert if attempting to remove collateral that is not in the pool
         uint256[] memory tokenIdsToRemove = new uint256[](2);
@@ -212,8 +220,8 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         _tokenIds[2] = 10;
         vm.prank((address(_borrower)));
         vm.expectEmit(true, true, false, true);
-        emit AddNFTCollateralMultiple(address(_borrower), _tokenIds);
-        _NFTSubsetPool.addCollateralMultiple(_tokenIds);
+        emit AddNFTCollateral(address(_borrower), _tokenIds);
+        _NFTSubsetPool.addCollateral(_tokenIds);
 
         // check pool and borrower state after adding collateral
         assertEq(_collateral.balanceOf(address(_borrower)),      57);
@@ -245,8 +253,8 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         tokenIdsReadd[1] = 5;
         vm.prank((address(_borrower)));
         vm.expectEmit(true, true, false, true);
-        emit AddNFTCollateralMultiple(address(_borrower), tokenIdsReadd);
-        _NFTSubsetPool.addCollateralMultiple(tokenIdsReadd);
+        emit AddNFTCollateral(address(_borrower), tokenIdsReadd);
+        _NFTSubsetPool.addCollateral(tokenIdsReadd);
 
         // check pool and borrower state after readding collateral
         assertEq(_collateral.balanceOf(address(_borrower)),      57);
@@ -327,11 +335,17 @@ contract ERC721PoolCollateralTest is DSTestPlus {
 
         // add iniitial collateral to pool
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(1);
+        uint256[] memory tokens = new uint256[](1);
+        tokens[0] = 1;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(5);
+        tokens = new uint256[](1);
+        tokens[0] = 5;
+        _NFTSubsetPool.addCollateral(tokens);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(50);
+        tokens = new uint256[](1);
+        tokens[0] = 50;
+        _NFTSubsetPool.addCollateral(tokens);
         assertEq(_NFTSubsetPool.getCollateralDeposited().length, 3);
   
         // borrow from pool
@@ -442,7 +456,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         invalidTokenIds[2] = 3;
         vm.prank((address(_borrower)));
         vm.expectRevert("P:ONLY_SUBSET");
-        _NFTSubsetPool.addCollateralMultiple(invalidTokenIds);
+        _NFTSubsetPool.addCollateral(invalidTokenIds);
 
         // check pool and borrower state before adding collateral
         assertEq(_collateral.balanceOf(address(_borrower)),      60);
@@ -457,8 +471,8 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         _tokenIds[2] = 10;
         vm.prank((address(_borrower)));
         vm.expectEmit(true, true, false, true);
-        emit AddNFTCollateralMultiple(address(_borrower), _tokenIds);
-        _NFTSubsetPool.addCollateralMultiple(_tokenIds);
+        emit AddNFTCollateral(address(_borrower), _tokenIds);
+        _NFTSubsetPool.addCollateral(_tokenIds);
 
         // check pool and borrower state after adding collateral
         assertEq(_collateral.balanceOf(address(_borrower)),      57);

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -93,7 +93,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         uint256 targetUtilization = _NFTSubsetPool.getPoolTargetUtilization();
         uint256 actualUtilization = _NFTSubsetPool.getPoolActualUtilization();
         assertEq(poolEncumbered,    0);
-        assertEq(collateralization, Maths.ONE_WAD);
+        assertEq(collateralization, Maths.WAD);
         assertEq(_NFTSubsetPool.getCollateralDeposited().length, 0);
 
         // check collateral balances
@@ -131,7 +131,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         assertEq(collateralDeposited[1],     5);
         assertEq(collateralDeposited[2],     50);
         assertEq(borrowerEncumbered,         0);
-        assertEq(borrowerCollateralization,  Maths.ONE_WAD);
+        assertEq(borrowerCollateralization,  Maths.WAD);
         assertEq(_NFTSubsetPool.getPoolCollateralization(), borrowerCollateralization);
 
         // borrow from pool
@@ -279,7 +279,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         assertEq(collateralDeposited[1],     1);
         assertEq(collateralDeposited[2],     5);
         assertEq(borrowerEncumbered,         0);
-        assertEq(borrowerCollateralization,  Maths.ONE_WAD);
+        assertEq(borrowerCollateralization,  Maths.WAD);
         assertEq(_NFTSubsetPool.getPoolCollateralization(), borrowerCollateralization);
 
         // borrow against collateral
@@ -399,7 +399,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         (, , , uint256 deposit, uint256 debt, , , uint256 bucketCollateral, uint256[] memory collateralDeposited) = _NFTSubsetPool.nftBucketAt(_p4000);
         assertEq(deposit,          4_000 * 1e18);
         assertEq(debt,             5_000.651054657058420273 * 1e18);
-        assertEq(bucketCollateral, Maths.ONE_WAD);
+        assertEq(bucketCollateral, Maths.WAD);
         assertEq(collateralDeposited[0], _tokenIds[0]);
         assertEq(collateralDeposited.length, 1);
 

--- a/src/_test/ERC721Pool/ERC721PoolInterestRate.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolInterestRate.t.sol
@@ -70,9 +70,13 @@ contract ERC721PoolInterestRateTriggerTest is DSTestPlus {
         skip(864000);
 
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(1);
+        _tokenIds = new uint256[](1);
+        _tokenIds[0] = 1;
+        _NFTSubsetPool.addCollateral(_tokenIds);
         vm.prank((address(_borrower)));
-        _NFTSubsetPool.addCollateral(5);
+        _tokenIds = new uint256[](1);
+        _tokenIds[0] = 5;
+        _NFTSubsetPool.addCollateral(_tokenIds);
         _borrower.borrow(_NFTSubsetPool, 6_000 * 1e18, _p2503);
     }
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -66,15 +66,13 @@ contract DSTestPlus is Test {
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event ClaimCollateral(address indexed claimer_, uint256 indexed price_, uint256 amount_, uint256 lps_);
-    event ClaimNFTCollateral(address indexed claimer_, uint256 indexed price_, uint256 indexed tokenId_, uint256 lps_);
-    event ClaimNFTCollateralMultiple(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_, uint256 lps_);
+    event ClaimNFTCollateral(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_, uint256 lps_);
     event Liquidate(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event Purchase(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256 collateral_);
     event PurchaseWithNFTs(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256[] tokenIds_);
     event RemoveCollateral(address indexed borrower_, uint256 amount_);
-    event RemoveNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
-    event RemoveNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+    event RemoveNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
     event RemoveQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
     event UpdateInterestRate(uint256 oldRate_, uint256 newRate_);

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -62,8 +62,7 @@ contract DSTestPlus is Test {
 
     // Pool events
     event AddCollateral(address indexed borrower_, uint256 amount_);
-    event AddNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
-    event AddNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+    event AddNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event ClaimCollateral(address indexed claimer_, uint256 indexed price_, uint256 amount_, uint256 lps_);

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -91,7 +91,7 @@ contract DSTestPlus is Test {
     }
 
     function wadPercentDifference(uint256 lhs, uint256 rhs) internal pure returns (uint256 difference_) {
-        difference_ = lhs < rhs ? Maths.ONE_WAD - Maths.wdiv(lhs, rhs) : Maths.ONE_WAD - Maths.wdiv(rhs, lhs);
+        difference_ = lhs < rhs ? Maths.WAD - Maths.wdiv(lhs, rhs) : Maths.WAD - Maths.wdiv(rhs, lhs);
     }
 
 }

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -67,16 +67,18 @@ contract UserWithNFTCollateral {
         pool_.borrow(amount_, price_);
     }
 
-    function purchaseBidNFTCollateral(ERC721Pool pool_, uint256 amount_, uint256 price_, uint256[] memory tokenIds_) public {
-        pool_.purchaseBidNFTCollateral(amount_, price_, tokenIds_);
+    function purchaseBid(ERC721Pool pool_, uint256 amount_, uint256 price_, uint256[] memory tokenIds_) public {
+        pool_.purchaseBid(amount_, price_, tokenIds_);
     }
 
     function repay(ERC721Pool pool_, uint256 amount_) public {
         pool_.repay(amount_);
     }
 
-    function removeCollateral(ERC721Pool pool_, uint256 amount_) public {
-        pool_.removeCollateral(amount_);
+    function removeCollateral(ERC721Pool pool_, uint256 tokenId_) public {
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = tokenId_;
+        pool_.removeCollateral(tokens);
     }
 
     // Implementing this method allows contracts to receive ERC721 tokens
@@ -145,11 +147,13 @@ contract UserWithQuoteTokenInNFTPool {
     }
 
     function claimCollateral(ERC721Pool pool_, address recipient_, uint256 tokenId_, uint256 price_) public {
-        pool_.claimCollateral(recipient_, tokenId_, price_);
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = tokenId_;
+        pool_.claimCollateral(recipient_, tokens, price_);
     }
 
     function claimCollateralMultiple(ERC721Pool pool_, address recipient_, uint256[] memory tokenIds_, uint256 price_) public {
-        pool_.claimCollateralMultiple(recipient_, tokenIds_, price_);
+        pool_.claimCollateral(recipient_, tokenIds_, price_);
     }
 
     function liquidate(ERC721Pool pool_, address borrower) public {

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -48,15 +48,19 @@ contract UserWithNFTCollateral {
         uint256 tokenId_
     ) public {
         token_.approve(address(pool_), tokenId_);
-        pool_.addCollateral(tokenId_);
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = tokenId_;
+        pool_.addCollateral(tokens);
     }
 
     function approveToken(IERC721 token_, address spender_, uint256 _tokenId) public {
         token_.approve(spender_, _tokenId);
     }
 
-    function addCollateral(ERC721Pool pool_, uint256 amount_) public {
-        pool_.addCollateral(amount_);
+    function addCollateral(ERC721Pool pool_, uint256 tokenId_) public {
+        uint[] memory tokens = new uint[](1);
+        tokens[0] = tokenId_;
+        pool_.addCollateral(tokens);
     }
 
     function borrow(ERC721Pool pool_, uint256 amount_, uint256 price_) public {

--- a/src/base/BasePool.sol
+++ b/src/base/BasePool.sol
@@ -70,7 +70,7 @@ abstract contract BasePool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 fromLpTokens, uint256 toLpTokens, uint256 movedAmount) = _moveQuoteTokenFromBucket(
             fromPrice_, toPrice_, maxAmount_, lpBalance[recipient_][fromPrice_], lpTimer[recipient_][fromPrice_], curInflator
         );
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:MQT:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:MQT:POOL_UNDER_COLLAT");
 
         // lender accounting
         lpBalance[recipient_][fromPrice_] -= fromLpTokens;
@@ -90,7 +90,7 @@ abstract contract BasePool is IPool, BorrowerManager, Clone, LenderManager {
         (uint256 amount, uint256 lpTokens) = _removeQuoteTokenFromBucket(
             price_, maxAmount_, lpBalance[recipient_][price_], lpTimer[recipient_][price_], curInflator
         );
-        require(_poolCollateralization(curDebt) >= Maths.ONE_WAD, "P:RQT:POOL_UNDER_COLLAT");
+        require(_poolCollateralization(curDebt) >= Maths.WAD, "P:RQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount;

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -45,7 +45,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         debt_                     = borrower.debt;
         pendingDebt_              = borrower.debt;
         collateralDeposited_      = borrower.collateralDeposited;
-        collateralization_        = Maths.ONE_WAD;
+        collateralization_        = Maths.WAD;
         borrowerInflatorSnapshot_ = borrower.inflatorSnapshot;
         inflatorSnapshot_         = inflatorSnapshot;
 
@@ -73,7 +73,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         debt_                     = borrower.debt;
         pendingDebt_              = debt_;
         collateralDeposited_      = borrower.collateralDeposited.values();
-        collateralization_        = Maths.ONE_WAD;
+        collateralization_        = Maths.WAD;
         borrowerInflatorSnapshot_ = borrower.inflatorSnapshot;
         inflatorSnapshot_         = inflatorSnapshot;
 
@@ -88,7 +88,7 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         if (lup != 0 && debt_ != 0) {
             return Maths.wrdivw(collateralDeposited_, getEncumberedCollateral(debt_));
         }
-        return Maths.ONE_WAD;
+        return Maths.WAD;
     }
 
     function estimatePrice(uint256 amount_) public view override returns (uint256) {

--- a/src/base/BorrowerManager.sol
+++ b/src/base/BorrowerManager.sol
@@ -91,8 +91,8 @@ abstract contract BorrowerManager is IBorrowerManager, Interest {
         return Maths.ONE_WAD;
     }
 
-    function estimatePriceForLoan(uint256 amount_) public view override returns (uint256) {
-        return estimatePrice(amount_, lup == 0 ? hpb : lup);
+    function estimatePrice(uint256 amount_) public view override returns (uint256) {
+        return _estimatePrice(amount_, lup == 0 ? hpb : lup);
     }
 
 }

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -169,15 +169,15 @@ abstract contract Buckets is IBuckets {
         Bucket memory bucket = _buckets[price_];
 
         // check available collateral given removal of the NFT
-        require(Maths.ONE_WAD <= bucket.collateral, "B:CC:AMT_GT_COLLAT");
+        require(Maths.WAD <= bucket.collateral, "B:CC:AMT_GT_COLLAT");
 
         // nft collateral is accounted for in WAD units
-        lpRedemption_ = Maths.wrdivr(Maths.wmul(Maths.ONE_WAD, bucket.price), getExchangeRate(bucket));
+        lpRedemption_ = Maths.wrdivr(Maths.wmul(Maths.WAD, bucket.price), getExchangeRate(bucket));
 
         require(lpRedemption_ <= lpBalance_, "B:CC:INSUF_LP_BAL");
 
         // update bucket accounting
-        bucket.collateral -= Maths.ONE_WAD;
+        bucket.collateral -= Maths.WAD;
         bucket.lpOutstanding -= lpRedemption_;
         collateralDeposited.remove(tokenId_);
 
@@ -540,7 +540,7 @@ abstract contract Buckets is IBuckets {
         if (debt_ != 0) {
             // To preserve precision, multiply WAD * RAY = RAD, and then scale back down to WAD
             debt_ += Maths.radToWadTruncate(
-                debt_ * (Maths.rdiv(poolInflator_, inflator_) - Maths.ONE_RAY)
+                debt_ * (Maths.rdiv(poolInflator_, inflator_) - Maths.RAY)
             );
         }
         return debt_;
@@ -575,7 +575,7 @@ abstract contract Buckets is IBuckets {
         Bucket storage bucket = _buckets[price_];
 
         bucket.price            = price_;
-        bucket.inflatorSnapshot = Maths.ONE_RAY;
+        bucket.inflatorSnapshot = Maths.RAY;
 
         if (price_ > hpb_) {
             bucket.down = hpb_;
@@ -1066,7 +1066,7 @@ abstract contract Buckets is IBuckets {
      */
     function getExchangeRate(Bucket memory bucket_) private pure returns (uint256) {
         uint256 size = bucket_.onDeposit + bucket_.debt + Maths.wmul(bucket_.collateral, bucket_.price);
-        return (size != 0 && bucket_.lpOutstanding != 0) ? Maths.wrdivr(size, bucket_.lpOutstanding) : Maths.ONE_RAY;
+        return (size != 0 && bucket_.lpOutstanding != 0) ? Maths.wrdivr(size, bucket_.lpOutstanding) : Maths.RAY;
     }
 
 }

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -1002,25 +1002,6 @@ abstract contract Buckets is IBuckets {
         collateralDeposited_ = collateralDeposited.values();
     }
 
-    function estimatePrice(uint256 amount_, uint256 hpb_) public view override returns (uint256 price_) {
-        Bucket memory curLup = _buckets[hpb_];
-
-        while (true) {
-            if (amount_ > curLup.onDeposit) {
-                amount_ -= curLup.onDeposit;
-            } else if (amount_ <= curLup.onDeposit) {
-                price_ = curLup.price;
-                break;
-            }
-
-            if (curLup.down == 0) {
-                break;
-            } else {
-                curLup = _buckets[curLup.down];
-            }
-        }
-    }
-
     function getHpb() public view override returns (uint256 newHpb_) {
         newHpb_ = hpb;
         while (true) {
@@ -1051,8 +1032,27 @@ abstract contract Buckets is IBuckets {
         }
     }
 
-    function isBucketInitialized(uint256 price_) public view override returns (bool) {
-        return BitMaps.get(_bitmap, price_);
+    /*******************************/
+    /*** Internal View Functions ***/
+    /*******************************/
+
+    function _estimatePrice(uint256 amount_, uint256 hpb_) internal view returns (uint256 price_) {
+        Bucket memory curLup = _buckets[hpb_];
+
+        while (true) {
+            if (amount_ > curLup.onDeposit) {
+                amount_ -= curLup.onDeposit;
+            } else if (amount_ <= curLup.onDeposit) {
+                price_ = curLup.price;
+                break;
+            }
+
+            if (curLup.down == 0) {
+                break;
+            } else {
+                curLup = _buckets[curLup.down];
+            }
+        }
     }
 
     /*******************************/

--- a/src/base/Buckets.sol
+++ b/src/base/Buckets.sol
@@ -191,7 +191,7 @@ abstract contract Buckets is IBuckets {
         }
     }
 
-    function _claimMultipleNFTCollateralFromBucket(uint256 price_, uint256[] memory tokenIds_, uint256 lpBalance_) internal returns (uint256 lpRedemption_) {
+    function _claimNFTCollateralFromBucket(uint256 price_, uint256[] memory tokenIds_, uint256 lpBalance_) internal returns (uint256 lpRedemption_) {
         Bucket memory bucket = _buckets[price_];
 
         // check available collateral given removal of the NFT

--- a/src/base/Interest.sol
+++ b/src/base/Interest.sol
@@ -96,7 +96,7 @@ abstract contract Interest is IInterest, PoolState {
         // Calculate annualized interest rate
         uint256 spr = Maths.wadToRay(interestRate_) / SECONDS_PER_YEAR;
         // secondsSinceLastUpdate is unscaled
-        return Maths.rmul(inflator_, Maths.rpow(Maths.ONE_RAY + spr, elapsed_));
+        return Maths.rmul(inflator_, Maths.rpow(Maths.RAY + spr, elapsed_));
     }
 
     /**
@@ -108,15 +108,15 @@ abstract contract Interest is IInterest, PoolState {
      */
     function _pendingInterest(uint256 debt_, uint256 pendingInflator_, uint256 currentInflator_) internal pure returns (uint256) {
         // To preserve precision, multiply WAD * RAY = RAD, and then scale back down to WAD
-        return Maths.radToWadTruncate(debt_ * (Maths.rdiv(pendingInflator_, currentInflator_) - Maths.ONE_RAY));
+        return Maths.radToWadTruncate(debt_ * (Maths.rdiv(pendingInflator_, currentInflator_) - Maths.RAY));
     }
 
     function _updateInterestRate(uint256 curDebt_) internal {
         uint256 poolCollateralization = _poolCollateralization(curDebt_);
-        if (block.timestamp - interestRateUpdate > SECONDS_PER_HALFDAY && poolCollateralization > Maths.ONE_WAD) {
+        if (block.timestamp - interestRateUpdate > SECONDS_PER_HALFDAY && poolCollateralization > Maths.WAD) {
             uint256 oldRate          = interestRate;
             int256 actualUtilization = int256(_poolActualUtilization(curDebt_));
-            int256 targetUtilization = int256(Maths.wdiv(Maths.ONE_WAD, poolCollateralization));
+            int256 targetUtilization = int256(Maths.wdiv(Maths.WAD, poolCollateralization));
 
             int256 decreaseFactor = 4 * (targetUtilization - actualUtilization);
             int256 increaseFactor = ((targetUtilization + actualUtilization - 10**18) ** 2) / 10**18;

--- a/src/base/PoolState.sol
+++ b/src/base/PoolState.sol
@@ -44,7 +44,7 @@ abstract contract PoolState is IPoolState, Buckets {
         if (totalDebt_ != 0) {
             return Maths.wrdivw(totalCollateral, Maths.wwdivr(totalDebt_, lup));
         }
-        return Maths.ONE_WAD;
+        return Maths.WAD;
     }
 
     function _poolMinDebtAmount(uint256 totalDebt_, uint256 totalBorrowers_) internal pure returns (uint256) {
@@ -52,7 +52,7 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function _poolTargetUtilization(uint256 totalDebt_) internal view returns (uint256) {
-        return Maths.wdiv(Maths.ONE_WAD, _poolCollateralization(totalDebt_));
+        return Maths.wdiv(Maths.WAD, _poolCollateralization(totalDebt_));
     }
 
     /**********************/
@@ -81,6 +81,6 @@ abstract contract PoolState is IPoolState, Buckets {
     }
 
     function getPoolTargetUtilization() public view override returns (uint256) {
-        return Maths.wdiv(Maths.ONE_WAD, getPoolCollateralization());
+        return Maths.wdiv(Maths.WAD, getPoolCollateralization());
     }
 }

--- a/src/interfaces/IBorrowerManager.sol
+++ b/src/interfaces/IBorrowerManager.sol
@@ -61,7 +61,7 @@ interface IBorrowerManager {
      *  @param  amount_  Amount of debt to draw.
      *  @return price_   Price of the loan.
      */
-    function estimatePriceForLoan(uint256 amount_) external view returns (uint256 price_);
+    function estimatePrice(uint256 amount_) external view returns (uint256 price_);
 
     /**
      *  @notice Returns the collateralization based on given collateral deposited and debt.

--- a/src/interfaces/IBuckets.sol
+++ b/src/interfaces/IBuckets.sol
@@ -89,21 +89,6 @@ interface IBuckets {
         );
 
     /**
-     *  @notice Estimate the price at which a loan can be taken
-     *  @param  amount_ The amount of quote tokens desired to borrow, WAD
-     *  @param  hpb_    The current highest price bucket of the pool, WAD
-     *  @return price_  The estimated price at which the loan can be taken, WAD
-     */
-    function estimatePrice(uint256 amount_, uint256 hpb_) external view returns (uint256 price_);
-
-    /**
-     *  @notice Returns whether a bucket price has been initialized or not.
-     *  @param  price_         The price of the bucket.
-     *  @return isInitialized_ Boolean indicating if the bucket has been initialized at this price.
-     */
-    function isBucketInitialized(uint256 price_) external view returns (bool isInitialized_);
-
-    /**
      *  @notice Returns the current Highest Price Bucket (HPB).
      *  @dev    Starting at the current HPB, iterate through down pointers until a new HPB found.
      *  @dev    HPB should have at on deposit or debt different than 0.

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -88,12 +88,6 @@ interface IPool {
     /***********************************/
 
     /**
-     *  @notice Called by borrowers to add collateral to the pool.
-     *  @param  amount_ The amount of collateral in deposit tokens to be added to the pool.
-     */
-    function addCollateral(uint256 amount_) external;
-
-    /**
      *  @notice Called by a borrower to open or expand a position.
      *  @dev    Can only be called if quote tokens have already been added to the pool.
      *  @param  amount_     The amount of quote token to borrow.
@@ -211,6 +205,16 @@ interface IFungiblePool is IPool {
      */
     function collateralScale() external view returns (uint256 collateralScale_);
 
+    /***********************************/
+    /*** Borrower External Functions ***/
+    /***********************************/
+
+    /**
+     *  @notice Called by borrowers to add collateral to the pool.
+     *  @param  amount_ The amount of collateral in deposit tokens to be added to the pool.
+     */
+    function addCollateral(uint256 amount_) external;
+
     /*******************************/
     /*** Pool External Functions ***/
     /*******************************/
@@ -233,16 +237,9 @@ interface INFTPool is IPool {
     /**
      *  @notice Emitted when borrower locks collateral in the pool.
      *  @param  borrower_ `msg.sender`.
-     *  @param  tokenId_  Token ID of the collateral locked in the pool.
-     */
-    event AddNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
-
-    /**
-     *  @notice Emitted when borrower locks collateral in the pool.
-     *  @param  borrower_ `msg.sender`.
      *  @param  tokenIds_ Array of tokenIds to be added to the pool.
      */
-    event AddNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+    event AddNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
 
     /**
      *  @notice Emitted when lender claims unencumbered collateral.
@@ -303,7 +300,7 @@ interface INFTPool is IPool {
      *  @notice Called by borrowers to add multiple NFTs to the pool.
      *  @param  tokenIds_ NFT token ids to be deposited as collateral in the pool.
      */
-    function addCollateralMultiple(uint256[] calldata tokenIds_) external;
+    function addCollateral(uint256[] calldata tokenIds_) external;
 
     /**
      *  @notice Called by borrowers to remove multiple NFTs from the pool.

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -96,12 +96,6 @@ interface IPool {
     function borrow(uint256 amount_, uint256 limitPrice_) external;
 
     /**
-     *  @notice Called by borrowers to remove an amount of collateral.
-     *  @param  amount_ The amount of collateral in deposit tokens to be removed from a position.
-     */
-    function removeCollateral(uint256 amount_) external;
-
-    /**
      *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
      *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
      */
@@ -119,14 +113,6 @@ interface IPool {
      *  @return lpTokens_  The amount of LP Tokens received for the added quote tokens.
      */
     function addQuoteToken(address recipient_, uint256 amount_, uint256 price_) external returns (uint256 lpTokens_);
-
-    /**
-     *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
-     *  @param  recipient_ The recipient claiming collateral.
-     *  @param  amount_    The amount of unencumbered collateral to claim.
-     *  @param  price_     The bucket from which unencumbered collateral will be claimed.
-     */
-    function claimCollateral(address recipient_, uint256 amount_, uint256 price_) external;
 
     /**
      *  @notice Called by lenders to move an amount of credit from a specified price bucket to another specified price bucket.
@@ -215,6 +201,24 @@ interface IFungiblePool is IPool {
      */
     function addCollateral(uint256 amount_) external;
 
+    /**
+     *  @notice Called by borrowers to remove an amount of collateral.
+     *  @param  amount_ The amount of collateral in deposit tokens to be removed from a position.
+     */
+    function removeCollateral(uint256 amount_) external;
+
+    /*********************************/
+    /*** Lender External Functions ***/
+    /*********************************/
+
+    /**
+     *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
+     *  @param  recipient_ The recipient claiming collateral.
+     *  @param  amount_    The amount of unencumbered collateral to claim.
+     *  @param  price_     The bucket from which unencumbered collateral will be claimed.
+     */
+    function claimCollateral(address recipient_, uint256 amount_, uint256 price_) external;
+
     /*******************************/
     /*** Pool External Functions ***/
     /*******************************/
@@ -242,22 +246,13 @@ interface INFTPool is IPool {
     event AddNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
 
     /**
-     *  @notice Emitted when lender claims unencumbered collateral.
-     *  @param  claimer_ Recipient that claimed collateral.
-     *  @param  price_   Price at which unencumbered collateral was claimed.
-     *  @param  tokenId_ Token ID of the collateral to be claimed from the pool.
-     *  @param  lps_     The amount of LP tokens burned in the claim.
-     */
-    event ClaimNFTCollateral(address indexed claimer_, uint256 indexed price_, uint256 indexed tokenId_, uint256 lps_);
-
-    /**
      *  @notice Emitted when lender claims multiple unencumbered NFT collateral.
      *  @param  claimer_  Recipient that claimed collateral.
      *  @param  price_    Price at which unencumbered collateral was claimed.
      *  @param  tokenIds_ Array of unencumbered tokenIds claimed as collateral.
      *  @param  lps_      The amount of LP tokens burned in the claim.
      */
-    event ClaimNFTCollateralMultiple(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_, uint256 lps_);
+    event ClaimNFTCollateral(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_, uint256 lps_);
 
     /**
      *  @notice Emitted when NFT collateral is exchanged for quote tokens.
@@ -269,18 +264,11 @@ interface INFTPool is IPool {
     event PurchaseWithNFTs(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256[] tokenIds_);
 
     /**
-     *  @notice Emitted when borrower removes collateral from the pool.
-     *  @param  borrower_ `msg.sender`.
-     *  @param  tokenId_  Token ID of the collateral removed from the pool.
-     */
-    event RemoveNFTCollateral(address indexed borrower_, uint256 indexed tokenId_);
-
-    /**
      *  @notice Emitted when borrower removes multiple collateral from the pool.
      *  @param  borrower_ `msg.sender`.
      *  @param  tokenIds_ Array of tokenIds removed from the pool.
      */
-    event RemoveNFTCollateralMultiple(address indexed borrower_, uint256[] tokenIds_);
+    event RemoveNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
 
     /*****************************/
     /*** Inititalize Functions ***/
@@ -306,7 +294,7 @@ interface INFTPool is IPool {
      *  @notice Called by borrowers to remove multiple NFTs from the pool.
      *  @param  tokenIds_ NFT token ids to be removed as collateral from the pool.
      */
-    function removeCollateralMultiple(uint256[] calldata tokenIds_) external;
+    function removeCollateral(uint256[] calldata tokenIds_) external;
 
     /*********************************/
     /*** Lender External Functions ***/
@@ -318,7 +306,7 @@ interface INFTPool is IPool {
      *  @param  tokenIds_  NFT token ids to be claimed from the pool.
      *  @param  price_     The bucket from which unencumbered collateral will be claimed.
      */
-    function claimCollateralMultiple(address recipient_, uint256[] calldata tokenIds_, uint256 price_) external;
+    function claimCollateral(address recipient_, uint256[] calldata tokenIds_, uint256 price_) external;
 
     /*******************************/
     /*** Pool External Functions ***/
@@ -332,5 +320,5 @@ interface INFTPool is IPool {
      *  @param  price_    The purchasing price of quote token.
      *  @param  tokenIds_ NFT token ids to be purchased from the pool.
      */
-    function purchaseBidNFTCollateral(uint256 amount_, uint256 price_, uint256[] calldata tokenIds_) external;
+    function purchaseBid(uint256 amount_, uint256 price_, uint256[] calldata tokenIds_) external;
 }

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -4,20 +4,15 @@ pragma solidity 0.8.14;
 library Maths {
 
     uint256 public constant WAD = 10**18;
-    uint256 public constant ONE_WAD = 1 * WAD;
-
     uint256 public constant RAY = 10**27;
-    uint256 public constant ONE_RAY = 1 * RAY;
-
     uint256 public constant RAD = 10**45;
-    uint256 public constant ONE_RAD = 1 * RAD;
 
     function wmul(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * y + WAD / 2) / WAD;
+        return (x * y + 10**18 / 2) / 10**18;
     }
 
     function wdiv(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * WAD + y / 2) / y;
+        return (x * 10**18 + y / 2) / y;
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -29,19 +24,19 @@ library Maths {
     }
 
     function wad(uint256 x) internal pure returns (uint256) {
-        return x * WAD;
+        return x * 10**18;
     }
 
     function ray(uint256 x) internal pure returns (uint256) {
-        return x * RAY;
+        return x * 10**27;
     }
 
     function rmul(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * y + RAY / 2) / RAY;
+        return (x * y + 10**27 / 2) / 10**27;
     }
 
     function rdiv(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * RAY + y / 2) / y;
+        return (x * 10**27 + y / 2) / y;
     }
 
     /** @notice Divides a WAD by a RAY and returns a RAY */
@@ -60,7 +55,7 @@ library Maths {
     }
 
     function rpow(uint256 x, uint256 n) internal pure returns (uint256 z) {
-        z = n % 2 != 0 ? x : RAY;
+        z = n % 2 != 0 ? x : 10**27;
 
         for (n /= 2; n != 0; n /= 2) {
             x = rmul(x, x);
@@ -72,7 +67,7 @@ library Maths {
     }
 
     function rad(uint256 x) internal pure returns (uint256) {
-        return x * RAD;
+        return x * 10**45;
     }
 
     function wadToRay(uint256 x) internal pure returns (uint256) {
@@ -80,7 +75,7 @@ library Maths {
     }
 
     function wadToRad(uint256 x) internal pure returns (uint256) {
-        return x * RAY;
+        return x * 10**27;
     }
 
     function rayToWad(uint256 x) internal pure returns (uint256) {


### PR DESCRIPTION
Reducing ERC721Pool size from 29643 to 26761 bytes and ERC20Pool from 25122 to 24784 bytes
I noticed that if replacing Maths.WAD / RAY with inline 10 ** 18 / 10 ** 27 in these contracts drastically reduce the size but will keep this as a last resort in case moving to custom errors is still not enough (from my quick tests it is enough)

Changes:
- keep same contract structure / functions for NFT collateral pool. Remove `multiple` and make multiple default, callers could pass an array with one element if adding / removing / claiming single token
- iterate only once through token ids, remove internal functions to check token ids
- ERC271 initialize subset to reuse initialize function
- Refactor estimate price function, remove view from buckets  and keep view only at pool contract level
- Remove Maths.ONE_WAD and use Maths.WAD which is equivalent