### PR TITLE
Update python tests tov10

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,12 +56,6 @@ def weth(ajna_protocol):
     return ajna_protocol.get_token(WETH_ADDRESS).get_contract()
 
 
-# TODO: convert to deploying all necessary libraries "libraries(deployer)"
-@pytest.fixture
-def bucket_math(ajna_protocol):
-    return ajna_protocol.bucket_math
-
-
 @pytest.fixture
 def mkr_dai_pool(ajna_protocol):
     return ajna_protocol.get_pool(MKR_ADDRESS, DAI_ADDRESS)
@@ -74,12 +68,6 @@ def scaled_pool(deployer):
     return ScaledPool.at(
         scaled_factory.deployedPools("2263c4378b4920f0bef611a3ff22c506afa4745b3319c50b6d704a874990b8b2", MKR_ADDRESS, DAI_ADDRESS)
         )
-
-
-@pytest.fixture
-def position_manager(deployer):
-    position_manager = PositionManager.deploy({"from": deployer})
-    yield position_manager
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,6 @@ def scaled_pool_utils(ajna_protocol):
 
 
 class TestUtils:
-    ZRO_ADD = ZRO_ADD
     capsys = None
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,7 @@ def scaled_pool_utils(ajna_protocol):
 
 
 class TestUtils:
+    OXO = '0x0000000000000000000000000000000000000000'
     capsys = None
 
     @staticmethod
@@ -203,6 +204,8 @@ class TestUtils:
         in_eth = gas * 100 * 10e-9
         in_fiat = in_eth * 3000
         return f"Gas amount: {gas}, Gas in ETH: {in_eth}, Gas price: ${in_fiat}"
+    
+
 
     class GasWatcher(object):
         _cache = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,9 @@ from brownie.exceptions import VirtualMachineError
 from brownie.network.state import TxHistory
 from brownie.utils import color
 
-
-ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+ZRO_ADD = '0x0000000000000000000000000000000000000000' 
 MIN_PRICE = 99836282890
 MAX_PRICE = 1_004_968_987606512354182109771
-
 
 @pytest.fixture(autouse=True)
 def get_capsys(capsys):
@@ -129,18 +127,18 @@ class ScaledPoolUtils:
         assert isinstance(borrower, str)
         assert isinstance(threshold_price, int)
 
-        if pool.loanQueueHead != ZERO_ADDRESS:
+        if pool.loanQueueHead != ZRO_ADD:
             if debug:
                 print(f"  looking for borrower {borrower[:6]} and TP {threshold_price / 1e18:.18f}")
-            old_previous_borrower = ZERO_ADDRESS
+            old_previous_borrower = ZRO_ADD
             node = Loan(pool.loanQueueHead(), pool.loanInfo(pool.loanQueueHead()))
 
             if node.tp >= threshold_price and node.borrower != borrower:
                 new_previous_borrower = node.borrower
             else:
-                new_previous_borrower = ZERO_ADDRESS
+                new_previous_borrower = ZRO_ADD
 
-            while node.borrower != ZERO_ADDRESS:
+            while node.borrower != ZRO_ADD:
                 if debug:
                     print(f"   {node.borrower[:6]} at TP {node.tp / 1e18:.18f}, next is {node.next[:6]}")
                 if node.next == borrower:
@@ -156,10 +154,10 @@ class ScaledPoolUtils:
             assert old_previous_borrower != borrower
             assert new_previous_borrower != borrower
             _, check_old_prev_next = pool.loanInfo(old_previous_borrower)
-            assert (old_previous_borrower == ZERO_ADDRESS or check_old_prev_next == borrower)
+            assert (old_previous_borrower == ZRO_ADD or check_old_prev_next == borrower)
             return old_previous_borrower, new_previous_borrower
         else:
-            return ZERO_ADDRESS, ZERO_ADDRESS
+            return ZRO_ADD, ZRO_ADD
 
     @staticmethod
     def get_origination_fee(pool: ScaledPool, amount):
@@ -184,7 +182,7 @@ def scaled_pool_utils(ajna_protocol):
 
 
 class TestUtils:
-    OXO = '0x0000000000000000000000000000000000000000'
+    ZRO_ADD = ZRO_ADD
     capsys = None
 
     @staticmethod
@@ -338,7 +336,7 @@ class TestUtils:
         borrower = pool.loanQueueHead()
         tp, next_borrower = pool.loanInfo(borrower)
         last_tp = tp
