### PR TITLE
removeQuoteToken overflow fix

### DIFF
--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -138,22 +138,31 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         uint256 curDebt = _accruePoolInterest();
 
         // determine amount of quote token to remove
-        Bucket storage bucket       = buckets[index_];
+        Bucket memory bucket        = buckets[index_];
         uint256 rate                = _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs        = lpBalance[index_][msg.sender];
         uint256 availableQuoteToken = _rangeSum(index_, index_);
         uint256 claimableQuoteToken = Maths.rayToWad(Maths.rmul(availableLPs, rate));
-        uint256 amount = Maths.min(maxAmount_, Maths.min(availableQuoteToken, claimableQuoteToken));
 
-        // calculate amount of LP required to remove it
-        uint256 lpbAmount = Maths.wrdivr(amount, rate);
+        uint256 amount;
+        uint256 lpRedemption;
+        if (maxAmount_ > claimableQuoteToken && availableQuoteToken >= claimableQuoteToken) {
+            // lender wants to redeem all of their LPB for quote token, and the bucket has enough to offer
+            amount = claimableQuoteToken;
+            lpRedemption = availableLPs;
+        } else {
+            // calculate how much quote token may be awarded to lender, and how much LPB to redeem
+            amount = Maths.min(maxAmount_, Maths.min(availableQuoteToken, claimableQuoteToken));
+            lpRedemption = Maths.wrdivr(amount, rate);
+        }
 
         // update bucket accounting
-        bucket.lpAccumulator -= lpbAmount;
+        bucket.lpAccumulator -= lpRedemption;
+        buckets[index_] = bucket;
+        _remove(index_, amount); // update FenwickTree
 
         // update lender accounting
-        lpBalance[index_][msg.sender] -= lpbAmount;
-        _remove(index_, amount); // update FenwickTree
+        lpBalance[index_][msg.sender] -= lpRedemption;
 
         // update pool accounting
         uint256 newLup = _lup();

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -251,10 +251,6 @@ def add_quote_token(lender, lender_index, pool):
     # try:
     tx = pool.addQuoteToken(quantity, deposit_index, {"from": lender})
     return deposit_price
-    # except VirtualMachineError as ex:
-    #     print(f" ERROR adding liquidity at {deposit_price / 10**18:.1f}\n{ex}")
-    #     print(TestUtils.dump_book(pool, MAX_BUCKET, MIN_BUCKET))
-    #     assert False
 
 
 def remove_quote_token(lender, lender_index, price, pool):
@@ -262,7 +258,7 @@ def remove_quote_token(lender, lender_index, price, pool):
     lp_balance = pool.lpBalance(price_index, lender)
     if lp_balance > 0:
         exchange_rate = pool.exchangeRate(price_index)
-        claimable_quote = lp_balance * 10**18 / exchange_rate
+        claimable_quote = lp_balance * exchange_rate / 10**36
         print(f" lender {lender_index} removing {lp_balance/1e27:.1f} lp "
               f"(~{claimable_quote / 10**18:.1f} quote) from bucket {price_index} ({price / 10**18:.1f}); "
               f"exchange rate is {exchange_rate/1e27:.8f}")


### PR DESCRIPTION
Running the real-world test revealed an issue with `removeQuoteToken`, where the bucket had sufficient quote token to remove after accumulation, but the lender had insufficient LP.  This ensures the withdrawal is scaled back appropriately.  The fix replicates my solution to the same problem in `removeCollateral`.