### PR TITLE
Incorporate inflator into the TP queue

### DIFF
--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -555,11 +555,8 @@ contract ScaledPool is Clone, FenwickTree, Queue {
     }
 
     function _threshold_price(uint256 debt_, uint256 collateral_, uint256 inflator_) internal pure returns (uint256) {
-        if (collateral_ == 0) {
-            return 0;
-        } else {
-            return Maths.wdiv(debt_, Maths.wmul(inflator_, collateral_));
-        }
+        if (collateral_ != 0) return Maths.wdiv(debt_, Maths.wmul(inflator_, collateral_));
+        return 0;
     }
 
     /**************************/

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -622,6 +622,10 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         );
     }
 
+    function pendingInflator() external view returns (uint256) {
+        return _pendingInflator();
+    }
+
     function exchangeRate(uint256 index_) external view returns (uint256) {
         Bucket storage bucket = buckets[index_];
         return _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);

--- a/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
@@ -136,7 +136,7 @@ contract ScaledCollateralTest is DSTestPlus {
         _borrower.removeCollateral(_pool, unencumberedCollateral, address(0), address(0), 1);
 
         // check pool state
-        assertEq(_pool.htp(), 2_981.007422784467321477 * 1e18);
+        assertEq(_pool.htp(), 2_981.007422784467321484 * 1e18);
         assertEq(_pool.lup(), 2_981.007422784467321543 * 1e18);
 
         assertEq(_pool.treeSum(),           30_025.933063881970800000 * 1e18);
@@ -179,7 +179,7 @@ contract ScaledCollateralTest is DSTestPlus {
 
         // should be able to now remove collateral
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_borrower), testCollateralAmount);        
+        emit RemoveCollateral(address(_borrower), testCollateralAmount);
         _borrower.removeCollateral(_pool, testCollateralAmount, address(0), address(0), 1);
     }
 

--- a/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
@@ -102,6 +102,25 @@ contract ScaledInterestRateTest is DSTestPlus {
         assertEq(_pool.interestRateUpdate(), 864000);
     }
 
+    function testPendingInflator() external {
+        // add liquidity
+        _lender.addQuoteToken(_pool, 10_000 * 1e18, 2550);
+        _lender.addQuoteToken(_pool, 10_000 * 1e18, 2552);
+        _lender.addQuoteToken(_pool, 10_000 * 1e18, 4200);
+        skip(3600);
+
+        // draw debt
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 0);
+        _borrower.borrow(_pool, 15_000 * 1e18, 4300, address(0), address(0), 0);
+        assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
+        assertEq(_pool.pendingInflator(), 1.000005707778841975 * 1e18);
+        vm.warp(block.timestamp+3600);
+
+        // ensure pendingInflator increases as time passes
+        assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
+        assertEq(_pool.pendingInflator(), 1.000011415590262688 * 1e18);
+    }
+
     // TODO: add test related to pool utilization changes
 
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,7 @@ class ScaledPoolUtils:
                     print(f"   {node.borrower[:6]} at TP {node.tp / 1e18:.18f}, next is {node.next[:6]}")
                 if node.next == borrower:
                     old_previous_borrower = node.borrower
-                if node.tp > threshold_price:
+                if node.tp > threshold_price and node.borrower != borrower:
                     new_previous_borrower = node.borrower
                 node = Loan(node.next, pool.loanInfo(node.next))
 


### PR DESCRIPTION
**Changes**
- Threshold prices are based upon a debt amount which changes over time.  To properly consider the time-value of debt, threshold prices are divided by the borrower's inflator snapshot when updating the queue, and multiplied by the inflator snapshot when reading the highest threshold price (HTP).
- Exposed the pending inflator, which was needed to calculate the TP offchain.
- Removed some unused cruft from the real-world test.