### PR TITLE
Erc20 test cleanup

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.14;
 
-import { ERC20 }  from "@solmate/tokens/ERC20.sol";
-import { DSTestPlus }                             from "../utils/DSTestPlus.sol";
+import { ERC20 }      from "@solmate/tokens/ERC20.sol";
+
+import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
+import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
+
+import { DSTestPlus } from "../utils/DSTestPlus.sol";
+import { Token }      from "../utils/Tokens.sol";
 
 abstract contract ERC20DSTestPlus is DSTestPlus {
 
@@ -20,4 +25,38 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         assertEq(address(erc1_), address(erc2_));
     }
 
+}
+
+abstract contract ERC20HelperContract is ERC20DSTestPlus {
+
+    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+
+    Token     internal _collateral;
+    Token     internal _quote;
+    ERC20Pool internal _pool;
+
+    constructor() {
+        _collateral = new Token("Collateral", "C");
+        _quote      = new Token("Quote", "Q");
+        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
+    }
+
+    function _mintQuoteAndApproveTokens(address operator_, uint256 mintAmount_) internal {
+        deal(address(_quote), operator_, mintAmount_);
+
+        vm.prank(operator_);
+        _quote.approve(address(_pool), type(uint256).max);
+        vm.prank(operator_);
+        _collateral.approve(address(_pool), type(uint256).max);
+    }
+
+    function _mintCollateralAndApproveTokens(address operator_, uint256 mintAmount_) internal {
+        deal(address(_collateral), operator_, mintAmount_);
+
+        vm.prank(operator_);
+        _collateral.approve(address(_pool), type(uint256).max);
+        vm.prank(operator_);
+        _quote.approve(address(_pool), type(uint256).max);
+
+    }
 }

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -27,6 +27,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
 
 }
 
+// TODO: merge this contract with parent ERC20DSTestPlus
 abstract contract ERC20HelperContract is ERC20DSTestPlus {
 
     uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -6,51 +6,26 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledBorrowTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
         _lender1   = makeAddr("lender1");
 
-        deal(address(_collateral), _borrower,  100 * 1e18);
-        deal(address(_collateral), _borrower2, 100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  100 * 1e18);
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _lender1, 200_000 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.approve(address(_pool), 200 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender1);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
     }
 
     function testScaledPoolBorrowAndRepay() external {

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -7,51 +7,26 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledCollateralTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
     address internal _bidder;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
         _bidder    = makeAddr("bidder");
 
-        deal(address(_collateral), _borrower,  150 * 1e18);
-        deal(address(_collateral), _borrower2, 100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  150 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  100 * 1e18);
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _bidder, 200_000 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.approve(address(_pool), 200 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_bidder);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_bidder,  200_000 * 1e18);
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20ScaledPoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolFactory.t.sol
@@ -4,17 +4,12 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
-import { DSTestPlus }                  from "../utils/DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledPoolFactoryTest is DSTestPlus {
-    CollateralToken  internal _collateral;
-    QuoteToken       internal _quote;
+contract ERC20ScaledPoolFactoryTest is ERC20HelperContract {
     ERC20PoolFactory internal _poolFactory;
 
     function setUp() external {
-        _collateral  = new CollateralToken();
-        _quote       = new QuoteToken();
         _poolFactory = new ERC20PoolFactory();
     }
 
@@ -53,10 +48,10 @@ contract ERC20ScaledPoolFactoryTest is DSTestPlus {
         skip(333);
 
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(address(0xaB62aBC832769E80D24a26216D5E828762d8c13A));
+        emit PoolCreated(address(0x9FE92fe72Ae1Bc5f008C3f405606717d43Fc468D));
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(address(_collateral), address(_quote), 0.0543 * 10**18));
 
-        assertEq(address(pool),                     address(0xaB62aBC832769E80D24a26216D5E828762d8c13A));
+        assertEq(address(pool),                     address(0x9FE92fe72Ae1Bc5f008C3f405606717d43Fc468D));
         assertEq(address(pool.collateral()),        address(_collateral));
         assertEq(pool.collateralScale(),            1);
         assertEq(address(pool.quoteToken()),        address(_quote));

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRate.t.sol
@@ -6,51 +6,26 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledInterestRateTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledInterestRateTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral  = new CollateralToken();
-        _quote       = new QuoteToken();
-        _pool        = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
         _lender1   = makeAddr("_lender1");
 
-        deal(address(_collateral), _borrower,  10_000 * 1e18);
-        deal(address(_collateral), _borrower2, 200 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  10_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2, 200 * 1e18);
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _lender1, 200_000 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 10_000 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.approve(address(_pool), 10_000 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender1);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
     }
 
     function testScaledPoolInterestRateIncreaseDecrease() external {

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -78,7 +78,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2549);
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2550);
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(_lender, _pool.indexToPrice(2551), 50_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 2551, 50_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_lender, address(_pool), 50_000 * _quotePrecision);
         _pool.addQuoteToken(50_000 * _quotePoolPrecision, 2551);
