### PR TITLE
ERC721 Test utils

### DIFF
--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -51,6 +51,11 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
         return _poolAddresses;
     }
 
+    // TODO: finish implementing
+    function _approveQuoteMultipleUserMultiplePool() internal {
+
+    }
+
     function _mintAndApproveQuoteTokens(address[] memory pools_, address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
 

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.14;
 
+import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
+import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
+
 import { DSTestPlus } from "../utils/DSTestPlus.sol";
+import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
 abstract contract ERC721DSTestPlus is DSTestPlus {
 
@@ -15,25 +19,81 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     event PullCollateralNFT(address indexed borrower_, uint256[] tokenIds_);
     event RemoveCollateralNFT(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_);
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
+}
 
-    // TODO: implement this for simplifying construction and maintenance of tests
-    function assertPoolState() internal {
+abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
-        // assertEq();
-        // assertEq(_pool.htp(), 0);
-        // assertEq(_pool.lup(), BucketMath.MAX_PRICE);
+    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
 
-        // assertEq(_pool.treeSum(),      110_162.490615980593600000 * 1e18);
-        // assertEq(_pool.borrowerDebt(), 0);
-        // assertEq(_pool.lenderDebt(),   0);
+    NFTCollateralToken internal _collateral;
+    QuoteToken         internal _quote;
+    ERC721Pool         internal _collectionPool;
+    ERC721Pool         internal _subsetPool;
+
+    // TODO: bool for pool type
+    constructor() {
+        _collateral      = new NFTCollateralToken();
+        _quote           = new QuoteToken();
     }
 
-    function assertPoolCollateralBalance() internal {
-
+    function _deployCollectionPool() internal returns (ERC721Pool) {
+            return ERC721Pool(new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
     }
 
-    function assertPoolQuoteBalance() internal {
+    function _deploySubsetPool(uint256[] memory subsetTokenIds_) internal returns (ERC721Pool) {
+            return ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
+    }
 
+    function _getPoolAddresses() internal returns (address[] memory) {
+        emit log_address(address(_collectionPool));
+        emit log_address(address(_subsetPool));
+        address[] memory _poolAddresses = new address[](2);
+        _poolAddresses[0] = address(_collectionPool);
+        _poolAddresses[1] = address(_subsetPool);
+        return _poolAddresses;
+    }
+
+    function _mintAndApproveQuoteTokens(address[] memory pools_, address operator_, uint256 mintAmount_) internal {
+        _quote.mint(operator_, mintAmount_);
+
+        vm.prank(operator_);
+        for (uint i; i < pools_.length;) {
+            _quote.approve(address(pools_[i]), type(uint256).max);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    function _mintAndApproveCollateralTokens(address[] memory pools_, address operator_, uint256 mintAmount_) internal {
+        _collateral.mint(address(operator_), mintAmount_);
+
+        vm.prank(operator_);
+        for (uint i; i < pools_.length;) {
+            emit log_string("approving");
+            emit log_address(address(pools_[i]));
+            _collateral.setApprovalForAll(address(pools_[i]), true);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    // TODO: implement this
+    function _assertBalances() internal {}
+
+    // TODO: check oldPrev and newPrev
+    function _pledgeCollateral(address borrower_, ERC721Pool pool_, uint256[] memory tokenIdsToAdd_) internal {
+        vm.prank(borrower_);
+        for (uint i; i < tokenIdsToAdd_.length;) {
+            emit Transfer(address(borrower_), address(pool_), tokenIdsToAdd_[i]);
+            vm.expectEmit(true, true, false, true);
+            unchecked {
+                ++i;
+            }
+        }
+        emit PledgeCollateralNFT(address(borrower_), tokenIdsToAdd_);
+        pool_.pledgeCollateral(tokenIdsToAdd_, address(0), address(0));
     }
 
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -54,10 +54,10 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _mintAndApproveQuoteTokens(address[] memory pools_, address operator_, uint256 mintAmount_) internal {
-        _quote.mint(operator_, mintAmount_);
+        deal(address(_quote), operator_, mintAmount_);
 
-        vm.prank(operator_);
         for (uint i; i < pools_.length;) {
+            vm.prank(operator_);
             _quote.approve(address(pools_[i]), type(uint256).max);
             unchecked {
                 ++i;
@@ -66,12 +66,10 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _mintAndApproveCollateralTokens(address[] memory pools_, address operator_, uint256 mintAmount_) internal {
-        _collateral.mint(address(operator_), mintAmount_);
+        _collateral.mint(operator_, mintAmount_);
 
-        vm.prank(operator_);
         for (uint i; i < pools_.length;) {
-            emit log_string("approving");
-            emit log_address(address(pools_[i]));
+            vm.prank(operator_);
             _collateral.setApprovalForAll(address(pools_[i]), true);
             unchecked {
                 ++i;
@@ -95,5 +93,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
         emit PledgeCollateralNFT(address(borrower_), tokenIdsToAdd_);
         pool_.pledgeCollateral(tokenIdsToAdd_, address(0), address(0));
     }
+
+    // TODO: implement _pullCollateral()
 
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -45,8 +45,6 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _getPoolAddresses() internal returns (address[] memory) {
-        emit log_address(address(_collectionPool));
-        emit log_address(address(_subsetPool));
         address[] memory _poolAddresses = new address[](2);
         _poolAddresses[0] = address(_collectionPool);
         _poolAddresses[1] = address(_subsetPool);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -7,12 +7,10 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721DSTestPlus }               from "./ERC721DSTestPlus.sol";
+import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
-contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
@@ -20,57 +18,17 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
     address internal _lender;
     address internal _lender2;
 
-    address internal _collectionPoolAddress;
-    address internal _subsetPoolAddress;
-
-    NFTCollateralToken internal _collateral;
-    QuoteToken         internal _quote;
-    ERC721Pool         internal _collectionPool;
-    ERC721Pool         internal _subsetPool;
-
     function setUp() external {
-        // deploy token and user contracts; mint and set balances
-        _collateral = new NFTCollateralToken();
-        _quote      = new QuoteToken();
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        _collateral.mint(address(_borrower),  52);
-        _collateral.mint(address(_borrower2), 10);
-        _collateral.mint(address(_borrower3), 13);
+        // deploy collection pool
+        _collectionPool = _deployCollectionPool();
 
-        deal(address(_quote), _lender, 200_000 * 1e18);
-
-        /*******************************/
-        /*** Setup NFT Collection State ***/
-        /*******************************/
-
-        _collectionPoolAddress = new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
-        _collectionPool        = ERC721Pool(_collectionPoolAddress);
-
-        vm.startPrank(_borrower);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_borrower3);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        /*******************************/
-        /*** Setup NFT Subset State ***/
-        /*******************************/
-
+        // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](6);
         subsetTokenIds[0] = 1;
         subsetTokenIds[1] = 3;
@@ -78,23 +36,21 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
         subsetTokenIds[5] = 73;
+        _subsetPool = _deploySubsetPool(subsetTokenIds);
 
-        _subsetPoolAddress = new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds, 0.05 * 10**18);
-        _subsetPool        = ERC721Pool(_subsetPoolAddress);
+        address[] memory _poolAddresses = _getPoolAddresses();
 
-        changePrank(_borrower);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
 
-        changePrank(_borrower2);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 10);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower3, 13);
 
-        changePrank(_borrower3);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        changePrank(_lender);
+        // TODO: figure out how to generally approve quote tokens for the borrowers to handle repays
+        // TODO: potentially use _approveQuoteMultipleUserMultiplePool()
+        vm.prank(_borrower);
+        _quote.approve(address(_collectionPool), 200_000 * 1e18);
+        vm.prank(_borrower);
         _quote.approve(address(_subsetPool), 200_000 * 1e18);
     }
 
@@ -293,7 +249,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
     function testBorrowAndRepay() external {
         // lender deposits 10000 Quote into 3 buckets
-        changePrank(_lender);
+        vm.startPrank(_lender);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2552);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -7,7 +7,7 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721HelperContract }               from "./ERC721DSTestPlus.sol";
+import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
 // TODO: pass different pool type to enable collection + subset test simplification

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -40,51 +40,10 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         address[] memory _poolAddresses = _getPoolAddresses();
 
-        // emit log_address(_poolAddresses[0]);
-
         _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
 
         _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
         _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 10);
-
-        // _collateral.mint(address(_borrower),  52);
-        // _collateral.mint(address(_bidder), 10);
-
-        // // deal(address(_quote), _lender, 200_000 * 1e18);
-
-
-        // /*******************************/
-        // /*** Setup NFT Collection State ***/
-        // /*******************************/
-
-
-        // vm.startPrank(_borrower);
-        // _collateral.setApprovalForAll(address(_collectionPool), true);
-        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        // changePrank(_bidder);
-        // _collateral.setApprovalForAll(address(_collectionPool), true);
-        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        // changePrank(_lender);
-        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        // /*******************************/
-        // /*** Setup NFT Subset State ***/
-        // /*******************************/
-
-
-
-        // changePrank(_borrower);
-        // _collateral.setApprovalForAll(address(_subsetPool), true);
-        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        // changePrank(_bidder);
-        // _collateral.setApprovalForAll(address(_subsetPool), true);
-        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        // changePrank(_lender);
-        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
     }
 
     /*******************************/

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -176,6 +176,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
     }
 
     function testPullCollateralPartiallyEncumbered() external {
+        vm.startPrank(_lender);
         // lender deposits 10000 Quote into 3 buckets
         _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
@@ -266,6 +267,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
     }
 
     function testPullCollateralOverlyEncumbered() external {
+        vm.startPrank(_lender);
         // lender deposits 10000 Quote into 3 buckets
         _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2551);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -7,13 +7,11 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721DSTestPlus }               from "./ERC721DSTestPlus.sol";
+import { ERC721HelperContract }               from "./ERC721DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
 // TODO: pass different pool type to enable collection + subset test simplification
-contract ERC721ScaledCollateralTest is ERC721DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
@@ -21,68 +19,72 @@ contract ERC721ScaledCollateralTest is ERC721DSTestPlus {
     address internal _lender;
     address internal _lender2;
 
-    NFTCollateralToken internal _collateral;
-    QuoteToken         internal _quote;
-    ERC721Pool         internal _collectionPool;
-    ERC721Pool         internal _subsetPool;
-
     function setUp() external {
-        // deploy token and user contracts; mint and set balances
-        _collateral = new NFTCollateralToken();
-        _quote      = new QuoteToken();
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _bidder    = makeAddr("bidder");
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        _collateral.mint(address(_borrower),  52);
-        _collateral.mint(address(_bidder), 10);
+        // deploy collection pool
+        _collectionPool = _deployCollectionPool();
 
-        deal(address(_quote), _lender, 200_000 * 1e18);
-
-
-        /*******************************/
-        /*** Setup NFT Collection State ***/
-        /*******************************/
-
-        _collectionPool = ERC721Pool(new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
-        vm.startPrank(_borrower);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_bidder);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        /*******************************/
-        /*** Setup NFT Subset State ***/
-        /*******************************/
-
+        // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](5);
         subsetTokenIds[0] = 1;
         subsetTokenIds[1] = 3;
         subsetTokenIds[2] = 5;
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
+        _subsetPool = _deploySubsetPool(subsetTokenIds);
 
-        _subsetPool = ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds, 0.05 * 10**18));
+        address[] memory _poolAddresses = _getPoolAddresses();
 
-        changePrank(_borrower);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        // emit log_address(_poolAddresses[0]);
 
-        changePrank(_bidder);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
 
-        changePrank(_lender);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
+        _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 10);
+
+        // _collateral.mint(address(_borrower),  52);
+        // _collateral.mint(address(_bidder), 10);
+
+        // // deal(address(_quote), _lender, 200_000 * 1e18);
+
+
+        // /*******************************/
+        // /*** Setup NFT Collection State ***/
+        // /*******************************/
+
+
+        // vm.startPrank(_borrower);
+        // _collateral.setApprovalForAll(address(_collectionPool), true);
+        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
+
+        // changePrank(_bidder);
+        // _collateral.setApprovalForAll(address(_collectionPool), true);
+        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
+
+        // changePrank(_lender);
+        // _quote.approve(address(_collectionPool), 200_000 * 1e18);
+
+        // /*******************************/
+        // /*** Setup NFT Subset State ***/
+        // /*******************************/
+
+
+
+        // changePrank(_borrower);
+        // _collateral.setApprovalForAll(address(_subsetPool), true);
+        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
+
+        // changePrank(_bidder);
+        // _collateral.setApprovalForAll(address(_subsetPool), true);
+        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
+
+        // changePrank(_lender);
+        // _quote.approve(address(_subsetPool), 200_000 * 1e18);
     }
 
     /*******************************/

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -7,12 +7,10 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721DSTestPlus }               from "./ERC721DSTestPlus.sol";
+import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
-contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
@@ -20,61 +18,17 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
     address internal _lender;
     address internal _lender2;
 
-    address internal _collectionPoolAddress;
-    address internal _subsetPoolAddress;
-
-    NFTCollateralToken internal _collateral;
-    QuoteToken         internal _quote;
-    ERC721Pool         internal _collectionPool;
-    ERC721Pool         internal _subsetPool;
-
     function setUp() external {
-        // deploy token and user contracts; mint and set balances
-        _collateral = new NFTCollateralToken();
-        _quote      = new QuoteToken();
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _bidder    = makeAddr("bidder");
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        _collateral.mint(address(_borrower),  52);
-        _collateral.mint(address(_borrower2), 10);
-        _collateral.mint(address(_bidder), 13);
+        // deploy collection pool
+        _collectionPool = _deployCollectionPool();
 
-        deal(address(_quote), _lender, 200_000 * 1e18);
-        deal(address(_quote), _lender2, 200_000 * 1e18);
-
-        /*******************************/
-        /*** Setup NFT Collection State ***/
-        /*******************************/
-
-        _collectionPoolAddress = new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
-        _collectionPool        = ERC721Pool(_collectionPoolAddress);
-
-        vm.startPrank(_borrower);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_bidder);
-        _collateral.setApprovalForAll(address(_collectionPool), true);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        changePrank(_lender2);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-
-        /*******************************/
-        /*** Setup NFT Subset State ***/
-        /*******************************/
-
+        // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](9);
         subsetTokenIds[0] = 1;
         subsetTokenIds[1] = 3;
@@ -85,27 +39,16 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         subsetTokenIds[6] = 70;
         subsetTokenIds[7] = 73;
         subsetTokenIds[8] = 74;
+        _subsetPool = _deploySubsetPool(subsetTokenIds);
 
-        _subsetPoolAddress = new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds, 0.05 * 10**18);
-        _subsetPool        = ERC721Pool(_subsetPoolAddress);
+        address[] memory _poolAddresses = _getPoolAddresses();
 
-        changePrank(_borrower);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
+        _mintAndApproveQuoteTokens(_poolAddresses, _lender2, 200_000 * 1e18);
 
-        changePrank(_borrower2);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        changePrank(_bidder);
-        _collateral.setApprovalForAll(address(_subsetPool), true);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
-
-        changePrank(_lender2);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);        
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 10);
+        _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 13);   
     }
 
     function testSubsetPurchaseQuote() external {


### PR DESCRIPTION
Creates a `ERC721HelperContract` abstract contract that is used to reduce the boilerplate in the setup methods for ERC721 tests