### PR TITLE
Interest accumulation changes

### DIFF
--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -11,11 +11,13 @@ import { FenwickTree } from "./FenwickTree.sol";
 import { IScaledPool } from "./IScaledPool.sol";
 import { Queue }       from "./Queue.sol";
 
-import { BucketMath } from "./libraries/BucketMath.sol";
-import { Maths }      from "./libraries/Maths.sol";
+import { BucketMath }     from "./libraries/BucketMath.sol";
+import { Maths }          from "./libraries/Maths.sol";
+import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 
 contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     using SafeERC20 for ERC20;
+    using PRBMathSD59x18 for int256;
 
     int256  public constant INDEX_OFFSET = 3232;
 
@@ -380,9 +382,9 @@ contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         if (curDebt_ != 0) {
             uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;
             if (elapsed != 0 ) {
-                uint256 spr          = interestRate / SECONDS_PER_YEAR;
+                uint256 rate         = (interestRate / SECONDS_PER_YEAR) * elapsed;
                 uint256 curInflator  = inflatorSnapshot;
-                uint256 nextInflator = Maths.wmul(curInflator, Maths.wpow(Maths.WAD + spr, elapsed));
+                uint256 nextInflator = Maths.wmul(curInflator, uint256(PRBMathSD59x18.exp(int256(rate))));
 
                 uint256 newHtp = _htp();
                 if (newHtp != 0) {

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -13,11 +13,10 @@ import { Queue }       from "./Queue.sol";
 
 import { BucketMath }     from "./libraries/BucketMath.sol";
 import { Maths }          from "./libraries/Maths.sol";
-import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
+import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
 contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     using SafeERC20 for ERC20;
-    using PRBMathSD59x18 for int256;
 
     int256  public constant INDEX_OFFSET = 3232;
 
@@ -518,9 +517,8 @@ contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     }
 
     function _pendingInterestFactor(uint256 elapsed_) internal view returns (uint256) {
-        uint256 rate         = (interestRate / SECONDS_PER_YEAR) * elapsed_;
-        uint256 curInflator  = inflatorSnapshot;
-        return uint256(PRBMathSD59x18.exp(int256(rate)));
+        uint256 rate = (interestRate / SECONDS_PER_YEAR) * elapsed_;
+        return PRBMathUD60x18.exp(rate);
     }
 
     function _pendingInflator() internal view returns (uint256) {

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -492,7 +492,7 @@ contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     }
 
     function _lupIndex(uint256 additionalDebt_) internal view returns (uint256) {
-        return _findSum(borrowerDebt + additionalDebt_);
+        return _findSum(lenderDebt + additionalDebt_);
     }
 
     function _indexToPrice(uint256 index_) internal pure returns (uint256) {

--- a/src/ScaledPool.sol
+++ b/src/ScaledPool.sol
@@ -606,8 +606,8 @@ contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     }
 
     function poolMinDebtAmount() external view returns (uint256) {
-        // TODO: unit test coverage
-        return Maths.wdiv(Maths.wdiv(borrowerDebt, Maths.wad(totalBorrowers)), 10**19);
+        if (borrowerDebt != 0) return _poolMinDebtAmount(borrowerDebt);
+        return 0;
     }
 
     /************************/

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { DSTestPlus } from "./utils/DSTestPlus.sol";
-import { Maths }      from "../libraries/Maths.sol";
+import { DSTestPlus }     from "./utils/DSTestPlus.sol";
+import { Maths }          from "../libraries/Maths.sol";
+import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 
 contract MathTest is DSTestPlus {
 
@@ -53,5 +54,9 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.wadToIntRoundingDown(testNum1), 11_000);
         assertEq(Maths.wadToIntRoundingDown(testNum2), 1_001);
         assertEq(Maths.wadToIntRoundingDown(testNum3), 0);
+    }
+
+    function testExp() external {
+        assertEq(PRBMathSD59x18.exp(1.53 * 1e18), 4.618176822299780807 * 1e18);
     }
 }

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.14;
 
 import { DSTestPlus }     from "./utils/DSTestPlus.sol";
 import { Maths }          from "../libraries/Maths.sol";
