### PR TITLE
Test utils rebase

### DIFF
--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.14;
 import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
-import { DSTestPlus } from "../utils/DSTestPlus.sol";
+import { DSTestPlus }                     from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
 abstract contract ERC721DSTestPlus is DSTestPlus {
@@ -32,23 +32,22 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
     // TODO: bool for pool type
     constructor() {
-        _collateral      = new NFTCollateralToken();
-        _quote           = new QuoteToken();
+        _collateral = new NFTCollateralToken();
+        _quote      = new QuoteToken();
     }
 
     function _deployCollectionPool() internal returns (ERC721Pool) {
-            return ERC721Pool(new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
+        return ERC721Pool(new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
     }
 
     function _deploySubsetPool(uint256[] memory subsetTokenIds_) internal returns (ERC721Pool) {
-            return ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
+        return ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
     }
 
-    function _getPoolAddresses() internal returns (address[] memory) {
-        address[] memory _poolAddresses = new address[](2);
-        _poolAddresses[0] = address(_collectionPool);
-        _poolAddresses[1] = address(_subsetPool);
-        return _poolAddresses;
+    function _getPoolAddresses() internal view returns (address[] memory poolAddresses_) {
+        poolAddresses_ = new address[](2);
+        poolAddresses_[0] = address(_collectionPool);
+        poolAddresses_[1] = address(_subsetPool);
     }
 
     // TODO: finish implementing
@@ -84,8 +83,8 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     function _assertBalances() internal {}
 
     // TODO: check oldPrev and newPrev
-    function _pledgeCollateral(address borrower_, ERC721Pool pool_, uint256[] memory tokenIdsToAdd_) internal {
-        vm.prank(borrower_);
+    function _pledgeCollateral(address pledger_, address borrower_, ERC721Pool pool_, uint256[] memory tokenIdsToAdd_) internal {
+        vm.prank(pledger_);
         for (uint i; i < tokenIdsToAdd_.length;) {
             emit Transfer(address(borrower_), address(pool_), tokenIdsToAdd_[i]);
             vm.expectEmit(true, true, false, true);
@@ -94,7 +93,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
             }
         }
         emit PledgeCollateralNFT(address(borrower_), tokenIdsToAdd_);
-        pool_.pledgeCollateral(tokenIdsToAdd_, address(0), address(0));
+        pool_.pledgeCollateral(borrower_, tokenIdsToAdd_, address(0), address(0));
     }
 
     // TODO: implement _pullCollateral()

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -39,9 +39,9 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        _collateral.mint(address(_borrower),  52);
-        _collateral.mint(address(_borrower2), 10);
-        _collateral.mint(address(_borrower3), 13);
+        _collateral.mint(_borrower,  52);
+        _collateral.mint(_borrower2, 10);
+        _collateral.mint(_borrower3, 13);
 
         deal(address(_quote), _lender, 200_000 * 1e18);
 
@@ -119,11 +119,11 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         _subsetPool.borrow(5_000 * 1e18, 2551, address(0), address(0));
 
         assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_010.981808341113791532 * 1e18);
         assertEq(col.length,  3);
@@ -133,9 +133,9 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         skip(864000);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 51;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 5_017.163540992622874208 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_017.163540992622874208 * 1e18);
         assertEq(pendingDebt, 5_017.163540992622874208 * 1e18);
         assertEq(col.length,  4);
@@ -147,7 +147,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToRemove[0] = 1;
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 5_022.733620353117867729 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_022.733620353117867729 * 1e18);
         assertEq(pendingDebt, 5_022.733620353117867729 * 1e18);
         assertEq(col.length,  3);
@@ -157,7 +157,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         skip(864000);
         _subsetPool.borrow(1_000 * 1e18, 3000, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 6_028.452940379879069654 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        6_028.452940379879069654 * 1e18);
         assertEq(pendingDebt, 6_028.452940379879069654 * 1e18);
         assertEq(col.length,  3);
@@ -168,10 +168,10 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
         // borrower repays their loan after some additional time
         skip(864000);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
-        _subsetPool.repay(pendingDebt, address(0), address(0));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
+        _subsetPool.repay(_borrower, pendingDebt, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 0);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  3);
@@ -195,10 +195,10 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         uint256 borrowAmount = 8_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551, address(0), address(0));
         skip(4 hours);
 
@@ -206,10 +206,10 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd, address(0), _borrower);
         borrowAmount = 2_750 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower2), _subsetPool.indexToPrice(2551), borrowAmount);
+        emit Borrow(_borrower2, _subsetPool.indexToPrice(2551), borrowAmount);
         _subsetPool.borrow(borrowAmount, 3000, address(0), address(0));
         skip(4 hours);
 
