### PR TITLE
Pass the amount of quote token in a bucket into _exchangeRate method

### DIFF
--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -70,9 +70,10 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
         // Pool interactions
         IERC20Pool pool = IERC20Pool(params_.pool);
+        uint256 deposit = pool.depositAt(params_.index);
 
         // calculate equivalent underlying collateral for given lpTokens
-        uint256 collateralToRemove = pool.lpsToCollateral(params_.lpTokens, params_.index);
+        uint256 collateralToRemove = pool.lpsToCollateral(deposit, params_.lpTokens, params_.index);
         uint256 lpTokensUsed;
         if (collateralToRemove != 0) {
             // remove collateral from price bucket and transfer to recipient
@@ -83,7 +84,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         uint256 remainingLpTokens = params_.lpTokens - lpTokensUsed;
         if (remainingLpTokens != 0) {
             // calculate equivalent quote tokens for remaining lpTokens
-            uint256 quoteTokensToRemove = pool.lpsToQuoteTokens(remainingLpTokens, params_.index);
+            uint256 quoteTokensToRemove = pool.lpsToQuoteTokens(deposit, remainingLpTokens, params_.index);
             // remove and transfer quote tokens to recipient
             lpTokensUsed += pool.removeQuoteToken(quoteTokensToRemove, params_.index);
             ERC20(pool.quoteTokenAddress()).safeTransfer(params_.recipient, quoteTokensToRemove);
@@ -168,7 +169,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         IScaledPool pool = IScaledPool(params_.pool);
 
         uint256 maxQuote = pool.lpsToQuoteTokens(
-            positions[params_.tokenId].lpTokens[params_.fromIndex], params_.fromIndex
+            pool.depositAt(params_.fromIndex),  positions[params_.tokenId].lpTokens[params_.fromIndex], params_.fromIndex
         );
         pool.moveQuoteToken(maxQuote, params_.fromIndex, params_.toIndex);
 

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -293,6 +293,13 @@ interface IScaledPool {
         );
 
     /**
+     *  @notice Get a bucket deposit for a given index.
+     *  @param  index_   The index of the bucket to retrieve deposit for.
+     *  @return deposit_ Quote tokens deposit at specified index (WAD).
+     */
+    function depositAt(uint256 index_) external view returns (uint256 deposit_);
+
+    /**
      *  @notice Returns the total encumbered collateral resulting from a given amount of debt at a specified price.
      *  @param  debt_        Amount of debt for corresponding collateral encumbrance.
      *  @param  price_       Price to use for calculating the collateral encumbrance, in WAD units.
@@ -337,17 +344,19 @@ interface IScaledPool {
 
     /**
      *  @notice Calculate the amount of collateral for a given amount of LP Tokens.
-     *  @param  lpTokens_            The number of lpTokens to calculate amounts for.
-     *  @param  index_               The price bucket index for which the value should be calculated.
+     *  @param  deposit_          The amount of quote tokens available at this bucket index.
+     *  @param  lpTokens_         The number of lpTokens to calculate amounts for.
+     *  @param  index_            The price bucket index for which the value should be calculated.
      *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
      */
-    function lpsToCollateral(uint256 lpTokens_, uint256 index_) external view returns (uint256 collateralAmount_);
+    function lpsToCollateral(uint256 deposit_, uint256 lpTokens_, uint256 index_) external view returns (uint256 collateralAmount_);
 
     /**
      *  @notice Calculate the amount of quote tokens for a given amount of LP Tokens.
+     *  @param  deposit_     The amount of quote tokens available at this bucket index.
      *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
      *  @param  index_       The price bucket index for which the value should be calculated.
      *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
      */
-    function lpsToQuoteTokens(uint256 lpTokens_, uint256 index_) external view returns (uint256 quoteAmount_);
+    function lpsToQuoteTokens(uint256 deposit_, uint256 lpTokens_, uint256 index_) external view returns (uint256 quoteAmount_);
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -196,7 +196,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         Bucket memory bucket = buckets[index_];
         // Calculate exchange rate before new collateral has been accounted for.
         // This is consistent with how lbpChange in addQuoteToken is adjusted before calling _add.
-        uint256 rate = _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
 
         uint256 quoteValue   = Maths.wmul(amount_, _indexToPrice(index_));
         lpbChange_           = Maths.rdiv(Maths.wadToRay(quoteValue), rate);
@@ -220,7 +220,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         // determine amount of collateral to remove
         Bucket memory bucket        = buckets[index_];
         uint256 price               = _indexToPrice(index_);
-        uint256 rate                = _exchangeRate(bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate                = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs        = lpBalance[index_][msg.sender];
         uint256 claimableCollateral = Maths.rwdivw(Maths.rmul(availableLPs, rate), price);
 


### PR DESCRIPTION
Calling `rangeSum` to find the amount of quote token in a bucket is an expensive operation.  To prevent multiple calls in the same function, this change passes that value as an argument.