### PR TITLE
Queue updates

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
@@ -317,6 +317,31 @@ contract ERC20ScaledQueueTest is DSTestPlus {
         assertEq(address(next), address(0));
     }
 
+    function testRemoveLoanInQueueWithWrongOldPrev() public {
+        // *borrower(HEAD)*
+        changePrank(_borrower);
+        _pool.pledgeCollateral(_borrower, 51 * 1e18, address(0), address(0));
+        _pool.borrow(15_000 * 1e18, 2551, address(0), address(0));
+
+        (uint256 thresholdPrice, address next) = _pool.loans(_borrower);
+        assertEq(address(next), address(0));
+        assertEq(_borrower,     address(_pool.loanQueueHead()));
+
+        // *borrower2(HEAD)* -> borrower
+        changePrank(_borrower2);
+        _pool.pledgeCollateral(_borrower2, 51 * 1e18, address(0), address(0));
+        _pool.borrow(20_000 * 1e18, 2551, address(0), address(0));
+
+        (thresholdPrice, next) = _pool.loans(_borrower2);
+        assertEq(address(next), _borrower);
+        assertEq(_borrower2, address(_pool.loanQueueHead()));
+
+        // repay entire loan with wrong old prev address
+        changePrank(_borrower);
+        vm.expectRevert("B:R:QUE_WRNG");
+        _pool.repay(_borrower, 15_100 * 1e18, _borrower3, address(0));
+    }
+
     // TODO: test with multiple borrowers and update of threshold prices causing queue reordering
     /**
      *  @notice With 1 lender and 1 borrower test adding collateral, borrowing, and adding additional collateral. 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
@@ -338,7 +338,7 @@ contract ERC20ScaledQueueTest is DSTestPlus {
 
         // repay entire loan with wrong old prev address
         changePrank(_borrower);
-        vm.expectRevert("B:R:QUE_WRNG");
+        vm.expectRevert("B:R:OLDPREV_WRNG");
         _pool.repay(_borrower, 15_100 * 1e18, _borrower3, address(0));
     }
 

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -24,24 +24,41 @@ abstract contract Queue is IQueue {
         require(oldPrev_ != borrower_ && newPrev_ != borrower_, "B:U:PNT_SELF_REF");
         require(thresholdPrice_ != 0, "B:U:TP_EQ_0");
 
-        LoanInfo memory oldPrevLoan = loans[oldPrev_];
-        LoanInfo memory newPrevLoan = loans[newPrev_];
+        address curLoanQueueHead = loanQueueHead;
+
+        LoanInfo storage oldPrevLoan = loans[oldPrev_];
         LoanInfo memory loan = loans[borrower_];
 
-        if (oldPrev_ == address(0)) {
-            require(loan.thresholdPrice == 0 || loanQueueHead == borrower_, "B:U:OLDPREV_WRNG");
-        } else {
-            require(oldPrevLoan.next == borrower_, "B:U:OLDPREV_NOT_CUR_BRW");
-        }
+        if (oldPrev_ == address(0)) require(loan.thresholdPrice == 0 || curLoanQueueHead == borrower_, "B:U:OLDPREV_WRNG");
+        else require(oldPrevLoan.next == borrower_, "B:U:OLDPREV_NOT_CUR_BRW");
 
-        if (loan.thresholdPrice > 0) {
+        LoanInfo storage newPrevLoan = loans[newPrev_];
+
+        if (loan.thresholdPrice != 0) {
             // loan already exists and needs to be moved within the queue
             if (oldPrev_ != newPrev_) {
-                (loan, oldPrevLoan, newPrevLoan) = _move(oldPrev_, oldPrevLoan, newPrev_, newPrevLoan);
+                address borrower;
+                if (oldPrev_ == address(0)) {
+                    loan          = loans[curLoanQueueHead];
+                    borrower      = curLoanQueueHead;
+                    loanQueueHead = loan.next;
+                } else {
+                    loan             = loans[oldPrevLoan.next];
+                    borrower         = oldPrevLoan.next;
+                    oldPrevLoan.next = loan.next;
+                }
+
+                if (newPrev_ == address(0)) {
+                    loan.next     = curLoanQueueHead;
+                    loanQueueHead = borrower;
+                } else {
+                    loan.next        = newPrevLoan.next;
+                    newPrevLoan.next = borrower;
+                }
             }
             loan.thresholdPrice = thresholdPrice_;
 
-        } else if (loanQueueHead != address(0)) {
+        } else if (curLoanQueueHead != address(0)) {
             // loan doesn't exist yet, other loans in queue
 
             require(oldPrev_ == address(0), "B:U:ALRDY_IN_QUE");
@@ -50,32 +67,26 @@ abstract contract Queue is IQueue {
 
             if (newPrev_ != address(0)) {
                 // loan gets appended to newPrev_
-                loan.next = newPrevLoan.next;
+                loan.next        = newPrevLoan.next;
                 newPrevLoan.next = borrower_;
 
             } else {
                 // loan becomes new queue head
-                loan.next = loanQueueHead;
+                loan.next     = curLoanQueueHead;
                 loanQueueHead = borrower_;
             }
         } else {
             // first loan in queue
             require(oldPrev_ == address(0) || newPrev_ == address(0), "B:U:PREV_SHD_B_ZRO");
-            loanQueueHead = borrower_;
+            loanQueueHead       = borrower_;
             loan.thresholdPrice = thresholdPrice_;
         }
 
         // check that queue has been ordered properly
-        if (newPrev_ != address(0)) {
-            require(newPrevLoan.thresholdPrice >= thresholdPrice_, "B:U:QUE_WRNG_ORD_P");
-        }
-        if (loan.next != address(0)) {
-            require(loans[loan.next].thresholdPrice <= thresholdPrice_, "B:U:QUE_WRNG_ORD_N");
-        }
+        if (newPrev_ != address(0))  require(newPrevLoan.thresholdPrice >= thresholdPrice_,      "B:U:QUE_WRNG_ORD_P");
+        if (loan.next != address(0)) require(loans[loan.next].thresholdPrice <= thresholdPrice_, "B:U:QUE_WRNG_ORD_N");
 
-        // update structs with the new ordering
-        loans[oldPrev_] = oldPrevLoan;
-        loans[newPrev_] = newPrevLoan;
+        // update loan with the new ordering
         loans[borrower_] = loan;
     }
 
@@ -86,49 +97,11 @@ abstract contract Queue is IQueue {
      *  @param  oldPrev_         Previous borrower that came before placed loan (old).
      */
     function _removeLoanQueue(address borrower_, address oldPrev_) internal {
-        require(oldPrev_ == address(0) || loans[oldPrev_].next == borrower_);
-        if (loanQueueHead == borrower_) {
-            loanQueueHead = loans[borrower_].next;
-        }
+        require(oldPrev_ == address(0) || loans[oldPrev_].next == borrower_, "B:R:QUE_WRNG");
+        if (loanQueueHead == borrower_) loanQueueHead = loans[borrower_].next;
 
         loans[oldPrev_].next = loans[borrower_].next;
-        loans[borrower_].next = address(0);
-        loans[borrower_].thresholdPrice = 0;
-    }
-
-    /**
-     *  @notice Move a given loan within the queue.
-     *  @dev    Called by _updateLoanQueue if loan exists in the queue and needs to be moved.
-     *  @param  oldPrev_         Previous borrower that came before placed loan (old)
-     *  @param  oldPrevLoan_     Previous loan that came before placed loan (old)
-     *  @param  newPrev_         Previous borrower that now comes before placed loan (new)
-     *  @param  newPrevLoan_     Previous loan that now comes before placed loan (new)
-     *  @return loan             Updated loan that is being placed in queue
-     *  @return oldPrevLoan_     Previous loan that came before placed loan (old)
-     *  @return newPrevLoan_     Previous loan that now comes before placed loan (new)
-     */
-    function _move(address oldPrev_, LoanInfo memory oldPrevLoan_, address newPrev_, LoanInfo memory newPrevLoan_) internal returns (LoanInfo memory loan, LoanInfo memory, LoanInfo memory) {
-        require(oldPrev_ != newPrev_, "B:U:QUE_INV_MOVE");
-        address borrower;
-
-        if (oldPrev_ == address(0)) {
-            loan = loans[loanQueueHead];
-            borrower = loanQueueHead;
-            loanQueueHead = loan.next;
-        } else {
-            loan = loans[oldPrevLoan_.next];
-            borrower = oldPrevLoan_.next;
-            oldPrevLoan_.next = loan.next;
-        }
-
-        if (newPrev_ == address(0)) {
-            loan.next = loanQueueHead;
-            loanQueueHead = borrower;
-        } else {
-            loan.next = newPrevLoan_.next;
-            newPrevLoan_.next = borrower;
-        }
-        return (loan, oldPrevLoan_, newPrevLoan_);
+        delete loans[borrower_];
     }
 
     /**************************/