-        while next_borrower != ZERO_ADDRESS:
+        while next_borrower != ZRO_ADD:
             # catch duplicate borrowers
             assert borrower not in found_borrowers
             found_borrowers.add(borrower)

--- a/tests/test_borrow_gas.py
+++ b/tests/test_borrow_gas.py
@@ -4,11 +4,10 @@ import pytest
 from decimal import *
 import inspect
 
-@pytest.mark.skip
 def test_borrow_gas(
     lenders,
     borrowers,
-    mkr_dai_pool,
+    scaled_pool,
     capsys,
     test_utils,
     bucket_math,
@@ -16,47 +15,33 @@ def test_borrow_gas(
     with test_utils.GasWatcher(["borrow", "addCollateral", "addQuoteToken"]):
         txes = []
         for i in range(1643, 1663):
-            mkr_dai_pool.addQuoteToken(
-                10_000 * 10**18,
-                bucket_math.indexToPrice(i),
-                {"from": lenders[0]},
-            )
+            scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
-        mkr_dai_pool.addCollateral(100 * 10**18, {"from": borrowers[0]})
-        mkr_dai_pool.addCollateral(100 * 10**18, {"from": borrowers[1]})
+        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[1]})
 
-        # borrow 10_000 DAI from single bucket (LUP)
-        tx_one_bucket = mkr_dai_pool.borrow(
-            10_000 * 10**18, 1 * 10**18, {"from": borrowers[0]}
-        )
-        tx_reallocate_debt_one_bucket = mkr_dai_pool.addQuoteToken(
-            10_000 * 10**18,
-            bucket_math.indexToPrice(1664),
-            {"from": lenders[1]},
-        )
-        txes.append(tx_one_bucket)
-        txes.append(tx_reallocate_debt_one_bucket)
+        # borrower 0 draws 10_000 DAI from single bucket (LUP)
+        tx1 = scaled_pool.borrow(
+            10_000 * 10**18, 1 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        txes.append(tx1)
+        tx2 = scaled_pool.addQuoteToken(10_000 * 10**18, 1664, {"from": lenders[1]})
+        txes.append(tx2)
 
-        # borrow 101_000 DAI from 11 buckets
-        tx_11_buckets = mkr_dai_pool.borrow(
-            101_000 * 10**18, 1 * 10**18, {"from": borrowers[1]}
-        )
-        tx_reallocate_debt_11_buckets = mkr_dai_pool.addQuoteToken(
-            150_000 * 10**18,
-            bucket_math.indexToPrice(1665),
-            {"from": lenders[2]},
-        )
-        txes.append(tx_11_buckets)
+        # borrower 1 draws 101_000 DAI from 11 buckets
+        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[1]})
+        tx4 = scaled_pool.addQuoteToken(150_000 * 10**18, 1665, {"from": lenders[2]})
+        txes.append(tx3)
+        txes.append(tx4)
 
         with capsys.disabled():
             print("\n==================================")
             print(f"Gas estimations({inspect.stack()[0][3]}):")
             print("==================================")
             print(
-                f"Borrow single bucket           - {test_utils.get_usage(tx_one_bucket.gas_used)}\n"
-                f"Reallocate debt single bucket  - {test_utils.get_usage(tx_reallocate_debt_one_bucket.gas_used)}"
+                f"Borrow single bucket           - {test_utils.get_usage(tx1.gas_used)}\n"
+                f"Reallocate debt single bucket  - {test_utils.get_usage(tx2.gas_used)}"
             )
             print(
-                f"Borrow from multiple buckets (11)      - {test_utils.get_usage(tx_11_buckets.gas_used)}\n"
-                f"Reallocate debt multiple buckets (11)  - {test_utils.get_usage(tx_reallocate_debt_11_buckets.gas_used)}"
+                f"Borrow from multiple buckets (11)      - {test_utils.get_usage(tx3.gas_used)}\n"
+                f"Reallocate debt multiple buckets (11)  - {test_utils.get_usage(tx4.gas_used)}"
             )

--- a/tests/test_borrow_gas.py
+++ b/tests/test_borrow_gas.py
@@ -1,8 +1,9 @@
 import brownie
-from brownie import Contract
 import pytest
-from decimal import *
 import inspect
