### PR TITLE
Split removeQuoteToken and removeCollateral into two methods; one to remove some, another to remove all

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -232,7 +232,12 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         assertEq(_quote.balanceOf(address(_pool)),        0);
 
         // actor withdraws their collateral
-        _pool.removeCollateral(collateralToDeposit, testIndex);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(address(_pool), address(_bidder), collateralToDeposit);
+        vm.expectEmit(true, true, true, true);
+        emit RemoveCollateral(address(_bidder), priceAtTestIndex, collateralToDeposit);
+        uint256 lpRedeemed = _pool.removeCollateral(collateralToDeposit, testIndex);
+        assertEq(lpRedeemed, 12_043.56808879152623138 * 1e27);
     }
 
     // TODO: add collateralization, utilization and encumberance test? -> use hardcoded amounts in pure functions without creaitng whole pool flows

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -152,7 +152,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         changePrank(_lender1);
         _pool.addQuoteToken(4_000 * 1e18, 2550);
         _pool.addQuoteToken(5_000 * 1e18, 2552);
-
         skip(3600);
 
         // borrower draws debt

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -112,7 +112,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         emit Transfer(address(_pool), address(_lender), lpValueInCollateral);
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_lender), priceAtTestIndex, lpValueInCollateral);
-        _pool.removeCollateral(availableCollateral, testIndex);
+        _pool.removeAllCollateral(testIndex);
         assertEq(_collateral.balanceOf(address(_lender)), lpValueInCollateral);
         assertEq(_pool.lpBalance(testIndex, address(_lender)), 0);
 
@@ -122,7 +122,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         emit Transfer(address(_pool), address(_bidder), 0.678725133191514712 * 1e18);
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_bidder), priceAtTestIndex, 0.678725133191514712 * 1e18);
-        _pool.removeCollateral(collateralToPurchaseWith, testIndex);
+        _pool.removeAllCollateral(testIndex);
         assertEq(_pool.lpBalance(testIndex, address(_bidder)), 0);
 
         // check pool balances
@@ -186,7 +186,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         uint256 expectedCollateral = 0.066544137733669793 * 1e18;
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_bidder), p2550, expectedCollateral);
-        _pool.removeCollateral(collateralToPurchaseWith, 2550);
+        _pool.removeAllCollateral(2550);
         collateralRemoved += expectedCollateral;
         assertEq(_pool.lpBalance(2550, address(_bidder)), 0);
         skip(7200);
@@ -196,7 +196,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         expectedCollateral = 1.992893012338599629 * 1e18;
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_lender), p2550, expectedCollateral);
-        _pool.removeCollateral(4 * 1e18, 2550);
+        _pool.removeAllCollateral(2550);
         collateralRemoved += expectedCollateral;
         assertEq(_pool.lpBalance(2550, address(_lender)), 0);
         skip(3600);
@@ -206,7 +206,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         expectedCollateral = 1.328595341559066420 * 1e18;
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(address(_lender1), p2550, expectedCollateral);
-        _pool.removeCollateral(4 * 1e18, 2550);
+        _pool.removeAllCollateral(2550);
         collateralRemoved += expectedCollateral;
         assertEq(_pool.lpBalance(2550, address(_lender1)), 0);
         assertEq(collateralRemoved, collateralToPurchaseWith);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -179,7 +179,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         emit Transfer(address(_pool), address(_bidder), amountWithInterest);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_bidder), p2550, amountWithInterest, _pool.indexToPrice(2552));
-        _pool.removeQuoteToken(amountToPurchase, 2550);
+        _pool.removeAllQuoteToken(2550);
         assertEq(_quote.balanceOf(address(_bidder)), amountWithInterest);
         // bidder withdraws unused collateral
         uint256 collateralRemoved = 0;

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -145,7 +145,8 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
 
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), 3_025.946482308870940904 * 1e18, 5_000 * 1e18, BucketMath.MAX_PRICE);
-        _pool.removeQuoteToken(5_000 * 1e18, 2549);
+        uint256 lpRedeemed = _pool.removeQuoteToken(5_000 * 1e18, 2549);
+        assertEq(lpRedeemed, 5_000 * 1e27);
 
         assertEq(_pool.lpBalance(2549, address(_lender)), 35_000 * 1e27);
 
@@ -212,9 +213,8 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         // ensure lender with no LP cannot remove anything
         changePrank(_lender1);
         assertEq(0, _pool.lpBalance(1606, address(_lender1)));