@@ -217,11 +217,11 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         changePrank(_borrower3);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 73;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower3, tokenIdsToAdd, address(0), _borrower);
         borrowAmount = 2_500 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower3), _subsetPool.indexToPrice(2551), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 3000, address(0), address(_borrower));
+        emit Borrow(_borrower3, _subsetPool.indexToPrice(2551), borrowAmount);
+        _subsetPool.borrow(borrowAmount, 3000, address(0), _borrower);
         skip(4 hours);
 
         // trigger an interest accumulation
@@ -230,13 +230,13 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
         // check pool and borrower debt to confirm interest has accumulated
         assertEq(_subsetPool.borrowerDebt(), 13_263.563121817930264782 * 1e18);
-        (uint256 debt, uint256 pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        8_007.692307692307696000 * 1e18);
         assertEq(pendingDebt, 8_007.692307692307696000 * 1e18);
-        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower2));
+        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower2);
         assertEq(debt,        2_752.644230769230770500 * 1e18);
         assertEq(pendingDebt, 2_752.644230769230770500 * 1e18);
-        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower3));
+        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower3);
         assertEq(debt,        2_502.403846153846155000 * 1e18);
         assertEq(pendingDebt, 2_502.403846153846155000 * 1e18);
     }
@@ -254,7 +254,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // should revert if insufficient quote available before limit price
         vm.expectRevert("S:B:LIMIT_REACHED");
@@ -272,7 +272,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         uint256[] memory tokenIdsToAdd = new uint256[](2);
         tokenIdsToAdd[0] = 5;
         tokenIdsToAdd[1] = 3;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // should revert if borrower did not deposit enough collateral
         vm.expectRevert("S:B:BUNDER_COLLAT");
@@ -300,11 +300,11 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
         // check initial token balances
         assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   30_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), 0);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 30_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            0);
 
         // check pool state
         assertEq(_subsetPool.htp(), 0);
@@ -328,21 +328,21 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // borrower borrows from the pool
         uint256 borrowAmount = 3_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551, address(0), address(0));
 
         // check token balances after borrow
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   27_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), borrowAmount);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            borrowAmount);
 
         // check pool state after borrow
         assertEq(_subsetPool.htp(), 1_000.961538461538462000 * 1e18);
@@ -362,7 +362,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         assertEq(availableCollateral, 0);
 
         // check borrower info after borrow
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col.length,  3);
@@ -373,16 +373,16 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
         // borrower partially repays half their loan
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount / 2);
-        _subsetPool.repay(borrowAmount / 2, address(0), address(0));
+        emit Repay(_borrower, _subsetPool.indexToPrice(2550), borrowAmount / 2);
+        _subsetPool.repay(_borrower, borrowAmount / 2, address(0), address(0));
 
         // check token balances after partial repay
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
         assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)),   borrowAmount / 2);
+        assertEq(_quote.balanceOf(_borrower),            borrowAmount / 2);
 
         // check pool state after partial repay
         assertEq(_subsetPool.htp(), 503.711801848555564077 * 1e18);
@@ -403,7 +403,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         assertEq(availableCollateral, 0);
 
         // check borrower info after partial repay
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
         assertEq(col.length,  3);
@@ -413,23 +413,23 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         skip(10 days);
 
         // find pending debt after interest accumulation
-        (, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower));
+        (, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower);
 
         // mint additional quote to allow borrower to repay their loan plus interest
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 1_000 * 1e18);
 
         // borrower repays their remaining loan balance
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), BucketMath.MAX_PRICE, pendingDebt);
-        _subsetPool.repay(pendingDebt, address(0), address(0));
+        emit Repay(_borrower, BucketMath.MAX_PRICE, pendingDebt);
+        _subsetPool.repay(_borrower, pendingDebt, address(0), address(0));
 
         // check token balances after fully repay
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
         assertEq(_quote.balanceOf(address(_subsetPool)), 30_008.860066921599064643 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)),   991.139933078400935357 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            991.139933078400935357 * 1e18);
 
         // check pool state after fully repay
         assertEq(_subsetPool.htp(), 0);
@@ -438,10 +438,10 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         // borrower pulls collateral
         uint256[] memory tokenIdsToRemove = tokenIdsToAdd;
         vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(address(_borrower), tokenIdsToRemove);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
         assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
         // check utilization changes make sense
@@ -461,7 +461,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         assertEq(availableCollateral, 0);
 
         // check borrower info after fully repay
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  0);
@@ -477,40 +477,83 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         // should revert if borrower has insufficient quote to repay desired amount
         changePrank(_borrower);
         vm.expectRevert("S:R:INSUF_BAL");
