### PR TITLE
Remove radius from Queue

### DIFF
--- a/src/Queue.sol
+++ b/src/Queue.sol
@@ -14,47 +14,13 @@ abstract contract Queue is IQueue {
     /************************/
 
     /**
-     *  @notice Search to the given radius for the correct previous borrower.
-     *  @dev    Called by _updateLoanQueue if the newPrev_ position is incorrect
-     *  @param  radius_         Distance checked to find lower thresholdPrice
-     *  @param  thresholdPrice_ Debt / collateralDeposited
-     *  @param  newPrev_        Previous location the caller believes points to their loan
-     *  @param  borrower_       Borrower whose TP might be changing, thus should be ignored
-     *  @return newPrev         Corrected previous borrower that now comes before placed loan (new)
-     *  @return newPrevLoan     Corrected previous loan that now comes before placed loan (new)
-     */
-    function _searchRadius(uint256 radius_, uint256 thresholdPrice_, address newPrev_, address borrower_) internal returns (address, LoanInfo memory) {
-        address current = newPrev_;
-        LoanInfo memory currentLoan = loans[current];
-        LoanInfo memory nextLoan;
-
-        for (uint256 i = 0; i < radius_;) {
-            nextLoan = loans[currentLoan.next];
-
-            if (current != borrower_ && (nextLoan.thresholdPrice <= thresholdPrice_)) {
-                break;
-            }
-
-            current = loans[current].next;
-            currentLoan = nextLoan;
-            unchecked {
-                ++i;
-            }
-        }
-
-        require(currentLoan.next == borrower_ || loans[currentLoan.next].thresholdPrice <= thresholdPrice_, "B:S:SRCH_RDS_FAIL");
-        return (current, currentLoan);
-    }
-
-    /**
      *  @notice Called by borrower methods to update loan position.
      *  @param  borrower_        Borrower whose loan is being placed
      *  @param  thresholdPrice_  debt / collateralDeposited
      *  @param  oldPrev_         Previous borrower that came before placed loan (old)
      *  @param  newPrev_         Previous borrower that now comes before placed loan (new)
-     *  @param  radius_          Distance checked to find lower thresholdPrice
      */
-    function _updateLoanQueue(address borrower_, uint256 thresholdPrice_, address oldPrev_, address newPrev_, uint256 radius_) internal {
+    function _updateLoanQueue(address borrower_, uint256 thresholdPrice_, address oldPrev_, address newPrev_) internal {
         require(oldPrev_ != borrower_ && newPrev_ != borrower_, "B:U:PNT_SELF_REF");
         LoanInfo memory oldPrevLoan = loans[oldPrev_];
         LoanInfo memory newPrevLoan = loans[newPrev_];
@@ -65,9 +31,6 @@ abstract contract Queue is IQueue {
         } else {
             require(oldPrevLoan.next == borrower_, "B:U:OLDPREV_NOT_CUR_BRW");
         }
-
-        // search for the correct previous borrower given the incoming threshold price
-        (newPrev_, newPrevLoan) = _searchRadius(radius_, thresholdPrice_, newPrev_, borrower_);
 
         if (loan.thresholdPrice > 0) {
             // loan already exists and needs to be moved within the queue

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -240,7 +240,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
     /*** Borrower External Functions ***/
     /***********************************/
 
-    function addCollateral(uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) external {
+    function addCollateral(uint256 amount_, address oldPrev_, address newPrev_) external {
         uint256 curDebt = _accruePoolInterest();
 
         // borrower accounting
@@ -249,7 +249,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         borrower.collateral += amount_;
 
         // update loan queue
-        if (borrower.debt != 0) _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_, radius_);
+        if (borrower.debt != 0) _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_);
 
         borrowers[msg.sender] = borrower;
 
@@ -262,7 +262,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         emit AddCollateral(msg.sender, amount_);
     }
 
-    function borrow(uint256 amount_, uint256 limitIndex_, address oldPrev_, address newPrev_, uint256 radius_) external {
+    function borrow(uint256 amount_, uint256 limitIndex_, address oldPrev_, address newPrev_) external {
 
         uint256 lupId = _lupIndex(amount_);
         require(lupId <= limitIndex_, "S:B:LIMIT_REACHED"); // TODO: add check that limitIndex is <= MAX_INDEX
@@ -293,7 +293,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         borrowerDebt = curDebt;
         lenderDebt   += amount_;
 
-        _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_, radius_);
+        _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_);
         borrowers[msg.sender] = borrower;
 
         _updateInterestRate(curDebt, newLup);
@@ -303,7 +303,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         emit Borrow(msg.sender, newLup, amount_);
     }
 
-    function removeCollateral(uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) external {
+    function removeCollateral(uint256 amount_, address oldPrev_, address newPrev_) external {
         uint256 curDebt = _accruePoolInterest();
 
         // borrower accounting
@@ -315,7 +315,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         borrower.collateral -= amount_;
 
         // update loan queue
-        if (borrower.debt != 0) _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_, radius_);
+        if (borrower.debt != 0) _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_);
 
         // update pool state
         pledgedCollateral -= amount_;
@@ -326,7 +326,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         emit RemoveCollateral(msg.sender, amount_);
     }
 
-    function repay(uint256 maxAmount_, address oldPrev_, address newPrev_, uint256 radius_) external {
+    function repay(uint256 maxAmount_, address oldPrev_, address newPrev_) external {
         require(quoteToken().balanceOf(msg.sender) * quoteTokenScale >= maxAmount_, "S:R:INSUF_BAL");
 
         Borrower memory borrower = borrowers[msg.sender];
@@ -352,7 +352,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
             _removeLoanQueue(msg.sender, oldPrev_);
         } else {
             if (borrowersCount != 0) require(borrower.debt > _poolMinDebtAmount(curDebt), "R:B:AMT_LT_AVG_DEBT");
-            _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_, radius_);
+            _updateLoanQueue(msg.sender, Maths.wdiv(borrower.debt, borrower.collateral), oldPrev_, newPrev_);
         }
         borrowers[msg.sender] = borrower;
 

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -78,7 +78,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
 
         // borrower deposit 100 MKR collateral
-        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0));
         assertEq(_pool.poolTargetUtilization(), 1 * 1e18);
         assertEq(_pool.poolActualUtilization(), 0);
 