-        vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender1), _pool.indexToPrice(1606), 0, _pool.lup());
-        _pool.removeQuoteToken(3_500 * 1e18, 1606);
+        vm.expectRevert("S:RAQT:NO_CLAIM");
+        _pool.removeAllQuoteToken(1606);
 
         // lender removes all quote token, including interest, from the bucket
         changePrank(_lender);
@@ -222,7 +222,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         uint256 quoteWithInterest = 3_400.023138863804135800 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(1606), quoteWithInterest, _pool.indexToPrice(1663));
-        _pool.removeQuoteToken(3_500 * 1e18, 1606);
+        _pool.removeAllQuoteToken(1606);
         assertEq(_quote.balanceOf(address(_lender)), lenderBalanceBefore + quoteWithInterest);
         assertEq(_pool.lpBalance(1606, address(_lender)), 0);
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -792,7 +792,6 @@ contract PositionManagerDecreaseLiquidityWithDebtTest is PositionManagerHelperCo
         IPositionManager.DecreaseLiquidityParams memory decreaseLiquidityParams = IPositionManager.DecreaseLiquidityParams(
             _tokenId, _testLender, address(_pool), _mintIndex, 50_000 * 1e27
         );
-
         vm.expectEmit(true, true, true, true);
         emit DecreaseLiquidity(_testLender, _mintPrice);
         _positionManager.decreaseLiquidity(decreaseLiquidityParams);

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -66,7 +66,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
     function decreaseLiquidity(DecreaseLiquidityParams calldata params_) external override payable mayInteract(params_.pool, params_.tokenId) nonReentrant {
         uint256 curPos = positions[params_.tokenId].lpTokens[params_.index];
-        require(params_.lpTokens != 0 && params_.lpTokens <= curPos, "PM:DL:INSUF_LP_BAL");
+        require(params_.lpTokens <= curPos, "PM:DL:INSUF_LP_BAL");
 
         // Pool interactions
         IERC20Pool pool = IERC20Pool(params_.pool);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -140,8 +140,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         emit MoveQuoteToken(msg.sender, fromIndex_, toIndex_, amount, newLup);
     }
 