-import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
+import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
 contract MathTest is DSTestPlus {
 
@@ -57,6 +57,6 @@ contract MathTest is DSTestPlus {
     }
 
     function testExp() external {
-        assertEq(PRBMathSD59x18.exp(1.53 * 1e18), 4.618176822299780807 * 1e18);
+        assertEq(PRBMathUD60x18.exp(1.53 * 1e18), 4.618176822299780807 * 1e18);
     }
 }

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -130,11 +130,11 @@ contract ScaledBorrowTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_borrower), 19_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_966.176540084047110076 * 1e18, 19_000 * 1e18);
+        emit Borrow(address(_borrower), 2_951.419442869698640451 * 1e18, 19_000 * 1e18);
         _borrower.borrow(_pool, 19_000 * 1e18, 3500, address(0), address(0));
 
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
-        assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
+        assertEq(_pool.lup(), 2_951.419442869698640451 * 1e18);
 
         assertEq(_pool.treeSum(),      50_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 40_038.461538461538480000 * 1e18);
@@ -204,7 +204,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(), 21_020.192307692307702000 * 1e18);
         (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_020.192307692307702000 * 1e18);
-        assertEq(pendingDebt, 21_051.890446205859712111 * 1e18);
+        assertEq(pendingDebt, 21_051.890446233188505554 * 1e18);
         assertEq(col,         50 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
@@ -248,7 +248,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(), 21_199.628356880380570924 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_199.628356880380570924 * 1e18);
-        assertEq(pendingDebt, 21_246.450141854883757085 * 1e18);
+        assertEq(pendingDebt, 21_246.450141911768550258 * 1e18);
         assertEq(col,         50 * 1e18);
         assertEq(inflator,    1.008536365726892447 * 1e18);
     }