@@ -103,7 +103,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // lender removes some quote token from highest priced bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, _pool.indexToPrice(2549), 25_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, 2549, 25_000 * _quotePoolPrecision, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), _lender, 25_000 * _quotePrecision);
         _pool.removeQuoteToken(25_000 * _quotePoolPrecision, 2549);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -61,7 +61,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
 
         // bidder uses their LP to purchase all quote token in the bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, priceAtTestIndex, 10_000 * 1e18, _pool.lup());
+        emit RemoveQuoteToken(_bidder, testIndex, 10_000 * 1e18, _pool.lup());
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), _bidder, 10_000 * 1e18);
         _pool.removeQuoteToken(10_000 * 1e18, testIndex);
@@ -154,7 +154,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
         assertEq(collateralToPurchaseWith, 3.388032491631335842 * 1e18);
         _pool.addCollateral(collateralToPurchaseWith, 2550);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, p2550, amountWithInterest, _pool.indexToPrice(2552));
+        emit RemoveQuoteToken(_bidder, 2550, amountWithInterest, _pool.indexToPrice(2552));
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), _bidder, amountWithInterest);
         _pool.removeAllQuoteToken(2550);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -7,52 +7,26 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledPurchaseQuoteTokenTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _bidder;
     address internal _lender;
     address internal _lender1;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower = makeAddr("borrower");
         _bidder   = makeAddr("bidder");
         _lender   = makeAddr("lender");
         _lender1  = makeAddr("lender1");
 
-        deal(address(_collateral), _borrower,  100 * 1e18);
-        deal(address(_collateral), _bidder, 100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,   100 * 1e18);
+        _mintCollateralAndApproveTokens(_bidder,     100 * 1e18);
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _lender1, 200_000 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_bidder);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender1);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-        _collateral.approve(address(_pool), 100 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQueue.t.sol
@@ -7,12 +7,9 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledQueueTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledQueueTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
@@ -22,15 +19,7 @@ contract ERC20ScaledQueueTest is ERC20DSTestPlus {
     address internal _borrower6;
     address internal _lender;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");
@@ -39,40 +28,18 @@ contract ERC20ScaledQueueTest is ERC20DSTestPlus {
         _borrower6 = makeAddr("borrower6");
         _lender    = makeAddr("lender");
 
-        deal(address(_collateral), _borrower,  100 * 1e18);
-        deal(address(_collateral), _borrower2, 100 * 1e18);
-        deal(address(_collateral), _borrower3, 100 * 1e18);
-        deal(address(_collateral), _borrower4, 100 * 1e18);
-        deal(address(_collateral), _borrower5, 100 * 1e18);
-        deal(address(_collateral), _borrower6, 100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,   100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower3,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower4,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower5,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower6,  100 * 1e18);
 
-        deal(address(_quote), _lender,    300_000 * 1e18);
-        deal(address(_quote), _borrower,  100 * 1e18);
-        deal(address(_quote), _borrower3, 100 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 300_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.approve(address(_pool), 100 * 1e18);
-
-        changePrank(_borrower3);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 300_000 * 1e18);
-
-        changePrank(_borrower4);
-        _collateral.approve(address(_pool), 100 * 1e18);
-
-        changePrank(_borrower5);
-        _collateral.approve(address(_pool), 100 * 1e18);
-
-        changePrank(_borrower6);
-        _collateral.approve(address(_pool), 100 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,    300_000 * 1e18);
+        _mintQuoteAndApproveTokens(_borrower,  100 * 1e18);
+        _mintQuoteAndApproveTokens(_borrower3, 100 * 1e18);
 
         changePrank(_lender);
-        _quote.approve(address(_pool), 300_000 * 1e18);
-
         _pool.addQuoteToken(50_000 * 1e18, 2549);
         _pool.addQuoteToken(50_000 * 1e18, 2550);
         _pool.addQuoteToken(50_000 * 1e18, 2551);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -8,7 +8,6 @@ import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
 import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
-import { Token }           from "../utils/Tokens.sol";
 
 contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
 
@@ -24,7 +23,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         _lender1   = makeAddr("bidder");
 
         _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
-        _mintCollateralAndApproveTokens(_borrower,  200 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  200 * 1e18);
 
         _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
         _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -7,51 +7,27 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
+import { Token }           from "../utils/Tokens.sol";
 
-contract ERC20ScaledQuoteTokenTest is ERC20DSTestPlus {
-
-    uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
+contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
         _lender1   = makeAddr("bidder");
 
-        deal(address(_collateral), _borrower,  100 * 1e18);
-        deal(address(_collateral), _borrower2, 200 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  200 * 1e18);
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _lender1, 200_000 * 1e18);
-
-        vm.startPrank(_borrower);
-        _collateral.approve(address(_pool), 100 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_borrower2);
-        _collateral.approve(address(_pool), 200 * 1e18);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-
-        changePrank(_lender1);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -40,7 +40,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         // test 10_000 DAI deposit at price of 1 MKR = 3_010.892022197881557845 DAI
         changePrank(_lender);
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(_lender, _p3010, 10_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 2550, 10_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_lender, address(_pool), 10_000 * 1e18);
         _pool.addQuoteToken(10_000 * 1e18, 2550);
@@ -65,7 +65,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
 
         // test 20_000 DAI deposit at price of 1 MKR = 2_995.912459898389633881 DAI
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(_lender, 2_995.912459898389633881 * 1e18, 20_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 2551, 20_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_lender, address(_pool), 20_000 * 1e18);
         _pool.addQuoteToken(20_000 * 1e18, 2551);
@@ -88,7 +88,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
 
         // test 40_000 DAI deposit at price of 1 MKR = 3_025.946482308870940904 DAI
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 40_000 * 1e18, BucketMath.MAX_PRICE);
+        emit AddQuoteToken(_lender, 2549, 40_000 * 1e18, BucketMath.MAX_PRICE);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_lender, address(_pool), 40_000 * 1e18);
         _pool.addQuoteToken(40_000 * 1e18, 2549);
@@ -126,7 +126,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_lender),        130_000 * 1e18);
 
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 5_000 * 1e18, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, 2549, 5_000 * 1e18, BucketMath.MAX_PRICE);
         uint256 lpRedeemed = _pool.removeQuoteToken(5_000 * 1e18, 2549);
         assertEq(lpRedeemed, 5_000 * 1e27);
 
