### PR TITLE
Fix bug handling call where borrower incorrectly passes oldPrev=0

### DIFF
--- a/src/_test/ERC20Pool/ERC20Pool.t.sol
+++ b/src/_test/ERC20Pool/ERC20Pool.t.sol
@@ -193,7 +193,7 @@ contract ERC20PoolTest is DSTestPlus {
         vm.expectRevert("P:R:AMT_LT_AVG_DEBT");
         _borrower2.repay(_pool, 199.9 * 1e18, address(_borrower1), address(0), _r3);
 
-        _borrower2.repay(_pool, 100 * 1e18, address(0), address(_borrower1), _r3);
+        _borrower2.repay(_pool, 100 * 1e18, address(_borrower), address(_borrower1), _r3);
         assertEq(_pool.getPoolMinDebtAmount(), 0.400003846153846154 * 1e18);
         assertEq(_pool.totalBorrowers(),       3);
         _borrower2.repay(_pool, 200 * 1e18, address(0), address(0), _r3);
@@ -217,7 +217,7 @@ contract ERC20PoolTest is DSTestPlus {
         assertEq(_pool.getPoolMinDebtAmount(), 0.100000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
 
-        _borrower1.repay(_pool, 20 * 1e18, address(_borrower), address(0), _r3);
+        _borrower1.repay(_pool, 20 * 1e18, address(0), address(0), 0);
         assertEq(_pool.getPoolMinDebtAmount(), 0.080000961538461538 * 1e18);
         assertEq(_pool.totalBorrowers(),       1);
         _borrower1.repay(_pool, 100 * 1e18, address(0), address(_borrower), _r3);

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -432,7 +432,7 @@ contract LoanQueueTest is DSTestPlus {
         assertEq(next, address(0));
 
         // borrower2 draws more debt, but should still be at the end of queue; should revert passing wrong oldPrev
-        vm.expectRevert("B:U:QUE_WRNG_ORD_P");
+        vm.expectRevert("B:U:OLDPREV_WRNG");
         _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), 0);
 
         _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(_borrower), address(_borrower), 0);

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -402,4 +402,45 @@ contract LoanQueueTest is DSTestPlus {
         (, next) = _pool.loans(address(_borrower));
         assertEq(next, address(0));
     }
+
+    function testMoveToBottom() public {
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p50159);
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p2807);
+        _lender.addQuoteToken(_pool, 50_000 * 1e18, _p12_66);
+
+        assertEq(0, _pool.getHighestThresholdPrice());
+
+        // borrower deposits some collateral and draws debt
+        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
+        _borrower.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(0), 0);
+        (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
+        assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
+
+        // borrower2 deposits slightly less collateral and draws the same debt, producing a higher TP
+        _borrower2.addCollateral(_pool, 39 * 1e18, address(0), address(_borrower), 0);
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(0), 0);
+        (thresholdPrice, next) = _pool.loans(address(_borrower2));
+        assertEq(thresholdPrice, 769.230793885601577909 * 1e18);
+
+        // borrower2 deposits some collateral, reducing their TP, pushing it to the end of the queue
+        _borrower2.addCollateral(_pool, 42 * 1e18, address(0), address(_borrower), 0);
+        (thresholdPrice, next) = _pool.loans(address(_borrower2));
+        assertEq(thresholdPrice, 370.370382241215574549 * 1e18);
+        assertEq(next, address(0));
+
+        // borrower2 draws more debt, but should still be at the end of queue
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), 0);
+        (thresholdPrice, ) = _pool.loans(address(_borrower2));
+        assertEq(thresholdPrice, 740.740764482431149098 * 1e18);
+        assertEq(next, address(0));
+
+        // confirm rest of queue is in the correct order
+        // FIXME: points to wrong borrower
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+
+        (thresholdPrice, next) = _pool.loans(address(_borrower));
+        assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
+        // FIXME: points to wrong borrower
+        assertEq(next, address(_borrower2));
+    }
 }

--- a/src/_test/ERC20Pool/ERC20Queue.t.sol
+++ b/src/_test/ERC20Pool/ERC20Queue.t.sol
@@ -413,34 +413,40 @@ contract LoanQueueTest is DSTestPlus {
         // borrower deposits some collateral and draws debt
         _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
         _borrower.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(0), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
 
         // borrower2 deposits slightly less collateral and draws the same debt, producing a higher TP
         _borrower2.addCollateral(_pool, 39 * 1e18, address(0), address(_borrower), 0);
         _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(0), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower2));
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 769.230793885601577909 * 1e18);
 
         // borrower2 deposits some collateral, reducing their TP, pushing it to the end of the queue
         _borrower2.addCollateral(_pool, 42 * 1e18, address(0), address(_borrower), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 370.370382241215574549 * 1e18);
         assertEq(next, address(0));
 
-        // borrower2 draws more debt, but should still be at the end of queue
+        // borrower2 draws more debt, but should still be at the end of queue; should revert passing wrong oldPrev
+        vm.expectRevert("B:U:QUE_WRNG_ORD_P");
         _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(0), address(_borrower), 0);
-        (thresholdPrice, ) = _pool.loans(address(_borrower2));
+
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2_000 * 1e18, address(_borrower), address(_borrower), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 740.740764482431149098 * 1e18);
         assertEq(next, address(0));
 
-        // confirm rest of queue is in the correct order
-        // FIXME: points to wrong borrower
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_borrower), address(0x70BEce5a3D1a6eFBC54e1A134cfF3b47EF346bbE));
+        assertEq(address(_borrower2), address(0xB4FFCD625FefD541b77925c7A37A55f488bC69d9));
 
+        // confirm rest of queue is in the correct order
         (thresholdPrice, next) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.000024038461538462 * 1e18);
-        // FIXME: points to wrong borrower
         assertEq(next, address(_borrower2));
     }
 }

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -64,16 +64,17 @@ abstract contract Queue is IQueue {
         require(oldPrev_ != borrower_ && newPrev_ != borrower_, "B:U:PNT_SELF_REF");
         LoanInfo memory oldPrevLoan = loans[oldPrev_];
         LoanInfo memory newPrevLoan = loans[newPrev_];
+        LoanInfo memory loan = loans[borrower_];
 
-        if (oldPrevLoan.next != address(0)) {
+        if (oldPrev_ == address(0)) {
+            require(loan.thresholdPrice == 0 || loanQueueHead == borrower_, "B:U:OLDPREV_WRNG");
+        } else {
             require(oldPrevLoan.next == borrower_, "B:U:OLDPREV_NOT_CUR_BRW");
         }
 
         // protections
         (newPrev_, newPrevLoan) = _searchRadius(radius_, thresholdPrice_, newPrev_, borrower_);
 
-        LoanInfo memory loan = loans[borrower_];
-        
         if (loan.thresholdPrice > 0) {
             // loan exists
             if (oldPrev_ != newPrev_) {


### PR DESCRIPTION
This should be the last one going to `loan-linked-list` branch.  I'll take responsibility of merging this into `diez`, likely through my `diez-rwt` branch.

**Change**
If the caller passed `oldPrev=0`, the contract skipped checking whether `oldPrev.next` actually points to the borrower.  As such, the state machine continued calling `_move` which mangled `loanQueueHead` and the adjacent `next` pointer.  This adds a new revert to trap two use cases where `oldPrev=0` is incorrect.

**Out-of-scope**
The queue currently checks for loan existence by checking for TP>0, which is problematic.