### PR TITLE
Eliminate lenderDebt accumulator; calculate LUP using borrowerDebt

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -73,7 +73,6 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),              50_000 * 1e18);
         assertEq(_pool.borrowerDebt(),          0);
-        assertEq(_pool.lenderDebt(),            0);
         assertEq(_pool.poolActualUtilization(), 0);
         assertEq(_pool.poolMinDebtAmount(),     0);
 
@@ -99,7 +98,6 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     50_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 21_020.192307692307702000 * 1e18);
-        assertEq(_pool.lenderDebt(),   21_000 * 1e18);
         assertEq(_pool.poolTargetUtilization(), 1 * 1e18);
         assertEq(_pool.poolActualUtilization(), 0.420403846153846154 * 1e18);
         assertEq(_pool.poolMinDebtAmount(),     2_102.0192307692307702 * 1e18);
@@ -134,17 +132,16 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // borrow 19_000 DAI
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_966.176540084047110076 * 1e18, 19_000 * 1e18);
+        emit Borrow(address(_borrower), 2_951.419442869698640451 * 1e18, 19_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), address(_borrower), 19_000 * 1e18);
         _pool.borrow(19_000 * 1e18, 3500, address(0), address(0));
 
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
-        assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
+        assertEq(_pool.lup(), 2_951.419442869698640451 * 1e18);
 
         assertEq(_pool.poolSize(),          50_000 * 1e18);
         assertEq(_pool.borrowerDebt(),      40_038.461538461538480000 * 1e18);
-        assertEq(_pool.lenderDebt(),        40_000 * 1e18);
         assertEq(_pool.poolMinDebtAmount(), 4_003.846153846153848 * 1e18);
 
         // check balances
@@ -163,7 +160,6 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     50_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 30_038.461538461538480000 * 1e18);
-        assertEq(_pool.lenderDebt(),   30_009.606147934678200000 * 1e18);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   20_000 * 1e18);
@@ -182,7 +178,6 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     50_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 0);
-        assertEq(_pool.lenderDebt(),   0);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   50_038.461538461538480000 * 1e18);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -74,7 +74,6 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     30_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 0);
-        assertEq(_pool.lenderDebt(),   0);
 
         assertEq(_pool.pledgedCollateral(),   0);
         assertEq(_collateral.balanceOf(address(_borrower)), 150 * 1e18);
@@ -102,11 +101,9 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),          30_000 * 1e18);
         assertEq(_pool.borrowerDebt(),      21_020.192307692307702000 * 1e18);
-        assertEq(_pool.lenderDebt(),        21_000 * 1e18);
         assertEq(_pool.pledgedCollateral(), 100 * 1e18);
 
         assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.051372011699988577 * 1e18);
-        assertEq(_pool.encumberedCollateral(_pool.lenderDebt(), _pool.lup()),   7.044598359431304627 * 1e18);
 
         // check borrower state
         (uint256 borrowerDebt, , uint256 borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));
@@ -152,11 +149,9 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),          30_025.933063902025680000 * 1e18);
         assertEq(_pool.borrowerDebt(),      21_049.006823139002918431 * 1e18);
-        assertEq(_pool.lenderDebt(),        21_000 * 1e18);
         assertEq(_pool.pledgedCollateral(), _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()));
 
         assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.061038044473493202 * 1e18);
-        assertEq(_pool.encumberedCollateral(_pool.lenderDebt(), _pool.lup()),   7.044598359431304627 * 1e18);
 
         // check borrower state
         (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
@@ -77,7 +77,6 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     110_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 46_044.230769230769252000 * 1e18);
-        assertEq(_pool.lenderDebt(),   46_000 * 1e18);
 
         assertEq(_pool.interestRate(),       0.055 * 1e18);
         assertEq(_pool.interestRateUpdate(), 864000);
@@ -97,7 +96,6 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
 
         assertEq(_pool.poolSize(),     110_162.490615984432250000 * 1e18);
         assertEq(_pool.borrowerDebt(), 0);
-        assertEq(_pool.lenderDebt(),   0);
 
         (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        0);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -183,7 +183,6 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
-        assertEq(_pool.lenderDebt(),        10_000 * _quotePoolPrecision);
 
         assertEq(_pool.poolSize(),                        150_000 * _quotePoolPrecision);
         assertEq(_pool.lpBalance(2549, address(_lender)), 50_000 * _lpPoolPrecision);

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -707,7 +707,6 @@ contract PositionManagerDecreaseLiquidityWithDebtTest is PositionManagerHelperCo
 
         assertEq(_pool.poolSize(),     50_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 25_024.038461538461550000 * 1e18);