-        _subsetPool.repay(10_000 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower, _quote.balanceOf(_borrower) + 10_000 * 1e18);
         vm.expectRevert("S:R:NO_DEBT");
-        _subsetPool.repay(10_000 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
         uint256[] memory tokenIdsToAdd = new uint256[](3);
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         _subsetPool.borrow(1_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower), _subsetPool.loanQueueHead());
+        assertEq(_borrower, _subsetPool.loanQueueHead());
 
         // borrower 2 borrows 3k quote from the pool and becomes new queue HEAD
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd, address(0), _borrower);
         _subsetPool.borrow(3_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower2), _subsetPool.loanQueueHead());
+        assertEq(_borrower2, _subsetPool.loanQueueHead());
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
         vm.expectRevert("R:B:AMT_LT_AVG_DEBT");
-        _subsetPool.repay(900 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 900 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _subsetPool.lup(), 1_000.961538461538462000 * 1e18);
-        _subsetPool.repay(1_100 * 1e18, address(_borrower2), address(_borrower2));
+        emit Repay(_borrower, _subsetPool.lup(), 1_000.961538461538462000 * 1e18);
+        _subsetPool.repay(_borrower, 1_100 * 1e18, _borrower2, _borrower2);
+    }
+
+    function testRepayLoanFromDifferentActor() external {
+        changePrank(_lender);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+
+        // borrower deposits three NFTs into the subset pool
+        changePrank(_borrower);
+        uint256[] memory tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+        tokenIdsToAdd[2] = 5;
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
+
+        // borrower borrows from the pool
+        _subsetPool.borrow(3_000 * 1e18, 2551, address(0), address(0));
+
+        // check token balances after borrow
+        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),              170_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
+
+        // pass time to allow interest to accumulate
+        skip(10 days);
+
+        // lender partially repays borrower's loan
+        changePrank(_lender);
+        _subsetPool.repay(_borrower, 1_500 * 1e18, address(0), address(0));
+
+        // check token balances after partial repay
+        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+
+        assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
+        assertEq(_quote.balanceOf(_lender),              168_500 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
     }
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -75,11 +75,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         _subsetPool.borrow(5_000 * 1e18, 2551, address(0), address(0));
 
         assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_010.981808341113791532 * 1e18);
         assertEq(col.length,  3);
@@ -89,9 +89,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         skip(864000);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 51;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 5_017.163540992622874208 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_017.163540992622874208 * 1e18);
         assertEq(pendingDebt, 5_017.163540992622874208 * 1e18);
         assertEq(col.length,  4);
@@ -103,7 +103,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToRemove[0] = 1;
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 5_022.733620353117867729 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_022.733620353117867729 * 1e18);
         assertEq(pendingDebt, 5_022.733620353117867729 * 1e18);
         assertEq(col.length,  3);
@@ -113,7 +113,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         skip(864000);
         _subsetPool.borrow(1_000 * 1e18, 3000, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 6_028.452940379879069654 * 1e18);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        6_028.452940379879069654 * 1e18);
         assertEq(pendingDebt, 6_028.452940379879069654 * 1e18);
         assertEq(col.length,  3);
@@ -124,10 +124,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // borrower repays their loan after some additional time
         skip(864000);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
-        _subsetPool.repay(pendingDebt, address(0), address(0));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
+        _subsetPool.repay(_borrower, pendingDebt, address(0), address(0));
         assertEq(_subsetPool.borrowerDebt(), 0);
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  3);
@@ -151,10 +151,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         uint256 borrowAmount = 8_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551, address(0), address(0));
         skip(4 hours);
 
@@ -162,10 +162,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd, address(0), _borrower);
         borrowAmount = 2_750 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower2), _subsetPool.indexToPrice(2551), borrowAmount);
+        emit Borrow(_borrower2, _subsetPool.indexToPrice(2551), borrowAmount);
         _subsetPool.borrow(borrowAmount, 3000, address(0), address(0));
         skip(4 hours);
 
@@ -173,11 +173,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         changePrank(_borrower3);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 73;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower3, tokenIdsToAdd, address(0), _borrower);
         borrowAmount = 2_500 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower3), _subsetPool.indexToPrice(2551), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 3000, address(0), address(_borrower));
+        emit Borrow(_borrower3, _subsetPool.indexToPrice(2551), borrowAmount);
+        _subsetPool.borrow(borrowAmount, 3000, address(0), _borrower);
         skip(4 hours);
 
         // trigger an interest accumulation
