### PR TITLE
Removed real-world test reference to lenderDebt

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -304,8 +304,6 @@ class TestUtils:
         if pool.lupIndex() > ScaledPoolUtils.price_to_index_safe(pool, pool.htp()):
             # ...ensure debt is less than the size of the pool
             assert pool.borrowerDebt <= pool.poolSize()
-            # ...ensure borrowers owe more than lenders are owed
-            assert pool.borrowerDebt() >= pool.lenderDebt()
 
         # if there are no borrowers in the pool, ensure there is no debt
         if pool.totalBorrowers() == 0:
@@ -403,7 +401,6 @@ class TestUtils:
               f"target utlzn: {pool.poolTargetUtilization()/1e18:>10.1%}   "
               f"collateralization: {pool.poolCollateralization()/1e18:>7.1%}  "
               f"borrowerDebt: {pool.borrowerDebt()/1e18:>12.1f}  "
-              f"lenderDebt: {pool.lenderDebt()/1e18:>12.1f}  "
               f"pendingInf: {pool.pendingInflator()/1e18:>20.18f}")
 
         contract_quote_balance = Contract(pool.quoteToken()).balanceOf(pool)


### PR DESCRIPTION
Missed this in my PR to eliminate `lenderDebt`.