### PR TITLE
Any actor may recollateralize or repay another borrower’s loan

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -82,7 +82,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // borrower deposit 100 WETH collateral
         changePrank(_borrower);
-        _pool.pledgeCollateral(100 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
         assertEq(_pool.poolTargetUtilization(), 1 * 1e18);
         assertEq(_pool.poolActualUtilization(), 0);
 
@@ -158,7 +158,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         emit Repay(address(_borrower), 2_966.176540084047110076 * 1e18, 10_000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 10_000 * 1e18);
-        _pool.repay(10_000 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 300.384615384615384800 * 1e18);
         assertEq(_pool.lup(), 2_966.176540084047110076 * 1e18);
@@ -176,7 +176,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         emit Repay(address(_borrower), BucketMath.MAX_PRICE, 30_038.461538461538480000 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 30_038.461538461538480000 * 1e18);
-        _pool.repay(30_040 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 30_040 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
@@ -207,7 +207,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         skip(864000);
 
         changePrank(_borrower);
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(21_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(_pool.borrowerDebt(), 21_020.192307692307702000 * 1e18);
@@ -218,7 +218,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1 * 1e18);
 
         skip(864000);
-        _pool.pledgeCollateral(10 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 10 * 1e18, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_083.636385101213387311 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_083.636385101213387311 * 1e18);
@@ -245,7 +245,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(inflator,    1.006515655675920014 * 1e18);
 
         skip(864000);
-        _pool.repay(0, address(0), address(0));
+        _pool.repay(_borrower, 0, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_199.628356897284446170 * 1e18);
         (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
         assertEq(debt,        21_199.628356897284446170 * 1e18);
@@ -287,12 +287,12 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after adding sufficient collateral
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         // borrower 2 borrows 15k quote from the pool with borrower2 becoming new queue HEAD
         changePrank(_borrower2);
-        _pool.pledgeCollateral(6 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower2, 6 * 1e18, address(0), address(0));
         _pool.borrow(15_000 * 1e18, 3000, address(0), address(0));
 
         changePrank(_borrower);
@@ -330,22 +330,22 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         // should revert if borrower has insufficient quote to repay desired amount
         changePrank(_borrower);
         vm.expectRevert("S:R:INSUF_BAL");
-        _pool.repay(10_000 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
         vm.expectRevert("S:R:NO_DEBT");
-        _pool.repay(10_000 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(1_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(address(_borrower), _pool.loanQueueHead());
 
         // borrower 2 borrows 5k quote from the pool and becomes new queue HEAD
         changePrank(_borrower2);
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(_borrower));
+        _pool.pledgeCollateral(_borrower2, 50 * 1e18, address(0), address(_borrower));
         _pool.borrow(5_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(address(_borrower2), _pool.loanQueueHead());
@@ -353,14 +353,14 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
         vm.expectRevert("R:B:AMT_LT_AVG_DEBT");
-        _pool.repay(750 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 750 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
         emit Repay(address(_borrower), _pool.lup(), 0.0001 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 0.0001 * 1e18);
-        _pool.repay(0.0001 * 1e18, address(_borrower2), address(_borrower2));
+        _pool.repay(_borrower, 0.0001 * 1e18, address(_borrower2), address(_borrower2));
     }
 
     /**
@@ -379,12 +379,12 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // borrower 1 initiates a highly overcollateralized loan with a TP of 0 that won't be inserted into the Queue
         changePrank(_borrower);
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         vm.expectRevert("B:U:TP_EQ_0");
         _pool.borrow(0.00000000000000001 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after using a non 0 TP
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         assertGt(_pool.htp(), 0);
@@ -408,7 +408,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // borrower 1 borrows 500 quote from the pool
         changePrank(_borrower);
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(500 * 1e18, 2551, address(0), address(0));
 
         assertGt(_pool.htp(), 0);
@@ -419,10 +419,10 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
         vm.expectRevert("B:U:TP_EQ_0");
-        _pool.repay(pendingDebt - 1, address(0), address(0));
+        _pool.repay(_borrower, pendingDebt - 1, address(0), address(0));
 
         // should be able to pay back all pendingDebt
-        _pool.repay(pendingDebt, address(0), address(0));
+        _pool.repay(_borrower, pendingDebt, address(0), address(0));
         assertEq(_pool.htp(), 0);
         assertEq(address(_pool.loanQueueHead()), address(0));
     }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -77,8 +77,8 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.poolMinDebtAmount(),     0);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   50_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 50_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
 
         // borrower deposit 100 WETH collateral
         changePrank(_borrower);
@@ -88,9 +88,9 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // get a 21_000 DAI loan
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
+        emit Borrow(_borrower, 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower), 21_000 * 1e18);
+        emit Transfer(address(_pool), _borrower, 21_000 * 1e18);
         _pool.borrow(21_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(_pool.htp(), 210.201923076923077020 * 1e18);
@@ -103,19 +103,19 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.poolMinDebtAmount(),     2_102.0192307692307702 * 1e18);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   29_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 29_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
 
         // check LPs
-        (uint256 lpBalance, ) = _pool.bucketLenders(depositIndexHighest, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(depositIndexHighest, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexHigh, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexHigh, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexMed, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexMed, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexLow, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexLow, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexLowest, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexLowest, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
 
         // check buckets
@@ -137,9 +137,9 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // borrow 19_000 DAI
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_951.419442869698640451 * 1e18, 19_000 * 1e18);
+        emit Borrow(_borrower, 2_951.419442869698640451 * 1e18, 19_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower), 19_000 * 1e18);
+        emit Transfer(address(_pool), _borrower, 19_000 * 1e18);
         _pool.borrow(19_000 * 1e18, 3500, address(0), address(0));
 
         assertEq(_pool.htp(), 400.384615384615384800 * 1e18);
@@ -150,14 +150,14 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.poolMinDebtAmount(), 4_003.846153846153848 * 1e18);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   10_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 10_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
 
         // repay partial
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), 2_966.176540084047110076 * 1e18, 10_000 * 1e18);
+        emit Repay(_borrower, 2_966.176540084047110076 * 1e18, 10_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_pool), 10_000 * 1e18);
+        emit Transfer(_borrower, address(_pool), 10_000 * 1e18);
         _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 300.384615384615384800 * 1e18);
@@ -167,15 +167,15 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(), 30_038.461538461538480000 * 1e18);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   20_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 20_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
 
         // repay entire loan
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 40 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), BucketMath.MAX_PRICE, 30_038.461538461538480000 * 1e18);
+        emit Repay(_borrower, BucketMath.MAX_PRICE, 30_038.461538461538480000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_pool), 30_038.461538461538480000 * 1e18);
+        emit Transfer(_borrower, address(_pool), 30_038.461538461538480000 * 1e18);
         _pool.repay(_borrower, 30_040 * 1e18, address(0), address(0));
 
         assertEq(_pool.htp(), 0);
@@ -185,8 +185,8 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(), 0);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   50_038.461538461538480000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 50_038.461538461538480000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
     }
 
     function testScaledPoolBorrowerInterestAccumulation() external {
@@ -211,7 +211,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         _pool.borrow(21_000 * 1e18, 3000, address(0), address(0));
 
         assertEq(_pool.borrowerDebt(), 21_020.192307692307702000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_020.192307692307702000 * 1e18);
         assertEq(pendingDebt, 21_051.890446235135648008 * 1e18);
         assertEq(col,         50 * 1e18);
@@ -220,7 +220,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         skip(864000);
         _pool.pledgeCollateral(_borrower, 10 * 1e18, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_083.636385101213387311 * 1e18);
-        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_083.636385101213387311 * 1e18);
         assertEq(pendingDebt, 21_083.636385101213387311 * 1e18);
         assertEq(col,         60 * 1e18);
@@ -229,7 +229,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         skip(864000);
         _pool.pullCollateral(10 * 1e18, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_118.612213260575675180 * 1e18);
-        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_118.612213260575675180 * 1e18);
         assertEq(pendingDebt, 21_118.612213260575675180 * 1e18);
         assertEq(col,         50 * 1e18);
@@ -238,7 +238,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         skip(864000);
         _pool.borrow(0, 3000, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_157.152643010853298669 * 1e18);
-        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_157.152643010853298669 * 1e18);
         assertEq(pendingDebt, 21_157.152643010853298669 * 1e18);
         assertEq(col,         50 * 1e18);
@@ -247,7 +247,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         skip(864000);
         _pool.repay(_borrower, 0, address(0), address(0));
         assertEq(_pool.borrowerDebt(), 21_199.628356897284446170 * 1e18);
-        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_199.628356897284446170 * 1e18);
         assertEq(pendingDebt, 21_199.628356897284446170 * 1e18);
         assertEq(col,         50 * 1e18);
@@ -255,7 +255,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         skip(864000);
         assertEq(_pool.borrowerDebt(), 21_199.628356897284446170 * 1e18);
-        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        21_199.628356897284446170 * 1e18);
         assertEq(pendingDebt, 21_246.450141935843879765 * 1e18);
         assertEq(col,         50 * 1e18);
@@ -298,19 +298,19 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         changePrank(_borrower);
         // should revert if borrower attempts to borrow more than minimum amount
         vm.expectRevert("S:B:AMT_LT_AVG_DEBT");
-        _pool.borrow(10 * 1e18, 3000, address(0), address(_borrower2));
+        _pool.borrow(10 * 1e18, 3000, address(0), _borrower2);
 
         changePrank(_borrower2);
         // should revert if borrow would result in borrower under collateralization
         assertEq(_pool.lup(), 2_995.912459898389633881 * 1e18);
         vm.expectRevert("S:B:BUNDER_COLLAT");
-        _pool.borrow(2_976 * 1e18, 3000, address(0), address(_borrower));
+        _pool.borrow(2_976 * 1e18, 3000, address(0), _borrower);
 
         // should be able to borrow if properly specified
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower2), 2_995.912459898389633881 * 1e18, 10 * 1e18);
+        emit Borrow(_borrower2, 2_995.912459898389633881 * 1e18, 10 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower2), 10 * 1e18);
+        emit Transfer(address(_pool), _borrower2, 10 * 1e18);
         _pool.borrow(10 * 1e18, 3000, address(0), address(0));
     }
 
@@ -341,14 +341,14 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(1_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower), _pool.loanQueueHead());
+        assertEq(_borrower, _pool.loanQueueHead());
 
         // borrower 2 borrows 5k quote from the pool and becomes new queue HEAD
         changePrank(_borrower2);
-        _pool.pledgeCollateral(_borrower2, 50 * 1e18, address(0), address(_borrower));
+        _pool.pledgeCollateral(_borrower2, 50 * 1e18, address(0), _borrower);
         _pool.borrow(5_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower2), _pool.loanQueueHead());
+        assertEq(_borrower2, _pool.loanQueueHead());
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
@@ -357,10 +357,29 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _pool.lup(), 0.0001 * 1e18);
+        emit Repay(_borrower, _pool.lup(), 0.0001 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_pool), 0.0001 * 1e18);
-        _pool.repay(_borrower, 0.0001 * 1e18, address(_borrower2), address(_borrower2));
+        emit Transfer(_borrower, address(_pool), 0.0001 * 1e18);
+        _pool.repay(_borrower, 0.0001 * 1e18, _borrower2, _borrower2);
+    }
+
+    function testRepayLoanFromDifferentActor() external {
+        changePrank(_lender);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+
+        // borrower 1 borrows 1000 quote from the pool
+        changePrank(_borrower);
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
+        _pool.borrow(1_000 * 1e18, 3000, address(0), address(0));
+
+        // should be able to repay loan on behalf of borrower
+        changePrank(_lender);
+        vm.expectEmit(true, true, false, true);
+        emit Repay(_borrower, _pool.lup(), 0.0001 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(_lender, address(_pool), 0.0001 * 1e18);
+        _pool.repay(_borrower, 0.0001 * 1e18, address(0), address(0));
     }
 
     /**
@@ -388,7 +407,7 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         assertGt(_pool.htp(), 0);
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_pool.loanQueueHead()), _borrower);
 
     }
 
@@ -412,9 +431,9 @@ contract ERC20ScaledBorrowTest is DSTestPlus {
         _pool.borrow(500 * 1e18, 2551, address(0), address(0));
 
         assertGt(_pool.htp(), 0);
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_pool.loanQueueHead()), _borrower);
 
-        (, uint256 pendingDebt, , ) = _pool.borrowerInfo(address(_borrower));
+        (, uint256 pendingDebt, , ) = _pool.borrowerInfo(_borrower);
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
 
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -76,23 +76,23 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         assertEq(_pool.borrowerDebt(), 0);
 
         assertEq(_pool.pledgedCollateral(),   0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 150 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower), 150 * 1e18);
 
         // borrower deposits 100 collateral
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateral(address(_borrower), 100 * 1e18);
+        emit PledgeCollateral(_borrower, 100 * 1e18);
         _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
 
         // check pool state collateral accounting updated successfully
-        assertEq(_pool.pledgedCollateral(), 100 * 1e18);
-        assertEq(_collateral.balanceOf(address(_borrower)), 50 * 1e18);
+        assertEq(_pool.pledgedCollateral(),        100 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower), 50 * 1e18);
 
         // get a 21_000 Quote loan
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
+        emit Borrow(_borrower, 2_981.007422784467321543 * 1e18, 21_000 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower), 21_000 * 1e18);
+        emit Transfer(address(_pool), _borrower, 21_000 * 1e18);
         _pool.borrow(21_000 * 1e18, 3000, address(0), address(0));
 
         // check pool state
@@ -106,14 +106,14 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.051372011699988577 * 1e18);
 
         // check borrower state
-        (uint256 borrowerDebt, , uint256 borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));
+        (uint256 borrowerDebt, , uint256 borrowerCollateral, ) = _pool.borrowerInfo(_borrower);
         assertEq(borrowerDebt,       _pool.borrowerDebt());
         assertEq(borrowerCollateral, _pool.pledgedCollateral());
         assertEq(
             _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()),
             _pool.encumberedCollateral(borrowerDebt, _pool.lup())
         );
-        assertEq(_collateral.balanceOf(address(_borrower)), 50 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower), 50 * 1e18);
 
         assertEq(_pool.borrowerCollateralization(borrowerDebt, borrowerCollateral, _pool.lup()), _pool.poolCollateralization());
 
@@ -122,25 +122,25 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
 
         // remove some of the collateral
         vm.expectEmit(true, true, false, true);
-        emit PullCollateral(address(_borrower), 50 * 1e18);
+        emit PullCollateral(_borrower, 50 * 1e18);
         _pool.pullCollateral(50 * 1e18, address(0), address(0));
 
         // check borrower state
-        (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));
+        (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(_borrower);
         assertEq(borrowerDebt,       _pool.borrowerDebt());
         assertEq(borrowerCollateral, _pool.pledgedCollateral());
         assertEq(
             _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()),
             _pool.encumberedCollateral(borrowerDebt, _pool.lup())
         );
-        assertEq(_collateral.balanceOf(address(_borrower)), 100 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower), 100 * 1e18);
 
         assertEq(_pool.borrowerCollateralization(borrowerDebt, borrowerCollateral, _pool.lup()), _pool.poolCollateralization());
 
         // remove all of the remaining unencumbered collateral
         uint256 unencumberedCollateral = borrowerCollateral - _pool.encumberedCollateral(borrowerDebt, _pool.lup());
         vm.expectEmit(true, true, false, true);
-        emit PullCollateral(address(_borrower), unencumberedCollateral);
+        emit PullCollateral(_borrower, unencumberedCollateral);
         _pool.pullCollateral(unencumberedCollateral, address(0), address(0));
 
         // check pool state
@@ -154,14 +154,14 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         assertEq(_pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()), 7.061038044473493202 * 1e18);
 
         // check borrower state
-        (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(address(_borrower));
+        (borrowerDebt, , borrowerCollateral, ) = _pool.borrowerInfo(_borrower);
         assertEq(borrowerDebt,       _pool.borrowerDebt());
         assertEq(borrowerCollateral, _pool.pledgedCollateral());
         assertEq(
             _pool.encumberedCollateral(_pool.borrowerDebt(), _pool.lup()),
             _pool.encumberedCollateral(borrowerDebt, _pool.lup())
         );
-        assertEq(_collateral.balanceOf(address(_borrower)), 142.938961955526506798 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower), 142.938961955526506798 * 1e18);
 
         assertEq(_pool.borrowerCollateralization(borrowerDebt, borrowerCollateral, _pool.lup()), _pool.poolCollateralization());
     }
@@ -181,12 +181,12 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
 
         // borrower deposits 100 collateral
         vm.expectEmit(true, true, true, true);
-        emit PledgeCollateral(address(_borrower), testCollateralAmount);
+        emit PledgeCollateral(_borrower, testCollateralAmount);
         _pool.pledgeCollateral(_borrower, testCollateralAmount, address(0), address(0));
 
         // should be able to now remove collateral
         vm.expectEmit(true, true, true, true);
-        emit PullCollateral(address(_borrower), testCollateralAmount);
+        emit PullCollateral(_borrower, testCollateralAmount);
         _pool.pullCollateral(testCollateralAmount, address(0), address(0));
     }
 
@@ -205,38 +205,38 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         // actor deposits collateral into a bucket
         uint256 collateralToDeposit = 4 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit AddCollateral(address(_bidder), priceAtTestIndex, collateralToDeposit);
+        emit AddCollateral(_bidder, priceAtTestIndex, collateralToDeposit);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_bidder), address(_pool), collateralToDeposit);
+        emit Transfer(_bidder, address(_pool), collateralToDeposit);
         _pool.addCollateral(collateralToDeposit, testIndex);
 
         // check bucket state
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(testIndex);
         assertEq(availableCollateral, collateralToDeposit);
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndex, address(_bidder));
+        (uint256 lpBalance, ) = _pool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, 12_043.56808879152623138 * 1e27);
         assertEq(lpAccumulator, lpBalance);
 
         // check pool state and balances
-        assertEq(_collateral.balanceOf(address(_lender)), 0);
+        assertEq(_collateral.balanceOf(_lender),        0);
         assertEq(_collateral.balanceOf(address(_pool)), collateralToDeposit);
-        assertEq(_quote.balanceOf(address(_pool)),        0);
+        assertEq(_quote.balanceOf(address(_pool)),      0);
 
         // actor withdraws some of their collateral
         uint256 collateralToWithdraw = 1.53 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_bidder), priceAtTestIndex, collateralToWithdraw);
+        emit RemoveCollateral(_bidder, priceAtTestIndex, collateralToWithdraw);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_bidder), collateralToWithdraw);
+        emit Transfer(address(_pool), _bidder, collateralToWithdraw);
         uint256 lpRedeemed = _pool.removeCollateral(collateralToWithdraw, testIndex);
         assertEq(lpRedeemed, 4_606.664793962758783502850000000 * 1e27);
 
         // actor withdraws remainder of their _collateral
         collateralToWithdraw = 2.47 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_bidder), priceAtTestIndex, collateralToWithdraw);
+        emit RemoveCollateral(_bidder, priceAtTestIndex, collateralToWithdraw);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_bidder), collateralToWithdraw);
+        emit Transfer(address(_pool), _bidder, collateralToWithdraw);
         uint256 collateralRemoved;
         (collateralRemoved, lpRedeemed) = _pool.removeAllCollateral(testIndex);
         assertEq(collateralRemoved, collateralToWithdraw);
@@ -269,6 +269,26 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         _pool.removeAllCollateral(testIndex);
         vm.expectRevert("S:RC:INSUF_LPS");
         _pool.removeCollateral(0.32 * 1e18, testIndex);
+    }
+
+    function testPledgeCollateralFromDifferentActor() external {
+        // check initial pool state
+        assertEq(_pool.pledgedCollateral(),   0);
+        assertEq(_collateral.balanceOf(_borrower),  150 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower2), 100 * 1e18);
+
+        // borrower deposits 100 collateral
+        changePrank(_borrower2);
+        vm.expectEmit(true, true, false, true);
+        emit PledgeCollateral(_borrower, 100 * 1e18);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(_borrower2, address(_pool), 100 * 1e18);
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
+
+        // check pool state collateral accounting updated properly
+        assertEq(_pool.pledgedCollateral(),         100 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower),  150 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower2), 0);
     }
 
     // TODO: add collateralization, utilization and encumberance test? -> use hardcoded amounts in pure functions without creaitng whole pool flows

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -82,7 +82,7 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
         emit PledgeCollateral(address(_borrower), 100 * 1e18);
-        _pool.pledgeCollateral(100 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
 
         // check pool state collateral accounting updated successfully
         assertEq(_pool.pledgedCollateral(), 100 * 1e18);
@@ -182,7 +182,7 @@ contract ERC20ScaledCollateralTest is DSTestPlus {
         // borrower deposits 100 collateral
         vm.expectEmit(true, true, true, true);
         emit PledgeCollateral(address(_borrower), testCollateralAmount);
-        _pool.pledgeCollateral(testCollateralAmount, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, testCollateralAmount, address(0), address(0));
 
         // should be able to now remove collateral
         vm.expectEmit(true, true, true, true);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
@@ -69,7 +69,7 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
         assertEq(_pool.interestRateUpdate(), 0);
 
         changePrank(_borrower);
-        _pool.pledgeCollateral(100 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
         _pool.borrow(46_000 * 1e18, 4300, address(0), address(0));
 
         assertEq(_pool.htp(), 460.442307692307692520 * 1e18);
@@ -83,7 +83,7 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
 
         // repay entire loan
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 200 * 1e18);
-        _pool.repay(46_200 * 1e18, address(0), address(0));
+        _pool.repay(_borrower, 46_200 * 1e18, address(0), address(0));
 
         skip(864000);
 
@@ -117,7 +117,7 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
 
         // draw debt
         changePrank(_borrower);
-        _pool.pledgeCollateral(50 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * 1e18, address(0), address(0));
         _pool.borrow(15_000 * 1e18, 4300, address(0), address(0));
         assertEq(_pool.inflatorSnapshot(), 1.0 * 1e18);
         assertEq(_pool.pendingInflator(), 1.000005707778846384 * 1e18);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
@@ -97,7 +97,7 @@ contract ERC20ScaledInterestRateTest is DSTestPlus {
         assertEq(_pool.poolSize(),     110_162.490615984432250000 * 1e18);
         assertEq(_pool.borrowerDebt(), 0);
 
-        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col,         100 * 1e18);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -147,7 +147,7 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         emit PledgeCollateral(address(_borrower), 50 * _collateralPoolPrecision);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 50 * _collateralPrecision);
-        _pool.pledgeCollateral(50 * _collateralPoolPrecision, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 50 * _collateralPoolPrecision, address(0), address(0));
 
         // check balances
         assertEq(_collateral.balanceOf(address(_pool)),   50 * _collateralPrecision);
@@ -197,7 +197,7 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         emit Repay(address(_borrower), _pool.indexToPrice(2549), 5_000 * _quotePoolPrecision);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_borrower), address(_pool), 5_000 * _quotePrecision);
-        _pool.repay(5_000 * _quotePoolPrecision, address(0), address(0));
+        _pool.repay(_borrower, 5_000 * _quotePoolPrecision, address(0), address(0));
 
         // check balances
         assertEq(_collateral.balanceOf(address(_pool)),   50 * _collateralPrecision);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -78,20 +78,20 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2549);
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2550);
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(address(_lender), _pool.indexToPrice(2551), 50_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, _pool.indexToPrice(2551), 50_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_lender), address(_pool), 50_000 * _quotePrecision);
+        emit Transfer(_lender, address(_pool), 50_000 * _quotePrecision);
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2551);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   150_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_lender)), 50_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(address(_pool)), 150_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_lender),        50_000 * _quotePrecision);
 
         // check initial pool state
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -103,20 +103,20 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
 
         // lender removes some quote token from highest priced bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(2549), 25_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, _pool.indexToPrice(2549), 25_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_lender), 25_000 * _quotePrecision);
+        emit Transfer(address(_pool), _lender, 25_000 * _quotePrecision);
         _pool.removeQuoteToken(25_000 * _quotePoolPrecision, 2549);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   125_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_lender)), 75_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(address(_pool)), 125_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_lender),        75_000 * _quotePrecision);
 
         // check pool state
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(),         125_000 * _quotePoolPrecision);
         assertEq(lpBalance,                25_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -144,77 +144,77 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         // borrowers adds collateral
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateral(address(_borrower), 50 * _collateralPoolPrecision);
+        emit PledgeCollateral(_borrower, 50 * _collateralPoolPrecision);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_pool), 50 * _collateralPrecision);
+        emit Transfer(_borrower, address(_pool), 50 * _collateralPrecision);
         _pool.pledgeCollateral(_borrower, 50 * _collateralPoolPrecision, address(0), address(0));
 
         // check balances
         assertEq(_collateral.balanceOf(address(_pool)),   50 * _collateralPrecision);
-        assertEq(_collateral.balanceOf(address(_borrower)), 100 * _collateralPrecision);
+        assertEq(_collateral.balanceOf(_borrower), 100 * _collateralPrecision);
         assertEq(_quote.balanceOf(address(_pool)),   150_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_borrower)), 0);
+        assertEq(_quote.balanceOf(_borrower), 0);
 
         // check pool state
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
         assertEq(address(_pool.loanQueueHead()), address(0));
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
 
         // borrower borrows
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _pool.indexToPrice(2549), 10_000 * _quotePoolPrecision);
+        emit Borrow(_borrower, _pool.indexToPrice(2549), 10_000 * _quotePoolPrecision);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower), 10_000 * _quotePrecision);
+        emit Transfer(address(_pool), _borrower, 10_000 * _quotePrecision);
         _pool.borrow(10_000 * _quotePoolPrecision, 3000, address(0), address(0));
 
         // check balances
         assertEq(_collateral.balanceOf(address(_pool)),   50 * _collateralPrecision);
-        assertEq(_collateral.balanceOf(address(_borrower)), 100 * _collateralPrecision);
+        assertEq(_collateral.balanceOf(_borrower), 100 * _collateralPrecision);
         assertEq(_quote.balanceOf(address(_pool)),   140_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_borrower)), 10_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_borrower), 10_000 * _quotePrecision);
 
         // check pool state
-        (uint256 debt, , uint256 col,) = _pool.borrowerInfo(address(_borrower));
+        (uint256 debt, , uint256 col,) = _pool.borrowerInfo(_borrower);
         assertEq(_pool.htp(), Maths.wdiv(debt, col));
         assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_pool.loanQueueHead()), _borrower);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
 
         // borrower repays half of loan
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _pool.indexToPrice(2549), 5_000 * _quotePoolPrecision);
+        emit Repay(_borrower, _pool.indexToPrice(2549), 5_000 * _quotePoolPrecision);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_pool), 5_000 * _quotePrecision);
+        emit Transfer(_borrower, address(_pool), 5_000 * _quotePrecision);
         _pool.repay(_borrower, 5_000 * _quotePoolPrecision, address(0), address(0));
 
         // check balances
         assertEq(_collateral.balanceOf(address(_pool)),   50 * _collateralPrecision);
-        assertEq(_collateral.balanceOf(address(_borrower)), 100 * _collateralPrecision);
+        assertEq(_collateral.balanceOf(_borrower), 100 * _collateralPrecision);
         assertEq(_quote.balanceOf(address(_pool)),   145_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_borrower)), 5_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_borrower), 5_000 * _quotePrecision);
 
         // check pool state
-        (debt, , col,) = _pool.borrowerInfo(address(_borrower));
+        (debt, , col,) = _pool.borrowerInfo(_borrower);
         assertEq(_pool.htp(), Maths.wdiv(debt, col));
         assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_pool.loanQueueHead()), _borrower);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -222,22 +222,22 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         // remove all of the remaining unencumbered collateral
         uint256 unencumberedCollateral = col - _pool.encumberedCollateral(debt, _pool.lup());
         vm.expectEmit(true, true, false, true);
-        emit PullCollateral(address(_borrower), unencumberedCollateral);
+        emit PullCollateral(_borrower, unencumberedCollateral);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_borrower), unencumberedCollateral / _pool.collateralScale());
+        emit Transfer(address(_pool), _borrower, unencumberedCollateral / _pool.collateralScale());
         _pool.pullCollateral(unencumberedCollateral, address(0), address(0));
 
         //  FIXME: check balances
         // assertEq(_collateral.balanceOf(address(_pool)),   1.7 * _collateralPrecision);
-        // assertEq(_collateral.balanceOf(address(_borrower)), 148.30 * _collateralPrecision);
+        // assertEq(_collateral.balanceOf(_borrower), 148.30 * _collateralPrecision);
         assertEq(_quote.balanceOf(address(_pool)),   145_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_borrower)), 5_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_borrower), 5_000 * _quotePrecision);
 
         // check pool state
-        (debt, , col,) = _pool.borrowerInfo(address(_borrower));
+        (debt, , col,) = _pool.borrowerInfo(_borrower);
         assertEq(_pool.htp(), Maths.wdiv(debt, col));
         assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(address(_pool.loanQueueHead()), address(_borrower));
+        assertEq(address(_pool.loanQueueHead()), _borrower);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col); 
@@ -264,32 +264,32 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         uint256 collateralRequired = Maths.wdiv(quoteToPurchase, _pool.indexToPrice(2549));
         uint256 adjustedCollateralReq = collateralRequired / _pool.collateralScale();
         vm.expectEmit(true, true, false, true);
-        emit Purchase(address(_bidder), _pool.indexToPrice(2549), quoteToPurchase, collateralRequired);
+        emit Purchase(_bidder, _pool.indexToPrice(2549), quoteToPurchase, collateralRequired);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_bidder), address(_pool), adjustedCollateralReq);
+        emit Transfer(_bidder, address(_pool), adjustedCollateralReq);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_bidder), 500 * _quotePrecision);
+        emit Transfer(address(_pool), _bidder, 500 * _quotePrecision);
 //        _bidder.purchaseQuote(_pool, quoteToPurchase, 2549);
 
         // check bucket state
         (uint256 lpAccumulatorStateOne, uint256 availableCollateral) = _pool.buckets(2549);
-        (uint256 lpBalance, )                                        = _pool.bucketLenders(2549, address(_lender));
+        (uint256 lpBalance, )                                        = _pool.bucketLenders(2549, _lender);
         assertEq(availableCollateral,   collateralRequired);
         assertGt(availableCollateral,   0);
         assertEq(lpAccumulatorStateOne, lpBalance);
         assertGt(lpAccumulatorStateOne, 0);
 
         // check balances
-        assertEq(_collateral.balanceOf(address(_pool)),   adjustedCollateralReq);
-        assertEq(_collateral.balanceOf(address(_bidder)), 150 * _collateralPrecision - adjustedCollateralReq);
-        assertEq(_quote.balanceOf(address(_pool)),   150_000 * _quotePrecision - 500 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_bidder)), 500 * _quotePrecision);
+        assertEq(_collateral.balanceOf(address(_pool)), adjustedCollateralReq);
+        assertEq(_collateral.balanceOf(_bidder),        150 * _collateralPrecision - adjustedCollateralReq);
+        assertEq(_quote.balanceOf(address(_pool)),      150_000 * _quotePrecision - 500 * _quotePrecision);
+        assertEq(_quote.balanceOf(_bidder),             500 * _quotePrecision);
 
         // check pool state
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(), 149_500 * _quotePoolPrecision);
         assertEq(lpBalance,        50_000 * _lpPoolPrecision);
 
@@ -297,25 +297,25 @@ contract ERC20ScaledPoolPrecisionTest is DSTestPlus {
         changePrank(_lender);
         uint256 lpRedemption = Maths.wrdivr(Maths.wmul(availableCollateral, _pool.indexToPrice(2549)), _pool.exchangeRate(2549));
         vm.expectEmit(true, true, true, true);
-        emit ClaimCollateral(address(_lender), _pool.indexToPrice(2549), availableCollateral, lpRedemption);
+        emit ClaimCollateral(_lender, _pool.indexToPrice(2549), availableCollateral, lpRedemption);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_lender), adjustedCollateralReq);
+        emit Transfer(address(_pool), _lender, adjustedCollateralReq);
 //        _lender.claimCollateral(_pool, availableCollateral, 2549);
 
         // check bucket state
         (uint256 lpAccumulatorStateTwo, uint256 availableCollateralStateTwo) = _pool.buckets(2549);
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(availableCollateralStateTwo, 0);
         assertEq(lpAccumulatorStateTwo, lpBalance);
         assertGt(lpAccumulatorStateTwo, 0);
         assertLt(lpAccumulatorStateTwo, lpAccumulatorStateOne);
 
         // check balances
-        assertEq(_collateral.balanceOf(address(_pool)),   0);
-        assertEq(_collateral.balanceOf(address(_bidder)), 150 * _collateralPrecision - adjustedCollateralReq);
-        assertEq(_collateral.balanceOf(address(_lender)), adjustedCollateralReq);
-        assertEq(_quote.balanceOf(address(_pool)),   150_000 * _quotePrecision - 500 * _quotePrecision);
-        assertEq(_quote.balanceOf(address(_bidder)), 500 * _quotePrecision);
+        assertEq(_collateral.balanceOf(address(_pool)), 0);
+        assertEq(_collateral.balanceOf(_bidder),        150 * _collateralPrecision - adjustedCollateralReq);
+        assertEq(_collateral.balanceOf(_lender),        adjustedCollateralReq);
+        assertEq(_quote.balanceOf(address(_pool)),      150_000 * _quotePrecision - 500 * _quotePrecision);
+        assertEq(_quote.balanceOf(_bidder),             500 * _quotePrecision);
 
         // check pool state
         assertEq(_pool.htp(),      0);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -73,38 +73,38 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         changePrank(_bidder);
         uint256 collateralToPurchaseWith = 4 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit AddCollateral(address(_bidder), priceAtTestIndex, collateralToPurchaseWith);
+        emit AddCollateral(_bidder, priceAtTestIndex, collateralToPurchaseWith);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_bidder), address(_pool), collateralToPurchaseWith);
+        emit Transfer(_bidder, address(_pool), collateralToPurchaseWith);
         _pool.addCollateral(collateralToPurchaseWith, testIndex);
 
         // check bucket state
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(testIndex);
         assertEq(availableCollateral, collateralToPurchaseWith);
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndex, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(testIndex, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndex, address(_bidder));
+        (lpBalance, ) = _pool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, 12_043.56808879152623138 * 1e27);
 
         // bidder uses their LP to purchase all quote token in the bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_bidder), priceAtTestIndex, 10_000 * 1e18, _pool.lup());
+        emit RemoveQuoteToken(_bidder, priceAtTestIndex, 10_000 * 1e18, _pool.lup());
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_bidder), 10_000 * 1e18);
+        emit Transfer(address(_pool), _bidder, 10_000 * 1e18);
         _pool.removeQuoteToken(10_000 * 1e18, testIndex);
-        assertEq(_quote.balanceOf(address(_bidder)), 10_000 * 1e18);
+        assertEq(_quote.balanceOf(_bidder), 10_000 * 1e18);
 
         // check bucket state
         (lpAccumulator, availableCollateral) = _pool.buckets(testIndex);
         assertEq(availableCollateral, collateralToPurchaseWith);
         assertGt(availableCollateral, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndex, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(testIndex, _lender);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndex, address(_bidder));
+        (lpBalance, ) = _pool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, 2_043.56808879152623138 * 1e27);
 
         // check pool state and balances
-        assertEq(_collateral.balanceOf(address(_lender)), 0);
+        assertEq(_collateral.balanceOf(_lender), 0);
         assertEq(_collateral.balanceOf(address(_pool)),   collateralToPurchaseWith);
         assertGe(_collateral.balanceOf(address(_pool)), availableCollateral);
         assertEq(_quote.balanceOf(address(_pool)),        0);
@@ -113,22 +113,22 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         changePrank(_lender);
         uint256 lpValueInCollateral = 3.321274866808485288 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), priceAtTestIndex, lpValueInCollateral);
+        emit RemoveCollateral(_lender, priceAtTestIndex, lpValueInCollateral);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_lender), lpValueInCollateral);
+        emit Transfer(address(_pool), _lender, lpValueInCollateral);
         _pool.removeAllCollateral(testIndex);
-        assertEq(_collateral.balanceOf(address(_lender)), lpValueInCollateral);
-        (lpBalance, ) = _pool.bucketLenders(testIndex, address(_lender));
+        assertEq(_collateral.balanceOf(_lender), lpValueInCollateral);
+        (lpBalance, ) = _pool.bucketLenders(testIndex, _lender);
         assertEq(lpBalance, 0);
 
         // bidder removes their _collateral
         changePrank(_bidder);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_bidder), priceAtTestIndex, 0.678725133191514712 * 1e18);
+        emit RemoveCollateral(_bidder, priceAtTestIndex, 0.678725133191514712 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit Transfer(address(_pool), address(_bidder), 0.678725133191514712 * 1e18);
+        emit Transfer(address(_pool), _bidder, 0.678725133191514712 * 1e18);
         _pool.removeAllCollateral(testIndex);
-        (lpBalance, ) = _pool.bucketLenders(testIndex, address(_bidder));
+        (lpBalance, ) = _pool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, 0);
 
         // check pool balances
@@ -181,20 +181,20 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         assertEq(collateralToPurchaseWith, 3.388032491631335842 * 1e18);
         _pool.addCollateral(collateralToPurchaseWith, 2550);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_bidder), p2550, amountWithInterest, _pool.indexToPrice(2552));
+        emit RemoveQuoteToken(_bidder, p2550, amountWithInterest, _pool.indexToPrice(2552));
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_pool), address(_bidder), amountWithInterest);
+        emit Transfer(address(_pool), _bidder, amountWithInterest);
         _pool.removeAllQuoteToken(2550);
-        assertEq(_quote.balanceOf(address(_bidder)), amountWithInterest);
+        assertEq(_quote.balanceOf(_bidder), amountWithInterest);
         // bidder withdraws unused collateral
         uint256 collateralRemoved = 0;
         uint256 expectedCollateral = 0.066544137733644449 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_bidder), p2550, expectedCollateral);
+        emit RemoveCollateral(_bidder, p2550, expectedCollateral);
         (uint256 amount, ) = _pool.removeAllCollateral(2550);
         assertEq(amount, expectedCollateral);
         collateralRemoved += expectedCollateral;
-        (uint256 lpBalance, ) = _pool.bucketLenders(2550, address(_bidder));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2550, _bidder);
         assertEq(lpBalance, 0);
         skip(7200);
 
@@ -202,11 +202,11 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         changePrank(_lender);
         expectedCollateral = 1.992893012338614836 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), p2550, expectedCollateral);
+        emit RemoveCollateral(_lender, p2550, expectedCollateral);
         (amount, ) = _pool.removeAllCollateral(2550);
         assertEq(amount, expectedCollateral);
         collateralRemoved += expectedCollateral;
-        (lpBalance, ) = _pool.bucketLenders(2550, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2550, _lender);
         assertEq(lpBalance, 0);
         skip(3600);
 
@@ -214,11 +214,11 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
         changePrank(_lender1);
         expectedCollateral = 1.328595341559076557 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender1), p2550, expectedCollateral);
+        emit RemoveCollateral(_lender1, p2550, expectedCollateral);
         (amount, ) = _pool.removeAllCollateral(2550);
         assertEq(amount, expectedCollateral);
         collateralRemoved += expectedCollateral;
-        (lpBalance, ) = _pool.bucketLenders(2550, address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(2550, _lender1);
         assertEq(lpBalance, 0);
         assertEq(collateralRemoved, collateralToPurchaseWith);
 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -162,7 +162,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is DSTestPlus {
 
         // borrower draws debt
         changePrank(_borrower);
-        _pool.pledgeCollateral(100 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
         _pool.borrow(15_000 * 1e18, 3000, address(0), address(0));
         assertEq(_pool.lup(), _pool.indexToPrice(2551));
         skip(86400);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -186,7 +186,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_borrower);
         deal(address(_collateral), _borrower,  _collateral.balanceOf(_borrower) + 3_500_000 * 1e18);
         _collateral.approve(address(_pool), 3_500_000 * 1e18);
-        _pool.pledgeCollateral(3_500_000 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 3_500_000 * 1e18, address(0), address(0));
         _pool.borrow(70_000 * 1e18, 4551, address(0), address(0));
 
         // ensure lender cannot withdraw from a bucket with no deposit
@@ -240,7 +240,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_borrower);
         deal(address(_collateral), _borrower, _collateral.balanceOf(_borrower) + 100 * 1e18);
         _collateral.approve(address(_pool), 100 * 1e18);
-        _pool.pledgeCollateral(100 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 100 * 1e18, address(0), address(0));
         uint256 limitPrice = _pool.priceToIndex(4_000 * 1e18);
         assertGt(limitPrice, 1663);
         _pool.borrow(3_000 * 1e18, limitPrice, address(0), address(0));
@@ -347,7 +347,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_borrower);
         deal(address(_collateral), _borrower, _collateral.balanceOf(_borrower) + 1_500_000 * 1e18);
         _collateral.approve(address(_pool), 1_500_000 * 1e18);
-        _pool.pledgeCollateral(1500000 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 1500000 * 1e18, address(0), address(0));
         _pool.borrow(60000.1 * 1e18, 4651, address(0), address(0));
 
         // should revert if movement would drive lup below htp
@@ -371,7 +371,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         // borrower draws debt, establishing a pool threshold price
         skip(2 hours);
         changePrank(_borrower);
-        _pool.pledgeCollateral(10 * 1e18, address(0), address(0));
+        _pool.pledgeCollateral(_borrower, 10 * 1e18, address(0), address(0));
         _pool.borrow(5_000 * 1e18, 3000, address(0), address(0));
         uint256 ptp = Maths.wdiv(_pool.borrowerDebt(), 10 * 1e18);
         assertEq(ptp, 500.480769230769231 * 1e18);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -64,22 +64,22 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         // test 10_000 DAI deposit at price of 1 MKR = 3_010.892022197881557845 DAI
         changePrank(_lender);
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(address(_lender), _p3010, 10_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, _p3010, 10_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_lender), address(_pool), 10_000 * 1e18);
+        emit Transfer(_lender, address(_pool), 10_000 * 1e18);
         _pool.addQuoteToken(10_000 * 1e18, 2550);
 
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2550, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2550, _lender);
         assertEq(_pool.poolSize(),         10_000 * 1e18);
         assertEq(lpBalance,                10_000 * 1e27);
         assertEq(_pool.exchangeRate(2550), 1 * 1e27);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   10_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 190_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 10_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        190_000 * 1e18);
 
         // check bucket balance
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(2550);
@@ -88,21 +88,21 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
 
         // test 20_000 DAI deposit at price of 1 MKR = 2_995.912459898389633881 DAI
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(address(_lender), 2_995.912459898389633881 * 1e18, 20_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 2_995.912459898389633881 * 1e18, 20_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_lender), address(_pool), 20_000 * 1e18);
+        emit Transfer(_lender, address(_pool), 20_000 * 1e18);
         _pool.addQuoteToken(20_000 * 1e18, 2551);
 
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2551, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2551, _lender);
         assertEq(_pool.poolSize(), 30_000 * 1e18);
         assertEq(lpBalance,        20_000 * 1e27);
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)),   30_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 170_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 170_000 * 1e18);
 
         // check bucket balance
         (lpAccumulator, availableCollateral) = _pool.buckets(2551);
@@ -111,21 +111,21 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
 
         // test 40_000 DAI deposit at price of 1 MKR = 3_025.946482308870940904 DAI
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(address(_lender), 3_025.946482308870940904 * 1e18, 40_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 40_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_lender), address(_pool), 40_000 * 1e18);
+        emit Transfer(_lender, address(_pool), 40_000 * 1e18);
         _pool.addQuoteToken(40_000 * 1e18, 2549);
 
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(_pool.poolSize(), 70_000 * 1e18);
         assertEq(lpBalance,        40_000 * 1e27);
 
         // check balances
-        assertEq(_quote.balanceOf(address(_pool)),   70_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 130_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 70_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        130_000 * 1e18);
 
         // check bucket balance
         (lpAccumulator, availableCollateral) = _pool.buckets(2549);
@@ -134,33 +134,33 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
     }
 
     function testScaledPoolRemoveQuoteToken() external {
-        assertEq(_quote.balanceOf(address(_pool)),   0);
-        assertEq(_quote.balanceOf(address(_lender)), 200_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 0);
+        assertEq(_quote.balanceOf(_lender),        200_000 * 1e18);
 
         changePrank(_lender);
         _pool.addQuoteToken(40_000 * 1e18, 2549);
         _pool.addQuoteToken(10_000 * 1e18, 2550);
         _pool.addQuoteToken(20_000 * 1e18, 2551);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(lpBalance, 40_000 * 1e27);
 
-        assertEq(_quote.balanceOf(address(_pool)),   70_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 130_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 70_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),        130_000 * 1e18);
 
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), 3_025.946482308870940904 * 1e18, 5_000 * 1e18, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 5_000 * 1e18, BucketMath.MAX_PRICE);
         uint256 lpRedeemed = _pool.removeQuoteToken(5_000 * 1e18, 2549);
         assertEq(lpRedeemed, 5_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(lpBalance, 35_000 * 1e27);
 
         assertEq(_quote.balanceOf(address(_pool)),   65_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_lender)), 135_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 135_000 * 1e18);
 
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), 3_025.946482308870940904 * 1e18, 35_000 * 1e18, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 35_000 * 1e18, BucketMath.MAX_PRICE);
         uint256 removed;
         (removed, lpRedeemed) = _pool.removeAllQuoteToken(2549);
         assertEq(removed, 35_000 * 1e18);
@@ -194,7 +194,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         vm.expectRevert("S:RAQT:NO_QT");
         _pool.removeAllQuoteToken(1776);
         // ensure lender with no LP cannot remove anything
-        (uint256 lpBalance, ) = _pool.bucketLenders(4550, address(_lender1));
+        (uint256 lpBalance, ) = _pool.bucketLenders(4550, _lender1);
         assertEq(0, lpBalance);
         vm.expectRevert("S:RAQT:NO_CLAIM");
         _pool.removeAllQuoteToken(4550);
@@ -216,7 +216,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         _pool.removeQuoteToken(15_000 * 1e18, 4550);
 
         // should be able to removeQuoteToken if quote tokens haven't been encumbered by a borrower
-        emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
+        emit RemoveQuoteToken(_lender, _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
         _pool.removeQuoteToken(10_000 * 1e18, 4990);
     }
 
@@ -226,15 +226,15 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_lender);
         _pool.addQuoteToken(3_400 * 1e18, 1606);
         _pool.addQuoteToken(3_400 * 1e18, 1663);
-        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(1606, address(_lender));
+        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(1606, _lender);
         uint256 lpb_before = lpBalance;
         assertEq(lastQuoteDeposit, 60);
         uint256 exchangeRateBefore = _pool.exchangeRate(1606);
         skip(59 minutes);
-        (lpBalance, ) = _pool.bucketLenders(1606, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(1606, _lender);
         assertEq(lpb_before, lpBalance);
         assertEq(exchangeRateBefore, _pool.exchangeRate(1606));
-        uint256 lenderBalanceBefore = _quote.balanceOf(address(_lender));
+        uint256 lenderBalanceBefore = _quote.balanceOf(_lender);
 
         // borrower takes a loan of 3000 quote token
         changePrank(_borrower);
@@ -245,7 +245,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         assertGt(limitPrice, 1663);
         _pool.borrow(3_000 * 1e18, limitPrice, address(0), address(0));
         skip(2 hours);
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(1606, address(_lender));
+        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(1606, _lender);
         assertEq(lpb_before, lpBalance);
         assertEq(lastQuoteDeposit, 60);
         assertEq(exchangeRateBefore, _pool.exchangeRate(1606));
@@ -256,7 +256,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         assertLt(penalty, Maths.WAD);
         uint256 expectedWithdrawal1 = Maths.wmul(1_700 * 1e18, penalty);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(1606), expectedWithdrawal1, _pool.indexToPrice(1663));
+        emit RemoveQuoteToken(_lender, _pool.indexToPrice(1606), expectedWithdrawal1, _pool.indexToPrice(1663));
         uint lpRedeemed = _pool.removeQuoteToken(1_700 * 1e18, 1606);
         assertEq(lpRedeemed, 1_699.988430646832348876473462074 * 1e27);
 
@@ -265,13 +265,13 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         assertGt(_pool.indexToPrice(1606), _pool.htp());
         uint256 expectedWithdrawal2 = 1_700.146556206967894132 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), _pool.indexToPrice(1606), expectedWithdrawal2, _pool.indexToPrice(1663));
+        emit RemoveQuoteToken(_lender, _pool.indexToPrice(1606), expectedWithdrawal2, _pool.indexToPrice(1663));
         uint256 removed;
         (removed, lpRedeemed) = _pool.removeAllQuoteToken(1606);
         assertEq(removed, expectedWithdrawal2);
         assertEq(lpRedeemed, 1_700.011569353167651123526537926 * 1e27);
-        assertEq(_quote.balanceOf(address(_lender)), lenderBalanceBefore + expectedWithdrawal1 + expectedWithdrawal2);
-        (lpBalance, ) = _pool.bucketLenders(1606, address(_lender));
+        assertEq(_quote.balanceOf(_lender), lenderBalanceBefore + expectedWithdrawal1 + expectedWithdrawal2);
+        (lpBalance, ) = _pool.bucketLenders(1606, _lender);
         assertEq(lpBalance, 0);
 
         // ensure bucket is empty
@@ -287,36 +287,36 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         _pool.addQuoteToken(10_000 * 1e18, 2550);
         _pool.addQuoteToken(20_000 * 1e18, 2551);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(lpBalance, 40_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2552, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2552, _lender);
         assertEq(lpBalance, 0);
 
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 2549, 2552, 5_000 * 1e18, BucketMath.MAX_PRICE);
+        emit MoveQuoteToken(_lender, 2549, 2552, 5_000 * 1e18, BucketMath.MAX_PRICE);
         _pool.moveQuoteToken(5_000 * 1e18, 2549, 2552);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(lpBalance, 35_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2552, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2552, _lender);
         assertEq(lpBalance, 5_000 * 1e27);
 
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 2549, 2540, 5_000 * 1e18, BucketMath.MAX_PRICE);
+        emit MoveQuoteToken(_lender, 2549, 2540, 5_000 * 1e18, BucketMath.MAX_PRICE);
         _pool.moveQuoteToken(5_000 * 1e18, 2549, 2540);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
         assertEq(lpBalance, 30_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2540, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2540, _lender);
         assertEq(lpBalance, 5_000 * 1e27);
 
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 2551, 2777, 15_000 * 1e18, BucketMath.MAX_PRICE);
+        emit MoveQuoteToken(_lender, 2551, 2777, 15_000 * 1e18, BucketMath.MAX_PRICE);
         _pool.moveQuoteToken(15_000 * 1e18, 2551, 2777);
 
-        (lpBalance, ) = _pool.bucketLenders(2551, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2551, _lender);
         assertEq(lpBalance, 5_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2777, address(_lender));
+        (lpBalance, ) = _pool.bucketLenders(2777, _lender);
         assertEq(lpBalance, 15_000 * 1e27);
     }
 
@@ -357,7 +357,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
 
         // should be able to moveQuoteToken if properly specified
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 4549, 4550, 10_000 * 1e18, _pool.indexToPrice(4551));
+        emit MoveQuoteToken(_lender, 4549, 4550, 10_000 * 1e18, _pool.indexToPrice(4551));
         _pool.moveQuoteToken(10_000 * 1e18, 4549, 4550);
     }
 
@@ -382,7 +382,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         assertEq(_pool.priceToIndex(400 * 1e18), 2954);
         uint256 moved = 2_497.596153846153845000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 2873, 2954, moved, _pool.lup());
+        emit MoveQuoteToken(_lender, 2873, 2954, moved, _pool.lup());
         _pool.moveQuoteToken(2500 * 1e18, 2873, 2954);
 
         // another lender provides liquidity to prevent LUP from moving
@@ -395,7 +395,7 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_lender);
         moved = 2500 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit MoveQuoteToken(address(_lender), 2873, 2954, moved, _pool.lup());
+        emit MoveQuoteToken(_lender, 2873, 2954, moved, _pool.lup());
         _pool.moveQuoteToken(moved, 2873, 2954);
 
         // after a week, another lender funds the pool
@@ -408,6 +408,6 @@ contract ERC20ScaledQuoteTokenTest is DSTestPlus {
         changePrank(_lender);
         _pool.removeAllQuoteToken(2873);
         _pool.removeAllQuoteToken(2954);
-        assertGt(_quote.balanceOf(address(_lender)), 200_000 * 1e18);
+        assertGt(_quote.balanceOf(_lender), 200_000 * 1e18);
     }
 }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
@@ -53,7 +53,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
         // should fail if allowed owner is not set
         changePrank(_lender);
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // should fail if allowed owner is set to 0x
         changePrank(_lender1);
@@ -61,7 +61,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
 
         changePrank(_lender);
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
     function testTransferLPTokensToUnallowedAddress() external {
@@ -72,13 +72,13 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
 
         // should fail if allowed owner is set to lender2 address but trying to transfer to lender address
         changePrank(_lender1);
-        _pool.approveLpOwnership(address(_lender2), indexes[0], 1_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[1], 1_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[2], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[0], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[1], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[2], 1_000 * 1e27);
 
         changePrank(_lender);
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender), indexes);
+        _pool.transferLPTokens(_lender1, _lender, indexes);
     }
 
     function testTransferLPTokensToInvalidIndex() external {
@@ -89,13 +89,13 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
 
         // should fail since 9999 is not a valid index
         changePrank(_lender1);
-        _pool.approveLpOwnership(address(_lender2), indexes[0], 1_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[1], 1_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[2], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[0], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[1], 1_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[2], 1_000 * 1e27);
 
         changePrank(_lender);
         vm.expectRevert("S:TLT:INVALID_INDEX");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
     function testTransferLPTokensGreaterThanBalance() external {
@@ -107,12 +107,12 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
         _pool.addQuoteToken(10_000 * 1e18, indexes[0]);
         _pool.addQuoteToken(20_000 * 1e18, indexes[1]);
         // set allowed owner to lender2 address
-        _pool.approveLpOwnership(address(_lender2), indexes[0], 10_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[1], 30_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[0], 10_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[1], 30_000 * 1e27);
 
         changePrank(_lender2);
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
     function testTransferLPTokensForAllIndexes() external {
@@ -128,50 +128,50 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
         _pool.addQuoteToken(30_000 * 1e18, indexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], address(_lender1));
+        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
         assertEq(lpBalance, 0);
 
         // set allowed owner to lender2 address
-        _pool.approveLpOwnership(address(_lender2), indexes[0], 10_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[1], 20_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[2], 30_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[0], 10_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[1], 20_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[2], 30_000 * 1e27);
 
         // transfer LP tokens for all indexes
         changePrank(_lender);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(address(_lender1), address(_lender2), indexes, 60_000 * 1e27);
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        emit TransferLPTokens(_lender1, _lender2, indexes, 60_000 * 1e27);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check that old token ownership was removed - a new transfer should fail
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], address(_lender2));
+        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
     }
 
@@ -191,47 +191,47 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
         _pool.addQuoteToken(30_000 * 1e18, depositIndexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, ) = _pool.bucketLenders(depositIndexes[0], address(_lender1));
+        (uint256 lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender2);
         assertEq(lpBalance, 0);
 
         // set allowed owner to lender2 address
-        _pool.approveLpOwnership(address(_lender2), transferIndexes[0], 10_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), transferIndexes[1], 30_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, transferIndexes[0], 10_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, transferIndexes[1], 30_000 * 1e27);
 
         // transfer LP tokens for 2 indexes
         changePrank(_lender);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(address(_lender1), address(_lender2), transferIndexes, 40_000 * 1e27);
-        _pool.transferLPTokens(address(_lender1), address(_lender2), transferIndexes);
+        emit TransferLPTokens(_lender1, _lender2, transferIndexes, 40_000 * 1e27);
+        _pool.transferLPTokens(_lender1, _lender2, transferIndexes);
 
         // check that old token ownership was removed - transfer with same indexes should fail
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), transferIndexes);
+        _pool.transferLPTokens(_lender1, _lender2, transferIndexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
     }
 
@@ -254,52 +254,52 @@ contract ERC20ScaledPoolTransferLPTokensTest is DSTestPlus {
         _pool.addQuoteToken(15_000 * 1e18, indexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], address(_lender1));
+        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], address(_lender2));
+        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
         assertEq(lpBalance, 5_000 * 1e27);
         assertEq(lastQuoteDeposit, 7200);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
 
         // set allowed owner to lender2 address
         changePrank(_lender1);
-        _pool.approveLpOwnership(address(_lender2), indexes[0], 10_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[1], 20_000 * 1e27);
-        _pool.approveLpOwnership(address(_lender2), indexes[2], 30_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[0], 10_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[1], 20_000 * 1e27);
+        _pool.approveLpOwnership(_lender2, indexes[2], 30_000 * 1e27);
 
         // transfer LP tokens for all indexes
         changePrank(_lender);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(address(_lender1), address(_lender2), indexes, 60_000 * 1e27);
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        emit TransferLPTokens(_lender1, _lender2, indexes, 60_000 * 1e27);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check that old token ownership was removed - transfer with same indexes should fail
         vm.expectRevert("S:TLT:NO_ALLOWANCE");
-        _pool.transferLPTokens(address(_lender1), address(_lender2), indexes);
+        _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender1));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], address(_lender2));
+        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
         assertEq(lastQuoteDeposit, 7200);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_lender2));
+        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
         assertEq(lpBalance, 45_000 * 1e27);
     }
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -100,11 +100,12 @@ interface IERC20Pool is IScaledPool {
 
     /**
      *  @notice Called by borrowers to add collateral to the pool.
-     *  @param  amount_  The amount of collateral in deposit tokens to be added to the pool.
-     *  @param  oldPrev_ Previous borrower that came before placed loan (old)
-     *  @param  newPrev_ Previous borrower that now comes before placed loan (new)
+     *  @param  borrower_ The address of borrower to pledge collateral for.
+     *  @param  amount_   The amount of collateral in deposit tokens to be added to the pool.
+     *  @param  oldPrev_  Previous borrower that came before placed loan (old)
+     *  @param  newPrev_  Previous borrower that now comes before placed loan (new)
      */
-    function pledgeCollateral(uint256 amount_, address oldPrev_, address newPrev_) external;
+    function pledgeCollateral(address borrower_, uint256 amount_, address oldPrev_, address newPrev_) external;
 
     /**
      *  @notice Called by a borrower to open or expand a position.
@@ -126,11 +127,12 @@ interface IERC20Pool is IScaledPool {
 
     /**
      *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
+     *  @param  borrower_  The address of borrower to pledge collateral for.
      *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
      *  @param  oldPrev_   Previous borrower that came before placed loan (old)
      *  @param  newPrev_   Previous borrower that now comes before placed loan (new)
      */
-    function repay(uint256 maxAmount_, address oldPrev_, address newPrev_) external;
+    function repay(address borrower_, uint256 maxAmount_, address oldPrev_, address newPrev_) external;
 
     /*****************************/
     /*** Initialize Functions ***/

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -127,7 +127,7 @@ interface IERC20Pool is IScaledPool {
 
     /**
      *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
-     *  @param  borrower_  The address of borrower to pledge collateral for.
+     *  @param  borrower_  The address of borrower to repay quote token amount for.
      *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
      *  @param  oldPrev_   Previous borrower that came before placed loan (old)
      *  @param  newPrev_   Previous borrower that now comes before placed loan (new)

--- a/tests/test_scaled_pool.py
+++ b/tests/test_scaled_pool.py
@@ -61,7 +61,7 @@ def test_borrow_repay_scaled(
 
         col_txes = []
         for i in range(10):
-            tx = scaled_pool.pledgeCollateral(10 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+            tx = scaled_pool.pledgeCollateral(borrowers[0], 10 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
             col_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")
@@ -86,11 +86,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repay(110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(borrowers[0], 110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(borrowers[0], 110 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repay(50 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
+        tx = scaled_pool.repay(borrowers[0], 50 * 10**18, ZRO_ADD, ZRO_ADD, {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -152,7 +152,7 @@ def pledge_and_borrow(pool, borrower, borrower_index, collateral_to_deposit, bor
         print(f" borrower {borrower_index} pledging {collateral_to_deposit / 1e18:.8f} collateral TP={threshold_price / 1e18:.1f}")
     assert collateral_to_deposit > 10**18
     # TODO: if debt is 0, contracts require passing old_prev and new_prev=0, which is awkward
-    pool.pledgeCollateral(collateral_to_deposit, old_prev, new_prev, {"from": borrower})
+    pool.pledgeCollateral(borrower, collateral_to_deposit, old_prev, new_prev, {"from": borrower})
     test_utils.validate_queue(pool)
 
     # draw debt
@@ -291,7 +291,7 @@ def repay(borrower, borrower_index, pool, test_utils):
         repay_amount = int(repay_amount * 1.01)
         print(f" borrower {borrower_index} repaying {repay_amount/1e18:.1f} of {pending_debt/1e18:.1f} debt")
         old_prev, new_prev = ScaledPoolUtils.find_loan_queue_params(pool, borrower.address, 0)
-        pool.repay(repay_amount, old_prev, new_prev, {"from": borrower})
+        pool.repay(borrower, repay_amount, old_prev, new_prev, {"from": borrower})
 
         # withdraw appropriate amount of collateral to maintain a target-utilization-friendly collateralization
         (_, pending_debt, collateral_deposited, _) = pool.borrowerInfo(borrower)


### PR DESCRIPTION
    - pass borrower address as param in pledgeCollateral and repay functions
    - update forge and brownie tests
    - add tests for `pledgeCollateral` and `repay` from different address
    - simplify tests by not using `address()` where is not the case