@@ -87,7 +87,7 @@ contract ScaledBorrowTest is DSTestPlus {
         emit Transfer(address(_pool), address(_borrower), 21_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Borrow(address(_borrower), 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
-        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(_pool.htp(), 210.201923076923077020 * 1e18);
         assertEq(_pool.lup(), 2_981.007422784467321543 * 1e18);
@@ -131,7 +131,7 @@ contract ScaledBorrowTest is DSTestPlus {
         emit Transfer(address(_pool), address(_borrower), 19_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Borrow(address(_borrower), 2_966.176540084047110076 * 1e18, 19_000 * 1e18);
-        _borrower.borrow(_pool, 19_000 * 1e18, 3500, address(0), address(0), 1);
+        _borrower.borrow(_pool, 19_000 * 1e18, 3500, address(0), address(0));
 
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
         assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
@@ -149,7 +149,7 @@ contract ScaledBorrowTest is DSTestPlus {
         emit Transfer(address(_borrower), address(_pool), 10_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Repay(address(_borrower), 2_966.176540084047110076 * 1e18, 10_000 * 1e18);
-        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 300.384615384615384800 * 1e18);
         assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
@@ -168,7 +168,7 @@ contract ScaledBorrowTest is DSTestPlus {
         emit Transfer(address(_borrower), address(_pool), 30_038.461538461538480000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Repay(address(_borrower), BucketMath.MAX_PRICE, 30_038.461538461538480000 * 1e18);
-        _borrower.repay(_pool, 30_040 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 30_040 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
@@ -198,8 +198,8 @@ contract ScaledBorrowTest is DSTestPlus {
 
         skip(864000);
 
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(_pool.borrowerDebt(), 21_020.192307692307702000 * 1e18);
         (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
@@ -209,7 +209,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1 * 1e18);
 
         skip(864000);
-        _borrower.addCollateral(_pool, 10 * 1e18, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 10 * 1e18, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_083.636385042573188669 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_083.636385042573188669 * 1e18);
@@ -218,7 +218,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1.003018244382428805 * 1e18);
 
         skip(864000);
-        _borrower.removeCollateral(_pool, 10 * 1e18, address(0), address(0), 1);
+        _borrower.removeCollateral(_pool, 10 * 1e18, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_118.612213172841725096 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_118.612213172841725096 * 1e18);
@@ -227,7 +227,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1.004682160088731320 * 1e18);
 
         skip(864000);
-        _borrower.borrow(_pool, 0, 3000, address(0), address(0), 1);
+        _borrower.borrow(_pool, 0, 3000, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_157.152642868828624051 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_157.152642868828624051 * 1e18);
@@ -236,7 +236,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1.006515655669163431 * 1e18);
 
         skip(864000);
-        _borrower.repay(_pool, 0, address(0), address(0), 1);
+        _borrower.repay(_pool, 0, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_199.628356700342110209 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_199.628356700342110209 * 1e18);
@@ -263,7 +263,7 @@ contract ScaledBorrowTest is DSTestPlus {
     function testScaledPoolBorrowRequireChecks() external {
         // should revert if borrower attempts to borrow with an out of bounds limitIndex
         vm.expectRevert("S:B:LIMIT_REACHED");
-        _borrower.borrow(_pool, 1_000 * 1e18, 5000, address(0), address(0), 1);
+        _borrower.borrow(_pool, 1_000 * 1e18, 5000, address(0), address(0));
 
         // add initial quote to the pool
         _lender.addQuoteToken(_pool, 10_000 * 1e18, 2550);
@@ -271,30 +271,30 @@ contract ScaledBorrowTest is DSTestPlus {
 
         // should revert if borrow would result in pool under collateralization
         vm.expectRevert("S:B:PUNDER_COLLAT");
-        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after adding sufficient collateral
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0));
 
         // borrower 2 borrows 15k quote from the pool with borrower2 becoming new queue HEAD
-        _borrower2.addCollateral(_pool, 6 * 1e18, address(0), address(0), 1);
-        _borrower2.borrow(_pool, 15_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower2.addCollateral(_pool, 6 * 1e18, address(0), address(0));
+        _borrower2.borrow(_pool, 15_000 * 1e18, 3000, address(0), address(0));
 
         // should revert if borrower attempts to borrow more than minimum amount
         vm.expectRevert("S:B:AMT_LT_AVG_DEBT");
-        _borrower.borrow(_pool, 10 * 1e18, 3000, address(0), address(_borrower2), 1);
+        _borrower.borrow(_pool, 10 * 1e18, 3000, address(0), address(_borrower2));
 
         // should revert if borrow would result in borrower under collateralization
         vm.expectRevert("S:B:BUNDER_COLLAT");
-        _borrower2.borrow(_pool, 4_500 * 1e18, 3000, address(0), address(_borrower), 1);
+        _borrower2.borrow(_pool, 4_500 * 1e18, 3000, address(0), address(_borrower));
 
         // should be able to borrow if properly specified
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_borrower2), 10 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Borrow(address(_borrower2), 2_995.912459898389633881 * 1e18, 10 * 1e18);
-        _borrower2.borrow(_pool, 10 * 1e18, 3000, address(0), address(0), 1);
+        _borrower2.borrow(_pool, 10 * 1e18, 3000, address(0), address(0));
     }
 
     /**
@@ -311,35 +311,35 @@ contract ScaledBorrowTest is DSTestPlus {
 
         // should revert if borrower has insufficient quote to repay desired amount
         vm.expectRevert("S:R:INSUF_BAL");
-        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0));
 
         // should revert if borrower has no debt
         _quote.mint(address(_borrower), 10_000 * 1e18);
         vm.expectRevert("S:R:NO_DEBT");
-        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 1_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 1_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(address(_borrower), _pool.loanQueueHead());
 
         // borrower 2 borrows 5k quote from the pool and becomes new queue HEAD
-        _borrower2.addCollateral(_pool, 50 * 1e18, address(0), address(_borrower), 1);
-        _borrower2.borrow(_pool, 5_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower2.addCollateral(_pool, 50 * 1e18, address(0), address(_borrower));
+        _borrower2.borrow(_pool, 5_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(address(_borrower2), _pool.loanQueueHead());
 
         // should revert if amount left after repay is less than the average debt
         vm.expectRevert("R:B:AMT_LT_AVG_DEBT");
-        _borrower.repay(_pool, 750 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 750 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 0.0001 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Repay(address(_borrower), _pool.lup(), 0.0001 * 1e18);
-        _borrower.repay(_pool, 0.0001 * 1e18, address(_borrower2), address(_borrower2), 1);
+        _borrower.repay(_pool, 0.0001 * 1e18, address(_borrower2), address(_borrower2));
     }
 
 }

--- a/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
@@ -72,7 +72,7 @@ contract ScaledCollateralTest is DSTestPlus {
         // borrower deposits 100 collateral
         vm.expectEmit(true, true, false, true);
         emit AddCollateral(address(_borrower), 100 * 1e18);
-        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0));
 
         // check pool state collateral accounting updated successfully
         assertEq(_pool.pledgedCollateral(), 100 * 1e18);
@@ -83,7 +83,7 @@ contract ScaledCollateralTest is DSTestPlus {
         emit Transfer(address(_pool), address(_borrower), 21_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Borrow(address(_borrower), 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
-        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0));
 
         // check pool state
         assertEq(_pool.htp(), 210.201923076923077020 * 1e18);
@@ -115,7 +115,7 @@ contract ScaledCollateralTest is DSTestPlus {
         // remove some of the collateral
         vm.expectEmit(true, true, false, true);
         emit RemoveCollateral(address(_borrower), 50 * 1e18);
-        _borrower.removeCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
+        _borrower.removeCollateral(_pool, 50 * 1e18, address(0), address(0));
 
         // check borrower state
         (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));
@@ -133,7 +133,7 @@ contract ScaledCollateralTest is DSTestPlus {
         uint256 unencumberedCollateral = borrowerCollateral - _pool.encumberedCollateral(borrowerDebt, _pool.lup());
         vm.expectEmit(true, true, false, true);
         emit RemoveCollateral(address(_borrower), unencumberedCollateral);
-        _borrower.removeCollateral(_pool, unencumberedCollateral, address(0), address(0), 1);
+        _borrower.removeCollateral(_pool, unencumberedCollateral, address(0), address(0));
 
         // check pool state
         assertEq(_pool.htp(), 2_981.007422784467321477 * 1e18);
@@ -170,17 +170,17 @@ contract ScaledCollateralTest is DSTestPlus {
 
         // should revert if trying to remove more collateral than is available
         vm.expectRevert("S:RC:NOT_ENOUGH_COLLATERAL");
-        _borrower.removeCollateral(_pool, testCollateralAmount, address(0), address(0), 1);
+        _borrower.removeCollateral(_pool, testCollateralAmount, address(0), address(0));
 
         // borrower deposits 100 collateral
         vm.expectEmit(true, true, true, true);
         emit AddCollateral(address(_borrower), testCollateralAmount);
-        _borrower.addCollateral(_pool, testCollateralAmount, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, testCollateralAmount, address(0), address(0));
 
         // should be able to now remove collateral
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_borrower), testCollateralAmount);        
-        _borrower.removeCollateral(_pool, testCollateralAmount, address(0), address(0), 1);
+        _borrower.removeCollateral(_pool, testCollateralAmount, address(0), address(0));
     }
 
     /**

--- a/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
@@ -110,8 +110,8 @@ contract ScaledInterestRateTest is DSTestPlus {
         skip(3600);
 
         // draw debt
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 0);
-        _borrower.borrow(_pool, 15_000 * 1e18, 4300, address(0), address(0), 0);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 4300, address(0), address(0));
         assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
         assertEq(_pool.pendingInflator(), 1.000005707778841975 * 1e18);
         vm.warp(block.timestamp+3600);

--- a/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
@@ -64,8 +64,8 @@ contract ScaledInterestRateTest is DSTestPlus {
         assertEq(_pool.interestRate(),       0.05 * 1e18);
         assertEq(_pool.interestRateUpdate(), 0);
 
-        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 46_000 * 1e18, 4300, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 46_000 * 1e18, 4300, address(0), address(0));
 
         assertEq(_pool.htp(), 460.442307692307692520 * 1e18);
         assertEq(_pool.lup(), 2_981.007422784467321543 * 1e18);
@@ -79,7 +79,7 @@ contract ScaledInterestRateTest is DSTestPlus {
 
         // repay entire loan
         _quote.mint(address(_borrower), 200 * 1e18);
-        _borrower.repay(_pool, 46_200 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 46_200 * 1e18, address(0), address(0));
 
         // enforce rate update - decrease
         skip(864000);

--- a/src/_test/ScaledPool/ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolPurchaseQuote.t.sol
@@ -61,8 +61,8 @@ contract ScaledPurchaseQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 10_000 * 1e18, 2553);
         _lender.addQuoteToken(_pool, 10_000 * 1e18, 2554);
 
-        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 100 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 21_000 * 1e18, 3000, address(0), address(0));
 
         // check balances
         assertEq(_quote.balanceOf(address(_lender)),   150_000 * 1e18);
@@ -95,7 +95,7 @@ contract ScaledPurchaseQuoteTokenTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),      18_000 * 1e18);
         assertEq(_collateral.balanceOf(address(_pool)), 103.655062990922738057 * 1e18);
 
-        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0), 1);
+        _borrower.repay(_pool, 10_000 * 1e18, address(0), address(0));
 
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(2550);
         assertEq(lpAccumulator,       10_000 * 1e27);

--- a/src/_test/ScaledPool/ScaledPoolQueue.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQueue.t.sol
@@ -72,8 +72,8 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // borrow max possible from hdp
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0));
 
         // check queue head was set correctly
         (, address next) = _pool.loans(address(_borrower));
@@ -94,8 +94,8 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(0, _pool.getHighestThresholdPrice());
 
         // borrow and insert into the Queue
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 debt, , uint256 collateral, ) = _pool.borrowerInfo(address(_borrower));
 
@@ -107,7 +107,7 @@ contract ScaledQueueTest is DSTestPlus {
 
         // should revert if the borrower references themself and not the correct queue ordering
         vm.expectRevert("B:U:PNT_SELF_REF");
-        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(_borrower), _r3);
+        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(_borrower));
     }
 
     /**
@@ -119,31 +119,31 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // *borrower(HEAD)*
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(address(next), address(0));
         assertEq(address(_borrower), address(_pool.loanQueueHead()));
 
         // *borrower2(HEAD)* -> borrower
-        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(address(next), address(_borrower));
         assertEq(address(_borrower2), address(_pool.loanQueueHead()));
 
         // borrower2(HEAD) -> borrower -> *borrower3*
-        _borrower3.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower3.borrow(_pool, 10_000 * 1e18, 2551,  address(0), address(_borrower), _r3);
+        _borrower3.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower3.borrow(_pool, 10_000 * 1e18, 2551,  address(0), address(_borrower));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower3));
         assertEq(address(next), address(0));
         assertEq(address(_borrower2), address(_pool.loanQueueHead()));
 
         // borrower2(HEAD) -> borrower3 -> *borrower*
-        _borrower.repay(_pool, 10_000 * 1e18, address(_borrower2), address(_borrower3), _r3);
+        _borrower.repay(_pool, 10_000 * 1e18, address(_borrower2), address(_borrower3));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower));
         assertEq(address(next), address(0));
@@ -161,21 +161,21 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(0, _pool.getHighestThresholdPrice());
 
         // borrower deposits some collateral and draws debt
-        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
-        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0));
         assertEq(address(_pool.loanQueueHead()), address(_borrower));
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.721153846153846500 * 1e18);
 
         // borrower2 deposits slightly less collateral and draws the same debt, producing a higher TP
-        _borrower2.addCollateral(_pool, 39 * 1e18, address(0), address(_borrower), 0);
-        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower2.addCollateral(_pool, 39 * 1e18, address(0), address(_borrower));
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0));
         assertEq(address(_pool.loanQueueHead()), address(_borrower2));
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 769.970414201183432308 * 1e18);
 
         // borrower2 deposits some collateral, reducing their TP, pushing it to the end of the queue
-        _borrower2.addCollateral(_pool, 42 * 1e18, address(0), address(_borrower), 0);
+        _borrower2.addCollateral(_pool, 42 * 1e18, address(0), address(_borrower));
         assertEq(address(_pool.loanQueueHead()), address(_borrower));
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 370.726495726495726667 * 1e18);
@@ -183,9 +183,9 @@ contract ScaledQueueTest is DSTestPlus {
 
         // borrower2 draws more debt, but should still be at the end of queue; should revert passing wrong oldPrev
         vm.expectRevert("B:U:OLDPREV_WRNG");
-        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(_borrower), 0);
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(_borrower));
 
-        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(_borrower), address(_borrower), 0);
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(_borrower), address(_borrower));
         assertEq(address(_pool.loanQueueHead()), address(_borrower));
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 741.452991452991453333 * 1e18);
@@ -209,23 +209,23 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // borrower becomes head
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(address(next), address(0));
         assertEq(address(_borrower), address(_pool.loanQueueHead()));
 
         // borrower2 replaces borrower as head
-        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(address(next), address(_borrower));
         assertEq(address(_borrower2), address(_pool.loanQueueHead()));
 
         // borrower replaces borrower2 as head
-        _borrower.borrow(_pool, 10_000 * 1e18, 2551, address(_borrower2), address(0), _r3);
+        _borrower.borrow(_pool, 10_000 * 1e18, 2551, address(_borrower2), address(0));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower));
         assertEq(address(next), address(_borrower2));
@@ -243,25 +243,25 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(0, _pool.getHighestThresholdPrice());
 
         // borrower deposits some collateral and draws debt
-        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
-        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0));
         (uint256 thresholdPrice, ) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.721153846153846500 * 1e18);
 
         // borrower2 draws slightly more debt producing a higher TP
-        _borrower2.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
-        _borrower2.borrow(_pool, 31_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower2.addCollateral(_pool, 40 * 1e18, address(0), address(0));
+        _borrower2.borrow(_pool, 31_000 * 1e18, 2551, address(0), address(0));
         (thresholdPrice, ) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 775.745192307692308050 * 1e18);
 
         // borrower3 draws slightly more debt producing a higher TP
-        _borrower3.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
-        _borrower3.borrow(_pool, 32_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower3.addCollateral(_pool, 40 * 1e18, address(0), address(0));
+        _borrower3.borrow(_pool, 32_000 * 1e18, 2551, address(0), address(0));
         (thresholdPrice, ) = _pool.loans(address(_borrower3));
         assertEq(thresholdPrice, 800.769230769230769600 * 1e18);
 
         // borrower2 adds collateral, decreasing their TP, but maintaining their same position in queue
-        _borrower2.addCollateral(_pool, 0.1 * 1e18, address(_borrower3), address(_borrower3), 0);
+        _borrower2.addCollateral(_pool, 0.1 * 1e18, address(_borrower3), address(_borrower3));
         (thresholdPrice, ) = _pool.loans(address(_borrower2));
         assertEq(thresholdPrice, 773.810665643583349676 * 1e18);
 
@@ -289,16 +289,16 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // *borrower(HEAD)*
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3 );
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(address(next), address(0));
         assertEq(address(_borrower), address(_pool.loanQueueHead()));
 
         // *borrower2(HEAD)* -> borrower
-        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0));
 
         (thresholdPrice, next) = _pool.loans(address(_borrower2));
         assertEq(address(next), address(_borrower));
@@ -307,7 +307,7 @@ contract ScaledQueueTest is DSTestPlus {
         (uint256 debt, uint256 pendingDebt, uint256 collateral, ) = _pool.borrowerInfo(address(_borrower));
 
         // borrower2(HEAD)
-        _borrower.repay(_pool, pendingDebt, address(_borrower2), address(0), _r3);
+        _borrower.repay(_pool, pendingDebt, address(_borrower2), address(0));
 
         // check that borrower 1 has been removed from the queue, and queue head was updated to borrower 2
         (thresholdPrice, next) = _pool.loans(address(_borrower));
@@ -319,85 +319,11 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(address(next), address(0));
     }
 
-    // TODO: write test with radius of 0
-    // TODO: write test with decimal radius
-    // TODO: write test with radius larger than queue
-    /**
-     *  @notice With 1 lender and 6 borrowers test borrowing, check loan placement in the queue with various search radii.
-     */
-    function testRadiusInQueue() public {
-        _lender.addQuoteToken(_pool, 50_000 * 1e18, 2549);
-        _lender.addQuoteToken(_pool, 50_000 * 1e18, 2550);
-        _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
-
-        // *borrower(HEAD)*
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3);
-
-        (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
-        assertEq(address(next), address(0));
-        assertEq(address(_borrower), address(_pool.loanQueueHead()));
-
-        // *borrower2(HEAD)* -> borrower
-        _borrower2.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower2.borrow(_pool, 20_000 * 1e18, 2551, address(0), address(0), _r3);
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower2));
-        assertEq(address(next), address(_borrower));
-        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
-
-        // borrower2(HEAD) -> borrower -> *borrower3*
-        _borrower3.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower3.borrow(_pool, 10_000 * 1e18, 2551, address(0), address(_borrower), _r3);
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower3));
-        assertEq(address(next), address(0));
-        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
-
-        // borrower2(HEAD) -> borrower -> borrower3 -> *borrower4*
-        _borrower4.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower4.borrow(_pool, 5_000 * 1e18, 2551, address(0), address(_borrower3), _r3);
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower4));
-        assertEq(address(next), address(0));
-        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
-
-        // borrower2(HEAD) -> borrower -> borrower3 -> borrower4 -> *borrower5*
-        _borrower5.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower5.borrow(_pool, 2_000 * 1e18, 2551, address(0), address(_borrower4), _r3);
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower5));
-        assertEq(address(next), address(0));
-        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
-
-        // borrower2(HEAD) -> borrower -> borrower3 -> borrower4 -> borrower5 -> *borrower6*
-        _borrower6.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-
-        // newPrev passed in is incorrect & radius is too small, revert
-        vm.expectRevert("B:S:SRCH_RDS_FAIL");
-        _borrower6.borrow(_pool, 1_100 * 1e18, 2551, address(0), address(_borrower), _r1);
-
-        // newPrev passed in is incorrect & radius supports correct placement
-        _borrower6.borrow(_pool, 1_100 * 1e18, 2551, address(0), address(_borrower), _r3);
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower6));
-        assertEq(address(next), address(0));
-        assertEq(address(_borrower2), address(_pool.loanQueueHead()));
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower4));
-        assertEq(address(next), address(_borrower5));
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower5));
-        assertEq(address(next), address(_borrower6));
-
-        (thresholdPrice, next) = _pool.loans(address(_borrower));
-        assertEq(address(next), address(_borrower3));
-    }
-
     // TODO: test with multiple borrowers and update of threshold prices causing queue reordering
     /**
      *  @notice With 1 lender and 1 borrower test adding collateral, borrowing, and adding additional collateral. 
-     *  Check that loan queue updates, and threshold price shifts on each action.
+     ccccvlrnkcktivggctgvtlkeutgllknlgeiteldbtl
+
      */
     function testUpdateLoanQueueAddCollateral() public {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2549);