@@ -186,13 +186,13 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // check pool and borrower debt to confirm interest has accumulated
         assertEq(_subsetPool.borrowerDebt(), 13_263.563121817930264782 * 1e18);
-        (uint256 debt, uint256 pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        8_007.692307692307696000 * 1e18);
         assertEq(pendingDebt, 8_007.692307692307696000 * 1e18);
-        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower2));
+        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower2);
         assertEq(debt,        2_752.644230769230770500 * 1e18);
         assertEq(pendingDebt, 2_752.644230769230770500 * 1e18);
-        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower3));
+        (debt, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower3);
         assertEq(debt,        2_502.403846153846155000 * 1e18);
         assertEq(pendingDebt, 2_502.403846153846155000 * 1e18);
     }
@@ -210,7 +210,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // should revert if insufficient quote available before limit price
         vm.expectRevert("S:B:LIMIT_REACHED");
@@ -228,7 +228,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256[] memory tokenIdsToAdd = new uint256[](2);
         tokenIdsToAdd[0] = 5;
         tokenIdsToAdd[1] = 3;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // should revert if borrower did not deposit enough collateral
         vm.expectRevert("S:B:BUNDER_COLLAT");
@@ -256,11 +256,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // check initial token balances
         assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   30_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), 0);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 30_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            0);
 
         // check pool state
         assertEq(_subsetPool.htp(), 0);
@@ -284,21 +284,21 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // borrower borrows from the pool
         uint256 borrowAmount = 3_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551, address(0), address(0));
 
         // check token balances after borrow
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   27_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), borrowAmount);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            borrowAmount);
 
         // check pool state after borrow
         assertEq(_subsetPool.htp(), 1_000.961538461538462000 * 1e18);
@@ -318,7 +318,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after borrow
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col.length,  3);
@@ -329,16 +329,16 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // borrower partially repays half their loan
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _subsetPool.indexToPrice(2550), borrowAmount / 2);
-        _subsetPool.repay(borrowAmount / 2, address(0), address(0));
+        emit Repay(_borrower, _subsetPool.indexToPrice(2550), borrowAmount / 2);
+        _subsetPool.repay(_borrower, borrowAmount / 2, address(0), address(0));
 
         // check token balances after partial repay
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
         assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)),   borrowAmount / 2);
+        assertEq(_quote.balanceOf(_borrower),            borrowAmount / 2);
 
         // check pool state after partial repay
         assertEq(_subsetPool.htp(), 503.711801848555564077 * 1e18);
@@ -359,7 +359,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after partial repay
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
         assertEq(col.length,  3);
@@ -369,23 +369,23 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         skip(10 days);
 
         // find pending debt after interest accumulation
-        (, pendingDebt, , ) = _subsetPool.borrowerInfo(address(_borrower));
+        (, pendingDebt, , ) = _subsetPool.borrowerInfo(_borrower);
 
         // mint additional quote to allow borrower to repay their loan plus interest
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 1_000 * 1e18);
 
         // borrower repays their remaining loan balance
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), BucketMath.MAX_PRICE, pendingDebt);
-        _subsetPool.repay(pendingDebt, address(0), address(0));
+        emit Repay(_borrower, BucketMath.MAX_PRICE, pendingDebt);
+        _subsetPool.repay(_borrower, pendingDebt, address(0), address(0));
 
         // check token balances after fully repay
         assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
         assertEq(_quote.balanceOf(address(_subsetPool)), 30_008.860066921599064643 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)),   991.139933078400935357 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            991.139933078400935357 * 1e18);
 
         // check pool state after fully repay
         assertEq(_subsetPool.htp(), 0);
@@ -394,10 +394,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // borrower pulls collateral
         uint256[] memory tokenIdsToRemove = tokenIdsToAdd;
         vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(address(_borrower), tokenIdsToRemove);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
         assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
         // check utilization changes make sense
@@ -417,7 +417,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after fully repay
-        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(address(_borrower));
+        (debt, pendingDebt, col, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  0);
@@ -433,40 +433,83 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // should revert if borrower has insufficient quote to repay desired amount
         changePrank(_borrower);
         vm.expectRevert("S:R:INSUF_BAL");
-        _subsetPool.repay(10_000 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower, _quote.balanceOf(_borrower) + 10_000 * 1e18);
         vm.expectRevert("S:R:NO_DEBT");
