### PR TITLE
Fenwick improvements: replace _rangeSum with _valueAt

### DIFF
--- a/src/_test/FenwickTree.t.sol
+++ b/src/_test/FenwickTree.t.sol
@@ -24,8 +24,12 @@ contract FenwickTreeInstance is FenwickTree {
         return _treeSum();
     }
 
+    function rangeSum(uint256 i_, uint256 j_) external view returns (uint256 m_) {
+        return _rangeSum(i_, j_);
+    }
+
     function get(uint256 i_) external view returns (uint256 m_) {
-        return _rangeSum(i_, i_);
+        return _valueAt(i_);
     }
 
     function scale(uint256 i_) external view returns (uint256 a_) {
@@ -47,11 +51,18 @@ contract FenwickTreeTest is DSTestPlus {
         FenwickTreeInstance tree = new FenwickTreeInstance();
         tree.add(11, 300 * 1e18);
         tree.add(9,  200 * 1e18);
+
         assertEq(tree.get(8),  0);
         assertEq(tree.get(9),  200 * 1e18);
         assertEq(tree.get(11), 300 * 1e18);
         assertEq(tree.get(12), 0);
         assertEq(tree.get(13), 0);
+
+        assertEq(tree.rangeSum(8, 8),   0);
+        assertEq(tree.rangeSum(9, 9),   200 * 1e18);
+        assertEq(tree.rangeSum(11, 11), 300 * 1e18);
+        assertEq(tree.rangeSum(12, 12), 0);
+        assertEq(tree.rangeSum(13, 13), 0);
 
         assertEq(tree.prefixSum(0),    0);
         assertEq(tree.prefixSum(5),    0);
@@ -78,6 +89,16 @@ contract FenwickTreeTest is DSTestPlus {
         tree.add(11, 300 * 1e18);
         tree.add(9, 200 * 1e18);
         tree.mult(10, 1.2 * 1e18);
+
+        assertEq(tree.get(5),  132 * 1e18);
+        assertEq(tree.get(9),  480 * 1e18);
+        assertEq(tree.get(10), 0);
+        assertEq(tree.get(11), 300 * 1e18);
+
+        assertEq(tree.rangeSum(5, 5),   132 * 1e18);
+        assertEq(tree.rangeSum(9, 9),   480 * 1e18);
+        assertEq(tree.rangeSum(10, 10), 0);
+        assertEq(tree.rangeSum(11, 11), 300 * 1e18);
 
         assertEq(tree.prefixSum(0),    0);
         assertEq(tree.prefixSum(4),    0);
@@ -111,6 +132,16 @@ contract FenwickTreeTest is DSTestPlus {
         assertEq(tree.findSum(500 * 1e18),   9);
         assertEq(tree.findSum(900 * 1e18),   8191);
         assertEq(tree.findSum(1_000 * 1e18), 8191);
+
+        assertEq(tree.get(5),  132 * 1e18);
+        assertEq(tree.get(9),  480 * 1e18);
+        assertEq(tree.get(10), 0);
+        assertEq(tree.get(11), 0);
+
+        assertEq(tree.rangeSum(5, 5),   132 * 1e18);
+        assertEq(tree.rangeSum(9, 9),   480 * 1e18);
+        assertEq(tree.rangeSum(10, 10), 0);
+        assertEq(tree.rangeSum(11, 11), 0);
     }
 
     function testFenwickFirstBorrow() external {

--- a/src/base/FenwickTree.sol
+++ b/src/base/FenwickTree.sol
@@ -143,7 +143,6 @@ abstract contract FenwickTree {
 
         uint256 j  = i_;
         uint256 k  = 1;
-        uint256 sc = Maths.WAD;
 
         i_ += 1;
         s_ = values[i_];
@@ -151,13 +150,13 @@ abstract contract FenwickTree {
         uint256 scaled;
         while (j & k != 0) {
             scaled = scaling[j];
-            s_ = scaled != 0 ? s_ - Maths.wmul(Maths.wmul(sc, scaled), values[j]) : s_ - values[j];
+            s_ = scaled != 0 ? s_ - Maths.wmul(scaled, values[j]) : s_ - values[j];
             j  = j - k;
             k  = k << 1;
         }
         while (i_ <= SIZE) {
             scaled = scaling[i_];
-            if (scaled != 0) s_ = Maths.wmul(Maths.wmul(sc, scaled), s_);
+            if (scaled != 0) s_ = Maths.wmul(scaled, s_);
             i_ += _lsb(i_);
         }
     }

--- a/src/base/FenwickTree.sol
+++ b/src/base/FenwickTree.sol
@@ -138,6 +138,30 @@ abstract contract FenwickTree {
         return _prefixSum(stop_) - _prefixSum(start_ - 1);
     }
 
+    function _valueAt(uint256 i_) internal view returns (uint256 s_) {
+        require(i_ < SIZE, "FW:V:INVALID_INDEX");
+
+        uint256 j  = i_;
+        uint256 k  = 1;
+        uint256 sc = Maths.WAD;
+
+        i_ += 1;
+        s_ = values[i_];
+
+        uint256 scaled;
+        while (j & k != 0) {
+            scaled = scaling[j];
+            s_ = scaled != 0 ? s_ - Maths.wmul(Maths.wmul(sc, scaled), values[j]) : s_ - values[j];
+            j  = j - k;
+            k  = k << 1;
+        }
+        while (i_ <= SIZE) {
+            scaled = scaling[i_];
+            if (scaled != 0) s_ = Maths.wmul(Maths.wmul(sc, scaled), s_);
+            i_ += _lsb(i_);
+        }
+    }
+
     // TODO: rename this to findIndexOfSum
     // TODO: should this revert if failed to find a value past a given index instead of SIZE?
     function _findSum(uint256 x_) internal view returns (uint256 m_) {

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -184,7 +184,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         // Calculate exchange rate before new collateral has been accounted for.
         // This is consistent with how lbpChange in addQuoteToken is adjusted before calling _add.
-        uint256 rate = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
 
         uint256 quoteValue     = Maths.wmul(amount_, _indexToPrice(index_));
         lpbChange_             = Maths.rdiv(Maths.wadToRay(quoteValue), rate);
@@ -210,7 +210,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         uint256 price = _indexToPrice(index_);
-        uint256 rate  = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate  = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
         lpAmount_     = bucketLender.lpBalance;
         amount_       = Maths.rwdivw(Maths.rmul(lpAmount_, rate), price);
         require(amount_ != 0, "S:RAC:NO_CLAIM");
@@ -232,7 +232,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         uint256 price        = _indexToPrice(index_);
-        uint256 rate         = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate         = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs = bucketLender.lpBalance;
 
         // ensure user can actually remove that much


### PR DESCRIPTION
- replace old way of retrieving value at index (range sum)
- add FenwickTree tests
- gas test comparison current branch vs `develop` :

```

FenwickTree contract

╭──────────────────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/_test/FenwickTree.t.sol:FenwickTreeInstance contract ┆                 ┆        ┆        ┆        ┆         │
╞══════════════════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                                            ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ get                                                      ┆ 6077            ┆ 8030   ┆ 6668   ┆ 11571  ┆ 13      │
╰──────────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
vs

╭──────────────────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/_test/FenwickTree.t.sol:FenwickTreeInstance contract ┆                 ┆        ┆        ┆        ┆         │
╞══════════════════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                                            ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ get                                                      ┆ 16898           ┆ 19595  ┆ 19890  ┆ 22402  ┆ 5       │
╰──────────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯

PositionManager contract


╭───────────────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/base/PositionManager.sol:PositionManager contract ┆                 ┆        ┆        ┆        ┆         │
╞═══════════════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                                         ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveLiquidity                                         ┆ 5641            ┆ 111610 ┆ 142388 ┆ 186801 ┆ 3       │
╰───────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯

vs

╭───────────────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/base/PositionManager.sol:PositionManager contract ┆                 ┆        ┆        ┆        ┆         │
╞═══════════════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                                         ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveLiquidity                                         ┆ 5641            ┆ 139528 ┆ 185065 ┆ 227879 ┆ 3       │
╰───────────────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯

ERC20 Pool contract

────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ Function Name                              ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addCollateral                              ┆ 149676          ┆ 256720 ┆ 234171 ┆ 408864 ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addQuoteToken                              ┆ 84129           ┆ 211860 ┆ 142352 ┆ 439045 ┆ 139     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 20007           ┆ 158899 ┆ 191902 ┆ 305839 ┆ 50      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ bucketAt                                   ┆ 9157            ┆ 9157   ┆ 9157   ┆ 9157   ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ depositAt                                  ┆ 3207            ┆ 3276   ┆ 3207   ┆ 3483   ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ exchangeRate                               ┆ 14670           ┆ 15390  ┆ 15185  ┆ 15973  ┆ 9       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 466             ┆ 187355 ┆ 183580 ┆ 627477 ┆ 10      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pledgeCollateral                           ┆ 26890           ┆ 138935 ┆ 139312 ┆ 271814 ┆ 45      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllCollateral                        ┆ 4748            ┆ 55826  ┆ 47324  ┆ 108006 ┆ 8       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllQuoteToken                        ┆ 3240            ┆ 80991  ┆ 75622  ┆ 181691 ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeCollateral                           ┆ 825             ┆ 23275  ┆ 18216  ┆ 55845  ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeQuoteToken                           ┆ 6430            ┆ 88762  ┆ 69458  ┆ 321862 ┆ 8       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯

vs


────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ Function Name                              ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addCollateral                              ┆ 167989          ┆ 286525 ┆ 275073 ┆ 427967 ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addQuoteToken                              ┆ 101302          ┆ 237910 ┆ 157073 ┆ 469125 ┆ 139     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 20007           ┆ 151779 ┆ 177752 ┆ 285839 ┆ 50      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ bucketAt                                   ┆ 23513           ┆ 23513  ┆ 23513  ┆ 23513  ┆ 1       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ depositAt                                  ┆ 21520           ┆ 21786  ┆ 21520  ┆ 22586  ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ exchangeRate                               ┆ 30053           ┆ 31736  ┆ 32497  ┆ 32983  ┆ 9       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 466             ┆ 219054 ┆ 216216 ┆ 670229 ┆ 10      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pledgeCollateral                           ┆ 26890           ┆ 138935 ┆ 139312 ┆ 271814 ┆ 45      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllCollateral                        ┆ 4748            ┆ 69465  ┆ 62290  ┆ 127109 ┆ 8       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllQuoteToken                        ┆ 3240            ┆ 93446  ┆ 93730  ┆ 193176 ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeCollateral                           ┆ 825             ┆ 31726  ┆ 25962  ┆ 74158  ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeQuoteToken                           ┆ 21921           ┆ 101292 ┆ 85536  ┆ 336218 ┆ 8       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```