### PR TITLE
Restructure Queue._search

### DIFF
--- a/src/_test/ERC20Pool/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool/ERC20Pool.t.sol
@@ -217,7 +217,7 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(_pool.getPoolMinDebtAmount(), 0.100000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
 
-        _borrower1.repay(_pool, 20 * 1e18, address(0), address(0), _r3);
+        _borrower1.repay(_pool, 20 * 1e18, address(_borrower), address(0), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.080000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
         _borrower1.repay(_pool, 100 * 1e18, address(0), address(_borrower), _r3);

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -268,7 +268,7 @@ contract LoanQueueTest is DSTestPlus {
         assertEq(address(next), address(0));
     }
 
-    // TODO: write test with radius of 0 
+    // TODO: write test with radius of 0
     // TODO: write test with decimal radius
     // TODO: write test with radius larger than queue
     function testRadiusInQueue() public {
@@ -317,28 +317,27 @@ contract LoanQueueTest is DSTestPlus {
         assertEq(address(_borrower2), address(_pool.loanQueueHead()));
 
 
-       // borrower2(HEAD) -> borrower -> borrower3 -> borrower4 -> borrower5 -> *borrower6*
-       _borrower6.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-       // newPrev passed in is incorrect & radius is too small, revert
-       vm.expectRevert("B:S:SRCH_RDS_FAIL");
-       _borrower6.borrow(_pool, 1_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), _r1);
+        // borrower2(HEAD) -> borrower -> borrower3 -> borrower4 -> borrower5 -> *borrower6*
+        _borrower6.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
+        // newPrev passed in is incorrect & radius is too small, revert
+        vm.expectRevert("B:S:SRCH_RDS_FAIL");
+        _borrower6.borrow(_pool, 1_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), _r1);
 
-       // newPrev passed in is incorrect & radius supports correct placement
-       _borrower6.borrow(_pool, 1_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), _r2);
+        // newPrev passed in is incorrect & radius supports correct placement
+        _borrower6.borrow(_pool, 1_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), _r3);
 
-       (thresholdPrice, next) = _pool.loans(address(_borrower6));
-       assertEq(address(next), address(0));
-       assertEq(address(_borrower2), address(_pool.loanQueueHead()));
+        (thresholdPrice, next) = _pool.loans(address(_borrower6));
+        assertEq(address(next), address(0));
+        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
 
-       (thresholdPrice, next) = _pool.loans(address(_borrower4));
-       assertEq(address(next), address(_borrower5));
+        (thresholdPrice, next) = _pool.loans(address(_borrower4));
+        assertEq(address(next), address(_borrower5));
 
-       (thresholdPrice, next) = _pool.loans(address(_borrower5));
-       assertEq(address(next), address(_borrower6));
+        (thresholdPrice, next) = _pool.loans(address(_borrower5));
+        assertEq(address(next), address(_borrower6));
 
-       (thresholdPrice, next) = _pool.loans(address(_borrower));
-       assertEq(address(next), address(_borrower3));
-
+        (thresholdPrice, next) = _pool.loans(address(_borrower));
+        assertEq(address(next), address(_borrower3));
     }
 
     function testWrongOrder() public {

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -37,7 +37,7 @@ abstract contract Queue is IQueue {
         for (uint256 i = 0; i < radius_;) {
             nextLoan = loans[currentLoan.next];
 
-            if (current != borrower_ && (nextLoan.thresholdPrice <= thresholdPrice_ || nextLoan.thresholdPrice == 0)) {
+            if (current != borrower_ && (nextLoan.thresholdPrice <= thresholdPrice_)) {
                 break;
             }
 


### PR DESCRIPTION
**Changes**
- Resolved bug where queue would become misordered if a loan's TP changed, but `oldPrev` and `newPrev` remained the same.
- Support searching from head when passing `newPrev=0`.
- Allow search to be disabled when passing `radius=0`.

I know this isn't the right branch, but it's the only place I have unit tests to work with at the moment.