-        _subsetPool.repay(10_000 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
         uint256[] memory tokenIdsToAdd = new uint256[](3);
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         _subsetPool.borrow(1_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower), _subsetPool.loanQueueHead());
+        assertEq(_borrower, _subsetPool.loanQueueHead());
 
         // borrower 2 borrows 3k quote from the pool and becomes new queue HEAD
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(_borrower));
+        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd, address(0), _borrower);
         _subsetPool.borrow(3_000 * 1e18, 3000, address(0), address(0));
 
-        assertEq(address(_borrower2), _subsetPool.loanQueueHead());
+        assertEq(_borrower2, _subsetPool.loanQueueHead());
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
         vm.expectRevert("R:B:AMT_LT_AVG_DEBT");
-        _subsetPool.repay(900 * 1e18, address(0), address(0));
+        _subsetPool.repay(_borrower, 900 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
-        emit Repay(address(_borrower), _subsetPool.lup(), 1_000.961538461538462000 * 1e18);
-        _subsetPool.repay(1_100 * 1e18, address(_borrower2), address(_borrower2));
+        emit Repay(_borrower, _subsetPool.lup(), 1_000.961538461538462000 * 1e18);
+        _subsetPool.repay(_borrower, 1_100 * 1e18, _borrower2, _borrower2);
+    }
+
+    function testRepayLoanFromDifferentActor() external {
+        changePrank(_lender);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
+        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+
+        // borrower deposits three NFTs into the subset pool
+        changePrank(_borrower);
+        uint256[] memory tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+        tokenIdsToAdd[2] = 5;
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
+
+        // borrower borrows from the pool
+        _subsetPool.borrow(3_000 * 1e18, 2551, address(0), address(0));
+
+        // check token balances after borrow
+        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender),              170_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
+
+        // pass time to allow interest to accumulate
+        skip(10 days);
+
+        // lender partially repays borrower's loan
+        changePrank(_lender);
+        _subsetPool.repay(_borrower, 1_500 * 1e18, address(0), address(0));
+
+        // check token balances after partial repay
+        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+
+        assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
+        assertEq(_quote.balanceOf(_lender),              168_500 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
     }
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -42,8 +42,9 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
 
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
-        _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 10);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower,  52);
+        _mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 53);
+        _mintAndApproveCollateralTokens(_poolAddresses, _bidder,    10);
     }
 
     /*******************************/
@@ -56,8 +57,8 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
     function testPledgeCollateralSubset() external {
         // check initial token balances
-        assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_subsetPool.pledgedCollateral(),             0);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
         uint256[] memory tokenIdsToAdd = new uint256[](3);
@@ -68,18 +69,18 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 1);
+        emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 3);
+        emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 5);
+        emit Transfer(_borrower, address(_subsetPool), 5);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(address(_borrower), tokenIdsToAdd);
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // check token balances after add
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
     }
 
@@ -92,13 +93,49 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // should revert if borrower attempts to add tokens not in the pool subset
         changePrank(_borrower);
         vm.expectRevert("P:ONLY_SUBSET");
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
+    }
+
+    function testPledgeCollateralInSubsetFromDifferentActor() external {
+        // check initial token balances
+        assertEq(_subsetPool.pledgedCollateral(),             0);
+        assertEq(_collateral.balanceOf(_borrower),            52);
+        assertEq(_collateral.balanceOf(_borrower2),           53);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
+
+        (, , uint256[] memory col, ) = _subsetPool.borrowerInfo(_borrower);
+        assertEq(col.length,  0);
+        (, , col, ) = _subsetPool.borrowerInfo(_borrower2);
+        assertEq(col.length,  0);
+
+        uint256[] memory tokenIdsToAdd = new uint256[](1);
+        tokenIdsToAdd[0] = 53;
+
+        // borrower deposits three NFTs into the subset pool
+        changePrank(_borrower2);
+        _collateral.setApprovalForAll(address(_subsetPool), true);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(_borrower2, address(_subsetPool), 53);
+        vm.expectEmit(true, true, false, true);
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
+
+        // check token balances after add
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(1));
+        assertEq(_collateral.balanceOf(_borrower),            52);
+        assertEq(_collateral.balanceOf(_borrower2),           52);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 1);
+
+        (, , col, ) = _subsetPool.borrowerInfo(_borrower);
+        assertEq(col.length,  1);
+        (, , col, ) = _subsetPool.borrowerInfo(_borrower2);
+        assertEq(col.length,  0);
     }
 
     function testPullCollateral() external {
         // check initial token balances
-        assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_subsetPool.pledgedCollateral(),             0);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
         uint256[] memory tokenIdsToAdd = new uint256[](3);
@@ -109,18 +146,18 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 1);
+        emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 3);
+        emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 5);
+        emit Transfer(_borrower, address(_subsetPool), 5);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(address(_borrower), tokenIdsToAdd);
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // check token balances after add
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
         uint256[] memory tokenIdsToRemove = new uint256[](2);