@@ -405,8 +331,8 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // borrower 1 borrows and becomes initial HEAD
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0));
 
         // check queue head and threshold price were set correctly
         (uint256 debt, , uint256 collateral, ) = _pool.borrowerInfo(address(_borrower));
@@ -415,7 +341,7 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(address(_borrower), address(_pool.loanQueueHead()));
         assertEq(thresholdPrice, Maths.wdiv(debt, collateral));
 
-        _borrower.addCollateral(_pool, 11 * 1e18, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 11 * 1e18, address(0), address(0));
 
         (debt, , collateral, ) = _pool.borrowerInfo(address(_borrower));
         (thresholdPrice, next) = _pool.loans(address(_borrower));
@@ -434,8 +360,8 @@ contract ScaledQueueTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 50_000 * 1e18, 2551);
 
         // *borrower(HEAD)*
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 15_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 debt, , uint256 collateral, ) = _pool.borrowerInfo(address(_borrower));
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
@@ -443,7 +369,7 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(address(_borrower), address(_pool.loanQueueHead()));
         assertEq(thresholdPrice, Maths.wdiv(debt, collateral));
 
-        _borrower.removeCollateral(_pool, 11 * 1e18, address(0), address(0), _r3);
+        _borrower.removeCollateral(_pool, 11 * 1e18, address(0), address(0));
 
         (debt, , collateral, ) = _pool.borrowerInfo(address(_borrower));
         (thresholdPrice, next) = _pool.loans(address(_borrower));
