### PR TITLE
add moveLiq to PositionManager

### DIFF
--- a/src/_test/Multicall.t.sol
+++ b/src/_test/Multicall.t.sol
@@ -72,7 +72,7 @@ contract MulticallTest is DSTestPlus {
         pricesToMemorialize[2] = priceThree;
 
         IPositionManager.MemorializePositionsParams memory memorializeParams = IPositionManager.MemorializePositionsParams(
-            tokenId, testAddress, address(_pool), pricesToMemorialize
+            tokenId, testAddress, pricesToMemorialize
         );
 
         // Prepare to add quotte tokens to a new price bucket and associate with NFT
@@ -86,7 +86,7 @@ contract MulticallTest is DSTestPlus {
 
         // https://ethereum.stackexchange.com/questions/65980/passing-struct-as-an-argument-in-call
         callsToExecute[0] = abi.encodeWithSignature(
-            "memorializePositions((uint256,address,address,uint256[]))",
+            "memorializePositions((uint256,address,uint256[]))",
             memorializeParams
         );
         callsToExecute[1] = abi.encodeWithSignature(

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -772,4 +772,36 @@ contract PositionManagerTest is DSTestPlus {
 
     function testGetPositionValueInQuoteTokens() external {}
 
+    function testMoveLiquidity() external {
+        // generate a new address
+        address testAddress = generateAddress();
+        uint256 mintAmount  = 10000 * 1e18;
+        uint256 mintPrice   = _p1004;
+        mintAndApproveQuoteTokens(testAddress, mintAmount);
+
+        uint256 tokenId = mintNFT(testAddress, address(_pool));
+
+        // check newly minted position with no liquidity added
+        (, address originalPositionOwner, ) = _positionManager.positions(tokenId);
+        uint256 originalLPTokens = _positionManager.getLPTokens(tokenId, mintPrice);
+
+        assertEq(originalPositionOwner, testAddress);
+        assertEq(originalLPTokens, 0);
+
+        // add initial liquidity
+        increaseLiquidity(tokenId, testAddress, address(_pool), mintAmount / 4, mintPrice);
+
+        // construct move liquidity params
+        IPositionManager.MoveLiquidityParams memory moveLiquidityParams = IPositionManager.MoveLiquidityParams(
+            testAddress, tokenId, mintPrice, _p502
+        );
+
+        // move liquidity
+        vm.expectEmit(true, true, true, true);
+        emit MoveLiquidity(testAddress, tokenId);
+        _positionManager.moveLiquidity(moveLiquidityParams);
+
+        // check state
+    }
+
 }

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -160,7 +160,7 @@ contract PositionManagerTest is DSTestPlus {
         prices[1] = priceTwo;
         prices[2] = priceThree;
         IPositionManager.MemorializePositionsParams memory memorializeParams = IPositionManager.MemorializePositionsParams(
-            tokenId, testAddress, address(_pool), prices
+            tokenId, testAddress, prices
         );
 
         // should revert if access hasn't been granted to transfer LP tokens
@@ -257,7 +257,7 @@ contract PositionManagerTest is DSTestPlus {
         prices[1] = priceTwo;
         prices[2] = priceThree;
         IPositionManager.MemorializePositionsParams memory memorializeParams = IPositionManager.MemorializePositionsParams(
-            tokenId1, testLender1, address(_pool), prices
+            tokenId1, testLender1, prices
         );
 
         // should revert if access hasn't been granted to transfer LP tokens
@@ -306,7 +306,7 @@ contract PositionManagerTest is DSTestPlus {
         prices[0] = priceOne;
         prices[1] = priceFour;
         memorializeParams = IPositionManager.MemorializePositionsParams(
-            tokenId2, testLender2, address(_pool), prices
+            tokenId2, testLender2, prices
         );
 
         vm.expectEmit(true, true, true, true);

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -781,15 +781,13 @@ contract PositionManagerTest is DSTestPlus {
 
         uint256 tokenId = mintNFT(testAddress, address(_pool));
 
-        // check newly minted position with no liquidity added
-        (, address originalPositionOwner, ) = _positionManager.positions(tokenId);
-        uint256 originalLPTokens = _positionManager.getLPTokens(tokenId, mintPrice);
-
-        assertEq(originalPositionOwner, testAddress);
-        assertEq(originalLPTokens, 0);
-
         // add initial liquidity
         increaseLiquidity(tokenId, testAddress, address(_pool), mintAmount / 4, mintPrice);
+
+        // check pool state
+        assertEq(_pool.lpBalance(testAddress, mintPrice),               0);
+        assertGt(_pool.lpBalance(address(_positionManager), mintPrice), 0);
+        assertEq(_pool.lpBalance(address(_positionManager), _p502),     0);
 
         // construct move liquidity params
         IPositionManager.MoveLiquidityParams memory moveLiquidityParams = IPositionManager.MoveLiquidityParams(
@@ -801,7 +799,10 @@ contract PositionManagerTest is DSTestPlus {
         emit MoveLiquidity(testAddress, tokenId);
         _positionManager.moveLiquidity(moveLiquidityParams);
 
-        // check state
+        // check pool state
+        assertEq(_pool.lpBalance(testAddress, mintPrice),               0);
+        assertEq(_pool.lpBalance(address(_positionManager), mintPrice), 0);
+        assertGt(_pool.lpBalance(address(_positionManager), _p502),     0);
     }
 
 }

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -60,6 +60,7 @@ abstract contract DSTestPlus is Test {
     event IncreaseLiquidity(address indexed lender_, uint256 indexed price_, uint256 amount_);
     event MemorializePosition(address indexed lender_, uint256 tokenId_);
     event Mint(address indexed lender_, address indexed pool_, uint256 tokenId_);
+    event MoveLiquidity(address indexed owner_, uint256 tokenId_);
 
     // Pool events
     event AddCollateral(address indexed borrower_, uint256 amount_);

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -25,6 +25,15 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
     constructor() PositionNFT("Ajna Positions NFT-V1", "AJNA-V1-POS", "1") {}
 
+
+    // TODO: track list of prices associated with a positions
+
+    // TODO: enable operations on multiple price buckets at a time when decreasing liquidity, or increasing liquidity vs multicall
+
+    // TODO: check using tokenId to get pool instead of passing pool directly gas
+
+    // TODO: use msg.sender instead of _owner?
+
     /***********************/
     /*** State Variables ***/
     /***********************/
@@ -184,8 +193,16 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         emit Mint(params_.recipient, params_.pool, tokenId_);
     }
 
-    // TODO: implement moveLiquidity function
-    function moveLiquidity() external {}
+    function moveLiquidity(MoveLiquidityParams calldata params_) external {
+        address pool = poolKey[params_.tokenId];
+
+        uint256 lpBalance = IPool(pool).lpBalance(params_.owner, params_.fromPrice);
+        console.log(lpBalance);
+        (, uint256 maxQuote) = IPool(pool).getLPTokenExchangeValue(lpBalance, params_.fromPrice);
+        IPool(pool).moveQuoteToken(maxQuote, params_.fromPrice, params_.toPrice);
+
+        emit MoveLiquidity(params_.owner, params_.tokenId);
+    }
 
     /**************************/
     /*** Internal Functions ***/

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -214,6 +214,11 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         );
         pool.moveQuoteToken(maxQuote, params_.fromPrice, params_.toPrice);
 
+        // update prices set at which a position has liquidity
+        positionPrices[params_.tokenId].remove(params_.fromPrice);
+        positionPrices[params_.tokenId].add(params_.toPrice);
+
+
         emit MoveLiquidity(params_.owner, params_.tokenId);
     }
 

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -27,12 +27,6 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
     constructor() PositionNFT("Ajna Positions NFT-V1", "AJNA-V1-POS", "1") {}
 
-    // TODO: enable operations on multiple price buckets at a time when decreasing liquidity, or increasing liquidity vs multicall
-
-    // TODO: check using tokenId to get pool instead of passing pool directly gas
-
-    // TODO: use msg.sender instead of _owner? -> causes problems w/ permit and third party contracts
-
     /***********************/
     /*** State Variables ***/
     /***********************/

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -196,9 +196,9 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     function moveLiquidity(MoveLiquidityParams calldata params_) external {
         address pool = poolKey[params_.tokenId];
 
-        uint256 lpBalance = IPool(pool).lpBalance(params_.owner, params_.fromPrice);
-        console.log(lpBalance);
-        (, uint256 maxQuote) = IPool(pool).getLPTokenExchangeValue(lpBalance, params_.fromPrice);
+        (, uint256 maxQuote) = IPool(pool).getLPTokenExchangeValue(
+            positions[params_.tokenId].lpTokens[params_.fromPrice], params_.fromPrice
+        );
         IPool(pool).moveQuoteToken(maxQuote, params_.fromPrice, params_.toPrice);
 
         emit MoveLiquidity(params_.owner, params_.tokenId);

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -32,7 +32,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
     // TODO: check using tokenId to get pool instead of passing pool directly gas
 
-    // TODO: use msg.sender instead of _owner?
+    // TODO: use msg.sender instead of _owner? -> causes problems w/ permit and third party contracts
 
     /***********************/
     /*** State Variables ***/
@@ -157,11 +157,12 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     /// TODO: (X) prices can be memorialized at a time
     function memorializePositions(MemorializePositionsParams calldata params_) external override {
         Position storage position = positions[params_.tokenId];
+        IPool pool = IPool(poolKey[params_.tokenId]);
 
         uint256 pricesLength = params_.prices.length;
         for (uint256 i = 0; i < pricesLength; ) {
             // update PositionManager accounting
-            position.lpTokens[params_.prices[i]] = IPool(params_.pool).lpBalance(
+            position.lpTokens[params_.prices[i]] = pool.lpBalance(
                 params_.owner,
                 params_.prices[i]
             );
@@ -173,7 +174,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         }
 
         // update pool lp token accounting and transfer ownership of lp tokens to PositionManager contract
-        IPool(params_.pool).transferLPTokens(params_.owner, address(this), params_.prices);
+        pool.transferLPTokens(params_.owner, address(this), params_.prices);
 
         emit MemorializePosition(params_.owner, params_.tokenId);
     }

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -194,13 +194,13 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         emit Mint(params_.recipient, params_.pool, tokenId_);
     }
 
-    function moveLiquidity(MoveLiquidityParams calldata params_) external {
-        address pool = poolKey[params_.tokenId];
+    function moveLiquidity(MoveLiquidityParams calldata params_) external override {
+        IPool pool = IPool(poolKey[params_.tokenId]);
 
-        (, uint256 maxQuote) = IPool(pool).getLPTokenExchangeValue(
+        (, uint256 maxQuote) = pool.getLPTokenExchangeValue(
             positions[params_.tokenId].lpTokens[params_.fromPrice], params_.fromPrice
         );
-        IPool(pool).moveQuoteToken(maxQuote, params_.fromPrice, params_.toPrice);
+        pool.moveQuoteToken(maxQuote, params_.fromPrice, params_.toPrice);
 
         emit MoveLiquidity(params_.owner, params_.tokenId);
     }

--- a/src/base/interfaces/IPositionManager.sol
+++ b/src/base/interfaces/IPositionManager.sol
@@ -238,10 +238,17 @@ interface IPositionManager {
 
     /**
      *  @notice Called by lenders to add quote tokens and receive a representative NFT.
-     *  @param  params_  Calldata struct supplying inputs required to add quote tokens, and receive the NFT.
+     *  @param  params_  Calldata struct supplying inputs required to mint a position NFT.
      *  @return tokenId_ The tokenId of the newly minted NFT.
      */
     function mint(MintParams calldata params_) external payable returns (uint256 tokenId_);
+
+    /**
+     *  @notice Called by lenders to move liquidity between two price buckets.
+     *  @param  params_  Calldata struct supplying inputs required to move liquidity tokens.
+     */
+    function moveLiquidity(MoveLiquidityParams calldata params_) external;
+
 
     /**********************/
     /*** View Functions ***/

--- a/src/base/interfaces/IPositionManager.sol
+++ b/src/base/interfaces/IPositionManager.sol
@@ -150,13 +150,11 @@ interface IPositionManager {
      *  @notice Struct holding parameters for memorializing positions.
      *  @param  tokenId The tokenId of the NFT.
      *  @param  owner   The NFT owner address.
-     *  @param  pool    The pool address.
      *  @param  prices  The array of price buckets with LP tokens to be tracked by a NFT.
      */
     struct MemorializePositionsParams {
         uint256 tokenId;
         address owner;
-        address pool;
         uint256[] prices;
     }
 

--- a/src/base/interfaces/IPositionManager.sol
+++ b/src/base/interfaces/IPositionManager.sol
@@ -58,6 +58,13 @@ interface IPositionManager {
      */
     event Mint(address indexed lender_, address indexed pool_, uint256 tokenId_);
 
+    /**
+     *  @notice Emitted when a position's liquidity is moved between prices.
+     *  @param  lender_  Lender address.
+     *  @param  tokenId_ The tokenId of the newly minted NFT.
+     */
+    event MoveLiquidity(address indexed lender_, uint256 tokenId_);
+
     /***************/
     /*** Structs ***/
     /***************/
@@ -161,6 +168,20 @@ interface IPositionManager {
     struct MintParams {
         address recipient;
         address pool;
+    }
+
+    /**
+     *  @notice Struct holding parameters for moving the liquidity of a position.
+     *  @param  owner     The NFT owner address.
+     *  @param  tokenId   The tokenId of the NFT.
+     *  @param  fromPrice The price from which liquidity should be moved.
+     *  @param  toPrice   The Price to which liquidity should be moved.
+     */
+    struct MoveLiquidityParams {
+        address owner;
+        uint256 tokenId;
+        uint256 fromPrice;
+        uint256 toPrice;
     }
 
     /**


### PR DESCRIPTION
- Implement `moveLiquidity()` in `PositionManager` and associated test
- Add `positionPrices` set mapping to allow tracking of prices at which liquidity has been added in `PositionManager` for use by `burn()` safety check, and token rendering