@@ -129,16 +166,16 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // borrower removes some of their deposted NFTS from the pool
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 3);
+        emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 5);
+        emit Transfer(address(_subsetPool), _borrower, 5);
         vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(address(_borrower), tokenIdsToRemove);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
 
         // check token balances after remove
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(1));
-        assertEq(_collateral.balanceOf(address(_borrower)), 51);
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(1));
+        assertEq(_collateral.balanceOf(_borrower),            51);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 1);
     }
 
@@ -150,7 +187,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[2] = 5;
 
         changePrank(_borrower);
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // should revert if borrower attempts to remove collateral not in pool
         uint256[] memory tokenIdsToRemove = new uint256[](1);
@@ -165,13 +202,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         tokenIdsToRemove[2] = 5;
 
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 1);
+        emit Transfer(address(_subsetPool), _borrower, 1);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 3);
+        emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 5);
+        emit Transfer(address(_subsetPool), _borrower, 5);
         vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(address(_borrower), tokenIdsToRemove);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
     }
 
@@ -183,12 +220,12 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
 
         // check initial token balances
-        assertEq(_subsetPool.pledgedCollateral(), 0);
-        assertEq(_collateral.balanceOf(address(_borrower)), 52);
+        assertEq(_subsetPool.pledgedCollateral(),             0);
+        assertEq(_collateral.balanceOf(_borrower),            52);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   30_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), 0);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 30_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            0);
 
         // check pool state
         assertEq(_subsetPool.htp(), 0);
@@ -205,28 +242,28 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 1);
+        emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 3);
+        emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 5);
+        emit Transfer(_borrower, address(_subsetPool), 5);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(address(_borrower), tokenIdsToAdd);
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // TODO: determine how to handle checking both token types of Transfer
-        // emit Transfer(address(_borrower), address(_subsetPool), 5);
+        // emit Transfer(_borrower, address(_subsetPool), 5);
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), 3_000 * 1e18);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), 3_000 * 1e18);
         _subsetPool.borrow(3_000 * 1e18, 2551, address(0), address(0));
 
         // check token balances after borrow
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
-        assertEq(_collateral.balanceOf(address(_borrower)), 49);
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(3));
+        assertEq(_collateral.balanceOf(_borrower),            49);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   27_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), 3_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
 
         // check pool state
         assertEq(_subsetPool.htp(), 1000.961538461538462000 * 1e18);
@@ -242,20 +279,20 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // borrower removes some of their deposted NFTS from the pool
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 3);
+        emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_borrower), 5);
+        emit Transfer(address(_subsetPool), _borrower, 5);
         vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(address(_borrower), tokenIdsToRemove);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
 
         // check token balances after remove
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(1));
-        assertEq(_collateral.balanceOf(address(_borrower)), 51);
+        assertEq(_subsetPool.pledgedCollateral(),             Maths.wad(1));
+        assertEq(_collateral.balanceOf(_borrower),            51);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 1);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)),   27_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_borrower)), 3_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
 
         // check pool state
         assertEq(_subsetPool.htp(), 3002.884615384615386000 * 1e18);
@@ -281,21 +318,21 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 1);
+        emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 3);
+        emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_borrower), address(_subsetPool), 5);
+        emit Transfer(_borrower, address(_subsetPool), 5);
         vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(address(_borrower), tokenIdsToAdd);
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
 
         // check collateralization after pledge
         assertEq(_subsetPool.encumberedCollateral(_subsetPool.borrowerDebt(), _subsetPool.lup()), 0);
 
         // borrower borrows some quote
         vm.expectEmit(true, true, false, true);
-        emit Borrow(address(_borrower), _subsetPool.indexToPrice(2550), 9_000 * 1e18);
+        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), 9_000 * 1e18);
         _subsetPool.borrow(9_000 * 1e18, 2551, address(0), address(0));
 
         // check collateralization after borrow
@@ -308,8 +345,6 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         vm.expectRevert("S:PC:NOT_ENOUGH_COLLATERAL");
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
-
-
     }
 
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -39,9 +39,9 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        _collateral.mint(address(_borrower),  52);
-        _collateral.mint(address(_borrower2), 10);
-        _collateral.mint(address(_bidder), 13);
+        _collateral.mint(_borrower,  52);
+        _collateral.mint(_borrower2, 10);
+        _collateral.mint(_bidder, 13);
 
         deal(address(_quote), _lender, 200_000 * 1e18);
         deal(address(_quote), _lender2, 200_000 * 1e18);