-    event Debug(string where, uint256 what);
-
     function removeAllQuoteToken(uint256 index_) external returns (uint256 lpAmount_) {
         // scale the tree, accumulating interest owed to lenders
         _accruePoolInterest();
@@ -152,10 +150,8 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         lpAmount_                   = lpBalance[index_][msg.sender];
         uint256 amount              = Maths.rayToWad(Maths.rmul(lpAmount_, rate));
 
-        emit Debug("removeAllQuoteToken amount", amount);
-
-        require(availableQuoteToken > 0, "S:RAQT:NO_QT");
-        require(amount > 0,              "S:RAQT:NO_CLAIM");
+        require(availableQuoteToken != 0, "S:RAQT:NO_QT");
+        require(amount != 0,              "S:RAQT:NO_CLAIM");
 
         if (amount > availableQuoteToken) {
             // user is owed more quote token than is available in the bucket
@@ -170,7 +166,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         // scale the tree, accumulating interest owed to lenders
         _accruePoolInterest();
 
-        // determine amount of quote token to remove
         Bucket memory bucket        = buckets[index_];
         uint256 availableQuoteToken = _rangeSum(index_, index_);
         uint256 rate                = _exchangeRate(availableQuoteToken, bucket.availableCollateral, bucket.lpAccumulator, index_);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -378,15 +378,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         return lpAccumulator_ != 0 ? Maths.wrdivr(bucketSize, lpAccumulator_) : Maths.RAY;
     }
 
-    function _lpsToCollateral(uint256 deposit_, uint256 lpTokens_, uint256 index_) internal view returns (uint256 collateralAmount_) {
-        Bucket memory bucket  = buckets[index_];
-        if (bucket.availableCollateral != 0) {
-            uint256 price     = _indexToPrice(index_);
-            uint256 rate      = _exchangeRate(deposit_, bucket.availableCollateral, bucket.lpAccumulator, index_);
-            collateralAmount_ = Maths.min(bucket.availableCollateral, Maths.rwdivw(Maths.rmul(lpTokens_, rate), price));
-        }
-    }
-
     function _lpsToQuoteTokens(uint256 deposit_, uint256 lpTokens_, uint256 index_) internal view returns (uint256 quoteAmount_) {
         Bucket memory bucket  = buckets[index_];
         uint256 rate          = _exchangeRate(deposit_, bucket.availableCollateral, bucket.lpAccumulator, index_);
@@ -467,10 +458,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
 
     function liquidityToPrice(uint256 index_) external view returns (uint256 quoteToken_) {
         quoteToken_ = _prefixSum(index_);
-    }
-
-    function lpsToCollateral(uint256 deposit_, uint256 lpTokens_, uint256 index_) external view override returns (uint256) {
-        return _lpsToCollateral(deposit_, lpTokens_, index_);
     }
 
     function lpsToQuoteTokens(uint256 deposit_, uint256 lpTokens_, uint256 index_) external view override returns (uint256) {

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -218,7 +218,7 @@ interface IScaledPool {
     /**
      *  @notice Called by lenders to redeem the maximum amount of LP for quote token.
      *  @param  index_       The bucket index from which quote tokens will be removed.
-     *  @return lpAmount_    The amount of LP tokens used for removing quote tokens amount.
+     *  @return lpAmount_    The amount of LP used for removing quote tokens.
      */
     function removeAllQuoteToken(uint256 index_) external returns (uint256 lpAmount_);
 
@@ -226,7 +226,7 @@ interface IScaledPool {
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
      *  @param  amount_      The amount of quote token to be removed by a lender.
      *  @param  index_       The bucket index from which quote tokens will be removed.
-     *  @return lpAmount_    The amount of LP tokens used for removing quote tokens amount.
+     *  @return lpAmount_    The amount of LP used for removing quote tokens amount.
      */
     function removeQuoteToken(uint256 amount_, uint256 index_) external returns (uint256 lpAmount_);
 

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -363,15 +363,6 @@ interface IScaledPool {
     function quoteTokenAddress() external pure returns (address);
 
     /**
-     *  @notice Calculate the amount of collateral for a given amount of LP Tokens.
-     *  @param  deposit_          The amount of quote tokens available at this bucket index.
-     *  @param  lpTokens_         The number of lpTokens to calculate amounts for.
-     *  @param  index_            The price bucket index for which the value should be calculated.
-     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
-     */
-    function lpsToCollateral(uint256 deposit_, uint256 lpTokens_, uint256 index_) external view returns (uint256 collateralAmount_);
-
-    /**
      *  @notice Calculate the amount of quote tokens for a given amount of LP Tokens.
      *  @param  deposit_     The amount of quote tokens available at this bucket index.
      *  @param  lpTokens_    The number of lpTokens to calculate amounts for.

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -216,12 +216,19 @@ interface IScaledPool {
     function moveQuoteToken(uint256 maxAmount_, uint256 fromIndex_, uint256 toIndex_) external;
 
     /**
-     *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
-     *  @param  maxAmount_   The maximum amount of quote token to be removed by a lender.
+     *  @notice Called by lenders to redeem the maximum amount of LP for quote token.
      *  @param  index_       The bucket index from which quote tokens will be removed.
      *  @return lpAmount_    The amount of LP tokens used for removing quote tokens amount.
      */
-    function removeQuoteToken(uint256 maxAmount_, uint256 index_) external returns (uint256 lpAmount_);
+    function removeAllQuoteToken(uint256 index_) external returns (uint256 lpAmount_);
+
+    /**
+     *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
+     *  @param  amount_      The amount of quote token to be removed by a lender.
+     *  @param  index_       The bucket index from which quote tokens will be removed.
+     *  @return lpAmount_    The amount of LP tokens used for removing quote tokens amount.
+     */
+    function removeQuoteToken(uint256 amount_, uint256 index_) external returns (uint256 lpAmount_);
 
     /**
      *  @notice Called by lenders to transfers their LP tokens to a different address.

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -218,9 +218,10 @@ interface IScaledPool {
     /**
      *  @notice Called by lenders to redeem the maximum amount of LP for quote token.
      *  @param  index_       The bucket index from which quote tokens will be removed.
+     *  @return amount_      The amount of quote token removed.
      *  @return lpAmount_    The amount of LP used for removing quote tokens.
      */
-    function removeAllQuoteToken(uint256 index_) external returns (uint256 lpAmount_);
+    function removeAllQuoteToken(uint256 index_) external returns (uint256 amount_, uint256 lpAmount_);
 
     /**
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -236,7 +236,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
     }
 
     function removeCollateral(uint256 amount_, uint256 index_) external override returns (uint256 lpAmount_) {
-        Bucket memory bucket        = buckets[index_];
+        Bucket memory bucket = buckets[index_];
         require(amount_ <= bucket.availableCollateral, "S:RC:INSUF_COL");
 
         _accruePoolInterest();

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -156,9 +156,10 @@ interface IERC20Pool is IScaledPool {
     /**
      *  @notice Called by lenders to redeem the maximum amount of LP for unencumbered collateral.
      *  @param  index_    The bucket index from which unencumbered collateral will be removed.
+     *  @return amount_   The amount of collateral removed.
      *  @return lpAmount_ The amount of LP used for removing collateral.
      */
-    function removeAllCollateral(uint256 index_) external returns (uint256 lpAmount_);
+    function removeAllCollateral(uint256 index_) external returns (uint256 amount_, uint256 lpAmount_);
 
     /**
      *  @notice Called by lenders to claim unencumbered collateral from a price bucket.

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -154,10 +154,17 @@ interface IERC20Pool is IScaledPool {
     function addCollateral(uint256 amount_, uint256 index_) external returns (uint256 lpbChange_);
 
     /**
+     *  @notice Called by lenders to redeem the maximum amount of LP for unencumbered collateral.
+     *  @param  index_    The bucket index from which unencumbered collateral will be removed.
+     *  @return lpAmount_ The amount of LP used for removing collateral.
+     */
+    function removeAllCollateral(uint256 index_) external returns (uint256 lpAmount_);
+
+    /**
      *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
      *  @param  amount_   The amount of unencumbered collateral to claim.
-     *  @param  index_    The index of the bucket from which unencumbered collateral will be claimed.
-     *  @return lpAmount_ The amount of LP tokens used for removing collateral amount.
+     *  @param  index_    The bucket index from which unencumbered collateral will be removed.
+     *  @return lpAmount_ The amount of LP used for removing collateral amount.
      */
     function removeCollateral(uint256 amount_, uint256 index_) external returns (uint256 lpAmount_);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,7 +303,7 @@ class TestUtils:
         # if pool is collateralized...
         if pool.lupIndex() > ScaledPoolUtils.price_to_index_safe(pool, pool.htp()):
             # ...ensure debt is less than the size of the pool
-            assert pool.borrowerDebt <= pool.treeSum()
+            assert pool.borrowerDebt <= pool.poolSize()
             # ...ensure borrowers owe more than lenders are owed
             assert pool.borrowerDebt() >= pool.lenderDebt()
 
@@ -407,12 +407,12 @@ class TestUtils:
               f"pendingInf: {pool.pendingInflator()/1e18:>20.18f}")
 
         contract_quote_balance = Contract(pool.quoteToken()).balanceOf(pool)
-        reserves = contract_quote_balance + pool.borrowerDebt() - pool.treeSum()
+        reserves = contract_quote_balance + pool.borrowerDebt() - pool.poolSize()
         pledged_collateral = pool.pledgedCollateral()
         if pledged_collateral > 0:
             ptp = pool.borrowerDebt() * 10 ** 18 / pledged_collateral
             ptp_index = pool.priceToIndex(ptp)
-            ru = pool.prefixSum(ptp_index)
+            ru = pool.depositAt(ptp_index)
         else:
             ptp = 0
             ru = 0
@@ -421,7 +421,7 @@ class TestUtils:
               f"pledged collaterl: {pool.pledgedCollateral()/1e18:>7.1f}  "
               f"ptp: {ptp/1e18:>10.3f}  "
               f"ru: {ru/1e18:>12.1f}  "
-              f"sum: {pool.treeSum()/1e18:>12.1f}  "
+              f"sum: {pool.poolSize()/1e18:>12.1f}  "
               f"rate:     {pool.interestRate()/1e18:>10.6f}")
 
 


### PR DESCRIPTION
Before, removal methods were passed a `maxAmount` and calculated how much a user can actually remove given their LP.  We take a max instead of actual amount to allow users to perform a full withdrawal, because they cannot accurately predict how much interest will accumulate in the block where their transaction is mined.

The new solution is to break withdrawals into two methods:
- a full withdrawal, which takes no amount
- a partial withdrawal, which takes the actual amount

Removed the no-longer-necessary `lpsToCollateral` facility created for `PositionManager`.  Extended tests to cover all the potential reverts.  Per feedback on last PR, now also checking return values of removal functions.

Also brought real-world test up-to-date.