+from decimal import *
+from brownie import Contract
+from conftest import ZRO_ADD
 
 def test_borrow_gas(
     lenders,
@@ -16,18 +17,18 @@ def test_borrow_gas(
         for i in range(1643, 1663):
             scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[1]})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[1]})
 
         # borrower 0 draws 10_000 DAI from single bucket (LUP)
         tx1 = scaled_pool.borrow(
-            10_000 * 10**18, 1 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+            10_000 * 10**18, 1 * 10**18,ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx1)
         tx2 = scaled_pool.addQuoteToken(10_000 * 10**18, 1664, {"from": lenders[1]})
         txes.append(tx2)
 
         # borrower 1 draws 101_000 DAI from 11 buckets
-        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[1]})
+        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,ZRO_ADD, ZRO_ADD, {"from": borrowers[1]})
         tx4 = scaled_pool.addQuoteToken(150_000 * 10**18, 1665, {"from": lenders[2]})
         txes.append(tx3)
         txes.append(tx4)

--- a/tests/test_borrow_gas.py
+++ b/tests/test_borrow_gas.py
@@ -9,8 +9,7 @@ def test_borrow_gas(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
     with test_utils.GasWatcher(["borrow", "addCollateral", "addQuoteToken"]):
         txes = []

--- a/tests/test_borrow_gas.py
+++ b/tests/test_borrow_gas.py
@@ -16,18 +16,18 @@ def test_borrow_gas(
         for i in range(1643, 1663):
             scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[1]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[1]})
 
         # borrower 0 draws 10_000 DAI from single bucket (LUP)
         tx1 = scaled_pool.borrow(
-            10_000 * 10**18, 1 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+            10_000 * 10**18, 1 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx1)
         tx2 = scaled_pool.addQuoteToken(10_000 * 10**18, 1664, {"from": lenders[1]})
         txes.append(tx2)
 
         # borrower 1 draws 101_000 DAI from 11 buckets
-        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrowers[1]})
+        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[1]})
         tx4 = scaled_pool.addQuoteToken(150_000 * 10**18, 1665, {"from": lenders[2]})
         txes.append(tx3)
         txes.append(tx4)

--- a/tests/test_borrow_gas.py
+++ b/tests/test_borrow_gas.py
@@ -17,18 +17,18 @@ def test_borrow_gas(
         for i in range(1643, 1663):
             scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[1]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[1]})
 
         # borrower 0 draws 10_000 DAI from single bucket (LUP)
         tx1 = scaled_pool.borrow(
-            10_000 * 10**18, 1 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+            10_000 * 10**18, 1 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         txes.append(tx1)
         tx2 = scaled_pool.addQuoteToken(10_000 * 10**18, 1664, {"from": lenders[1]})
         txes.append(tx2)
 
         # borrower 1 draws 101_000 DAI from 11 buckets
-        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[1]})
+        tx3 = scaled_pool.borrow(101_000 * 10**18, 1 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrowers[1]})
         tx4 = scaled_pool.addQuoteToken(150_000 * 10**18, 1665, {"from": lenders[2]})
         txes.append(tx3)
         txes.append(tx4)

--- a/tests/test_collateral_gas.py
+++ b/tests/test_collateral_gas.py
@@ -3,28 +3,19 @@ from brownie import Contract
 import pytest
 import inspect
 
-@pytest.mark.skip
 def test_add_remove_collateral_gas(
     lenders,
     borrowers,
-    mkr_dai_pool,
+    scaled_pool,
     capsys,
     test_utils,
     bucket_math,
 ):
     with test_utils.GasWatcher(["addQuoteToken", "addCollateral", "removeCollateral"]):
-        mkr_dai_pool.addQuoteToken(
-            20_000 * 10**18,
-            bucket_math.indexToPrice(1708),
-            {"from": lenders[0]},
-        )
-        tx_add_collateral = mkr_dai_pool.addCollateral(
-            100 * 10**18, {"from": borrowers[0]}
-        )
-        mkr_dai_pool.borrow(20_000 * 10**18, 2500 * 10**18, {"from": borrowers[0]})
-        tx_remove_collateral = mkr_dai_pool.removeCollateral(
-            10 * 10**18, {"from": borrowers[0]}
-        )
+        scaled_pool.addQuoteToken(20_000 * 10**18, 1708, {"from": lenders[0]})
+        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         with capsys.disabled():
             print("\n==================================")
             print(f"Gas estimations({inspect.stack()[0][3]}):")