-        assertEq(_pool.lenderDebt(),   25_000 * 1e18);
 
         // check token balances
         assertEq(_collateral.balanceOf(address(_pool)),         5_000 * 1e18);
@@ -753,7 +752,6 @@ contract PositionManagerDecreaseLiquidityWithDebtTest is PositionManagerHelperCo
 
         assertEq(_pool.poolSize(),     43_010.892022197881557845 * 1e18);
         assertEq(_pool.borrowerDebt(), 25_024.038461538461550000 * 1e18);
-        assertEq(_pool.lenderDebt(),   25_000 * 1e18);
 
         // check token balances
         assertEq(_collateral.balanceOf(address(_pool)),         5_000 * 1e18);
@@ -802,7 +800,6 @@ contract PositionManagerDecreaseLiquidityWithDebtTest is PositionManagerHelperCo
 
         assertEq(_pool.poolSize(),     90_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 25_024.038461538461550000 * 1e18);
-        assertEq(_pool.lenderDebt(),   25_000 * 1e18);
 
         // check token balances
         assertEq(_collateral.balanceOf(address(_pool)),         5_083.393625665957573560 * 1e18);
@@ -845,7 +842,6 @@ contract PositionManagerDecreaseLiquidityWithDebtTest is PositionManagerHelperCo
 
         assertEq(_pool.poolSize(),     40_000 * 1e18);
         assertEq(_pool.borrowerDebt(), 25_024.038461538461550000 * 1e18);
-        assertEq(_pool.lenderDebt(),   25_000 * 1e18);
 
         // check token balances
         assertEq(_collateral.balanceOf(address(_pool)),         5_000 * 1e18);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -42,7 +42,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     uint256 public override interestRate;               // [WAD]
     uint256 public override interestRateUpdate;         // [SEC]
 
-    uint256 public override lenderDebt;
     uint256 public override borrowerDebt;
 
     uint256 public override totalBorrowers;
@@ -347,7 +346,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     }
 
     function _lupIndex(uint256 additionalDebt_) internal view returns (uint256) {
-        return _findSum(lenderDebt + additionalDebt_);
+        return _findSum(borrowerDebt + additionalDebt_);
     }
 
     function _indexToBucketIndex(uint256 index_) internal pure returns (int256) {

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -118,12 +118,6 @@ interface IScaledPool {
     function lenderInterestFactor() external view returns (uint256 lenderInterestFactor_);
 
     /**
-     *  @notice Returns the `lenderDebt` state variable.
-     *  @return lenderDebt_ Total amount of lender debt in pool.
-     */
-    function lenderDebt() external view returns (uint256 lenderDebt_);
-
-    /**
      *  @notice Returns the amount of quote token in the book down to the specified bucket index.
      *  @return quoteToken_ Amount of quote token (deposit + interest), regardless of pool debt.
      */

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -98,7 +98,6 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         // update actor accounting
         borrowerDebt = curDebt;
-        lenderDebt   += amount_;
 
         // update loan queue
         uint256 thresholdPrice = _thresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
@@ -148,11 +147,6 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
         uint256 amount = Maths.min(borrower.debt, maxAmount_);
         borrower.debt -= amount;
-
-        // update lender accounting
-        uint256 curLenderDebt = lenderDebt;
-        curLenderDebt -= Maths.min(curLenderDebt, Maths.wmul(Maths.wdiv(curLenderDebt, curDebt), amount));
-
         curDebt       -= amount;
 
         // update loan queue
@@ -170,10 +164,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         // update pool state
         if (curDebt != 0) {
             borrowerDebt = curDebt;
-            lenderDebt   = curLenderDebt;
         } else {
             borrowerDebt = 0;
-            lenderDebt   = 0;
         }
 
         uint256 newLup = _lup();

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -162,11 +162,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         borrowers[msg.sender] = borrower;
 
         // update pool state
-        if (curDebt != 0) {
-            borrowerDebt = curDebt;
-        } else {
-            borrowerDebt = 0;
-        }
+        borrowerDebt = curDebt;
 
         uint256 newLup = _lup();
         _updateInterestRate(curDebt, newLup);


### PR DESCRIPTION
The `lenderDebt` accumulator used to track the amount of interest owed to lenders, as opposed to `borrowerDebt`, which is a total debt accumulator (which includes origination fees, for example).  When there is no bad debt, `lenderDebt` should always be slightly lower.

We had been using `lenderDebt` to calculate the LUP, but Matt confirmed we may calculate that using `borrowerDebt` such that we may remove this accumulator.