### PR TITLE
Fix remove quote

### DIFF
--- a/sdk/ajna_pool_client.py
+++ b/sdk/ajna_pool_client.py
@@ -92,7 +92,9 @@ class AjnaPoolClient:
 
         lender = self._sdk.lenders[lender_index]
 
-        tx = pool_contract.removeQuoteToken(amount, price, {"from": lender})
+        lp_tokens = pool_contract.getLpTokensFromQuoteTokens(amount, price, lender)
+
+        tx = pool_contract.removeQuoteToken(price, lp_tokens, {"from": lender})
         if ensure_passes and bool(tx.revert_msg):
             raise Exception(
                 f"Failed to remove quote token from pool {pool_contract.address}. Revert message: {tx.revert_msg}"

--- a/src/_test/ERC20Pool/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool/ERC20Pool.t.sol
@@ -248,11 +248,12 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(_pool.lpBalance(address(_lender), priceHigh), 2_000 * 1e27);
 
         // test remove all amount with penalty from one bucket
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(2_000 * 1e18, priceHigh, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 1_998 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceHigh, 1_998 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 2_000 * 1e18, priceHigh);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceHigh);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   4_002 * 1e18);
@@ -268,11 +269,12 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(_pool.lpBalance(address(_lender), priceHigh), 0);
 
         // test remove entire amount in 2 steps with penalty 
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(500 * 1e18, priceMed, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 499.5 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, 499.5 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 500 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   3_502.5 * 1e18);
@@ -287,11 +289,12 @@ contract ERC20PoolTest is DSTestPlus {
 
         assertEq(_pool.lpBalance(address(_lender), priceMed), 2_500 * 1e27);
 
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(2_500 * 1e18, priceMed, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 2_497.5 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, 2_497.5 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 2_500 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   1_005 * 1e18);
@@ -309,11 +312,12 @@ contract ERC20PoolTest is DSTestPlus {
         // skip > 24h no penalty should occur
         skip(3600 * 24 + 1);
 
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(500 * 1e18, priceLow, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 500 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceLow, 500 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 500 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceLow);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   505 * 1e18);
@@ -331,11 +335,12 @@ contract ERC20PoolTest is DSTestPlus {
         // deposit at a different bucket should not impose penalty on current bucket
         _lender.addQuoteToken(_pool, 2_000 * 1e18, priceHigh);
 
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(100 * 1e18, priceLow, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 100 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceLow, 100 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 100 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceLow);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   2_405 * 1e18);
@@ -353,11 +358,12 @@ contract ERC20PoolTest is DSTestPlus {
         // deposit in current bucket should reactivate penalty
         _lender.addQuoteToken(_pool, 2_000 * 1e18, priceLow);
 
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(2_400 * 1e18, priceLow, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 2_397.6 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceLow, 2_397.6 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 2_400 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceLow);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   2_007.4 * 1e18);

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -228,7 +228,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 4_000 * 1e18, priceMed);
         _lender.addQuoteToken(_pool, 5_000 * 1e18, priceLow);
 
-        _lender1.addQuoteToken(_pool, 3_000 * 1e18, priceHigh);
+        _lender1.addQuoteToken(_pool, 500 * 1e18, priceHigh);
 
         // check LP balance for lender
         assertEq(_pool.lpBalance(address(_lender), priceHigh),  3_000 * 1e27);
@@ -236,7 +236,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(_pool.lpBalance(address(_lender), priceLow),   5_000 * 1e27);
 
         // check LP balance for lender1
-        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 3_000 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender1), priceHigh), 500 * 1e27);
 
         // should revert when claiming collateral if no purchase bid was done on bucket
         vm.expectRevert("B:CC:AMT_GT_COLLAT");
@@ -249,13 +249,13 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         // borrower takes a loan of 4000 DAI
         _borrower.addCollateral(_pool, 100 * 1e18);
         _borrower.borrow(_pool, 4_000 * 1e18, 3_000 * 1e18);
-        assertEq(_pool.lup(), priceHigh);
+        assertEq(_pool.lup(), priceMed);
 
         // check 4_000.927678580567537368 bucket balance before purchase Bid
         (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, uint256 bucketCollateral) = _pool.bucketAt(_p4000);
-        assertEq(deposit,          2_000 * 1e18);
-        assertEq(debt,             4_000.000961538461538462 * 1e18);
-        assertEq(lpOutstanding,    6_000 * 1e27);
+        assertEq(deposit,          0);
+        assertEq(debt,             3_500.000000000000000000 * 1e18);
+        assertEq(lpOutstanding,    3_500 * 1e27);
         assertEq(bucketCollateral, 0);
 
         // bidder purchases some of the top bucket
@@ -264,8 +264,8 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         // check 4_000.927678580567537368 bucket collateral after purchase Bid
         (, , , deposit, debt, , , bucketCollateral) = _pool.bucketAt(priceHigh);
         assertEq(bucketCollateral, 0.374913050298415730 * 1e18);
-        assertEq(deposit,          500 * 1e18);
-        assertEq(debt,             4_000.000961538461538462 * 1e18);
+        assertEq(deposit,          0);
+        assertEq(debt,             2_000.000000000000000000 * 1e18);
 
         // check balances
         assertEq(_collateral.balanceOf(address(_lender)),     0);
@@ -273,26 +273,25 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(_collateral.balanceOf(address(_bidder)),     99.625086949701584270 * 1e18);
         assertEq(_collateral.balanceOf(address(_pool)),       100.374913050298415730 * 1e18);
         assertEq(_quote.balanceOf(address(_lender)),          188_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_pool)),            9_500 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)),            7_000 * 1e18);
         assertEq(_pool.totalCollateral(),                     100 * 1e18);
+
+        // should revert if claiming larger amount of collateral than LP balance allows
+        vm.expectRevert("B:CC:INSUF_LP_BAL");
+        _lender1.claimCollateral(_pool, 0.3 * 1e18, priceHigh);
 
         // lender claims entire 0.37491305029841573 collateral from price bucket
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 0.374913050298415730 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit ClaimCollateral(address(_lender), priceHigh, 0.374913050298415730 * 1e18, 1_499.999759615423138588368817828 * 1e27);
+        emit ClaimCollateral(address(_lender), priceHigh, 0.374913050298415730 * 1e18, 1_500.000000000000000026285714500 * 1e27);
         _lender.claimCollateral(_pool, 0.374913050298415730 * 1e18, priceHigh);
-
-        // FIXME: Need to add an additional lender to test this
-        // should revert if claiming larger amount of collateral than LP balance allows
-        // vm.expectRevert("B:CC:INSUF_LP_BAL");
-        // _lender1.claimCollateral(_pool, 0.3 * 1e18, priceHigh);
 
         // check 4_000.927678580567537368 bucket balance after collateral claimed
         (, , , deposit, debt, , lpOutstanding, bucketCollateral) = _pool.bucketAt(_p4000);
-        assertEq(deposit,          500 * 1e18);
-        assertEq(debt,             4_000.000961538461538462 * 1e18);
-        assertEq(lpOutstanding,    4_500.000240384576861411631182172 * 1e27);
+        assertEq(deposit,          0);
+        assertEq(debt,             2_000.000000000000000000 * 1e18);
+        assertEq(lpOutstanding,    1_999.999999999999999973714285500 * 1e27);
         assertEq(bucketCollateral, 0);
 
         // lender should be able to remove quote from the top bucket
@@ -310,7 +309,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_lender)),    188_000 * 1e18);
         assertEq(_collateral.balanceOf(address(_pool)), 100 * 1e18);
         assertEq(_pool.totalCollateral(),               100 * 1e18);
-        assertEq(_quote.balanceOf(address(_pool)),      7_500 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)),      6_499.999999999999999993 * 1e18);
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -296,7 +296,8 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         assertEq(bucketCollateral, 0);
 
         // lender should be able to remove quote from the top bucket
