### PR TITLE
refactor file structure to bring external facing contracts to top lev…

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -7,14 +7,14 @@ import { Clone } from "@clones/Clone.sol";
 import { ERC20 }     from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import { ERC20BorrowerManager } from "./ERC20BorrowerManager.sol";
-import { ERC20BucketsManager }  from "./ERC20BucketsManager.sol";
-import { IERC20Pool }           from "./interfaces/IERC20Pool.sol";
+import { ERC20BorrowerManager } from "./base/erc20/ERC20BorrowerManager.sol";
+import { ERC20BucketsManager }  from "./base/erc20/ERC20BucketsManager.sol";
+import { IERC20Pool }           from "./base/erc20/interfaces/IERC20Pool.sol";
 
-import { Pool } from "../base/Pool.sol";
+import { Pool } from "./base/Pool.sol";
 
-import { BucketMath } from "../libraries/BucketMath.sol";
-import { Maths }      from "../libraries/Maths.sol";
+import { BucketMath } from "./libraries/BucketMath.sol";
+import { Maths }      from "./libraries/Maths.sol";
 
 contract ERC20Pool is IERC20Pool, ERC20BorrowerManager, ERC20BucketsManager, Pool {
 

--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -5,9 +5,9 @@ import { ClonesWithImmutableArgs } from "@clones/ClonesWithImmutableArgs.sol";
 
 import { ERC20Pool } from "./ERC20Pool.sol";
 
-import { PoolDeployer } from "../base/PoolDeployer.sol";
+import { PoolDeployer } from "./base/PoolDeployer.sol";
 
-import { IPoolFactory } from "../base/interfaces/IPoolFactory.sol";
+import { IPoolFactory } from "./base/interfaces/IPoolFactory.sol";
 
 contract ERC20PoolFactory is IPoolFactory, PoolDeployer {
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -11,14 +11,14 @@ import { SafeERC20 }     from "@openzeppelin/contracts/token/ERC20/utils/SafeERC
 import { ERC721 }        from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { ERC721BorrowerManager } from "./ERC721BorrowerManager.sol";
-import { ERC721BucketsManager }  from "./ERC721BucketsManager.sol";
-import { IERC721Pool }           from "./interfaces/IERC721Pool.sol";
+import { ERC721BorrowerManager } from "./base/erc721/ERC721BorrowerManager.sol";
+import { ERC721BucketsManager }  from "./base/erc721/ERC721BucketsManager.sol";
+import { IERC721Pool }           from "./base/erc721/interfaces/IERC721Pool.sol";
 
-import { Pool } from "../base/Pool.sol";
+import { Pool } from "./base/Pool.sol";
 
-import { BucketMath } from "../libraries/BucketMath.sol";
-import { Maths }      from "../libraries/Maths.sol";
+import { BucketMath } from "./libraries/BucketMath.sol";
+import { Maths }      from "./libraries/Maths.sol";
 
 contract ERC721Pool is IERC721Pool, ERC721BorrowerManager, ERC721BucketsManager, Pool {
 

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -6,9 +6,9 @@ import { ClonesWithImmutableArgs } from "@clones/ClonesWithImmutableArgs.sol";
 
 import { ERC721Pool } from "./ERC721Pool.sol";
 
-import { PoolDeployer } from "../base/PoolDeployer.sol";
+import { PoolDeployer } from "./base/PoolDeployer.sol";
 
-import { IERC721PoolFactory } from "./interfaces/IERC721PoolFactory.sol";
+import { IERC721PoolFactory } from "./base/erc721/interfaces/IERC721PoolFactory.sol";
 
 // TODO: add IERC721PoolFactory
 contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -3,15 +3,15 @@ pragma solidity 0.8.14;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-import { ILenderManager }   from "./interfaces/ILenderManager.sol";
-import { IPool }            from "./interfaces/IPool.sol";
-import { IPositionManager } from "./interfaces/IPositionManager.sol";
+import { ILenderManager }   from "./base/interfaces/ILenderManager.sol";
+import { IPool }            from "./base/interfaces/IPool.sol";
+import { IPositionManager } from "./base/interfaces/IPositionManager.sol";
 
-import { Multicall }   from "./Multicall.sol";
-import { PermitERC20 } from "./PermitERC20.sol";
-import { PositionNFT } from "./PositionNFT.sol";
+import { Multicall }   from "./base/Multicall.sol";
+import { PermitERC20 } from "./base/PermitERC20.sol";
+import { PositionNFT } from "./base/PositionNFT.sol";
 
-import { Maths } from "../libraries/Maths.sol";
+import { Maths } from "./libraries/Maths.sol";
 
 contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC20 {
 

--- a/src/_test/ERC20Pool/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool/ERC20Pool.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolBid.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBid.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool  }      from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory} from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool  }      from "../../ERC20Pool.sol";
+import { ERC20PoolFactory} from "../../ERC20PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { BucketsManager } from "../../base/BucketsManager.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { BucketsManager } from "../../base/BucketsManager.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.14;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { PoolDeployer } from "../../base/PoolDeployer.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolInflator.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInflator.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.14;
 
 import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { CollateralToken, QuoteToken }            from "../utils/Tokens.sol";
 import { DSTestPlus }                             from "../utils/DSTestPlus.sol";

--- a/src/_test/ERC20Pool/ERC20PoolInterestRate.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRate.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { DSTestPlus }                             from "../utils/DSTestPlus.sol";
 import { CollateralToken, QuoteToken }            from "../utils/Tokens.sol";

--- a/src/_test/ERC20Pool/ERC20PoolLiquidate.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidate.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { Maths } from "../../libraries/Maths.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolMove.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolMove.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolPerformanceTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPerformanceTest.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { DSTestPlus }                             from "../utils/DSTestPlus.sol";
 import { CollateralToken, QuoteToken }            from "../utils/Tokens.sol";

--- a/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { DSTestPlus }                                    from "../utils/DSTestPlus.sol";
 import { CollateralToken, CollateralTokenWith6Decimals } from "../utils/Tokens.sol";

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC20Pool/ERC20PoolRepay.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolRepay.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../ERC20PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC721Pool/ERC721Pool.t.sol
+++ b/src/_test/ERC721Pool/ERC721Pool.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { DSTestPlus }                                         from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken }                     from "../utils/Tokens.sol";