@@ -137,7 +137,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_lender), 135_000 * 1e18);
 
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, 3_025.946482308870940904 * 1e18, 35_000 * 1e18, BucketMath.MAX_PRICE);
+        emit RemoveQuoteToken(_lender, 2549, 35_000 * 1e18, BucketMath.MAX_PRICE);
         uint256 removed;
         (removed, lpRedeemed) = _pool.removeAllQuoteToken(2549);
         assertEq(removed, 35_000 * 1e18);
@@ -212,7 +212,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         _pool.removeQuoteToken(15_000 * 1e18, 4550);
 
         // should be able to removeQuoteToken if quote tokens haven't been encumbered by a borrower
-        emit RemoveQuoteToken(_lender, _pool.indexToPrice(4990), 10_000 * 1e18, _pool.indexToPrice(4551));
+        emit RemoveQuoteToken(_lender, 4990, 10_000 * 1e18, _pool.indexToPrice(4551));
         _pool.removeQuoteToken(10_000 * 1e18, 4990);
     }
 
@@ -252,7 +252,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         assertLt(penalty, Maths.WAD);
         uint256 expectedWithdrawal1 = Maths.wmul(1_700 * 1e18, penalty);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, _pool.indexToPrice(1606), expectedWithdrawal1, _pool.indexToPrice(1663));
+        emit RemoveQuoteToken(_lender, 1606, expectedWithdrawal1, _pool.indexToPrice(1663));
         uint lpRedeemed = _pool.removeQuoteToken(1_700 * 1e18, 1606);
         assertEq(lpRedeemed, 1_699.988430646832348876473462074 * 1e27);
 
@@ -261,7 +261,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
         assertGt(_pool.indexToPrice(1606), _pool.htp());
         uint256 expectedWithdrawal2 = 1_700.146556206967894132 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, _pool.indexToPrice(1606), expectedWithdrawal2, _pool.indexToPrice(1663));
+        emit RemoveQuoteToken(_lender, 1606, expectedWithdrawal2, _pool.indexToPrice(1663));
         uint256 removed;
         (removed, lpRedeemed) = _pool.removeAllQuoteToken(1606);
         assertEq(removed, expectedWithdrawal2);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