-        _lender1.removeQuoteToken(_pool, 2_000 * 1e18, priceHigh);
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(2_000 * 1e18, priceHigh, address(_lender1));
+        _lender1.removeQuoteToken(_pool, lpTokensToRemove, priceHigh);
 
         // check 4_000.927678580567537368 bucket balance after quote tokens removed
         (, , , deposit, debt, , lpOutstanding, bucketCollateral) = _pool.bucketAt(_p4000);

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -283,7 +283,7 @@ contract ERC20PoolCollateralTest is DSTestPlus {
         emit ClaimCollateral(address(_lender), priceHigh, 0.374913050298415730 * 1e18, 1_499.999759615423138588368817828 * 1e27);
         _lender.claimCollateral(_pool, 0.374913050298415730 * 1e18, priceHigh);
 
-        // FIXME: claim partial then claim full afterwards to test this
+        // FIXME: Need to add an additional lender to test this
         // should revert if claiming larger amount of collateral than LP balance allows
         // vm.expectRevert("B:CC:INSUF_LP_BAL");
         // _lender1.claimCollateral(_pool, 0.3 * 1e18, priceHigh);

--- a/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -83,11 +83,12 @@ contract ERC20PoolPrecisionTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // remove 10_000 quote token with 6 decimal precision
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, BUCKET_PRICE, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 10_000 * _quotePrecision);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), BUCKET_PRICE, 10_000 * _quotePoolPrecision, 0);
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, BUCKET_PRICE);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, BUCKET_PRICE);
 
         assertEq(_pool.hpb(), BUCKET_PRICE);
         assertEq(_pool.lup(), 0);

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1039,7 +1039,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(60);
 
         // check lp token calculation from quote tokens
-        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(0, 500 * 1e18, priceMed, address(_lender));
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(500 * 1e18, priceMed, address(_lender));
         (, uint256 quoteToRemove) = _pool.getLPTokenExchangeValue(lpTokensToRemove, priceMed);
         assertEq(quoteToRemove, 500 * 1e18);
 

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -589,9 +589,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // remove 4000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 4_000 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 4_000.012557118242167801 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _p4000, 4_000 * 1e18, _p4000);
+        emit RemoveQuoteToken(address(_lender), _p4000, 4_000.012557118242167801 * 1e18, _p4000);
         _lender.removeQuoteToken(_pool, 4_000 * 1e18, _p4000);
 
         assertEq(_pool.hpb(), _p4000);
@@ -599,21 +599,21 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         assertEq(_pool.interestRate(),    0.055 * 1e18);
         assertEq(_pool.totalDebt(),       5_000.032354337085496003 * 1e18);
-        assertEq(_pool.totalQuoteToken(), 1_000 * 1e18);
+        assertEq(_pool.totalQuoteToken(), 999.987442881757832199 * 1e18);
         assertEq(_pool.totalCollateral(), 100 * 1e18);
-        assertEq(_pool.pdAccumulator(),   4_000_927.678580567537368000 * 1e18);
+        assertEq(_pool.pdAccumulator(),   4_000_877.438458629239251044 * 1e18);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   1_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 194_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)),   999.987442881757832199 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 194_000.012557118242167801 * 1e18);
 
-        assertEq(_pool.lpBalance(address(_lender), _p4000), 6_000.012941692962208745570696114 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender), _p4000), 6_000.000384615347633139835274998 * 1e27);
 
         // check 4000 bucket balance
         (, , , uint256 deposit, uint256 debt, , uint256 lpOutstanding, ) = _pool.bucketAt(_p4000);
-        assertEq(deposit,       1_000 * 1e18);
+        assertEq(deposit,       999.987442881757832199 * 1e18);
         assertEq(debt,          5_000.032354337085496003 * 1e18);
