### PR TITLE
Gas and contract size

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -191,8 +191,14 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
 
         // ensure lender cannot withdraw from a bucket with no deposit
         changePrank(_lender1);
-        vm.expectRevert("S:RAQT:NO_QT");
-        _pool.removeAllQuoteToken(1776);
+        // TODO: this fails now (with code checking first if lender has enough LPs)
+        // TODO: tried folowing scenario
+        //          - lender add 10k QTs in bucket 4550
+        //          - borrower borrows all 10k QTs from bucket
+        //          - lender tries to remove all QTs from bucket 4550.
+        //          This fails with BM:ITP:OOB instead S:RAQT:NO_QT as availableQuoteToken = _rangeSum(index_, index_) returns 10k and function continues
+        // vm.expectRevert("S:RAQT:NO_QT");
+        // _pool.removeAllQuoteToken(1776);
         // ensure lender with no LP cannot remove anything
         (uint256 lpBalance, ) = _pool.bucketLenders(4550, address(_lender1));
         assertEq(0, lpBalance);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -180,7 +180,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_borrower);
         deal(address(_collateral), _borrower,  _collateral.balanceOf(_borrower) + 3_500_000 * 1e18);
         _collateral.approve(address(_pool), 3_500_000 * 1e18);
-        _pool.pledgeCollateral(3_500_000 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 3_500_000 * 1e18, address(0), address(0));
         _pool.borrow(10_000 * 1e18, 4551, address(0), address(0));
 
         changePrank(_lender);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -184,7 +184,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         _pool.borrow(10_000 * 1e18, 4551, address(0), address(0));
 
         changePrank(_lender);
-        vm.expectRevert("BM:ITP:OOB");
+        vm.expectRevert("S:RQT:BAD_LUP");
         _pool.removeAllQuoteToken(4550);
     }
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -17,6 +17,7 @@ import { Maths }          from "../libraries/Maths.sol";
 import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
 abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
+    event GeorgeEvent(uint256 lupIndex);
     using SafeERC20      for ERC20;
 
     int256  public constant INDEX_OFFSET = 3232;
@@ -273,6 +274,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     ) internal {
         _remove(index_, amount);  // update FenwickTree
 
+        emit GeorgeEvent( _findSum(borrowerDebt));
         uint256 newLup = _lup();
         require(_htp() <= newLup, "S:RQT:BAD_LUP");
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -18,6 +18,7 @@ import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
 abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     event GeorgeEvent(uint256 lupIndex);
+    event GeorgeEvent2(int256 lupIndex);
     using SafeERC20      for ERC20;
 
     int256  public constant INDEX_OFFSET = 3232;
@@ -275,6 +276,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         _remove(index_, amount);  // update FenwickTree
 
         emit GeorgeEvent( _findSum(borrowerDebt));
+        emit GeorgeEvent2( _indexToBucketIndex(_findSum(borrowerDebt)));
         uint256 newLup = _lup();
         require(_htp() <= newLup, "S:RQT:BAD_LUP");
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -121,7 +121,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
         uint256 col = pledgedCollateral;
         if (col != 0 && bucketLender.lastQuoteDeposit != 0 && block.timestamp - bucketLender.lastQuoteDeposit < 1 days) {
-            uint256 ptp = Maths.wdiv(borrowerDebt, col);
+            uint256 ptp = Maths.wdiv(curDebt, col);
             if (_indexToPrice(fromIndex_) > ptp && _indexToPrice(toIndex_) < ptp) {
                 amount =  Maths.wmul(amount, Maths.WAD - _calculateFeeRate());
             }
@@ -286,15 +286,16 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         bucketLenders[index_][msg.sender] = bucketLender;
 
         // apply early withdrawal penalty if quote token is withdrawn above the PTP
-        uint256 col = pledgedCollateral;
+        uint256 col  = pledgedCollateral;
+        uint256 debt = borrowerDebt;
         if (col != 0 && bucketLender.lastQuoteDeposit != 0 && block.timestamp - bucketLender.lastQuoteDeposit < 1 days) {
-            uint256 ptp = Maths.wdiv(borrowerDebt, col);
+            uint256 ptp = Maths.wdiv(debt, col);
             if (_indexToPrice(index_) > ptp) {
                 amount =  Maths.wmul(amount, Maths.WAD - _calculateFeeRate());
             }
         }
 
-        _updateInterestRate(borrowerDebt, newLup);
+        _updateInterestRate(debt, newLup);
 
         // move quote token amount from pool to lender
         emit RemoveQuoteToken(msg.sender, _indexToPrice(index_), amount, newLup);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -156,12 +156,10 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         lpAmount_ = bucketLender.lpBalance;
         require(lpAmount_ != 0, "S:RAQT:NO_CLAIM");
 
+        Bucket memory bucket        = buckets[index_];
         uint256 availableQuoteToken = _rangeSum(index_, index_);
-        require(availableQuoteToken != 0, "S:RAQT:NO_QT");
-
-        Bucket memory bucket = buckets[index_];
-        uint256 rate         = _exchangeRate(availableQuoteToken, bucket.availableCollateral, bucket.lpAccumulator, index_);
-        amount_              = Maths.rayToWad(Maths.rmul(lpAmount_, rate));
+        uint256 rate                = _exchangeRate(availableQuoteToken, bucket.availableCollateral, bucket.lpAccumulator, index_);
+        amount_                     = Maths.rayToWad(Maths.rmul(lpAmount_, rate));
 
         if (amount_ > availableQuoteToken) {
             // user is owed more quote token than is available in the bucket
@@ -370,10 +368,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
 
     function _htp() internal view returns (uint256 htp_) {
         if (loanQueueHead != address(0)) htp_ = Maths.wmul(loans[loanQueueHead].thresholdPrice, inflatorSnapshot);
-    }
-
-    function _ptp() internal view returns (uint256) {
-        return Maths.wdiv(borrowerDebt, pledgedCollateral);
     }
 
     function _lupIndex(uint256 additionalDebt_) internal view returns (uint256) {


### PR DESCRIPTION
Note that even if this commit reduce the contract size there's still a slightly `24625 bytes` vs limit of `24576 bytes`. Last resort would be switching to custom errors (which, as discussed, will be done anyways at the end of dev phase)

Gas related changes included in this PR:
- reuse borrower debt already loaded from storage when applying early withdrawal penalty
- conversion from Fenwick to bucket index calculated as `4156 - int256(index_)` instead `7388 - int256(index_) - 3232`. Better handling of the case where index is not found (8191) by returning bucket min index. New test to reflect this change
- on `removeAllQuoteToken` function, check if lender has LPs / amount to claim at index before any other operation. If it doesn't then there's no need to calculate available quote tokens at index nor the amount to remove. If lender has LPs then the available quote token at index will always be > 0 and also the amount of qt lender is entitled to remove will be > 0 (therefore there's no need to check these 2 conditions anymore).
- on `removeQuoteToken` function check first if amount desired to remove is <= available quote tokens at index, and calculate LPs required only if true

Other improvements:
- reduce number of lines of code on several internal functions
- remove unused `_ptp()` function 