@@ -287,8 +287,9 @@ contract ScaledBorrowTest is DSTestPlus {
         _borrower.borrow(_pool, 10 * 1e18, 3000, address(0), address(_borrower2));
 
         // should revert if borrow would result in borrower under collateralization
+        assertEq(_pool.lup(), 2_995.912459898389633881 * 1e18);
         vm.expectRevert("S:B:BUNDER_COLLAT");
-        _borrower2.borrow(_pool, 4_500 * 1e18, 3000, address(0), address(_borrower));
+        _borrower2.borrow(_pool, 2_976 * 1e18, 3000, address(0), address(_borrower));
 
         // should be able to borrow if properly specified
         vm.expectEmit(true, true, false, true);

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -210,46 +210,47 @@ contract ScaledBorrowTest is DSTestPlus {
 
         skip(864000);
         _borrower.addCollateral(_pool, 10 * 1e18, address(0), address(0));
-        assertEq(_pool.borrowerDebt(), 21_083.636385042573188669 * 1e18);
+        assertEq(_pool.borrowerDebt(), 21_083.636385097313216749 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
-        assertEq(debt,        21_083.636385042573188669 * 1e18);
-        assertEq(pendingDebt, 21_083.636385042573188669 * 1e18);
+        assertEq(debt,        21_083.636385097313216749 * 1e18);
+        assertEq(pendingDebt, 21_083.636385097313216749 * 1e18);
         assertEq(col,         60 * 1e18);
-        assertEq(inflator,    1.003018244382428805 * 1e18);
+        assertEq(inflator,    1.003018244385032969 * 1e18);
 
         skip(864000);
         _borrower.removeCollateral(_pool, 10 * 1e18, address(0), address(0));
-        assertEq(_pool.borrowerDebt(), 21_118.612213172841725096 * 1e18);
+        assertEq(_pool.borrowerDebt(), 21_118.612213256345042351 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
-        assertEq(debt,        21_118.612213172841725096 * 1e18);
-        assertEq(pendingDebt, 21_118.612213172841725096 * 1e18);
+        assertEq(debt,        21_118.612213256345042351 * 1e18);
+        assertEq(pendingDebt, 21_118.612213256345042351 * 1e18);
         assertEq(col,         50 * 1e18);
-        assertEq(inflator,    1.004682160088731320 * 1e18);
+        assertEq(inflator,    1.004682160092703849 * 1e18);
 
         skip(864000);
         _borrower.borrow(_pool, 0, 3000, address(0), address(0));
-        assertEq(_pool.borrowerDebt(), 21_157.152642868828624051 * 1e18);
+        assertEq(_pool.borrowerDebt(), 21_157.152642997118010824 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
-        assertEq(debt,        21_157.152642868828624051 * 1e18);
-        assertEq(pendingDebt, 21_157.152642868828624051 * 1e18);
+        assertEq(debt,        21_157.152642997118010824 * 1e18);
+        assertEq(pendingDebt, 21_157.152642997118010824 * 1e18);
         assertEq(col,         50 * 1e18);
-        assertEq(inflator,    1.006515655669163431 * 1e18);
+        assertEq(inflator,    1.006515655675266581 * 1e18);
 
         skip(864000);
         _borrower.repay(_pool, 0, address(0), address(0));
-        assertEq(_pool.borrowerDebt(), 21_199.628356700342110209 * 1e18);
+        assertEq(_pool.borrowerDebt(), 21_199.628356880380570924 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
-        assertEq(debt,        21_199.628356700342110209 * 1e18);
-        assertEq(pendingDebt, 21_199.628356700342110209 * 1e18);
+        assertEq(debt,        21_199.628356880380570924 * 1e18);
+        assertEq(pendingDebt, 21_199.628356880380570924 * 1e18);
         assertEq(col,         50 * 1e18);
-        assertEq(inflator,    1.008536365718327423 * 1e18);
+        assertEq(inflator,    1.008536365726892447 * 1e18);
 
         skip(864000);
+        assertEq(_pool.borrowerDebt(), 21_199.628356880380570924 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
-        assertEq(debt,        21_199.628356700342110209 * 1e18);
-        assertEq(pendingDebt, 21_246.450141674447660998 * 1e18);
+        assertEq(debt,        21_199.628356880380570924 * 1e18);
+        assertEq(pendingDebt, 21_246.450141854883757085 * 1e18);
         assertEq(col,         50 * 1e18);
-        assertEq(inflator,    1.008536365718327423 * 1e18);
+        assertEq(inflator,    1.008536365726892447 * 1e18);
     }
 
     /**

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -132,11 +132,11 @@ contract ScaledBorrowTest is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_borrower), 19_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_951.419442869698640451 * 1e18, 19_000 * 1e18);
+        emit Borrow(address(_borrower), 2_966.176540084047110076 * 1e18, 19_000 * 1e18);
         _borrower.borrow(_pool, 19_000 * 1e18, 3500, address(0), address(0));
 
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
-        assertEq(_pool.lup(), 2_951.419442869698640451 * 1e18);
+        assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
 
         assertEq(_pool.treeSum(),           50_000 * 1e18);
         assertEq(_pool.borrowerDebt(),      40_038.461538461538480000 * 1e18);

--- a/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolBorrow.t.sol
@@ -72,6 +72,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(),          0);
         assertEq(_pool.lenderDebt(),            0);
         assertEq(_pool.poolActualUtilization(), 0);
+        assertEq(_pool.poolMinDebtAmount(),     0);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   50_000 * 1e18);
@@ -97,6 +98,7 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.lenderDebt(),   21_000 * 1e18);
         assertEq(_pool.poolTargetUtilization(), 1 * 1e18);
         assertEq(_pool.poolActualUtilization(), 0.420403846153846154 * 1e18);
+        assertEq(_pool.poolMinDebtAmount(),     2_102.0192307692307702 * 1e18);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   29_000 * 1e18);
@@ -136,9 +138,10 @@ contract ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
         assertEq(_pool.lup(), 2_951.419442869698640451 * 1e18);
 
-        assertEq(_pool.treeSum(),      50_000 * 1e18);
-        assertEq(_pool.borrowerDebt(), 40_038.461538461538480000 * 1e18);
-        assertEq(_pool.lenderDebt(),   40_000 * 1e18);
+        assertEq(_pool.treeSum(),           50_000 * 1e18);
+        assertEq(_pool.borrowerDebt(),      40_038.461538461538480000 * 1e18);
+        assertEq(_pool.lenderDebt(),        40_000 * 1e18);
+        assertEq(_pool.poolMinDebtAmount(), 4_003.846153846153848 * 1e18);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   10_000 * 1e18);

--- a/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolCollateral.t.sol
@@ -136,15 +136,15 @@ contract ScaledCollateralTest is DSTestPlus {
         _borrower.removeCollateral(_pool, unencumberedCollateral, address(0), address(0));
 
         // check pool state
-        assertEq(_pool.htp(), 2_989.185764494416579966 * 1e18);
+        assertEq(_pool.htp(), 2_989.185764499773229142 * 1e18);
         assertEq(_pool.lup(), 2_981.007422784467321543 * 1e18);
 
-        assertEq(_pool.treeSum(),           30_025.933063881970800000 * 1e18);
-        assertEq(_pool.borrowerDebt(),      21_049.006823116719685828 * 1e18);
+        assertEq(_pool.treeSum(),           30_025.933063898944800000 * 1e18);
+        assertEq(_pool.borrowerDebt(),      21_049.006823135579696033 * 1e18);
         assertEq(_pool.lenderDebt(),        21_000 * 1e18);
         assertEq(_pool.pledgedCollateral(), _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()));
 
-        assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.061038044466018134 * 1e18);
+        assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.061038044472344858 * 1e18);
         assertEq(_pool.encumberedCollateral(_pool.lenderDebt(), _pool.lup()),   7.044598359431304627 * 1e18);
 
         // check borrower state
@@ -155,7 +155,7 @@ contract ScaledCollateralTest is DSTestPlus {
             _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()),
             _pool.encumberedCollateral(borrowerDebt, _pool.lup())
         );
-        assertEq(_collateral.balanceOf(address(_borrower)), 142.938961955533981866 * 1e18);
+        assertEq(_collateral.balanceOf(address(_borrower)), 142.938961955527655142 * 1e18);
 
         assertEq(_pool.borrowerCollateralization(borrowerDebt, borrowerCollateral, _pool.lup()), _pool.poolCollateralization());
     }

--- a/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
@@ -113,12 +113,12 @@ contract ScaledInterestRateTest is DSTestPlus {
         _borrower.addCollateral(_pool, 50 * 1e18, address(0), address(0));
         _borrower.borrow(_pool, 15_000 * 1e18, 4300, address(0), address(0));
         assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
-        assertEq(_pool.pendingInflator(), 1.000005707778841975 * 1e18);
+        assertEq(_pool.pendingInflator(), 1.000005707778845707 * 1e18);
         vm.warp(block.timestamp+3600);
 
         // ensure pendingInflator increases as time passes
         assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
-        assertEq(_pool.pendingInflator(), 1.000011415590262688 * 1e18);
+        assertEq(_pool.pendingInflator(), 1.000011415590270154 * 1e18);
     }
 
     // TODO: add test related to pool utilization changes

--- a/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolInterestRate.t.sol
@@ -88,7 +88,7 @@ contract ScaledInterestRateTest is DSTestPlus {
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        assertEq(_pool.treeSum(),      110_162.490615926716800000 * 1e18);
+        assertEq(_pool.treeSum(),      110_162.490615980593600000 * 1e18);
         assertEq(_pool.borrowerDebt(), 0);
         assertEq(_pool.lenderDebt(),   0);
 
@@ -96,7 +96,7 @@ contract ScaledInterestRateTest is DSTestPlus {
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col,         100 * 1e18);
-        assertEq(inflator,    1.001507985181560500 * 1e18);
+        assertEq(inflator,    1.001507985182860621 * 1e18);
 
         assertEq(_pool.interestRate(),       0.055 * 1e18); // FIXME here it should decrease
         assertEq(_pool.interestRateUpdate(), 864000);

--- a/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
@@ -174,7 +174,7 @@ contract ScaledQuoteTokenTest is DSTestPlus {
         vm.expectRevert("S:RQT:BAD_LUP");
         _lender.removeQuoteToken(_pool, 20_000 * 1e27, 4551);
 
-        // FIXME: Reverts with S:RQT:BAD_LUP when removing 10k, perhaps because interest accumulation has pushed debt to 4551.
+        assertEq(_pool.borrowerDebt(), 70_067.30769230769234 * 1e18);
         // should be able to removeQuoteToken if quote tokens haven't been encumbered by a borrower
         emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
         _lender.removeQuoteToken(_pool, 10_000 * 1e27, 4990);

--- a/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
@@ -174,7 +174,6 @@ contract ScaledQuoteTokenTest is DSTestPlus {
         vm.expectRevert("S:RQT:BAD_LUP");
         _lender.removeQuoteToken(_pool, 20_000 * 1e27, 4551);
 
-        assertEq(_pool.borrowerDebt(), 70_067.30769230769234 * 1e18);
         // should be able to removeQuoteToken if quote tokens haven't been encumbered by a borrower
         emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
         _lender.removeQuoteToken(_pool, 10_000 * 1e27, 4990);

--- a/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ScaledPool/ScaledPoolQuoteToken.t.sol
@@ -174,10 +174,10 @@ contract ScaledQuoteTokenTest is DSTestPlus {
         vm.expectRevert("S:RQT:BAD_LUP");
         _lender.removeQuoteToken(_pool, 20_000 * 1e27, 4551);
 
+        // FIXME: Reverts with S:RQT:BAD_LUP when removing 10k, perhaps because interest accumulation has pushed debt to 4551.
         // should be able to removeQuoteToken if quote tokens haven't been encumbered by a borrower
         emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
         _lender.removeQuoteToken(_pool, 10_000 * 1e27, 4990);
-
     }
 
     function testScaledPoolMoveQuoteToken() external {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -448,7 +448,8 @@ class TestUtils:
               f"pledged collaterl: {pool.pledgedCollateral()/1e18:>7.1f}  "
               f"ptp: {ptp/1e18:>10.3f}  "
               f"ru: {ru/1e18:>12.1f}  "
-              f"sum: {pool.treeSum()/1e18:>12.1f}")
+              f"sum: {pool.treeSum()/1e18:>12.1f}  "
+              f"rate:     {pool.interestRate()/1e18:>10.6f}")
 
 
 @pytest.fixture


### PR DESCRIPTION
**Changes**
- This branch uses the v10 formula for calculating the inflator: `e^(spr*elapsed)`.  PRBMath library was needed to get a working `exp` function.  This fixes issues with the `lenderDebt` accumulator and contract quote token balance (evidenced [here](https://docs.google.com/spreadsheets/d/17dhJwTBRSiBTrxzYIwMsa7QNR9QY_in_iovSTSvqy00/edit#gid=925719171)).
- Resolved issue with interest accumulation.  Old implementation was scaling the fenwick tree by the inflator rather than the factor.  As such, interest owed to lenders was roughly twice what it should have been, causing reserves to go negative.  To resolve, adjusted implementation using [sim](https://github.com/ajna-finance/ajna-sim/blob/diez/ajna_sim/scaledpool.py#L444) as a guide.
- Improved repayments in real-world test, which required exposing `poolMinDebtAmount` in the contract.
- Implemented facility to summarize pool data in Brownie tests.  