--- a/src/_test/ERC721Pool/ERC721PoolBid.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBid.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { IPool } from "../../base/interfaces/IPool.sol";
 

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { DSTestPlus }                                         from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken }                     from "../utils/Tokens.sol";

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { DSTestPlus }                                         from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken }                     from "../utils/Tokens.sol";

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { DSTestPlus }                                         from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken }                     from "../utils/Tokens.sol";

--- a/src/_test/ERC721Pool/ERC721PoolInterestRate.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolInterestRate.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+import { ERC721Pool }        from "../../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../ERC721PoolFactory.sol";
 
 import { DSTestPlus }                                         from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken }                     from "../utils/Tokens.sol";

--- a/src/_test/Multicall.t.sol
+++ b/src/_test/Multicall.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../erc20/ERC20PoolFactory.sol";
 
-import { PositionManager } from "../base/PositionManager.sol";
+import { PositionManager } from "../PositionManager.sol";
 
 import { IPositionManager } from "../base/interfaces/IPositionManager.sol";
 

--- a/src/_test/Multicall.t.sol
+++ b/src/_test/Multicall.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../ERC20PoolFactory.sol";
 
 import { PositionManager } from "../PositionManager.sol";
 

--- a/src/_test/Permit.t.sol
+++ b/src/_test/Permit.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../erc20/ERC20PoolFactory.sol";
 
-import { PositionManager } from "../base/PositionManager.sol";
+import { PositionManager } from "../PositionManager.sol";
 
 import { IPositionManager } from "../base/interfaces/IPositionManager.sol";
 

