### PR TITLE
Fixed bug redeeming LPB for quote token or collateral

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -174,28 +174,27 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
 
         // lender exchanges their LP for collateral
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_lender), 1.992631704391065311 * 1e18);
+        emit Transfer(address(_pool), address(_lender), 1.992893012338599629 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), p2550, 1.992631704391065311 * 1e18);
+        emit RemoveCollateral(address(_lender), p2550, 1.992893012338599629 * 1e18);
         _lender.removeCollateral(_pool, 4 * 1e18, 2550);
         assertEq(_pool.lpBalance(p2550, address(_lender)), 0);
         skip(3600);
 
         // lender1 exchanges their LP for collateral
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_lender1), 1.328154785003044376 * 1e18);
+        emit Transfer(address(_pool), address(_lender1), 1.328595341559066420 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender1), p2550, 1.328154785003044376 * 1e18);
+        emit RemoveCollateral(address(_lender1), p2550, 1.328595341559066420 * 1e18);
         _lender1.removeCollateral(_pool, 4 * 1e18, 2550);
         assertEq(_pool.lpBalance(p2550, address(_lender1)), 0);
 
         // check pool balances
-        // FIXME: pool should only have collateral pledged by borrower
-//        assertEq(_collateral.balanceOf(address(_pool)), 100 * 1e18);
+        assertEq(_collateral.balanceOf(address(_pool)), 100 * 1e18);
 
         // check bucket state
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(2550);
-//        assertEq(availableCollateral,  0);    // FIXME: extra collateral was left in bucket
+        assertEq(availableCollateral,  0);
         assertEq(lpAccumulator,        0);
         assertEq(_pool.get(2550), 0);
     }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -101,12 +101,11 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),        0);
 
         // lender exchanges their LP for collateral
-        uint256 lpBalance = _pool.lpBalance(testIndex, address(_lender));
         uint256 lpValueInCollateral = 3.321274866808485288 * 1e18;
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), address(_lender), lpValueInCollateral);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), priceAtTestIndex, lpValueInCollateral, lpBalance);
+        emit RemoveCollateral(address(_lender), priceAtTestIndex, lpValueInCollateral);
         _lender.removeCollateral(_pool, availableCollateral, testIndex);
         assertEq(_collateral.balanceOf(address(_lender)), lpValueInCollateral);
         assertEq(_pool.lpBalance(testIndex, address(_lender)), 0);
@@ -115,12 +114,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), address(_bidder), 0.678725133191514712 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(
-            address(_bidder),
-            priceAtTestIndex,
-            0.678725133191514712 * 1e18,
-            2_043.568088791526231380000000000 * 1e27
-        );
+        emit RemoveCollateral(address(_bidder), priceAtTestIndex, 0.678725133191514712 * 1e18);
         _bidder.removeCollateral(_pool, collateralToPurchaseWith, testIndex);
         assertEq(_pool.lpBalance(testIndex, address(_bidder)), 0);
 
@@ -179,21 +173,19 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         skip(7200);
 
         // lender exchanges their LP for collateral
-        uint256 lpBalance = _pool.lpBalance(2550, address(_lender));
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), address(_lender), 1.992631704391065311 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), p2550, 1.992631704391065311 * 1e18, lpBalance);
+        emit RemoveCollateral(address(_lender), p2550, 1.992631704391065311 * 1e18);
         _lender.removeCollateral(_pool, 4 * 1e18, 2550);
         assertEq(_pool.lpBalance(p2550, address(_lender)), 0);
         skip(3600);
 
         // lender1 exchanges their LP for collateral
-        lpBalance = _pool.lpBalance(2550, address(_lender1));
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), address(_lender1), 1.328154785003044376 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender1), p2550, 1.328154785003044376 * 1e18, lpBalance);
+        emit RemoveCollateral(address(_lender1), p2550, 1.328154785003044376 * 1e18);
         _lender1.removeCollateral(_pool, 4 * 1e18, 2550);
         assertEq(_pool.lpBalance(p2550, address(_lender1)), 0);
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -77,7 +77,7 @@ abstract contract DSTestPlus is Test {
     event Purchase(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256 collateral_);
     event PurchaseWithNFTs(address indexed bidder_, uint256 indexed price_, uint256 amount_, uint256[] tokenIds_);
     event RemoveCollateral(address indexed borrower_, uint256 amount_);
-    event RemoveCollateral(address indexed actor_, uint256 indexed price_, uint256 amount_, uint256 lps_);
+    event RemoveCollateral(address indexed actor_, uint256 indexed price_, uint256 amount_);
     event RemoveNFTCollateral(address indexed borrower_, uint256[] tokenIds_);
     event RemoveQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -11,7 +11,6 @@ abstract contract DSTestPlus is Test {
     // nonce for generating random addresses
     uint16 internal _nonce = 0;
 
-    // FIXME: these prices are all wrong; the highest priced bucket now has the lowest index
     uint256 internal _p50159    = 50_159.593888626183666006 * 1e18;
     uint256 internal _p49910    = 49_910.043670274810022205 * 1e18;
     uint256 internal _p15000    = 15_000.520048194378317056 * 1e18;

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -142,7 +142,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         uint256 rate                = _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs        = lpBalance[index_][msg.sender];
         uint256 availableQuoteToken = _rangeSum(index_, index_);
-        uint256 claimableQuoteToken = Maths.rrdivw(availableLPs, rate);
+        uint256 claimableQuoteToken = Maths.rayToWad(Maths.rmul(availableLPs, rate));
         uint256 amount = Maths.min(maxAmount_, Maths.min(availableQuoteToken, claimableQuoteToken));
 
         // calculate amount of LP required to remove it

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -248,7 +248,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         // move collateral from pool to lender
         collateral().safeTransfer(msg.sender, amount / collateralScale);
-        emit RemoveCollateral(msg.sender, price, amount, lpRedemption);
+        emit RemoveCollateral(msg.sender, price, amount);
     }
 
     /**********************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -222,7 +222,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 price               = _indexToPrice(index_);
         uint256 rate                = _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs        = lpBalance[index_][msg.sender];
-        uint256 claimableCollateral = Maths.rwdivw(Maths.rdiv(availableLPs, rate), price);
+        uint256 claimableCollateral = Maths.rwdivw(Maths.rmul(availableLPs, rate), price);
 
         uint256 amount;
         uint256 lpRedemption;

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -40,9 +40,8 @@ interface IERC20Pool is IScaledPool {
      *  @param  claimer_ Recipient that claimed collateral.
      *  @param  price_   Price at which unencumbered collateral was claimed.
      *  @param  amount_  The amount of collateral transferred to the claimer.
-     *  @param  lps_     The amount of LP tokens burned in the claim.
      */
-    event RemoveCollateral(address indexed claimer_, uint256 indexed price_, uint256 amount_, uint256 lps_);
+    event RemoveCollateral(address indexed claimer_, uint256 indexed price_, uint256 amount_);
 
     /**
      *  @notice Emitted when borrower removes pledged collateral from the pool.


### PR DESCRIPTION
I was dividing where I should have been multiplying.  Extending an existing test to accumulate interest brought it to light.

Also removed LP change argument from the `RemoveCollateral` event.  If we want to output that info, it should be consistently applied across all lender actions.  I'd argue the info is not useful to the consumer.