--- a/src/base/Queue.sol
+++ b/src/base/Queue.sol
@@ -97,7 +97,7 @@ abstract contract Queue is IQueue {
      *  @param  oldPrev_         Previous borrower that came before placed loan (old).
      */
     function _removeLoanQueue(address borrower_, address oldPrev_) internal {
-        require(oldPrev_ == address(0) || loans[oldPrev_].next == borrower_, "B:R:QUE_WRNG");
+        require(oldPrev_ == address(0) || loans[oldPrev_].next == borrower_, "B:R:OLDPREV_WRNG");
         if (loanQueueHead == borrower_) loanQueueHead = loans[borrower_].next;
 
         loans[oldPrev_].next = loans[borrower_].next;


### PR DESCRIPTION
- remove `_move()` function and use inline code in `_updateLoanQueue()` - reduce contract size
- gas optimization by loading only current loan struct in memory and saving to storage; old and new prev loans are loaded as storage, below gas comparison with `develop` branch
- add require string `B:R:QUE_WRNG` in `_removeLoanQueue` function. add test to check failing scenario and revert string
- use delete struct in `_removeLoanQueue` function (instead zeroing TP and next address)
- style updates

Tests comparison current branch vs `develop` 
```
[PASS] testAddLoanToQueue() (gas: 426127)
│ borrow                                     ┆ 211831          ┆ 211831 ┆ 211831 ┆ 211831 ┆ 1       │
vs
│ borrow                                     ┆ 217185          ┆ 217185 ┆ 217185 ┆ 217185 ┆ 1       │

[PASS] testBorrowerSelfRefLoanQueue() (gas: 476296)
│ borrow                                     ┆ 39687           ┆ 125759 ┆ 125759 ┆ 211831 ┆ 2       │
vs
│ borrow                                     ┆ 39687           ┆ 128436 ┆ 128436 ┆ 217185 ┆ 2       │

[PASS] testGetHighestThresholdPrice() (gas: 435711)
│ borrow                                     ┆ 211831          ┆ 211831 ┆ 211831 ┆ 211831 ┆ 1       │
vs
│ borrow                                     ┆ 217185          ┆ 217185 ┆ 217185 ┆ 217185 ┆ 1       │

[PASS] testMoveLoanInQueue() (gas: 927910)
│ borrow                                     ┆ 112150          ┆ 151111 ┆ 129353 ┆ 211831 ┆ 3       │
│ repay                                      ┆ 56648           ┆ 56648  ┆ 56648  ┆ 56648  ┆ 1       │
vs
│ borrow                                     ┆ 113198          ┆ 153694 ┆ 130701 ┆ 217185 ┆ 3       │
│ repay                                      ┆ 57400           ┆ 57400  ┆ 57400  ┆ 57400  ┆ 1       │

[PASS] testMoveLoanToHeadInQueue() (gas: 708152)
│ borrow                                     ┆ 51908           ┆ 131030 ┆ 129353 ┆ 211831 ┆ 3       │
vs
│ borrow                                     ┆ 52900           ┆ 133595 ┆ 130701 ┆ 217185 ┆ 3       │

[PASS] testMoveToBottom() (gas: 795047)
│ borrow                                     ┆ 35617           ┆ 106158 ┆ 88593  ┆ 211831 ┆ 4       │
vs
│ borrow                                     ┆ 36197           ┆ 108246 ┆ 89802  ┆ 217185 ┆ 4       │

[PASS] testMoveToSameLocation() (gas: 924785)
│ borrow                                     ┆ 112239          ┆ 152469 ┆ 133339 ┆ 211831 ┆ 3       │
vs
│ borrow                                     ┆ 113587          ┆ 155153 ┆ 134687 ┆ 217185 ┆ 3       │

[PASS] testRemoveLoanInQueue() (gas: 658586)
│ borrow                                     ┆ 129353          ┆ 170592 ┆ 170592 ┆ 211831 ┆ 2       │
│ repay                                      ┆ 38288           ┆ 38288  ┆ 38288  ┆ 38288  ┆ 1       │
vs
│ borrow                                     ┆ 130701          ┆ 173943 ┆ 173943 ┆ 217185 ┆ 2       │
│ repay                                      ┆ 38290           ┆ 38290  ┆ 38290  ┆ 38290  ┆ 1       │

[PASS] testUpdateLoanQueuePledgeCollateral() (gas: 485147)
│ borrow                                     ┆ 211831          ┆ 211831 ┆ 211831 ┆ 211831 ┆ 1       │
│ pledgeCollateral                           ┆ 42276           ┆ 120309 ┆ 120309 ┆ 198343 ┆ 2       │
vs
│ borrow                                     ┆ 217185          ┆ 217185 ┆ 217185 ┆ 217185 ┆ 1       │
│ pledgeCollateral                           ┆ 43621           ┆ 120982 ┆ 120982 ┆ 198343 ┆ 2       │

[PASS] testUpdateLoanQueuePullCollateral() (gas: 483080)
│ borrow                                     ┆ 211831          ┆ 211831 ┆ 211831 ┆ 211831 ┆ 1       │
│ pledgeCollateral                           ┆ 198343          ┆ 198343 ┆ 198343 ┆ 198343 ┆ 1       │
│ pullCollateral                             ┆ 40215           ┆ 40215  ┆ 40215  ┆ 40215  ┆ 1       │
vs
│ borrow                                     ┆ 217185          ┆ 217185 ┆ 217185 ┆ 217185 ┆ 1       │
│ pledgeCollateral                           ┆ 198343          ┆ 198343 ┆ 198343 ┆ 198343 ┆ 1       │
│ pullCollateral                             ┆ 41559           ┆ 41559  ┆ 41559  ┆ 41559  ┆ 1       │

[PASS] testWrongOrder() (gas: 589910)
│ borrow                                     ┆ 63730           ┆ 137780 ┆ 137780 ┆ 211831 ┆ 2       │
vs
│ borrow                                     ┆ 44023           ┆ 130604 ┆ 130604 ┆ 217185 ┆ 2       │
```