@@ -121,11 +121,11 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         assertEq(lpb,        0);
 
         // check pool state
-        assertEq(_collateral.balanceOf(address(_bidder)),       13);
-        assertEq(_collateral.balanceOf(address(_lender)),       0);
-        assertEq(_collateral.balanceOf(address(_subsetPool)),   0);
-        assertEq(_quote.balanceOf(address(_subsetPool)),        0);
-        assertEq(_quote.balanceOf(address(_bidder)),            0);
+        assertEq(_collateral.balanceOf(_bidder),              13);
+        assertEq(_collateral.balanceOf(_lender),              0);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
+        assertEq(_quote.balanceOf(address(_subsetPool)),      0);
+        assertEq(_quote.balanceOf(_bidder),                   0);
 
         // lender adds initial quote to pool
         changePrank(_lender);
@@ -144,32 +144,32 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[1] = 70;
         tokenIdsToAdd[2] = 73;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_bidder), address(_subsetPool), tokenIdsToAdd[0]);
+        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateralNFT(address(_bidder), priceAtTestIndex, tokenIdsToAdd);
+        emit AddCollateralNFT(_bidder, priceAtTestIndex, tokenIdsToAdd);
         uint256 lpBalanceChange = _subsetPool.addCollateral(tokenIdsToAdd, testIndex);
 
         // check bucket state
         (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18);
         assertEq(collateral, Maths.wad(3));
-        (uint256 lpBalance, ) = _subsetPool.bucketLenders(testIndex, address(_bidder));
+        (uint256 lpBalance, ) = _subsetPool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, lpBalanceChange);
 
         // check pool state
-        assertEq(_collateral.balanceOf(address(_bidder)),       10);
-        assertEq(_collateral.balanceOf(address(_lender)),       0);
-        assertEq(_collateral.balanceOf(address(_subsetPool)),   3);
-        assertEq(_quote.balanceOf(address(_subsetPool)),        10_000 * 1e18);
-        assertEq(_quote.balanceOf(address(_bidder)),            0);
+        assertEq(_collateral.balanceOf(_bidder),              10);
+        assertEq(_collateral.balanceOf(_lender),              0);
+        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_quote.balanceOf(address(_subsetPool)),      10_000 * 1e18);
+        assertEq(_quote.balanceOf(_bidder),                   0);
 
         // bidder removes quote token from bucket
         uint256 qtToRemove = Maths.wmul(priceAtTestIndex, 3 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_bidder), priceAtTestIndex, qtToRemove, _subsetPool.lup());
+        emit RemoveQuoteToken(_bidder, priceAtTestIndex, qtToRemove, _subsetPool.lup());
         _subsetPool.removeAllQuoteToken(testIndex);
-        assertEq(_quote.balanceOf(address(_bidder)), qtToRemove);
-        (lpBalance, ) = _subsetPool.bucketLenders(testIndex, address(_bidder));
+        assertEq(_quote.balanceOf(_bidder), qtToRemove);
+        (lpBalance, ) = _subsetPool.bucketLenders(testIndex, _bidder);
         assertEq(lpBalance, 0);
         (quote, collateral, , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18 - qtToRemove);
@@ -180,13 +180,13 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         uint256[] memory tokenIdsToRemove = new uint256[](2);
         tokenIdsToRemove = tokenIdsToAdd;
         vm.expectEmit(true, true, false, true);
-        emit RemoveCollateralNFT(address(_lender), priceAtTestIndex, tokenIdsToRemove);
+        emit RemoveCollateralNFT(_lender, priceAtTestIndex, tokenIdsToRemove);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_lender), tokenIdsToRemove[0]);
+        emit Transfer(address(_subsetPool), _lender, tokenIdsToRemove[0]);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_lender), tokenIdsToRemove[1]);
+        emit Transfer(address(_subsetPool), _lender, tokenIdsToRemove[1]);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_subsetPool), address(_lender), tokenIdsToRemove[2]);
+        emit Transfer(address(_subsetPool), _lender, tokenIdsToRemove[2]);
         _subsetPool.removeCollateral(tokenIdsToRemove, testIndex);
         (quote, collateral, , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      967.323933406355326465 * 1e18);
@@ -194,7 +194,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
 
         // lender removes remaining quote token to empty the bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_lender), priceAtTestIndex, quote, _subsetPool.lup());
+        emit RemoveQuoteToken(_lender, priceAtTestIndex, quote, _subsetPool.lup());
         _subsetPool.removeAllQuoteToken(testIndex);
         (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      0);
@@ -228,7 +228,7 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
         tokenIdsToAdd[3] = 51;
