### PR TITLE
Loan linked list ordering

### DIFF
--- a/src/_test/ERC20Pool/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool/ERC20Pool.t.sol
@@ -184,19 +184,19 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(_pool.getPoolMinDebtAmount(), 0.300002884615384615 * 1e18);
         assertEq(_pool.totalBorrowers(),       2);
 
-        _borrower2.borrow(_pool, 200 * 1e18, 3000 * 1e18, address(0), address(_borrower1), _r3);
+        _borrower2.borrow(_pool, 200 * 1e18, 3000 * 1e18, address(0), address(_borrower), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.500003846153846154 * 1e18);
         assertEq(_pool.totalBorrowers(),       3);
 
         // repay should fail if remaining debt < 10% of pool average debt amount
         _quote.mint(address(_borrower2), 200 * 1e18);
         vm.expectRevert("P:R:AMT_LT_AVG_DEBT");
-         _borrower2.repay(_pool, 199.9 * 1e18, address(_borrower1), address(0), _r3);
+        _borrower2.repay(_pool, 199.9 * 1e18, address(_borrower1), address(0), _r3);
 
         _borrower2.repay(_pool, 100 * 1e18, address(0), address(_borrower1), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.400003846153846154 * 1e18);
         assertEq(_pool.totalBorrowers(),       3);
-        _borrower2.repay(_pool, 200 * 1e18, address(_borrower1), address(0), _r3);
+        _borrower2.repay(_pool, 200 * 1e18, address(0), address(0), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.300002884615384615 * 1e18);
         assertEq(_pool.totalBorrowers(),       2);
 
@@ -210,14 +210,14 @@ contract ERC20PoolTest is DSTestPlus {
         _quote.mint(address(_borrower), 200 * 1e18);
         _quote.mint(address(_borrower1), 200 * 1e18);
 
-        _borrower.repay(_pool, 100 * 1e18, address(_borrower2), address(0), _r3);
+        _borrower.repay(_pool, 100 * 1e18, address(0), address(0), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.200002884615384615 * 1e18);
         assertEq(_pool.totalBorrowers(),       2);
         _borrower.repay(_pool, 200 * 1e18, address(0), address(0), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.100000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
 
-        _borrower1.repay(_pool, 20 * 1e18, address(0), address(_borrower), _r3);
+        _borrower1.repay(_pool, 20 * 1e18, address(0), address(0), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.080000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
         _borrower1.repay(_pool, 100 * 1e18, address(0), address(_borrower), _r3);

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -341,8 +341,29 @@ contract LoanQueueTest is DSTestPlus {
 
     }
 
+    function testWrongOrder() public {
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p50159);
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p2807);
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p12_66);
 
+        assertEq(0, _pool.getHighestThresholdPrice());
 
+        // borrower deposits some collateral and draws debt
+        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
+        _borrower.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(0), 0);
+        (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
+        assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
 
+        // borrower2 deposits slightly less collateral but specifies wrong order
+        (uint256 debt, , , , , , ) = _pool.getBorrowerInfo(address(_borrower2));
+        assertEq(debt, 0);  // no debt, so their TP should be 0
+        vm.expectRevert("B:U:QUE_WRNG_ORD");
+        _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(0), 0);
 
+        // borrower2 successfully deposits slightly less collateral
+        _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(_borrower), 0);
+        // borrower2 draws the same debt, producing a higher TP, but supplies the wrong order
+        vm.expectRevert("B:U:QUE_WRNG_ORD");
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), 0);
+    }
 }

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -357,7 +357,7 @@ contract LoanQueueTest is DSTestPlus {
         // borrower2 successfully deposits slightly less collateral
         _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(_borrower), 0);
         // borrower2 draws the same debt, producing a higher TP, but supplies the wrong order
-        vm.expectRevert("B:U:QUE_WRNG_ORD");
+        vm.expectRevert("B:U:QUE_WRNG_ORD_P");
         _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), 0);
     }
 }

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -354,12 +354,6 @@ contract LoanQueueTest is DSTestPlus {
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
 
-        // borrower2 deposits slightly less collateral but specifies wrong order
-        (uint256 debt, , , , , , ) = _pool.getBorrowerInfo(address(_borrower2));
-        assertEq(debt, 0);  // no debt, so their TP should be 0
-        vm.expectRevert("B:U:QUE_WRNG_ORD");
-        _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(0), 0);
-
         // borrower2 successfully deposits slightly less collateral
         _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(_borrower), 0);
         // borrower2 draws the same debt, producing a higher TP, but supplies the wrong order

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -102,6 +102,9 @@ abstract contract Queue is IQueue {
         }
 
         // protections
+        if (newPrev_ != address(0)) {
+            require(newPrevLoan.thresholdPrice >= thresholdPrice_, "B:U:QUE_WRNG_ORD");
+        }
         if (loan.next != address(0)) {
             require(loans[loan.next].thresholdPrice <= thresholdPrice_, "B:U:QUE_WRNG_ORD");
         }

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -103,10 +103,10 @@ abstract contract Queue is IQueue {
 
         // protections
         if (newPrev_ != address(0)) {
-            require(newPrevLoan.thresholdPrice >= thresholdPrice_, "B:U:QUE_WRNG_ORD");
+            require(newPrevLoan.thresholdPrice >= thresholdPrice_, "B:U:QUE_WRNG_ORD_P");
         }
         if (loan.next != address(0)) {
-            require(loans[loan.next].thresholdPrice <= thresholdPrice_, "B:U:QUE_WRNG_ORD");
+            require(loans[loan.next].thresholdPrice <= thresholdPrice_, "B:U:QUE_WRNG_ORD_N");
         }
 
         loans[oldPrev_] = oldPrevLoan;


### PR DESCRIPTION
Developing the real-world test for the scaled pool, I implemented an offchain validation which showed the borrower queue was becoming misordered.  I was able to write a unit test which showed a loan with a greater TP than the previous loan could be added to the end of the queue.

I ported over the missing validation logic from the simulator to resolve, and remedied some unrelated test breakage.