@@ -465,17 +391,17 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(0, _pool.getHighestThresholdPrice());
 
         // borrower deposits some collateral and draws debt
-        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0), 0);
-        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0), 0);
+        _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0));
         (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.721153846153846500 * 1e18);
 
         // borrower2 successfully deposits slightly less collateral
-        _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(_borrower), 0);
+        _borrower2.addCollateral(_pool, 39.9 * 1e18, address(0), address(_borrower));
 
         // borrower2 draws the same debt, producing a higher TP, but supplies the wrong order
         vm.expectRevert("B:U:QUE_WRNG_ORD_P");
-        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(_borrower), 0);
+        _borrower2.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(_borrower));
     }
 
     /**
@@ -489,8 +415,8 @@ contract ScaledQueueTest is DSTestPlus {
         assertEq(0, _pool.getHighestThresholdPrice());
 
         // borrow and insert into the Queue
-        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0), _r3);
-        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0), _r3);
+        _borrower.addCollateral(_pool, 51 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 50_000 * 1e18, 2551, address(0), address(0));
 
         (uint256 debt, , uint256 collateral, ) = _pool.borrowerInfo(address(_borrower));
 

--- a/src/_test/ScaledPool/ScaledPoolQueue.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQueue.t.sol
@@ -393,7 +393,7 @@ contract ScaledQueueTest is DSTestPlus {
         // borrower deposits some collateral and draws debt
         _borrower.addCollateral(_pool, 40 * 1e18, address(0), address(0));
         _borrower.borrow(_pool, 30_000 * 1e18, 2551, address(0), address(0));
-        (uint256 thresholdPrice, address next) = _pool.loans(address(_borrower));
+        (uint256 thresholdPrice, ) = _pool.loans(address(_borrower));
         assertEq(thresholdPrice, 750.721153846153846500 * 1e18);
 
         // borrower2 successfully deposits slightly less collateral

--- a/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
@@ -167,8 +167,8 @@ contract ScaledQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 30_000 * 1e18, 4990);
         _collateral.mint(address(_borrower), 3500000 * 1e18);
         _borrower.approveToken(_collateral, address(_pool), 3500000 * 1e18);
-        _borrower.addCollateral(_pool, 3500000 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 70000 * 1e18, 4551, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 3500000 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 70000 * 1e18, 4551, address(0), address(0));
 
         // should revert if removing quote token from higher price buckets would drive lup below htp
         vm.expectRevert("S:RQT:BAD_LUP");
@@ -249,8 +249,8 @@ contract ScaledQuoteTokenTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 30_000 * 1e18, 4651);
         _collateral.mint(address(_borrower), 1500000 * 1e18);
         _borrower.approveToken(_collateral, address(_pool), 1500000 * 1e18);
-        _borrower.addCollateral(_pool, 1500000 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 60000.1 * 1e18, 4651, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 1500000 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 60000.1 * 1e18, 4651, address(0), address(0));
 
         // should revert if movement would drive lup below htp
         vm.expectRevert("S:MQT:LUP_BELOW_HTP");

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -11,11 +11,6 @@ abstract contract DSTestPlus is Test {
     // nonce for generating random addresses
     uint16 internal _nonce = 0;
 
-    // radius for borrow queue
-    uint256 internal _r1 = 1;
-    uint256 internal _r2 = 2;
-    uint256 internal _r3 = 3;
-
     // prices
     uint256 internal _p50159    = 50_159.593888626183666006 * 1e18;
     uint256 internal _p49910    = 49_910.043670274810022205 * 1e18;

--- a/src/_test/utils/Users.sol
+++ b/src/_test/utils/Users.sol
@@ -45,29 +45,29 @@ contract UserWithCollateral {
 
 contract UserWithCollateralInScaledPool {
 
-    function approveAndDepositTokenAsCollateral(IERC20 token_, ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) public {
+    function approveAndDepositTokenAsCollateral(IERC20 token_, ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_) public {
         token_.approve(address(pool_), amount_);
-        pool_.addCollateral(amount_, oldPrev_, newPrev_, radius_);
+        pool_.addCollateral(amount_, oldPrev_, newPrev_);
     }
 
     function approveToken(IERC20 token_, address spender_, uint256 amount_) public {
         token_.approve(spender_, amount_);
     }
 
-    function addCollateral(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) public {
-        pool_.addCollateral(amount_, oldPrev_, newPrev_, radius_);
+    function addCollateral(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_) public {
+        pool_.addCollateral(amount_, oldPrev_, newPrev_);
     }
 
-    function borrow(ScaledPool pool_, uint256 amount_, uint256 limitIndex_, address oldPrev_, address newPrev_, uint256 radius_) public {
-        pool_.borrow(amount_, limitIndex_, oldPrev_, newPrev_, radius_);
+    function borrow(ScaledPool pool_, uint256 amount_, uint256 limitIndex_, address oldPrev_, address newPrev_) public {
+        pool_.borrow(amount_, limitIndex_, oldPrev_, newPrev_);
     }
 
-    function removeCollateral(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) public {
-        pool_.removeCollateral(amount_, oldPrev_, newPrev_, radius_);
+    function removeCollateral(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_) public {
+        pool_.removeCollateral(amount_, oldPrev_, newPrev_);
     }
 
-    function repay(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_, uint256 radius_) public {
-        pool_.repay(amount_, oldPrev_, newPrev_, radius_);
+    function repay(ScaledPool pool_, uint256 amount_, address oldPrev_, address newPrev_) public {
+        pool_.repay(amount_, oldPrev_, newPrev_);
     }
 
 }


### PR DESCRIPTION
To reduce complexity for future development / testing as well as come up with a better solution, removed radius from queue implementation.
* Removed `_searchRadius()` method
* Removed `radius` arg from following methods : `addCollateral`, `_updateLoanQueue`, `borrow`, `removeCollateral`, `repay`
* Updated corresponding tests