--- a/src/_test/Permit.t.sol
+++ b/src/_test/Permit.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { ERC20Pool }        from "../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory } from "../erc20/ERC20PoolFactory.sol";
+import { ERC20Pool }        from "../ERC20Pool.sol";
+import { ERC20PoolFactory } from "../ERC20PoolFactory.sol";
 
 import { PositionManager } from "../PositionManager.sol";
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -8,10 +8,10 @@ import { UserWithCollateral, UserWithNFTCollateral, UserWithQuoteToken, UserWith
 
 import { Maths } from "../libraries/Maths.sol";
 
-import { ERC20Pool }         from "../erc20/ERC20Pool.sol";
-import { ERC20PoolFactory}   from "../erc20/ERC20PoolFactory.sol";
-import { ERC721Pool }        from "../erc721/ERC721Pool.sol";
-import { ERC721PoolFactory } from "../erc721/ERC721PoolFactory.sol";
+import { ERC20Pool }         from "../ERC20Pool.sol";
+import { ERC20PoolFactory}   from "../ERC20PoolFactory.sol";
+import { ERC721Pool }        from "../ERC721Pool.sol";
+import { ERC721PoolFactory } from "../ERC721PoolFactory.sol";
 
 import { PositionManager } from "../PositionManager.sol";
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -10,7 +10,7 @@ import { Maths } from "../libraries/Maths.sol";
 import { ERC20Pool }       from "../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory} from "../erc20/ERC20PoolFactory.sol";
 
-import { PositionManager } from "../base/PositionManager.sol";
+import { PositionManager } from "../PositionManager.sol";
 
 import { IPositionManager } from "../base/interfaces/IPositionManager.sol";
 

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.14;
 import { IERC20 }  from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
-import { ERC20Pool }  from "../../erc20/ERC20Pool.sol";
-import { ERC721Pool } from "../../erc721/ERC721Pool.sol";
+import { ERC20Pool }  from "../../ERC20Pool.sol";
+import { ERC721Pool } from "../../ERC721Pool.sol";
 
 contract UserWithCollateral {
 

--- a/src/base/erc20/ERC20BorrowerManager.sol
+++ b/src/base/erc20/ERC20BorrowerManager.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.14;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { BorrowerManager } from "../base/BorrowerManager.sol";
+import { BorrowerManager } from "../BorrowerManager.sol";
 
 import { ERC20InterestManager }  from "./ERC20InterestManager.sol";
 import { IERC20BorrowerManager } from "./interfaces/IERC20BorrowerManager.sol";
 
-import { Maths } from "../libraries/Maths.sol";
+import { Maths } from "../../libraries/Maths.sol";
 
 /**
  *  @notice Lender Management related functionality

--- a/src/base/erc20/ERC20BucketsManager.sol
+++ b/src/base/erc20/ERC20BucketsManager.sol
@@ -6,9 +6,9 @@ import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableS
 
 import { console } from "@std/console.sol";
 
-import { BucketsManager } from "../base/BucketsManager.sol";
+import { BucketsManager } from "../BucketsManager.sol";
 
-import "../libraries/Maths.sol";
+import "../../libraries/Maths.sol";
 
 abstract contract ERC20BucketsManager is BucketsManager {
 

--- a/src/base/erc20/ERC20InterestManager.sol
+++ b/src/base/erc20/ERC20InterestManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.14;
 
 import { IERC20BorrowerManager } from "./interfaces/IERC20BorrowerManager.sol";
 
-import { InterestManager } from "../base/InterestManager.sol";
+import { InterestManager } from "../InterestManager.sol";
 
 /**
  *  @notice Interest related functionality.

--- a/src/base/erc20/interfaces/IERC20BorrowerManager.sol
+++ b/src/base/erc20/interfaces/IERC20BorrowerManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.14;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { IBorrowerManager } from "../../base/interfaces/IBorrowerManager.sol";
+import { IBorrowerManager } from "../../interfaces/IBorrowerManager.sol";
 
 /**
  *  @title Ajna ERC20 Borrower Manager

--- a/src/base/erc20/interfaces/IERC20Pool.sol
+++ b/src/base/erc20/interfaces/IERC20Pool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.14;
 
-import { IPool } from "../../base/interfaces/IPool.sol";
+import { IPool } from "../../interfaces/IPool.sol";
 
 /**
  * @title Ajna ERC20 Pool

--- a/src/base/erc721/ERC721BorrowerManager.sol
+++ b/src/base/erc721/ERC721BorrowerManager.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.14;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { BorrowerManager } from "../base/BorrowerManager.sol";
+import { BorrowerManager } from "../BorrowerManager.sol";
 
 import { IERC721BorrowerManager } from "./interfaces/IERC721BorrowerManager.sol";
 import { ERC721InterestManager }  from "./ERC721InterestManager.sol";
 
-import { Maths } from "../libraries/Maths.sol";
+import { Maths } from "../../libraries/Maths.sol";
 
 /**
  *  @notice Lender Management related functionality

--- a/src/base/erc721/ERC721BucketsManager.sol
+++ b/src/base/erc721/ERC721BucketsManager.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.14;
 import { BitMaps }       from "@openzeppelin/contracts/utils/structs/BitMaps.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { BucketsManager } from "../base/BucketsManager.sol";
+import { BucketsManager } from "../BucketsManager.sol";
 
-import "../libraries/Maths.sol";
+import "../../libraries/Maths.sol";
 
 abstract contract ERC721BucketsManager is BucketsManager {
 

--- a/src/base/erc721/ERC721InterestManager.sol
+++ b/src/base/erc721/ERC721InterestManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.14;
 
 import { IERC721BorrowerManager } from "./interfaces/IERC721BorrowerManager.sol";
 
-import { InterestManager } from "../base/InterestManager.sol";
+import { InterestManager } from "../InterestManager.sol";
 
 /**
  *  @notice Interest related functionality.

--- a/src/base/erc721/interfaces/IERC721BorrowerManager.sol
+++ b/src/base/erc721/interfaces/IERC721BorrowerManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.14;
 
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import { IBorrowerManager } from "../../base/interfaces/IBorrowerManager.sol";
+import { IBorrowerManager } from "../../interfaces/IBorrowerManager.sol";
 
 /**
  *  @title Ajna NFT Borrower Manager

--- a/src/base/erc721/interfaces/IERC721Pool.sol
+++ b/src/base/erc721/interfaces/IERC721Pool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.14;
 
-import { IPool } from "../../base/interfaces/IPool.sol";
+import { IPool } from "../../interfaces/IPool.sol";
 
 /**
  * @title Ajna ERC721 Pool

--- a/src/base/erc721/interfaces/IERC721PoolFactory.sol
+++ b/src/base/erc721/interfaces/IERC721PoolFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.14;
 
-import { IPoolFactory } from "../../base/interfaces/IPoolFactory.sol";
+import { IPoolFactory } from "../../interfaces/IPoolFactory.sol";
 
 /**
  *  @title Ajna Pool Factory


### PR DESCRIPTION
The goal of this PR is to refactor the file structure to make navigation a bit easier. All top level, externally facing contracts like ERC20Pool, ERC721Pool, and PositionManager are brought to the top level of the `src/` directory. `base/` directory is now exclusively used by abstract contracts. The top level of `base/` is now for shared abstract contracts used by the top level of external contracts directly, with the separate erc20, erc721 directories hosting pool type specific content.