### PR TITLE
0 TP Testing; Fix collateralScale bug; 0 TP safety checks

### DIFF
--- a/src/Queue.sol
+++ b/src/Queue.sol
@@ -23,7 +23,7 @@ abstract contract Queue is IQueue {
      *  @return newPrev         Corrected previous borrower that now comes before placed loan (new)
      *  @return newPrevLoan     Corrected previous loan that now comes before placed loan (new)
      */
-    function _searchRadius(uint256 radius_, uint256 thresholdPrice_, address newPrev_, address borrower_) internal returns (address, LoanInfo memory) {
+    function _searchRadius(uint256 radius_, uint256 thresholdPrice_, address newPrev_, address borrower_) internal view returns (address, LoanInfo memory) {
         address current = newPrev_;
         LoanInfo memory currentLoan = loans[current];
         LoanInfo memory nextLoan;
@@ -56,6 +56,8 @@ abstract contract Queue is IQueue {
      */
     function _updateLoanQueue(address borrower_, uint256 thresholdPrice_, address oldPrev_, address newPrev_, uint256 radius_) internal {
         require(oldPrev_ != borrower_ && newPrev_ != borrower_, "B:U:PNT_SELF_REF");
+        require(thresholdPrice_ != 0, "B:U:TP_EQ_0");
+
         LoanInfo memory oldPrevLoan = loans[oldPrev_];
         LoanInfo memory newPrevLoan = loans[newPrev_];
         LoanInfo memory loan = loans[borrower_];
@@ -78,15 +80,18 @@ abstract contract Queue is IQueue {
 
         } else if (loanQueueHead != address(0)) {
             // loan doesn't exist yet, other loans in queue
+
             require(oldPrev_ == address(0), "B:U:ALRDY_IN_QUE");
 
             loan.thresholdPrice = thresholdPrice_;
 
             if (newPrev_ != address(0)) {
+                // loan gets appended to newPrev_
                 loan.next = newPrevLoan.next;
                 newPrevLoan.next = borrower_;
 
             } else {
+                // loan becomes new queue head
                 loan.next = loanQueueHead;
                 loanQueueHead = borrower_;
             }

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -13,8 +13,6 @@ import { Queue }       from "./Queue.sol";
 import { BucketMath } from "./libraries/BucketMath.sol";
 import { Maths }      from "./libraries/Maths.sol";
 
-import { console } from "@std/console.sol";
-
 contract ScaledPool is Clone, FenwickTree, Queue {
     using SafeERC20 for ERC20;
 

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -13,6 +13,8 @@ import { Queue }       from "./Queue.sol";
 import { BucketMath } from "./libraries/BucketMath.sol";
 import { Maths }      from "./libraries/Maths.sol";
 
+import { console } from "@std/console.sol";
+
 contract ScaledPool is Clone, FenwickTree, Queue {
     using SafeERC20 for ERC20;
 
@@ -284,7 +286,7 @@ contract ScaledPool is Clone, FenwickTree, Queue {
         require(_borrowerCollateralization(borrower.debt, borrower.collateral, newLup) >= Maths.WAD, "S:B:BUNDER_COLLAT");
 
         require(
-            _poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral / collateralScale, newLup) >= Maths.WAD,
+            _poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral, newLup) >= Maths.WAD,
             "S:B:PUNDER_COLLAT"
         );
         curDebt += debt;

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -343,7 +343,7 @@ contract ScaledBorrowTest is DSTestPlus {
     }
 
     /**
-     *  @notice 1 lender, 1 borrower tests reverts in borrow.
+     *  @notice 1 lender, 1 borrower test significantly overcollateralized loans with 0 TP.
      *          Reverts:
      *              Attempts to borrow with a TP of 0.
      */
@@ -352,7 +352,8 @@ contract ScaledBorrowTest is DSTestPlus {
         _lender.addQuoteToken(_pool, 10_000 * 1e18, 2550);
         _lender.addQuoteToken(_pool, 10_000 * 1e18, 2551);
 
-        assertEq(0, _pool.getHighestThresholdPrice());
+        assertEq(_pool.getHighestThresholdPrice(), 0);
+        assertEq(address(_pool.loanQueueHead()), address(0));
 
         // borrower 1 initiates a highly overcollateralized loan with a TP of 0 that won't be inserted into the Queue
         _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
@@ -364,6 +365,41 @@ contract ScaledBorrowTest is DSTestPlus {
         _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0), 1);
 
         assertGt(_pool.getHighestThresholdPrice(), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+
+    }
+
+    /**
+     *  @notice 1 lender, 1 borrower test repayment that would result in significant overcollateraization and 0 TP.
+     *          Reverts:
+     *              Attempts to repay with a subsequent TP of 0.
+     */
+    function testZeroThresholdPriceLoanAfterRepay() external {
+
+        // add initial quote to the pool
+        _lender.addQuoteToken(_pool, 10_000 * 1e18, 2550);
+        _lender.addQuoteToken(_pool, 10_000 * 1e18, 2551);
+
+        assertEq(_pool.getHighestThresholdPrice(), 0);
+
+        // borrower 1 borrows 500 quote from the pool
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
+        _borrower.borrow(_pool, 500 * 1e18, 2551, address(0), address(0), 1);
+
+        assertGt(_pool.getHighestThresholdPrice(), 0);
+        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
+        _quote.mint(address(_borrower), 10_000 * 1e18);
+
+        // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
+        vm.expectRevert("B:U:TP_EQ_0");
+        _borrower.repay(_pool, pendingDebt - 1, address(0), address(0), 1);
+
+        // should be able to pay back all pendingDebt
+        _borrower.repay(_pool, pendingDebt, address(0), address(0), 1);
+        assertEq(_pool.getHighestThresholdPrice(), 0);
+        assertEq(address(_pool.loanQueueHead()), address(0));
     }
 
 }

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -356,13 +356,13 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(address(_pool.loanQueueHead()), address(0));
 
         // borrower 1 initiates a highly overcollateralized loan with a TP of 0 that won't be inserted into the Queue
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
         vm.expectRevert("B:U:TP_EQ_0");
-        _borrower.borrow(_pool, .00000000000000001 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.borrow(_pool, .00000000000000001 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after using a non 0 TP
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 500 * 1e18, 3000, address(0), address(0));
 
         assertGt(_pool.getHighestThresholdPrice(), 0);
         assertEq(address(_pool.loanQueueHead()), address(_borrower));
@@ -383,8 +383,8 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.getHighestThresholdPrice(), 0);
 
         // borrower 1 borrows 500 quote from the pool
-        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0), 1);
-        _borrower.borrow(_pool, 500 * 1e18, 2551, address(0), address(0), 1);
+        _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
+        _borrower.borrow(_pool, 500 * 1e18, 2551, address(0), address(0));
 
         assertGt(_pool.getHighestThresholdPrice(), 0);
         assertEq(address(_pool.loanQueueHead()), address(_borrower));
@@ -394,10 +394,10 @@ contract ScaledBorrowTest is DSTestPlus {
 
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
         vm.expectRevert("B:U:TP_EQ_0");
-        _borrower.repay(_pool, pendingDebt - 1, address(0), address(0), 1);
+        _borrower.repay(_pool, pendingDebt - 1, address(0), address(0));
 
         // should be able to pay back all pendingDebt
-        _borrower.repay(_pool, pendingDebt, address(0), address(0), 1);
+        _borrower.repay(_pool, pendingDebt, address(0), address(0));
         assertEq(_pool.getHighestThresholdPrice(), 0);
         assertEq(address(_pool.loanQueueHead()), address(0));
     }


### PR DESCRIPTION
- Add check for 0 TP to `Queue.sol`
- Add tests for 0 TP case to borrow and repay flows
- Fix bug with improper division by `collateralScale` - found while working on tests for non-standard decimal's that I decided to break into a separate PR.