@@ -6,38 +6,22 @@ import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
-import { ERC20DSTestPlus }             from "./ERC20DSTestPlus.sol";
-import { CollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
-contract ERC20ScaledPoolTransferLPTokensTest is ERC20DSTestPlus {
+contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
 
     address internal _lender;
     address internal _lender1;
     address internal _lender2;
 
-    CollateralToken internal _collateral;
-    QuoteToken      internal _quote;
-    ERC20Pool       internal _pool;
-
     function setUp() external {
-        _collateral = new CollateralToken();
-        _quote      = new QuoteToken();
-        _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
-
         _lender  = makeAddr("lender");
         _lender1 = makeAddr("lender1");
         _lender2 = makeAddr("lender2");
 
-        deal(address(_quote), _lender,  200_000 * 1e18);
-        deal(address(_quote), _lender1, 200_000 * 1e18);
-        deal(address(_quote), _lender2, 200_000 * 1e18);
-
-        vm.startPrank(_lender);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-        changePrank(_lender1);
-        _quote.approve(address(_pool), 200_000 * 1e18);
-        changePrank(_lender2);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender,  200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1, 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender2, 200_000 * 1e18);
     }
 
     /********************************/

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.14;
 import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
-import { DSTestPlus }                     from "../utils/DSTestPlus.sol";
-import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { DSTestPlus }                from "../utils/DSTestPlus.sol";
+import { NFTCollateralToken, Token } from "../utils/Tokens.sol";
 
 abstract contract ERC721DSTestPlus is DSTestPlus {
 
@@ -26,14 +26,14 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
 
     NFTCollateralToken internal _collateral;
-    QuoteToken         internal _quote;
+    Token              internal _quote;
     ERC721Pool         internal _collectionPool;
     ERC721Pool         internal _subsetPool;
 
     // TODO: bool for pool type
     constructor() {
         _collateral = new NFTCollateralToken();
-        _quote      = new QuoteToken();
+        _quote      = new Token("Quote", "Q");
     }
 
     function _deployCollectionPool() internal returns (ERC721Pool) {

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -7,8 +7,7 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
-import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
 
 contract ERC721ScaledBorrowTest is ERC721HelperContract {
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -7,8 +7,7 @@ import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
-import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
-import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
 
 // TODO: pass different pool type to enable collection + subset test simplification
 contract ERC721ScaledCollateralTest is ERC721HelperContract {

--- a/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
@@ -5,7 +5,7 @@ import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
 import { DSTestPlus }                     from "../utils/DSTestPlus.sol";
-import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
+import { NFTCollateralToken, Token } from "../utils/Tokens.sol";
 
 contract ERC721ScaledPoolFactoryTest is DSTestPlus {
     address            internal _NFTCollectionPoolAddress;
@@ -16,13 +16,13 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
     ERC721Pool         internal _NFTSubsetTwoPool;
     ERC721PoolFactory  internal _factory;
     NFTCollateralToken internal _collateral;
-    QuoteToken         internal _quote;
+    Token              internal _quote;
     uint256[]          internal _tokenIdsSubsetOne;
     uint256[]          internal _tokenIdsSubsetTwo;
 
     function setUp() external {
         _collateral  = new NFTCollateralToken();
-        _quote       = new QuoteToken();
+        _quote       = new Token("Quote", "Q");
 
         // deploy factory
         _factory = new ERC721PoolFactory();

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -108,7 +108,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // bidder removes quote token from bucket
         uint256 qtToRemove = Maths.wmul(priceAtTestIndex, 3 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, priceAtTestIndex, qtToRemove, _subsetPool.lup());
+        emit RemoveQuoteToken(_bidder, testIndex, qtToRemove, _subsetPool.lup());
         _subsetPool.removeAllQuoteToken(testIndex);
         assertEq(_quote.balanceOf(_bidder), qtToRemove);
         (lpBalance, ) = _subsetPool.bucketLenders(testIndex, _bidder);
@@ -136,7 +136,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // lender removes remaining quote token to empty the bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, priceAtTestIndex, quote, _subsetPool.lup());
+        emit RemoveQuoteToken(_lender, testIndex, quote, _subsetPool.lup());
         _subsetPool.removeAllQuoteToken(testIndex);
         (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      0);
@@ -198,7 +198,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, _subsetPool.indexToPrice(2350), amountWithInterest, _subsetPool.indexToPrice(2352));
+        emit RemoveQuoteToken(_bidder, 2350, amountWithInterest, _subsetPool.indexToPrice(2352));
         _subsetPool.removeAllQuoteToken(2350);
         assertEq(_quote.balanceOf(_bidder), amountWithInterest);
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -8,7 +8,6 @@ import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
 import { ERC721HelperContract }           from "./ERC721DSTestPlus.sol";
-import { NFTCollateralToken, QuoteToken } from "../utils/Tokens.sol";
 
 contract ERC721ScaledBorrowTest is ERC721HelperContract {
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { CollateralToken, NFTCollateralToken, QuoteToken } from "./utils/Tokens.sol";
+import { Token } from "./utils/Tokens.sol";
 import { DSTestPlus }                                      from "./utils/DSTestPlus.sol";
 
 import { Maths } from "../libraries/Maths.sol";
@@ -13,16 +13,17 @@ import { PositionManager } from "../base/PositionManager.sol";
 
 import { IPositionManager } from "../base/interfaces/IPositionManager.sol";
 
+// TODO: test this against ERC721Pool
 abstract contract PositionManagerHelperContract is DSTestPlus {
-    CollateralToken  internal _collateral;
     ERC20Pool        internal _pool;
     ERC20PoolFactory internal _factory;
     PositionManager  internal _positionManager;
-    QuoteToken       internal _quote;
+    Token            internal _collateral;
+    Token            internal _quote;
 
     constructor() {
-        _collateral      = new CollateralToken();
-        _quote           = new QuoteToken();
+        _collateral      = new Token("Collateral", "C");
+        _quote           = new Token("Quote", "Q");
         _factory         = new ERC20PoolFactory();
         _positionManager = new PositionManager();
         _pool            = ERC20Pool(_factory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18));

--- a/src/_test/utils/Tokens.sol
+++ b/src/_test/utils/Tokens.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.14;
 import { ERC20 }  from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
+// TODO: remove this after replacing with Token
 contract CollateralToken is ERC20 {
 
     constructor() ERC20("Collateral", "C") {}
@@ -14,6 +15,7 @@ contract CollateralToken is ERC20 {
 
 }
 
+// TODO: remove this after replacing with Token
 contract QuoteToken is ERC20 {
 
     constructor() ERC20("Quote", "Q") {}
@@ -22,6 +24,15 @@ contract QuoteToken is ERC20 {
         _mint(to_, amount_);
     }
 
+}
+
+contract Token is ERC20 {
+
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to_, uint256 amount_) public {
+        _mint(to_, amount_);
+    }
 }
 
 contract NFTCollateralToken is ERC721 {

--- a/src/_test/utils/Tokens.sol
+++ b/src/_test/utils/Tokens.sol
@@ -4,28 +4,6 @@ pragma solidity 0.8.14;
 import { ERC20 }  from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
-// TODO: remove this after replacing with Token
-contract CollateralToken is ERC20 {
-
-    constructor() ERC20("Collateral", "C") {}
-
-    function mint(address to_, uint256 amount_) public {
-        _mint(to_, amount_);
-    }
-
-}
-
-// TODO: remove this after replacing with Token
-contract QuoteToken is ERC20 {
-
-    constructor() ERC20("Quote", "Q") {}
-
-    function mint(address to_, uint256 amount_) public {
-        _mint(to_, amount_);
-    }
-
-}
-
 contract Token is ERC20 {
 
     constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -95,7 +95,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         _updateInterestRateAndEMAs(curDebt, newLup);
 
         // move quote token amount from lender to pool
-        emit AddQuoteToken(msg.sender, _indexToPrice(index_), amount_, newLup);
+        emit AddQuoteToken(msg.sender, index_, amount_, newLup);
         quoteToken().safeTransferFrom(msg.sender, address(this), amount_ / quoteTokenScale);
     }
 
@@ -298,7 +298,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         _updateInterestRateAndEMAs(debt, newLup);
 
         // move quote token amount from pool to lender
-        emit RemoveQuoteToken(msg.sender, _indexToPrice(index_), amount, newLup);
+        emit RemoveQuoteToken(msg.sender, index_, amount, newLup);
         quoteToken().safeTransfer(msg.sender, amount / quoteTokenScale);
     }
 


### PR DESCRIPTION
- Emit index instead of price in `addQuoteToken`, and `removeQuoteToken` to save on gas costs via avoiding additional `indexToPrice` conversion
- Create `ERC20HelperContract` test utility class to simplify ERC20 test setup
- Replace `QuoteToken` and `CollateralToken` with a single `Token` contract that takes names as constructor args