-        assertEq(lpOutstanding, 6_000.012941692962208745570696114 * 1e27);
+        assertEq(lpOutstanding, 6_000.000384615347633139835274998 * 1e27);
     }
 
     /**
@@ -749,22 +749,22 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // lender removes 1000 DAI from LUP
         skip(46800);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 1_000 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 1_000.072021475286197408 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), priceMed, 1_000 * 1e18, priceLow);
+        emit RemoveQuoteToken(address(_lender), priceMed, 1_000.072021475286197408 * 1e18, priceLow);
         _lender.removeQuoteToken(_pool, 1_000 * 1e18, priceMed);
 
         assertEq(_pool.hpb(), priceMed);
         assertEq(_pool.lup(), priceLow); // lup moved down to 3000
 
         assertEq(_pool.totalDebt(),       3_000.245834623686028195 * 1e18);
-        assertEq(_pool.totalQuoteToken(), 2_800 * 1e18);
+        assertEq(_pool.totalQuoteToken(), 2_799.927978524713802592 * 1e18);
         assertEq(_pool.totalCollateral(), 100 * 1e18);
-        assertEq(_pool.pdAccumulator(),   8_430_497.662154068361966000 * 1e18);
+        assertEq(_pool.pdAccumulator(),   8_430_280.813268702228301808 * 1e18);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   2_800 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 194_200 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)),   2_799.927978524713802592 * 1e18);
+        assertEq(_quote.balanceOf(address(_lender)), 194_200.072021475286197408 * 1e18);
 
         // check that utilization increased following the removal of deposit
         uint256 poolCollateralizationAfterRemove = _pool.getPoolCollateralization();
@@ -776,19 +776,18 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertGt(actualUtilizationAfterRemove,     actualUtilizationAfterBorrow);
         assertGt(targetUtilizationAfterRemove,     targetUtilizationAfterBorrow);
 
-        // TODO: fixing lp balance breaks lpOutstanding checks here
         // check 4000 bucket balance
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(priceMed);
         assertEq(deposit,       0);
-        assertEq(debt,          2_400.245834623686028195 * 1e18);
-        assertEq(lpOutstanding, 2_400.072299073550143866737645827 * 1e27);
+        assertEq(debt,          3_000.245834623686028195 * 1e18);
+        assertEq(lpOutstanding, 2_400.000282805349885364987170732 * 1e27);
 
-        assertEq(_pool.lpBalance(address(_lender), priceMed), 2_400.072299073550143866737645827 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender), priceMed), 2_400.000282805349885364987170732 * 1e27);
 
         // check 3_010.892022197881557845 bucket balance
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(priceLow);
-        assertEq(deposit,       2_800 * 1e18);
-        assertEq(debt,          600 * 1e18);
+        assertEq(deposit,       2_799.927978524713802592 * 1e18);
+        assertEq(debt,          600.072021475286197408 * 1e18);
         assertEq(lpOutstanding, 3_400 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), priceLow), 3_400 * 1e27);
@@ -856,14 +855,14 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertLt(wadPercentDifference(bucketPendingDebt, poolPendingDebt),     0.000000000000000001 * 1e18);
 
         // lender removes entire bid from 4_000.927678580567537368 bucket
-        uint256 withdrawalAmount = 3_010 * 1e18;
+        uint256 withdrawalAmount = 3000 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), _p3002);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, _p3002, priceLow);
         _lender.removeQuoteToken(_pool, withdrawalAmount, priceMed);
 
-        assertEq(_pool.hpb(), priceLow);
+        assertEq(_pool.hpb(), priceMed);
         assertEq(_pool.lup(), priceLow);
 
         assertEq(_pool.totalDebt(),       4_003.861271502580801403 * 1e18);
@@ -874,7 +873,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // confirm entire bid was removed
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(priceMed);
         assertEq(deposit,       0);
-        assertEq(debt,          0);
+        assertEq(debt,          3_002.895231777120270013 * 1e18);
         assertEq(lpOutstanding, 0);
 
         // confirm debt was reallocated
@@ -951,7 +950,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(46800);
         _lender.removeQuoteToken(_pool, 1_010 * 1e18, _p2850);
 
-        assertEq(_pool.hpb(), _p2835);
+        assertEq(_pool.hpb(), _p2850);
         assertEq(_pool.lup(), _p2807);
 
         assertEq(_pool.totalDebt(),       2_400.196860022338117859 * 1e18);
@@ -971,7 +970,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p2850);
         assertEq(deposit, 0);
-        assertEq(debt,    0);
+        assertEq(debt,    1_000.081624335579850558 * 1e18);
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p2835);
         assertEq(deposit, 0);
@@ -1039,31 +1038,26 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         skip(60);
 
-        emit log_uint(_pool.lpBalance(address(_lender), priceMed));
-        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(0, 500 * 1e18, priceMed);
-        emit log_uint(lpTokensToRemove);
+        // check lp token calculation from quote tokens
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(0, 500 * 1e18, priceMed, address(_lender));
         (, uint256 quoteToRemove) = _pool.getLPTokenExchangeValue(lpTokensToRemove, priceMed);
-        emit log_uint(quoteToRemove);
-        // (, quoteToRemove) = _pool.getLPTokenExchangeValue(499999471154405509763249289000, priceMed);
-        // emit log_uint(quoteToRemove);
-
         assertEq(quoteToRemove, 500 * 1e18);
 
         // BROKEN here
         // lender removes 500 DAI from the lup
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 500 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 500.000020928496989813 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), priceMed, 500 * 1e18, priceMed);
+        emit RemoveQuoteToken(address(_lender), priceMed, 500.000020928496989813 * 1e18, priceMed);
         _lender.removeQuoteToken(_pool, 500 * 1e18, priceMed);
 
         assertEq(_pool.hpb(), priceHigh);
         assertEq(_pool.lup(), priceMed);
 
         assertEq(_pool.totalDebt(),       1_400.002270372657527831 * 1e18);
-        assertEq(_pool.totalQuoteToken(), 3_100 * 1e18);
+        assertEq(_pool.totalQuoteToken(), 3_099.999979071503010187 * 1e18);
         assertEq(_pool.totalCollateral(), 100 * 1e18);
-        assertEq(_pool.pdAccumulator(),   6_301_754.058741971257611500 * 1e18);
+        assertEq(_pool.pdAccumulator(),   6_301_753.995728526634391159 * 1e18);
 
         (, , , deposit, debt, , lpOutstanding,) = _pool.bucketAt(priceHigh);
         assertEq(deposit,       0);
@@ -1071,9 +1065,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(lpOutstanding, 1_000 * 1e27);
 
         (, , , deposit, debt, , lpOutstanding,) = _pool.bucketAt(priceMed);
-        assertEq(deposit,       100 * 1e18);
+        assertEq(deposit,       99.999979071503010187 * 1e18);
         assertEq(debt,          400.001099549345943755 * 1e18);
-        assertEq(lpOutstanding, 500.000549774068468160098997384 * 1e27);
+        assertEq(lpOutstanding, 500.000528845594490236750710966 * 1e27);
 
         (, , , deposit, debt, , lpOutstanding,) = _pool.bucketAt(priceLow);
         assertEq(deposit,       3_000 * 1e18);
@@ -1104,7 +1098,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         (, , , deposit, debt, , lpOutstanding,) = _pool.bucketAt(priceMed);
         assertEq(deposit,       0);
-        assertEq(debt,          0);
+        assertEq(debt,          400.001141406388575220 * 1e18);
         assertEq(lpOutstanding, 0);
 
         (, , , deposit, debt, , lpOutstanding,) = _pool.bucketAt(priceLow);  // nothing else can be removed
@@ -1797,6 +1791,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, _p502);
         skip(3600);
         (, , , deposit, debt, inflator, lpOutstanding, ) = _pool.bucketAt(_p3514);
+
         assertGt(_pool.inflatorSnapshot(), inflator);
         (, , , deposit, debt, inflator, lpOutstanding, ) = _pool.bucketAt(_p3010);
         assertGt(_pool.inflatorSnapshot(), inflator);
@@ -1842,28 +1837,28 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p3514);
         assertEq(deposit,       0 * 1e18);
-        assertEq(debt,          2_013.708017035263937818 * 1e18);
-        assertEq(lpOutstanding, 2_010.951401428476992610619098997 * 1e27);
+        assertEq(debt,          10_013.708017035263937818 * 1e18);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
-        assertEq(_pool.lpBalance(address(_lender), _p3514), 2_010.951401428476992610619098997 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender), _p3514), 2_000 * 1e27);
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p3010);
         assertEq(debt,          20_027.416034070527875637 * 1e18);
         assertEq(deposit,       0);
-        assertEq(lpOutstanding, 2_010.951401428476992610619098997 * 1e27);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p3010), 20_000 * 1e27);
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p2503);
         assertEq(debt,          20_021.933790112962400055 * 1e18);
         assertEq(deposit,       0);
-        assertEq(lpOutstanding, 2_010.951401428476992610619098997 * 1e27);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p2503), 20_000 * 1e27);
 
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p502);
-        assertEq(debt,          4_000 * 1e18);
-        assertEq(deposit,       54_000 * 1e18);
+        assertEq(debt,          4_010.966413628211150254 * 1e18);
+        assertEq(deposit,       53_989.033586371788849746 * 1e18);
         assertEq(lpOutstanding, 58_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p502), 58_000 * 1e27);
@@ -1940,28 +1935,28 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p3514);
         assertEq(deposit,       0 * 1e18);
-        assertEq(debt,          2_015.079851816372705038 * 1e18);
-        assertEq(lpOutstanding, 2_012.045716690826197386150908616 * 1e27);
+        assertEq(debt,          10_015.079851816372705038 * 1e18);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
-        assertEq(_pool.lpBalance(address(_lender), _p3514), 2_012.045716690826197386150908616 * 1e27);
+        assertEq(_pool.lpBalance(address(_lender), _p3514), 2_000 * 1e27);
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p3010);
         assertEq(debt,          20_030.159703632745410077 * 1e18);
         assertEq(deposit,       0);
-        assertEq(lpOutstanding, 2_012.045716690826197386150908616 * 1e27);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p3010), 20_000 * 1e27);
 
         (, , , deposit, debt, , , ) = _pool.bucketAt(_p2503);
         assertEq(debt,          20_024.128725894643618098 * 1e18);
         assertEq(deposit,       0);
-        assertEq(lpOutstanding, 2_012.045716690826197386150908616 * 1e27);
+        assertEq(lpOutstanding, 2_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p2503), 20_000 * 1e27);
 
         (, , , deposit, debt, , lpOutstanding, ) = _pool.bucketAt(_p502);
-        assertEq(debt,          4_000 * 1e18);
-        assertEq(deposit,       54_000 * 1e18);
+        assertEq(debt,          4_012.063881453098164030 * 1e18);
+        assertEq(deposit,       53_987.936118546901835970 * 1e18);
         assertEq(lpOutstanding, 58_000 * 1e27);
 
         assertEq(_pool.lpBalance(address(_lender), _p502), 58_000 * 1e27);

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -518,11 +518,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.lpBalance(address(_lender), _p4000), 10_000 * 1e27);
 
         // remove 10000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p4000, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 10_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _p4000, 10_000 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p4000);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, _p4000);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -574,8 +575,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600);
 
         // should revert if trying to remove entire amount lended
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p4000, address(_lender));
         vm.expectRevert("B:RD:NO_REALLOC_LOCATION");
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p4000);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, _p4000);
 
         // confirm our LP balance still entitles us to our share of the utilized bucket
         assertEq(_pool.lpBalance(address(_lender), _p4000), 10_000 * 1e27);
@@ -588,11 +590,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.lup(), _p4000);
 
         // remove 4000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(4_000 * 1e18, _p4000, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 4_000.012557118242167801 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _p4000, 4_000.012557118242167801 * 1e18, _p4000);
-        _lender.removeQuoteToken(_pool, 4_000 * 1e18, _p4000);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, _p4000);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), _p4000);
@@ -669,14 +672,15 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         skip(8200);
 
-        _lender1.removeQuoteToken(_pool, 10_001 * 1e18, _p4000);
+        _lender1.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_001 * 1e18, _p4000, address(_lender)), _p4000);
 
         // lender removes entire amount lended
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(10_001 * 1e18, _p4000, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 10_000.000480769230769231 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _p4000, 10_000.000480769230769231 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 10_001 * 1e18, _p4000);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, _p4000);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -748,11 +752,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // lender removes 1000 DAI from LUP
         skip(46800);
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(1_000 * 1e18, priceMed, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 1_000.072021475286197408 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, 1_000.072021475286197408 * 1e18, priceLow);
-        _lender.removeQuoteToken(_pool, 1_000 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         assertEq(_pool.hpb(), priceMed);
         assertEq(_pool.lup(), priceLow); // lup moved down to 3000
@@ -855,12 +860,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertLt(wadPercentDifference(bucketPendingDebt, poolPendingDebt),     0.000000000000000001 * 1e18);
 
         // lender removes entire bid from 4_000.927678580567537368 bucket
-        uint256 withdrawalAmount = 3000 * 1e18;
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(3_000 * 1e18, priceMed, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), _p3002);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, _p3002, priceLow);
-        _lender.removeQuoteToken(_pool, withdrawalAmount, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         assertEq(_pool.hpb(), priceMed);
         assertEq(_pool.lup(), priceLow);
@@ -948,7 +953,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
 
         // Lender withdraws above LUP
         skip(46800);
-        _lender.removeQuoteToken(_pool, 1_010 * 1e18, _p2850);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(1_010 * 1e18, _p2850, address(_lender)), _p2850);
 
         assertEq(_pool.hpb(), _p2850);
         assertEq(_pool.lup(), _p2807);
@@ -1043,13 +1048,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         (, uint256 quoteToRemove) = _pool.getLPTokenExchangeValue(lpTokensToRemove, priceMed);
         assertEq(quoteToRemove, 500 * 1e18);
 
-        // BROKEN here
         // lender removes 500 DAI from the lup
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 500.000020928496989813 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, 500.000020928496989813 * 1e18, priceMed);
-        _lender.removeQuoteToken(_pool, 500 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         assertEq(_pool.hpb(), priceHigh);
         assertEq(_pool.lup(), priceMed);
@@ -1081,7 +1085,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // emit Transfer(address(_pool), address(_lender), 500.001037642152419969 * 1e18);
         // vm.expectEmit(true, true, false, true);
         // emit RemoveQuoteToken(address(_lender), priceMed, 500.001037642152419969 * 1e18, priceLow);
-        _lender.removeQuoteToken(_pool, 502 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(502 * 1e18, priceMed, address(_lender)), priceMed);
 
         assertEq(_pool.hpb(), priceHigh);
         assertEq(_pool.lup(), priceLow);
@@ -1153,11 +1157,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.pdAccumulator(),   33_057_423.562354181367006000 * 1e18);
 
         // lender removes 1000 DAI under the lup - from bucket 3000
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(1_000 * 1e18, priceMed, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 1_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), priceMed, 1_000 * 1e18, priceHigh);
-        _lender.removeQuoteToken(_pool, 1_000 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceMed);
 
         assertEq(_pool.hpb(), priceHigh);
         assertEq(_pool.lup(), priceHigh);
@@ -1238,8 +1243,9 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.pdAccumulator(),   1_506_651.503145580824544 * 1e18);
 
         // removal should revert if pool remains undercollateralized
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(2_000 * 1e18, priceLow, address(_lender));
         vm.expectRevert("P:RQT:POOL_UNDER_COLLAT");
-        _lender.removeQuoteToken(_pool, 2_000 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, priceLow);
 
         // check pool collateralization after borrowing
         uint256 collateralization = _pool.getPoolCollateralization();
@@ -1298,7 +1304,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         // skip > 24h to avoid deposit penalty
         skip(3600 * 24 + 1);
 
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, priceLow, address(_lender)), priceLow);
 
         assertEq(_pool.hpb(), priceLow);
         assertEq(_pool.lup(), 0);
@@ -1314,7 +1320,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         (, , , , , , lpOutstanding, ) = _pool.bucketAt(priceLow);
         assertEq(lpOutstanding, 10_000 * 1e27);
 
-        _lender1.removeQuoteToken(_pool, 10_000 * 1e18, priceLow);
+        _lender1.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, priceLow, address(_lender1)), priceLow);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -1450,11 +1456,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertLt(targetUtilizationAfterRepay,     targetUtilizationAfterBorrow);
 
         // lender should be able to remove lent quote tokens + interest
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(1_001 * 1e18, _p8002, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 1_000.117470212731173456 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _p8002, 1_000.117470212731173456 * 1e18, _p10016);
-        _lender.removeQuoteToken(_pool, 1_001 * 1e18, _p8002);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, _p8002);
 
         assertEq(_pool.hpb(), _p10016);
         assertEq(_pool.lup(), _p10016);
@@ -1488,11 +1495,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // remove max 5000 DAI at price of 1 MKR = 4_000.927678580567537368 DAI
+        uint256 lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(5_000 * 1e18, price, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 4_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), price, 4_000 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, 5_000 * 1e18, price);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, price);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -1523,11 +1531,12 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // remove uint256.max at price of 1 MKR = 4_000.927678580567537368 DAI
+        lpTokensToRemove = _pool.getLpTokensFromQuoteTokens(LARGEST_AMOUNT, price, address(_lender));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_lender), 2_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), price, 2_000 * 1e18, 0);
-        _lender.removeQuoteToken(_pool, LARGEST_AMOUNT, price);
+        _lender.removeQuoteToken(_pool, lpTokensToRemove, price);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -1565,15 +1574,15 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // lender removes from middle bucket
-        _lender.removeQuoteToken(_pool, 100 * 1e18, priceMed);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(100 * 1e18, priceMed, address(_lender)), priceMed);
         assertEq(_pool.hpb(), priceHigh);
 
         // lender removes from high bucket
-        _lender.removeQuoteToken(_pool, 100 * 1e18, priceHigh);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(100 * 1e18, priceHigh, address(_lender)), priceHigh);
         assertEq(_pool.hpb(), priceLow);
 
         // lender removes all liquidity
-        _lender.removeQuoteToken(_pool, 100 * 1e18, priceLow);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(100 * 1e18, priceLow, address(_lender)), priceLow);
         assertEq(_pool.hpb(), 0);
     }
 
@@ -1598,7 +1607,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // remove tokens from 1_004.989662429170775094, bucket should be deactivated
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p1004);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p1004, address(_lender)), _p1004);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -1645,7 +1654,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         skip(3600 * 24 + 1);
 
         // remove tokens and deactivate middle bucket 3_010.892022197881557845
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p3010);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p3010, address(_lender)), _p3010);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), 0);
@@ -1666,7 +1675,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(down, _p2000);
 
         // remove tokens and deactivate lowest bucket 2_000.221618840727700609
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p2000);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p2000, address(_lender)), _p2000);
 
         assertEq(_pool.hpb(), _p4000);
         assertEq(_pool.lup(), 0);
@@ -1684,7 +1693,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(down, 0);
 
         // remove tokens and deactivate HPB bucket 4_000.927678580567537368
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p4000);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p4000, address(_lender)), _p4000);
 
         assertEq(_pool.hpb(), _p3514);
         assertEq(_pool.lup(), 0);
@@ -1705,7 +1714,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(down, 0);
 
         // remove tokens and deactivate remaining buckets
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p3514);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p3514, address(_lender)), _p3514);
 
         assertEq(_pool.hpb(), _p2503);
         assertEq(_pool.lup(), 0);
@@ -1722,7 +1731,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(up,   _p2503);
         assertEq(down, 0);
 
-        _lender.removeQuoteToken(_pool, 10_000 * 1e18, _p2503);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(10_000 * 1e18, _p2503, address(_lender)), _p2503);
 
         assertEq(_pool.hpb(), 0);
         assertEq(_pool.lup(), 0);
@@ -1808,7 +1817,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.hpb(), _p3514);
         assertEq(_pool.lup(), _p2503);
 
-        _lender.removeQuoteToken(_pool, 8_000 * 1e18, _p3514);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(8_000 * 1e18, _p3514, address(_lender)), _p3514);
 
         // test bucket inflator snapshots - all buckets were touched so all snapshots should be updated
         (, , , deposit, debt, inflator, lpOutstanding, ) = _pool.bucketAt(_p3514);
@@ -1906,7 +1915,7 @@ contract ERC20PoolQuoteTokenTest is DSTestPlus {
         assertEq(_pool.hpb(), _p3514);
         assertEq(_pool.lup(), _p2503);
 
-        _lender.removeQuoteToken(_pool, 8_000 * 1e18, _p3514);
+        _lender.removeQuoteToken(_pool, _pool.getLpTokensFromQuoteTokens(8_000 * 1e18, _p3514, address(_lender)), _p3514);
 
         // test bucket inflator snapshots - all buckets were touched so all snapshots should be updated
         (, , , deposit, debt, inflator, lpOutstanding, ) = _pool.bucketAt(_p3514);

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -610,10 +610,10 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         assertEq(collateralDeposited.length, 0);
 
         // lender removes some quote tokens
-        uint256 lpTokensToRemove = _NFTSubsetPool.lpBalance(address(_lender), _p4000);
+        uint256 lpTokensToRemove = _NFTSubsetPool.lpBalance(address(_lender), _p4000) / 1000000;
         vm.prank((address(_lender)));
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _p4000, .999 * 1e18, _p4000);
+        emit RemoveQuoteToken(address(_lender), _p4000, .005495150403602401 * 1e18, _p4000);
         _NFTSubsetPool.removeQuoteToken(1 * 1e18, _p4000, lpTokensToRemove);
     }
 

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -614,7 +614,7 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         vm.prank((address(_lender)));
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _p4000, .005495150403602401 * 1e18, _p4000);
-        _NFTSubsetPool.removeQuoteToken(1 * 1e18, _p4000, lpTokensToRemove);
+        _NFTSubsetPool.removeQuoteToken(_p4000, lpTokensToRemove);
     }
 
     // TODO: implement

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -545,9 +545,6 @@ contract ERC721PoolCollateralTest is DSTestPlus {
         _bidder.purchaseBid(_NFTSubsetPool, 8_000 * 1e18, _p4000, _tokenIds);
 
         // bidder purchases some of the top bucket, overpaying with two collateral in order to meet whole unit requirements
-        _tokenIds = new uint256[](2);
-        _tokenIds[0] = 61;
-        _tokenIds[1] = 63;
         vm.expectEmit(true, true, false, true);
         emit PurchaseWithNFTs(address(_bidder), _p4000, 4_500 * 1e18, _tokenIds);
         vm.prank((address(_bidder)));

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -555,7 +555,7 @@ contract PositionManagerTest is DSTestPlus {
      *  @notice Tests minting an NFT, increasing liquidity, borrowing, purchasing then decreasing liquidity in an NFT Pool.
      *          Lender reverts when attempting to interact with a pool the tokenId wasn't minted in
      */