-        _subsetPool.pledgeCollateral(tokenIdsToAdd, address(0), address(0));
+        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
         _subsetPool.borrow(24_000 * 1e18, 2351, address(0), address(0));
         assertEq(_subsetPool.lup(), _subsetPool.indexToPrice(2351));
         skip(86400);
@@ -250,15 +250,15 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         assertGt(_quote.balanceOf(address(_subsetPool)), amountToPurchase);
         uint256 amountWithInterest = 24_001.511204352939432000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(address(_bidder), address(_subsetPool), tokenIdsToAdd[0]);
+        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateralNFT(address(_bidder), _subsetPool.indexToPrice(2350), tokenIdsToAdd);        
+        emit AddCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToAdd);        
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(address(_bidder), _subsetPool.indexToPrice(2350), amountWithInterest, _subsetPool.indexToPrice(2352));
+        emit RemoveQuoteToken(_bidder, _subsetPool.indexToPrice(2350), amountWithInterest, _subsetPool.indexToPrice(2352));
         _subsetPool.removeAllQuoteToken(2350);
-        assertEq(_quote.balanceOf(address(_bidder)), amountWithInterest);
+        assertEq(_quote.balanceOf(_bidder), amountWithInterest);
 
         // check bucket state
         (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
@@ -270,9 +270,9 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 65;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateralNFT(address(_bidder), _subsetPool.indexToPrice(2350), tokenIdsToRemove);
+        emit RemoveCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (uint256 amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        (uint256 lpBalance, ) = _subsetPool.bucketLenders(2350, address(_bidder));
+        (uint256 lpBalance, ) = _subsetPool.bucketLenders(2350, _bidder);
         assertEq(lpBalance, 490.713717393968418590429863923 * 1e27);
         skip(7200);
 
@@ -296,9 +296,9 @@ contract ERC721ScaledBorrowTest is ERC721DSTestPlus {
         tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 73;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateralNFT(address(_lender), _subsetPool.indexToPrice(2350), tokenIdsToRemove);
+        emit RemoveCollateralNFT(_lender, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        (lpBalance, ) = _subsetPool.bucketLenders(2350, address(_lender));
+        (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
         assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
         skip(3600);
 

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -28,11 +28,11 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(collateral_, quote_);
 
         ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
-        pool.initialize(interestRate_);
         pool_ = address(pool);
-
         deployedPools[ERC721_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
+
+        pool.initialize(interestRate_);
     }
 
     function deploySubsetPool(
@@ -41,11 +41,11 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(collateral_, quote_, tokenIds_);
 
         ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
-        pool.initializeSubset(tokenIds_, interestRate_);
         pool_ = address(pool);
-
         deployedPools[getNFTSubsetHash(tokenIds_)][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
+
+        pool.initializeSubset(tokenIds_, interestRate_);
     }
 
     /*********************************/

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -92,11 +92,12 @@ interface IERC721Pool is IScaledPool {
 
     /**
      *  @notice Emitted when borrower locks collateral in the pool.
+     *  @param  borrower_ The address of borrower to pledge collateral for.
      *  @param  tokenIds_ Array of tokenIds to be added to the pool.
-     *  @param  oldPrev_ Previous borrower that came before placed loan (old)
-     *  @param  newPrev_ Previous borrower that now comes before placed loan (new)
+     *  @param  oldPrev_  Previous borrower that came before placed loan (old)
+     *  @param  newPrev_  Previous borrower that now comes before placed loan (new)
      */
-    function pledgeCollateral(uint256[] calldata tokenIds_, address oldPrev_, address newPrev_) external;
+    function pledgeCollateral(address borrower_, uint256[] calldata tokenIds_, address oldPrev_, address newPrev_) external;
 
     /**
      *  @notice Called by a borrower to open or expand a position.
@@ -118,11 +119,12 @@ interface IERC721Pool is IScaledPool {
 
     /**
      *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
+     *  @param  borrower_  The address of borrower to repay quote token amount for.
      *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
      *  @param  oldPrev_   Previous borrower that came before placed loan (old)
      *  @param  newPrev_   Previous borrower that now comes before placed loan (new)
      */
-    function repay(uint256 maxAmount_, address oldPrev_, address newPrev_) external;
+    function repay(address borrower_, uint256 maxAmount_, address oldPrev_, address newPrev_) external;
 
     /*********************************/
     /*** Lender External Functions ***/


### PR DESCRIPTION
- rebase with `test-utils`
- `ERC721DSTestPlus._pledgeCollateral` to accept pledger as param + some style updates
- fixed `testPledgeCollateralInSubsetFromDifferentActor` test by `_mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 53);` 