@@ -38,10 +29,11 @@ def test_add_remove_collateral_gas(
 def test_claim_collateral_gas(
     lenders,
     borrowers,
-    mkr_dai_pool,
+    scaled_pool,
     capsys,
     test_utils,
     bucket_math,
+    dai
 ):
     with test_utils.GasWatcher(
         ["addQuoteToken", "addCollateral", "borrow", "purchaseBid", "claimCollateral"]
@@ -51,31 +43,37 @@ def test_claim_collateral_gas(
         bidder = borrowers[1]
 
         # deposit DAI in 3 buckets
-        mkr_dai_pool.addQuoteToken(
-            3_000 * 10**18, bucket_math.indexToPrice(1663), {"from": lender}
+        scaled_pool.addQuoteToken(
+            3_000 * 10**18, 1663, {"from": lender}
         )
-        mkr_dai_pool.addQuoteToken(
-            4_000 * 10**18, bucket_math.indexToPrice(1606), {"from": lender}
+        scaled_pool.addQuoteToken(
+            4_000 * 10**18, 1606, {"from": lender}
         )
-        mkr_dai_pool.addQuoteToken(
-            5_000 * 10**18, bucket_math.indexToPrice(1386), {"from": lender}
+        scaled_pool.addQuoteToken(
+            5_000 * 10**18, 1386, {"from": lender}
         )
 
-        mkr_dai_pool.addCollateral(100 * 10**18, {"from": borrower})
-        mkr_dai_pool.borrow(4_000 * 10**18, 3000 * 10**18, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
 
         # bidder purchases some of the middle bucket
-        mkr_dai_pool.purchaseBid(
-            1_500 * 10**18, bucket_math.indexToPrice(1606), {"from": bidder}
+        print(f"balance of bidder - {dai.balanceOf(bidder)}")
+
+        scaled_pool.purchaseQuote(
+            1_500 * 10**18, 1606, {"from": bidder}
         )
 
-        tx = mkr_dai_pool.claimCollateral(
-            0.4 * 10**18, bucket_math.indexToPrice(1606), {"from": lender}
+        print(f"bucket at - {scaled_pool.bucketAt(1606)}")
+        print(f"bucket math - {bucket_math.indexToPrice(1606)}")
+
+        tx = scaled_pool.claimCollateral(
+            0.004 * 10**18, 1606, {"from": lender}
         )
+        assert 1 == 0
 
         with capsys.disabled():
             print("\n==================================")
-            print("Gas estimations:")
+            print(f"Gas estimations({inspect.stack()[0][3]}):")
             print("==================================")
             print(f"Claim collateral           - {test_utils.get_usage(tx.gas_used)}")
             print("==================================")

--- a/tests/test_collateral_gas.py
+++ b/tests/test_collateral_gas.py
@@ -1,7 +1,8 @@
 import brownie
-from brownie import Contract
 import pytest
 import inspect
+from conftest import ZRO_ADD
+from brownie import Contract
 
 def test_add_remove_collateral_gas(
     lenders,
@@ -12,9 +13,9 @@ def test_add_remove_collateral_gas(
 ):
     with test_utils.GasWatcher(["addQuoteToken", "addCollateral", "removeCollateral"]):
         scaled_pool.addQuoteToken(20_000 * 10**18, 1708, {"from": lenders[0]})
-        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         with capsys.disabled():
             print("\n==================================")
             print(f"Gas estimations({inspect.stack()[0][3]}):")
@@ -50,8 +51,8 @@ def test_claim_collateral_gas(
             5_000 * 10**18, 1386, {"from": lender}
         )
 
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
-        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,ZRO_ADD, ZRO_ADD, {"from": borrower})
 
         # bidder purchases some of the middle bucket
         scaled_pool.purchaseQuote(

--- a/tests/test_collateral_gas.py
+++ b/tests/test_collateral_gas.py
@@ -30,8 +30,7 @@ def test_claim_collateral_gas(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math
+    test_utils
 ):
     with test_utils.GasWatcher(
         ["addQuoteToken", "addCollateral", "borrow", "purchaseBid", "claimCollateral"]

--- a/tests/test_collateral_gas.py
+++ b/tests/test_collateral_gas.py
@@ -12,9 +12,9 @@ def test_add_remove_collateral_gas(
 ):
     with test_utils.GasWatcher(["addQuoteToken", "addCollateral", "removeCollateral"]):
         scaled_pool.addQuoteToken(20_000 * 10**18, 1708, {"from": lenders[0]})
-        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         with capsys.disabled():
             print("\n==================================")
             print(f"Gas estimations({inspect.stack()[0][3]}):")
@@ -50,8 +50,8 @@ def test_claim_collateral_gas(
             5_000 * 10**18, 1386, {"from": lender}
         )
 
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
-        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
 
         # bidder purchases some of the middle bucket
         scaled_pool.purchaseQuote(

--- a/tests/test_collateral_gas.py
+++ b/tests/test_collateral_gas.py
@@ -8,14 +8,13 @@ def test_add_remove_collateral_gas(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
     with test_utils.GasWatcher(["addQuoteToken", "addCollateral", "removeCollateral"]):
         scaled_pool.addQuoteToken(20_000 * 10**18, 1708, {"from": lenders[0]})
-        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
-        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
-        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx_add_collateral = scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(20_000 * 10**18, 2500 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx_remove_collateral = scaled_pool.removeCollateral(10 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         with capsys.disabled():
             print("\n==================================")
             print(f"Gas estimations({inspect.stack()[0][3]}):")
@@ -32,8 +31,7 @@ def test_claim_collateral_gas(
     scaled_pool,
     capsys,
     test_utils,
-    bucket_math,
-    dai
+    bucket_math
 ):
     with test_utils.GasWatcher(
         ["addQuoteToken", "addCollateral", "borrow", "purchaseBid", "claimCollateral"]
@@ -53,18 +51,13 @@ def test_claim_collateral_gas(
             5_000 * 10**18, 1386, {"from": lender}
         )
 
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
-        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.borrow(4_000 * 10**18, 3000 * 10**18,test_utils.OXO, test_utils.OXO, {"from": borrower})
 
         # bidder purchases some of the middle bucket
-        print(f"balance of bidder - {dai.balanceOf(bidder)}")
-
         scaled_pool.purchaseQuote(
             1_500 * 10**18, 1606, {"from": bidder}
         )
-
-        print(f"bucket at - {scaled_pool.bucketAt(1606)}")
-        print(f"bucket math - {bucket_math.indexToPrice(1606)}")
 
         tx = scaled_pool.claimCollateral(
             0.004 * 10**18, 1606, {"from": lender}

--- a/tests/test_purchase_bid_gas.py
+++ b/tests/test_purchase_bid_gas.py
@@ -1,7 +1,7 @@
 import brownie
-from brownie import Contract
 import pytest
 from decimal import *
+from brownie import Contract
 
 @pytest.mark.skip
 def test_purchase_bid_gas(

--- a/tests/test_quote_token_gas.py
+++ b/tests/test_quote_token_gas.py
@@ -72,8 +72,8 @@ def test_quote_removal_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -115,8 +115,8 @@ def test_quote_removal_below_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -153,8 +153,8 @@ def test_quote_move_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
 
         # lender moves 400 DAI
         tx = scaled_pool.moveQuoteToken(
@@ -194,8 +194,8 @@ def test_quote_move_to_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
 
         # lender moves 1000 DAI to lup
         tx = scaled_pool.moveQuoteToken(

--- a/tests/test_quote_token_gas.py
+++ b/tests/test_quote_token_gas.py
@@ -31,8 +31,7 @@ def test_quote_deposit_gas_above_hdp(
     lenders,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
     with test_utils.GasWatcher(["addQuoteToken"]):
         txes = []
@@ -57,8 +56,7 @@ def test_quote_removal_from_lup_with_reallocation(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
 
     with test_utils.GasWatcher(
@@ -75,8 +73,8 @@ def test_quote_removal_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18,'0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -98,8 +96,7 @@ def test_quote_removal_below_lup(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
 
     with test_utils.GasWatcher(
@@ -119,8 +116,8 @@ def test_quote_removal_below_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -140,8 +137,7 @@ def test_quote_move_from_lup_with_reallocation(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
 
     with test_utils.GasWatcher(
@@ -158,8 +154,8 @@ def test_quote_move_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
 
         # lender moves 400 DAI
         tx = scaled_pool.moveQuoteToken(
@@ -179,8 +175,7 @@ def test_quote_move_to_lup(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
 
     with test_utils.GasWatcher(
@@ -200,8 +195,8 @@ def test_quote_move_to_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrower})
 
         # lender moves 1000 DAI to lup
         tx = scaled_pool.moveQuoteToken(

--- a/tests/test_quote_token_gas.py
+++ b/tests/test_quote_token_gas.py
@@ -8,8 +8,7 @@ def test_quote_deposit_gas_below_hdp(
     lenders,
     scaled_pool,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
     with test_utils.GasWatcher(["addQuoteToken"]):
         txes = []

--- a/tests/test_quote_token_gas.py
+++ b/tests/test_quote_token_gas.py
@@ -1,8 +1,9 @@
 import brownie
-from brownie import Contract
 import pytest
-from decimal import *
 import inspect
+from decimal import *
+from conftest import ZRO_ADD
+from brownie import Contract
 
 def test_quote_deposit_gas_below_hdp(
     lenders,
@@ -72,8 +73,8 @@ def test_quote_removal_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -115,8 +116,8 @@ def test_quote_removal_below_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4_000 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
 
         lp_tokens = scaled_pool.lpBalance(1_663, lender)
 
@@ -153,8 +154,8 @@ def test_quote_move_from_lup_with_reallocation(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
 
         # lender moves 400 DAI
         tx = scaled_pool.moveQuoteToken(
@@ -194,8 +195,8 @@ def test_quote_move_to_lup(
         )
 
         # borrower takes a loan of 3000 DAI
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
-        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrower})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
+        scaled_pool.borrow(3_000 * 10**18, 4000 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrower})
 
         # lender moves 1000 DAI to lup
         tx = scaled_pool.moveQuoteToken(

--- a/tests/test_repay_gas.py
+++ b/tests/test_repay_gas.py
@@ -4,38 +4,28 @@ from brownie import Contract
 import pytest
 import inspect
 
-@pytest.mark.skip
 def test_repay_gas(
     lenders,
     borrowers,
-    mkr_dai_pool,
+    scaled_pool,
     dai,
     capsys,
-    test_utils,
-    bucket_math,
+    test_utils
 ):
     with test_utils.GasWatcher(["addQuoteToken", "addCollateral", "repay", "borrow"]):
         for i in range(1643, 1663):
-            mkr_dai_pool.addQuoteToken(
-                10_000 * 10**18,
-                bucket_math.indexToPrice(i),
-                {"from": lenders[0]},
-            )
+            scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
         dai.transfer(borrowers[0], 10_000 * 10**18, {"from": lenders[1]})
-        mkr_dai_pool.addCollateral(100 * 10**18, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
 
         # borrow 10_000 DAI from single bucket (LUP)
-        mkr_dai_pool.borrow(10_000 * 10**18, 1 * 10**18, {"from": borrowers[0]})
-        tx_repay_to_one_bucket = mkr_dai_pool.repay(
-            10_001 * 10**18, {"from": borrowers[0]}
-        )
+        scaled_pool.borrow(10_000 * 10**18, 1 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx_repay_to_one_bucket = scaled_pool.repay(10_001 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
 
         # borrow 101_000 DAI from 11 buckets
-        mkr_dai_pool.borrow(101_000 * 10**18, 1 * 10**18, {"from": borrowers[0]})
-        tx_repay_to_11_buckets = mkr_dai_pool.repay(
-            101_001 * 10**18, {"from": borrowers[0]}
-        )
+        scaled_pool.borrow(101_000 * 10**18, 1 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx_repay_to_11_buckets = scaled_pool.repay(101_001 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
 
         with capsys.disabled():
             print("\n==================================")

--- a/tests/test_repay_gas.py
+++ b/tests/test_repay_gas.py
@@ -1,8 +1,9 @@
-from multiprocessing import pool
 import brownie
-from brownie import Contract
 import pytest
 import inspect
+from conftest import ZRO_ADD
+from brownie import Contract
+from multiprocessing import pool
 
 def test_repay_gas(
     lenders,
@@ -17,15 +18,15 @@ def test_repay_gas(
             scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
         dai.transfer(borrowers[0], 10_000 * 10**18, {"from": lenders[1]})
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
 
         # borrow 10_000 DAI from single bucket (LUP)
-        scaled_pool.borrow(10_000 * 10**18, 1 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        tx_repay_to_one_bucket = scaled_pool.repay(10_001 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(10_000 * 10**18, 1 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx_repay_to_one_bucket = scaled_pool.repay(10_001 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
 
         # borrow 101_000 DAI from 11 buckets
-        scaled_pool.borrow(101_000 * 10**18, 1 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        tx_repay_to_11_buckets = scaled_pool.repay(101_001 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(101_000 * 10**18, 1 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx_repay_to_11_buckets = scaled_pool.repay(101_001 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
 
         with capsys.disabled():
             print("\n==================================")

--- a/tests/test_repay_gas.py
+++ b/tests/test_repay_gas.py
@@ -17,15 +17,15 @@ def test_repay_gas(
             scaled_pool.addQuoteToken(10_000 * 10**18, i, {"from": lenders[0]})
 
         dai.transfer(borrowers[0], 10_000 * 10**18, {"from": lenders[1]})
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
 
         # borrow 10_000 DAI from single bucket (LUP)
-        scaled_pool.borrow(10_000 * 10**18, 1 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        tx_repay_to_one_bucket = scaled_pool.repay(10_001 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(10_000 * 10**18, 1 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx_repay_to_one_bucket = scaled_pool.repay(10_001 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
 
         # borrow 101_000 DAI from 11 buckets
-        scaled_pool.borrow(101_000 * 10**18, 1 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        tx_repay_to_11_buckets = scaled_pool.repay(101_001 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(101_000 * 10**18, 1 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx_repay_to_11_buckets = scaled_pool.repay(101_001 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
 
         with capsys.disabled():
             print("\n==================================")

--- a/tests/test_scaled_pool.py
+++ b/tests/test_scaled_pool.py
@@ -1,8 +1,9 @@
 import brownie
-from brownie import Contract
 import pytest
-from decimal import *
 import inspect
+from decimal import *
+from brownie import Contract
+from conftest import ZRO_ADD
 
 
 def test_quote_deposit_move_remove_scaled(
@@ -61,7 +62,7 @@ def test_borrow_repay_scaled(
 
         col_txes = []
         for i in range(10):
-            tx = scaled_pool.addCollateral(10 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+            tx = scaled_pool.addCollateral(10 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
             col_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -71,11 +72,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(col_txes[i].gas_used)}")
         
         txes = []
-        tx1 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx1 = scaled_pool.borrow(110 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx1)
-        tx2 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx2 = scaled_pool.borrow(110 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx2)
-        tx3 = scaled_pool.borrow(50 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx3 = scaled_pool.borrow(50 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx3)
 
         with capsys.disabled():
@@ -86,11 +87,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repay(110 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(110 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(50 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(50 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -113,11 +114,11 @@ def test_borrow_purchase_scaled(
         scaled_pool.addQuoteToken(100 * 10**18, 2560, {"from": lenders[0]})
         scaled_pool.addQuoteToken(100 * 10**18, 2570, {"from": lenders[0]})
         
-        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
 
-        scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
-        scaled_pool.borrow(50 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(50 * 10**18, 5000, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
 
         purchase_txes = []
         tx = scaled_pool.purchaseQuote(100 * 10**18, 2550, {"from": borrowers[1]})

--- a/tests/test_scaled_pool.py
+++ b/tests/test_scaled_pool.py
@@ -64,7 +64,7 @@ def test_borrow_repay_scaled(
 
         col_txes = []
         for i in range(10):
-            tx = scaled_pool.addCollateral(10 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+            tx = scaled_pool.addCollateral(10 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
             col_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -74,11 +74,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(col_txes[i].gas_used)}")
         
         txes = []
-        tx1 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx1 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         txes.append(tx1)
-        tx2 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx2 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         txes.append(tx2)
-        tx3 = scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx3 = scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         txes.append(tx3)
 
         with capsys.disabled():
@@ -89,11 +89,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(50 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        tx = scaled_pool.repay(50 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -118,11 +118,11 @@ def test_borrow_purchase_scaled(
         scaled_pool.addQuoteToken(100 * 10**18, 2560, {"from": lenders[0]})
         scaled_pool.addQuoteToken(100 * 10**18, 2570, {"from": lenders[0]})
         
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
 
-        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
-        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
-        scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', 1, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
 
         purchase_txes = []
         tx = scaled_pool.purchaseQuote(100 * 10**18, 2550, {"from": borrowers[1]})

--- a/tests/test_scaled_pool.py
+++ b/tests/test_scaled_pool.py
@@ -61,7 +61,7 @@ def test_borrow_repay_scaled(
 
         col_txes = []
         for i in range(10):
-            tx = scaled_pool.addCollateral(10 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+            tx = scaled_pool.addCollateral(10 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
             col_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -71,11 +71,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(col_txes[i].gas_used)}")
         
         txes = []
-        tx1 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx1 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx1)
-        tx2 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx2 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx2)
-        tx3 = scaled_pool.borrow(50 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx3 = scaled_pool.borrow(50 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         txes.append(tx3)
 
         with capsys.disabled():
@@ -86,11 +86,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repay(110 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(110 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(50 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        tx = scaled_pool.repay(50 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -113,11 +113,11 @@ def test_borrow_purchase_scaled(
         scaled_pool.addQuoteToken(100 * 10**18, 2560, {"from": lenders[0]})
         scaled_pool.addQuoteToken(100 * 10**18, 2570, {"from": lenders[0]})
         
-        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
 
-        scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
-        scaled_pool.borrow(50 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
+        scaled_pool.borrow(50 * 10**18, 5000, test_utils.ZRO_ADD, test_utils.ZRO_ADD, {"from": borrowers[0]})
 
         purchase_txes = []
         tx = scaled_pool.purchaseQuote(100 * 10**18, 2550, {"from": borrowers[1]})

--- a/tests/test_scaled_pool.py
+++ b/tests/test_scaled_pool.py
@@ -9,8 +9,7 @@ def test_quote_deposit_move_remove_scaled(
     lenders,
     scaled_pool,
     capsys,
-    test_utils,
-    dai,
+    test_utils
 ):
     with test_utils.GasWatcher(["addQuoteToken"]):
         add_txes = []
@@ -52,9 +51,7 @@ def test_borrow_repay_scaled(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    dai,
-    mkr,
+    test_utils
 ):
     with test_utils.GasWatcher(["borrow"]):
 
@@ -64,7 +61,7 @@ def test_borrow_repay_scaled(
 
         col_txes = []
         for i in range(10):
-            tx = scaled_pool.addCollateral(10 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+            tx = scaled_pool.addCollateral(10 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
             col_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -74,11 +71,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(col_txes[i].gas_used)}")
         
         txes = []
-        tx1 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx1 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         txes.append(tx1)
-        tx2 = scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx2 = scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         txes.append(tx2)
-        tx3 = scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx3 = scaled_pool.borrow(50 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         txes.append(tx3)
 
         with capsys.disabled():
@@ -89,11 +86,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(110 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx = scaled_pool.repay(110 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(50 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        tx = scaled_pool.repay(50 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -108,9 +105,7 @@ def test_borrow_purchase_scaled(
     borrowers,
     scaled_pool,
     capsys,
-    test_utils,
-    dai,
-    mkr,
+    test_utils
 ):
     with test_utils.GasWatcher(["borrow"]):
 
@@ -118,11 +113,11 @@ def test_borrow_purchase_scaled(
         scaled_pool.addQuoteToken(100 * 10**18, 2560, {"from": lenders[0]})
         scaled_pool.addQuoteToken(100 * 10**18, 2570, {"from": lenders[0]})
         
-        scaled_pool.addCollateral(100 * 10**18, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.addCollateral(100 * 10**18, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
 
-        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
-        scaled_pool.borrow(110 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
-        scaled_pool.borrow(50 * 10**18, 5000, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000', {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(110 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
+        scaled_pool.borrow(50 * 10**18, 5000, test_utils.OXO, test_utils.OXO, {"from": borrowers[0]})
 
         purchase_txes = []
         tx = scaled_pool.purchaseQuote(100 * 10**18, 2550, {"from": borrowers[1]})

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -3,11 +3,11 @@ import math
 import brownie
 import pytest
 import random
+from decimal import *
 from brownie import Contract
 from brownie.exceptions import VirtualMachineError
-from conftest import MAX_PRICE, ScaledPoolUtils, TestUtils
-from decimal import *
 from sdk import AjnaProtocol, DAI_ADDRESS, MKR_ADDRESS
+from conftest import MAX_PRICE, ScaledPoolUtils, TestUtils
 
 
 MAX_BUCKET = 2532  # 3293.70191, highest bucket for initial deposits, is exceeded after initialization


### PR DESCRIPTION
Cleaned up brownie tests for `v10`:
* updated tests to include queue args in relevant methods
* updated tests passing index of bucket rather than price to relevant methods
* retained `@pytest.mark.skip` for purchase related tests. Will update to collateral insertion once the method is ready in `v10`