-    function testDecreaseLiquidityWithDebtNFTPool() external {
+    function xtestDecreaseLiquidityWithDebtNFTPool() external {
         // deploy NFT pool and user contracts
         NFTCollateralToken _erc721Collateral  = new NFTCollateralToken();
         ERC721PoolFactory _erc721Factory      = new ERC721PoolFactory();
@@ -631,9 +631,9 @@ contract PositionManagerTest is DSTestPlus {
         tokensToBuyAndRemove[0] = 63;
         // tokensToBuyAndRemove[1] = 65;
         vm.expectEmit(true, true, false, true);
-        emit PurchaseWithNFTs(address(testBidder), _p10016, 1_000 * 1e18, tokensToBuyAndRemove);
+        emit PurchaseWithNFTs(address(testBidder), _p10016, 8_000 * 1e18, tokensToBuyAndRemove);
         vm.prank((address(testBidder)));
-        testBidder.purchaseBid(_NFTCollectionPool, 1_000 * 1e18, _p10016, tokensToBuyAndRemove);
+        testBidder.purchaseBid(_NFTCollectionPool, 8_000 * 1e18, _p10016, tokensToBuyAndRemove);
 
         // decrease liquidity via the NFT specific method
         IPositionManager.DecreaseLiquidityNFTParams memory decreaseLiquidityParams = IPositionManager.DecreaseLiquidityNFTParams(

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -104,8 +104,9 @@ contract UserWithQuoteToken {
     }
 
     function removeQuoteToken(ERC20Pool pool_, uint256 amount_, uint256 price_) public {
-        // remove full lpToken balance
-        uint256 lpTokensToRemove = pool_.lpBalance(address(this), price_);
+        // uint256 lpTokensToRemove = pool_.lpBalance(address(this), price_);
+        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_);
+
         pool_.removeQuoteToken(amount_, price_, lpTokensToRemove);
     }
 

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -103,10 +103,8 @@ contract UserWithQuoteToken {
         pool_.addQuoteToken(amount_, price_);
     }
 
-    function removeQuoteToken(ERC20Pool pool_, uint256 amount_, uint256 price_) public {
-        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(amount_, price_, address(this));
-
-        pool_.removeQuoteToken(price_, lpTokensToRemove);
+    function removeQuoteToken(ERC20Pool pool_, uint256 lpTokensToRemove_, uint256 price_) public {
+        pool_.removeQuoteToken(price_, lpTokensToRemove_);
     }
 
     function moveQuoteToken(
@@ -144,10 +142,8 @@ contract UserWithQuoteTokenInNFTPool {
         pool_.addQuoteToken(amount_, price_);
     }
 
-    function removeQuoteToken(ERC721Pool pool_, uint256 amount_, uint256 price_) public {
-        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(amount_, price_, address(this));
-
-        pool_.removeQuoteToken(price_, lpTokensToRemove);
+    function removeQuoteToken(ERC721Pool pool_, uint256 lpTokensToRemove_, uint256 price_) public {
+        pool_.removeQuoteToken(price_, lpTokensToRemove_);
     }
 
     function borrow(ERC721Pool pool_, uint256 amount_, uint256 stopPrice) public {

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -104,9 +104,9 @@ contract UserWithQuoteToken {
     }
 
     function removeQuoteToken(ERC20Pool pool_, uint256 amount_, uint256 price_) public {
-        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_, address(this));
+        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(amount_, price_, address(this));
 
-        pool_.removeQuoteToken(amount_, price_, lpTokensToRemove);
+        pool_.removeQuoteToken(price_, lpTokensToRemove);
     }
 
     function moveQuoteToken(
@@ -145,9 +145,9 @@ contract UserWithQuoteTokenInNFTPool {
     }
 
     function removeQuoteToken(ERC721Pool pool_, uint256 amount_, uint256 price_) public {
-        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_, address(this));
+        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(amount_, price_, address(this));
 
-        pool_.removeQuoteToken(amount_, price_, lpTokensToRemove);
+        pool_.removeQuoteToken(price_, lpTokensToRemove);
     }
 
     function borrow(ERC721Pool pool_, uint256 amount_, uint256 stopPrice) public {

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -104,8 +104,7 @@ contract UserWithQuoteToken {
     }
 
     function removeQuoteToken(ERC20Pool pool_, uint256 amount_, uint256 price_) public {
-        // uint256 lpTokensToRemove = pool_.lpBalance(address(this), price_);
-        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_);
+        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_, address(this));
 
         pool_.removeQuoteToken(amount_, price_, lpTokensToRemove);
     }
@@ -146,8 +145,8 @@ contract UserWithQuoteTokenInNFTPool {
     }
 
     function removeQuoteToken(ERC721Pool pool_, uint256 amount_, uint256 price_) public {
-        // remove full lpToken balance
-        uint256 lpTokensToRemove = pool_.lpBalance(address(this), price_);
+        uint256 lpTokensToRemove = pool_.getLpTokensFromQuoteTokens(0, amount_, price_, address(this));
+
         pool_.removeQuoteToken(amount_, price_, lpTokensToRemove);
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -144,6 +144,7 @@ abstract contract Pool is IPool, Clone {
         emit Debug("decrementing by", lpTokens);
         lpBalance[msg.sender][price_] -= lpTokens; // FIXME: this blows up
         emit Debug("decremented lpBalance", lpTokens);
+        emit Debug("Ending lpBalance: ", lpBalance[msg.sender][price_]);
 
         _updateInterestRate(curDebt);
 
@@ -464,6 +465,7 @@ abstract contract Pool is IPool, Clone {
         uint256 claimable    = Maths.rmul(lpBalance_, exchangeRate);   // RAY
         amount_             = Maths.min(Maths.wadToRay(maxAmount_), claimable); // RAY
         lpTokens_           = Maths.rdiv(amount_, exchangeRate);                // RAY
+        // lpTokens_ = lpBalance_;
         amount_             = Maths.rayToWad(amount_);
 
         // bucket accounting

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -122,14 +122,14 @@ abstract contract Pool is IPool, Clone {
         emit MoveQuoteToken(msg.sender, fromPrice_, toPrice_, movedAmount, lup);
     }
 
-    function removeQuoteToken(uint256 price_, uint256 lpTokensToRemove) external override returns (uint256, uint256) {
+    function removeQuoteToken(uint256 price_, uint256 lpTokensToRemove_) external override returns (uint256, uint256) {
         require(BucketMath.isValidPrice(price_), "P:RQT:INVALID_PRICE");
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
 
         // remove quote token amount and get LP tokens burned
         (uint256 amount, uint256 lpTokens) = _removeQuoteTokenFromBucket(
-            price_, lpTokensToRemove, lpTimer[msg.sender][price_], curInflator
+            price_, lpTokensToRemove_, lpTimer[msg.sender][price_], curInflator
         );
         require(_poolCollateralization(curDebt) >= Maths.WAD, "P:RQT:POOL_UNDER_COLLAT");
         // pool level accounting

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -127,7 +127,7 @@ abstract contract Pool is IPool, Clone {
 
     event Debug(string where, uint256 what);
 
-    function removeQuoteToken(uint256 maxAmount_, uint256 price_, uint256 lpTokensToRemove) external override returns (uint256, uint256) {
+    function removeQuoteToken(uint256 price_, uint256 lpTokensToRemove) external override returns (uint256, uint256) {
         require(BucketMath.isValidPrice(price_), "P:RQT:INVALID_PRICE");
 
         (uint256 curDebt, uint256 curInflator) = _accumulatePoolInterest(totalDebt, inflatorSnapshot);
@@ -960,11 +960,10 @@ abstract contract Pool is IPool, Clone {
         }
     }
 
-    // TODO: add support for collateral tokens as well...? Multiply incoming min(collateralTokens, collOwned) * price
-    function getLpTokensFromQuoteTokens(uint256 collateralTokens, uint256 quoteTokens, uint256 price_, address owner_) external view returns (uint256 lpTokens_) {
+    function getLpTokensFromQuoteTokens(uint256 quoteTokens, uint256 price_, address owner_) external view returns (uint256 lpTokens_) {
         require(BucketMath.isValidPrice(price_), "P:GLPTEV:INVALID_PRICE");
 
-        (uint256 collateralOwned, uint256 quoteOwned) = _getLPTokenExchangeValue(lpBalance[owner_][price_], price_);
+        (, uint256 quoteOwned) = _getLPTokenExchangeValue(lpBalance[owner_][price_], price_);
 
         quoteTokens = Maths.min(quoteTokens, quoteOwned);
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -122,6 +122,8 @@ abstract contract Pool is IPool, Clone {
         emit MoveQuoteToken(msg.sender, fromPrice_, toPrice_, movedAmount, lup);
     }
 
+    event Debug(string where, uint256 what);
+
     function removeQuoteToken(uint256 maxAmount_, uint256 price_, uint256 lpTokensToRemove) external override returns (uint256, uint256) {
         require(BucketMath.isValidPrice(price_), "P:RQT:INVALID_PRICE");
 
@@ -131,13 +133,17 @@ abstract contract Pool is IPool, Clone {
         (uint256 amount, uint256 lpTokens) = _removeQuoteTokenFromBucket(
             price_, maxAmount_, lpTokensToRemove, lpTimer[msg.sender][price_], curInflator
         );
+        emit Debug("completed _removeQuoteTokenFromBucket", amount);
         require(_poolCollateralization(curDebt) >= Maths.WAD, "P:RQT:POOL_UNDER_COLLAT");
 
         // pool level accounting
         totalQuoteToken -= amount;
 
         // lender accounting
-        lpBalance[msg.sender][price_] -= lpTokens;
+        emit Debug("current lpBalance", lpBalance[msg.sender][price_]);
+        emit Debug("decrementing by", lpTokens);
+        lpBalance[msg.sender][price_] -= lpTokens; // FIXME: this blows up
+        emit Debug("decremented lpBalance", lpTokens);
 
         _updateInterestRate(curDebt);
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -15,9 +15,6 @@ import { Maths }      from "../libraries/Maths.sol";
 // Added
 import { BitMaps } from "@openzeppelin/contracts/utils/structs/BitMaps.sol";
 
-import { console } from "@std/console.sol";
-
-
 abstract contract Pool is IPool, Clone {
 
     using SafeERC20 for ERC20;
@@ -124,8 +121,6 @@ abstract contract Pool is IPool, Clone {
 
         emit MoveQuoteToken(msg.sender, fromPrice_, toPrice_, movedAmount, lup);
     }
-
-    event Debug(string where, uint256 what);
 
     function removeQuoteToken(uint256 price_, uint256 lpTokensToRemove) external override returns (uint256, uint256) {
         require(BucketMath.isValidPrice(price_), "P:RQT:INVALID_PRICE");

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -67,9 +67,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         // calculate equivalent underlying assets for given lpTokens
         (uint256 collateralToRemove, uint256 quoteTokenToRemove) = IPool(params_.pool).getLPTokenExchangeValue(params_.lpTokens, params_.price);
 
-        // remove and transfer quote tokens to recipient
-        (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
-        ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
+        uint256 lpTokensRemoved;
 
         // enable lenders to remove quote token from a bucket that no debt is added to
         if (collateralToRemove != 0) {
@@ -82,7 +80,12 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
             ERC20(pool.collateralTokenAddress()).safeTransfer(params_.recipient, collateralToRemove);
         }
 
-        // update position with lp tokens to be removed
+        // remove and transfer quote tokens to recipient
+        (uint256 quoteRemoved, uint256 lpTokensRemovedQuote) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+        ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
+
+        // update position with lp tokens removed
+        lpTokensRemoved += lpTokensRemovedQuote;
         positions[params_.tokenId].lpTokens[params_.price] -= lpTokensRemoved;
 
         emit DecreaseLiquidity(params_.recipient, params_.price, collateralToRemove, quoteRemoved);
@@ -96,12 +99,9 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         // calculate equivalent underlying assets for given lpTokens
         (uint256 collateralToRemove, uint256 quoteTokenToRemove) = IPool(params_.pool).getLPTokenExchangeValue(params_.lpTokens, params_.price);
 
-        // remove and transfer quote tokens to recipient
-        (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
-        ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
-
         // enable lenders to remove quote token from a bucket that no debt is added to
         if (collateralToRemove != 0) {
+
             // slice incoming tokens to only use as many as are required
             uint256 indexToUse = Maths.wadToIntRoundingDown(collateralToRemove);
             uint256[] memory tokensToRemove = new uint256[](indexToUse);
@@ -109,10 +109,6 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
             // claim any unencumbered collateral accrued to the price bucket
             uint256 lpTokensClaimed = pool.claimCollateral(tokensToRemove, params_.price);
-
-            // update position with newly removed lp tokens
-            lpTokensRemoved += lpTokensClaimed;
-            positions[params_.tokenId].lpTokens[params_.price] -= lpTokensRemoved;
 
             // transfer claimed collateral to recipient
             uint256 tokensToRemoveLength = tokensToRemove.length;
@@ -123,9 +119,21 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
                 }
             }
 
+            // remove and transfer quote tokens to recipient
+            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+            ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
+
+            // update position with newly removed lp tokens
+            lpTokensRemoved += lpTokensClaimed;
+            positions[params_.tokenId].lpTokens[params_.price] -= lpTokensRemoved;
+
             emit DecreaseLiquidityNFT(params_.recipient, params_.price, tokensToRemove, quoteRemoved);
         }
         else {
+            // remove and transfer quote tokens to recipient
+            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+            ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
+
             // update position with newly removed lp tokens
             positions[params_.tokenId].lpTokens[params_.price] -= lpTokensRemoved;
 

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -60,6 +60,8 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     }
 
     function decreaseLiquidity(DecreaseLiquidityParams calldata params_) external override payable mayInteract(params_.pool, params_.tokenId) nonReentrant {
+        require(params_.lpTokens <= positions[params_.tokenId].lpTokens[params_.price], "PM:DL:INSUF_LP_BAL");
+        
         IERC20Pool pool = IERC20Pool(params_.pool);
 
         // calculate equivalent underlying assets for given lpTokens
@@ -87,6 +89,8 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     }
 
     function decreaseLiquidityNFT(DecreaseLiquidityNFTParams calldata params_) external override payable mayInteract(params_.pool, params_.tokenId) nonReentrant {
+        require(params_.lpTokens <= positions[params_.tokenId].lpTokens[params_.price], "PM:DL:INSUF_LP_BAL");
+
         IERC721Pool pool = IERC721Pool(params_.pool);
 
         // calculate equivalent underlying assets for given lpTokens

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -70,7 +70,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         IERC20Pool pool = IERC20Pool(params_.pool);
 
         // calculate equivalent underlying assets for given lpTokens
-        (uint256 collateralToRemove, uint256 quoteTokenToRemove) = pool.getLPTokenExchangeValue(params_.lpTokens, params_.price);
+        (uint256 collateralToRemove, ) = pool.getLPTokenExchangeValue(params_.lpTokens, params_.price);
 
         uint256 lpTokensRemoved;
 
@@ -86,7 +86,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         }
 
         // remove and transfer quote tokens to recipient
-        (uint256 quoteRemoved, uint256 lpTokensRemovedQuote) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+        (uint256 quoteRemoved, uint256 lpTokensRemovedQuote) = pool.removeQuoteToken(params_.price, params_.lpTokens);
         ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
 
         // update position with lp tokens removed
@@ -107,7 +107,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         IERC721Pool pool = IERC721Pool(params_.pool);
 
         // calculate equivalent underlying assets for given lpTokens
-        (uint256 collateralToRemove, uint256 quoteTokenToRemove) = pool.getLPTokenExchangeValue(params_.lpTokens, params_.price);
+        (uint256 collateralToRemove, ) = pool.getLPTokenExchangeValue(params_.lpTokens, params_.price);
 
         // enable lenders to remove quote token from a bucket that no debt is added to
         if (collateralToRemove != 0) {
@@ -130,7 +130,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
             }
 
             // remove and transfer quote tokens to recipient
-            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(params_.price, params_.lpTokens);
             ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
 
             // update position with newly removed lp tokens
@@ -141,7 +141,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         }
         else {
             // remove and transfer quote tokens to recipient
-            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(quoteTokenToRemove, params_.price, params_.lpTokens);
+            (uint256 quoteRemoved, uint256 lpTokensRemoved) = pool.removeQuoteToken(params_.price, params_.lpTokens);
             ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteRemoved);
 
             // update position with newly removed lp tokens

--- a/src/base/interfaces/IPool.sol
+++ b/src/base/interfaces/IPool.sol
@@ -350,6 +350,8 @@ interface IPool {
      */
     function getLPTokenExchangeValue(uint256 lpTokens_, uint256 price_) external view returns (uint256 collateralTokens_, uint256 quoteTokens_);
 
+    function getLpTokensFromQuoteTokens(uint256 collateralTokens, uint256 quoteTokens, uint256 price_, address owner_) external view returns (uint256 lpTokens_);
+
     /**
      *  @notice Returns the current minimum pool price.
      *  @return minPrice_ The current minimum pool price.

--- a/src/base/interfaces/IPool.sol
+++ b/src/base/interfaces/IPool.sol
@@ -253,13 +253,12 @@ interface IPool {
 
     /**
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
-     *  @param  maxAmount_ The maximum amount of quote token to be removed by a lender.
      *  @param  price_     The bucket from which quote tokens will be removed.
      *  @param  lpTokens_  The amount of LP tokens to be removed by a lender.
      *  @return amount     The amount of quote tokens actually removed by the lender.
      *  @return lpTokens     The amount of quote LP tokens actually removed by the lender.
      */
-    function removeQuoteToken(uint256 maxAmount_, uint256 price_, uint256 lpTokens_) external returns (uint256 amount, uint256 lpTokens);
+    function removeQuoteToken(uint256 price_, uint256 lpTokens_) external returns (uint256 amount, uint256 lpTokens);
 
     /**
      *  @notice Called by lenders to transfers their LP tokens to a different address.
@@ -350,7 +349,14 @@ interface IPool {
      */
     function getLPTokenExchangeValue(uint256 lpTokens_, uint256 price_) external view returns (uint256 collateralTokens_, uint256 quoteTokens_);
 
-    function getLpTokensFromQuoteTokens(uint256 collateralTokens, uint256 quoteTokens, uint256 price_, address owner_) external view returns (uint256 lpTokens_);
+    /**
+     *  @notice Calculate the amount of lpTokens equivalent to a given amount of quote tokens.
+     *  @param  quoteTokens_      The number of quote tokens to calculate LP tokens for, WAD units.
+     *  @param  price_            The price bucket for which the value should be calculated.
+     *  @param  owner_            The address which owns the LP tokens.
+     *  @return lpTokens_         The equivalent value of LP tokens for the given quote Tokens, RAY units.
+     */
+    function getLpTokensFromQuoteTokens(uint256 quoteTokens_, uint256 price_, address owner_) external view returns (uint256 lpTokens_);
 
     /**
      *  @notice Returns the current minimum pool price.

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -337,7 +337,7 @@ contract ERC721Pool is IERC721Pool, Pool {
     function _purchaseBidFromBucketNFTCollateral(
         uint256 price_, uint256 amount_, uint256[] memory tokenIds_, uint256 inflator_
     ) internal {
-        Bucket memory bucket    = _buckets[price_];
+        Bucket storage bucket    = _buckets[price_];
         bucket.debt             = _accumulateBucketInterest(bucket.debt, bucket.inflatorSnapshot, inflator_);
         bucket.inflatorSnapshot = inflator_;
 

--- a/tests/test_quote_token_gas.py
+++ b/tests/test_quote_token_gas.py
@@ -85,7 +85,7 @@ def test_quote_removal_from_lup_with_reallocation(
 
         # lender removes 1000 DAI
         tx = mkr_dai_pool.removeQuoteToken(
-            1_000 * 10**18, bucket_math.indexToPrice(1663), lp_tokens, {"from": lender}
+            bucket_math.indexToPrice(1663), lp_tokens, {"from": lender}
         )
 
         with capsys.disabled():
@@ -130,7 +130,7 @@ def test_quote_removal_below_lup(
 
         # lender removes 1000 DAI
         tx = mkr_dai_pool.removeQuoteToken(
-            1_000 * 10**18, bucket_math.indexToPrice(1606), lp_tokens, {"from": lender}
+            bucket_math.indexToPrice(1606), lp_tokens, {"from": lender}
         )
 
         with capsys.disabled():

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -162,13 +162,13 @@ def draw_and_bid(lenders, borrowers, start_from, pool, bucket_math, chain, gas_v
             utilization = pool.getPoolActualUtilization() / 10**18
             if utilization < MAX_UTILIZATION and len(buckets_deposited[user_index]) > 0:
                 price = buckets_deposited[user_index].pop()
-                # try:
-                remove_quote_token(lenders[user_index], user_index, price, pool)
-                # except VirtualMachineError as ex:
-                #     print(f" ERROR removing liquidity at {price / 10**18:.1f}, "
-                #           f"collateralized at {pool.getPoolCollateralization()/10**18:.1%}: {ex}")
-                #     print(TestUtils.dump_book(pool, bucket_math, MIN_BUCKET, bucket_math.priceToIndex(pool.hpb())))
-                #     buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
+                try:
+                    remove_quote_token(lenders[user_index], user_index, price, pool)
+                except VirtualMachineError as ex:
+                    print(f" ERROR removing liquidity at {price / 10**18:.1f}, "
+                          f"collateralized at {pool.getPoolCollateralization()/10**18:.1%}: {ex}")
+                    print(TestUtils.dump_book(pool, bucket_math, MIN_BUCKET, bucket_math.priceToIndex(pool.hpb())))
+                    buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
             else:
                 price = add_quote_token(lenders[user_index], user_index, pool, bucket_math, gas_validator)
                 if price:
@@ -251,9 +251,11 @@ def remove_quote_token(lender, lender_index, price, pool):
     if lp_balance > 0:
         assert lp_outstanding > 0
         (_, claimable_quote) = pool.getLPTokenExchangeValue(lp_balance, price)
+        lpTokensToRemove = pool.getLpTokensFromQuoteTokens(0, claimable_quote, price, lender)
+
         # claimable_quote = claimable_quote * 1.1  # include extra for unaccumulated interest
         print(f" lender {lender_index} removing {claimable_quote / 10**18:.1f} at {price / 10**18:.1f}")
-        tx = pool.removeQuoteToken(claimable_quote, price, lp_outstanding, {"from": lender})
+        tx = pool.removeQuoteToken(claimable_quote, price, lpTokensToRemove, {"from": lender})
     else:
         print(f" lender {lender_index} has no claim to bucket {price / 10**18:.1f}")
 

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -162,13 +162,13 @@ def draw_and_bid(lenders, borrowers, start_from, pool, bucket_math, chain, gas_v
             utilization = pool.getPoolActualUtilization() / 10**18
             if utilization < MAX_UTILIZATION and len(buckets_deposited[user_index]) > 0:
                 price = buckets_deposited[user_index].pop()
-                try:
-                    remove_quote_token(lenders[user_index], user_index, price, pool)
-                except VirtualMachineError as ex:
-                    print(f" ERROR removing liquidity at {price / 10**18:.1f}, "
-                          f"collateralized at {pool.getPoolCollateralization()/10**18:.1%}: {ex}")
-                    print(TestUtils.dump_book(pool, bucket_math, MIN_BUCKET, bucket_math.priceToIndex(pool.hpb())))
-                    buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
+                # try:
+                remove_quote_token(lenders[user_index], user_index, price, pool)
+                # except VirtualMachineError as ex:
+                #     print(f" ERROR removing liquidity at {price / 10**18:.1f}, "
+                #           f"collateralized at {pool.getPoolCollateralization()/10**18:.1%}: {ex}")
+                #     print(TestUtils.dump_book(pool, bucket_math, MIN_BUCKET, bucket_math.priceToIndex(pool.hpb())))
+                #     buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
             else:
                 price = add_quote_token(lenders[user_index], user_index, pool, bucket_math, gas_validator)
                 if price:
@@ -251,9 +251,9 @@ def remove_quote_token(lender, lender_index, price, pool):
     if lp_balance > 0:
         assert lp_outstanding > 0
         (_, claimable_quote) = pool.getLPTokenExchangeValue(lp_balance, price)
-        claimable_quote = claimable_quote * 1.1  # include extra for unaccumulated interest
+        # claimable_quote = claimable_quote * 1.1  # include extra for unaccumulated interest
         print(f" lender {lender_index} removing {claimable_quote / 10**18:.1f} at {price / 10**18:.1f}")
-        tx = pool.removeQuoteToken(claimable_quote, price, {"from": lender})
+        tx = pool.removeQuoteToken(claimable_quote, price, lp_outstanding, {"from": lender})
     else:
         print(f" lender {lender_index} has no claim to bucket {price / 10**18:.1f}")
 
@@ -278,7 +278,7 @@ def repay(borrower, borrower_index, pool, gas_validator):
             print(f" borrower {borrower_index} has insufficient funds to repay {pending_debt / 10**18:.1f}")
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_stable_volatile_one(pool1, dai, weth, lenders, borrowers, bucket_math, test_utils, chain, tx_validator):
     # Validate test set-up
     assert pool1.collateral() == weth

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -251,11 +251,11 @@ def remove_quote_token(lender, lender_index, price, pool):
     if lp_balance > 0:
         assert lp_outstanding > 0
         (_, claimable_quote) = pool.getLPTokenExchangeValue(lp_balance, price)
-        lpTokensToRemove = pool.getLpTokensFromQuoteTokens(0, claimable_quote, price, lender)
+        lpTokensToRemove = pool.getLpTokensFromQuoteTokens(claimable_quote, price, lender)
 
         # claimable_quote = claimable_quote * 1.1  # include extra for unaccumulated interest
         print(f" lender {lender_index} removing {claimable_quote / 10**18:.1f} at {price / 10**18:.1f}")
-        tx = pool.removeQuoteToken(claimable_quote, price, lpTokensToRemove, {"from": lender})
+        tx = pool.removeQuoteToken(price, lpTokensToRemove, {"from": lender})
     else:
         print(f" lender {lender_index} has no claim to bucket {price / 10**18:.1f}")
 

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -47,7 +47,7 @@ def lenders(ajna_protocol, pool_client, weth_dai_pool):
 @pytest.fixture
 def borrowers(ajna_protocol, pool_client, weth_dai_pool):
     weth_client = pool_client.get_collateral_token()
-    amount = 13_000 * 10**18
+    amount = 5_000 * 10**18
     dai_client = pool_client.get_quote_token()
     borrowers = []
     for _ in range(100):
@@ -234,7 +234,7 @@ def add_quote_token(lender, lender_index, pool, bucket_math, gas_validator, ):
 
     print(f" lender {lender_index} adding {quantity / 10**18:.1f} liquidity at {price / 10**18:.1f}")
     try:
-        tx = pool.addQuoteToken(lender, quantity, price, {"from": lender})
+        tx = pool.addQuoteToken(quantity, price, {"from": lender})
         gas_validator.validate(tx)
         return price
     except VirtualMachineError as ex:
@@ -253,7 +253,7 @@ def remove_quote_token(lender, lender_index, price, pool):
         (_, claimable_quote) = pool.getLPTokenExchangeValue(lp_balance, price)
         claimable_quote = claimable_quote * 1.1  # include extra for unaccumulated interest
         print(f" lender {lender_index} removing {claimable_quote / 10**18:.1f} at {price / 10**18:.1f}")
-        tx = pool.removeQuoteToken(lender, claimable_quote, price, {"from": lender})
+        tx = pool.removeQuoteToken(claimable_quote, price, {"from": lender})
     else:
         print(f" lender {lender_index} has no claim to bucket {price / 10**18:.1f}")
 


### PR DESCRIPTION
- Add require check to `removeQuoteToken` ensuring all collateral has been removed from the bucket prior to quote token removal
- Remove `maxAmount` parameter from `removeQuoteToken`
- Add `getLpTokensFromQuoteTokens` method to calculate LP tokens to remove for a desired amount of quote
- Update tests for LP token based calculations of quote removals
- Fix RW stable-volatile test

TODO:

- Resolve issue with NFT collateral dust amounts. Quote token removal is blocked in certain `PositonManager.decreaseLiquidityNFT` cases, as there will always be some amount of collateral tokens left in the bucket below the required minimum of a whole WAD claimable.