### PR TITLE
Move collateral between buckets

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -282,13 +282,13 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
         assertEq(lpb, 1212.5476695591403933005 * 1e27);
         (, collateral, lpb, ) = _pool.bucketAt(3334);
         assertEq(collateral, 1.3 * 1e18);
-        assertEq(lpb, 78.4234811157652997051 * 1e27);
+        assertEq(lpb, 78.423481115765299705 * 1e27);
 
         // check actor LP
         (uint256 lpBalance, ) = _pool.bucketLenders(3333, address(_lender));
         assertEq(lpBalance, 1212.5476695591403933005 * 1e27);
         (lpBalance, ) = _pool.bucketLenders(3334, address(_lender));
-//        assertEq(lpBalance, 0);  // FIXME: 100000000 dust
+        assertEq(lpBalance, 0);
     }
 
     function testPledgeCollateralFromDifferentActor() external {

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -279,14 +279,14 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
         // check buckets
         (, uint256 collateral, uint256 lpb, ) = _pool.bucketAt(3333);
         assertEq(collateral, 20 * 1e18);
-        assertEq(lpb, 1212.5476695591403933005 * 1e27);
+        assertEq(lpb, 1212.547669559140393301 * 1e27);
         (, collateral, lpb, ) = _pool.bucketAt(3334);
         assertEq(collateral, 1.3 * 1e18);
         assertEq(lpb, 78.423481115765299705 * 1e27);
 
         // check actor LP
         (uint256 lpBalance, ) = _pool.bucketLenders(3333, address(_lender));
-        assertEq(lpBalance, 1212.5476695591403933005 * 1e27);
+        assertEq(lpBalance, 1212.547669559140393301 * 1e27);
         (lpBalance, ) = _pool.bucketLenders(3334, address(_lender));
         assertEq(lpBalance, 0);
     }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -261,7 +261,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
         skip(2 hours);
 
         // should revert if bucket doesn't have enough collateral to move
-        vm.expectRevert("S:MC:INSUF_C");
+        vm.expectRevert("S:MC:INSUF_COL");
         _pool.moveCollateral(5 * 1e18, 3334, 3333);
 
         // should revert if actor doesn't have enough LP to move specified amount

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -251,6 +251,46 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
         _pool.removeCollateral(0.32 * 1e18, testIndex);
     }
 
+    function testMoveCollateral() external {
+        // actor deposits collateral into two buckets
+        changePrank(_lender);
+        deal(address(_collateral), _lender, 20 * 1e18);
+        _collateral.approve(address(_pool), 20 * 1e18);
+        _pool.addCollateral(16.3 * 1e18, 3333);
+        _pool.addCollateral(3.7 * 1e18, 3334);
+        skip(2 hours);
+
+        // should revert if bucket doesn't have enough collateral to move
+        vm.expectRevert("S:MC:INSUF_C");
+        _pool.moveCollateral(5 * 1e18, 3334, 3333);
+
+        // should revert if actor doesn't have enough LP to move specified amount
+        changePrank(_borrower);
+        _pool.addCollateral(1.3 * 1e18, 3334);
+        changePrank(_lender);
+        vm.expectRevert("S:MC:INSUF_LPS");
+        _pool.moveCollateral(5 * 1e18, 3334, 3333);
+
+        // actor moves all their LP into one bucket
+        vm.expectEmit(true, true, true, true);
+        emit MoveCollateral(_lender, 3334, 3333, 3.7 * 1e18);
+        _pool.moveCollateral(3.7 * 1e18, 3334, 3333);
+
+        // check buckets
+        (, uint256 collateral, uint256 lpb, ) = _pool.bucketAt(3333);
+        assertEq(collateral, 20 * 1e18);
+        assertEq(lpb, 1212.5476695591403933005 * 1e27);
+        (, collateral, lpb, ) = _pool.bucketAt(3334);
+        assertEq(collateral, 1.3 * 1e18);
+        assertEq(lpb, 78.4234811157652997051 * 1e27);
+
+        // check actor LP
+        (uint256 lpBalance, ) = _pool.bucketLenders(3333, address(_lender));
+        assertEq(lpBalance, 1212.5476695591403933005 * 1e27);
+        (lpBalance, ) = _pool.bucketLenders(3334, address(_lender));
+//        assertEq(lpBalance, 0);  // FIXME: 100000000 dust
+    }
+
     function testPledgeCollateralFromDifferentActor() external {
         // check initial pool state
         assertEq(_pool.pledgedCollateral(),   0);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -404,6 +404,10 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         (, collateral, , ) = _subsetPool.bucketAt(1447);
         assertEq(collateral, 1 * 1e18);
 
+        // check actor
+        (lpb, ) = _subsetPool.bucketLenders(1530, _borrower);
+//        assertEq(lpb, 0);   // FIXME: rounding error producing dust amount
+
         // remove the last token
         tokenIds[0] = 3;
         emit RemoveCollateralNFT(_borrower, _subsetPool.indexToPrice(1447), tokenIds);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -191,9 +191,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256 amountToPurchase = 10_100 * 1e18;
         assertGt(_quote.balanceOf(address(_subsetPool)), amountToPurchase);
         uint256 amountWithInterest = 24_001.511204352939432000 * 1e18;
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, true, true);
         emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
-        vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, true, true);
         emit AddCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToAdd);        
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -70,6 +70,7 @@ abstract contract DSTestPlus is Test {
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event Liquidate(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
+    event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
     event RemoveQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event TransferLPTokens(address owner_, address newOwner_, uint256[] prices_, uint256 lpTokens_);
     event UpdateInterestRate(uint256 oldRate_, uint256 newRate_);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -163,7 +163,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         Bucket storage fromBucket = buckets[fromIndex_];
         require(fromBucket.availableCollateral >= amount_, "S:MC:INSUF_COL");
         uint256 rate              = _exchangeRate(_valueAt(fromIndex_), fromBucket.availableCollateral, fromBucket.lpAccumulator, fromIndex_);
-        lpbAmountFrom_            = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, _indexToPrice(fromIndex_))), rate);
+        lpbAmountFrom_            = Maths.wrdivr(Maths.wmul(amount_, _indexToPrice(fromIndex_)), rate);
         require(bucketLender.lpBalance != 0 && lpbAmountFrom_ <= bucketLender.lpBalance, "S:MC:INSUF_LPS");
 
         // update "from" bucket accounting
@@ -173,7 +173,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         // update "to" bucket accounting
         Bucket storage toBucket      = buckets[toIndex_];
         rate                         = _exchangeRate(_valueAt(toIndex_), toBucket.availableCollateral, toBucket.lpAccumulator, toIndex_);
-        lpbAmountTo_                 = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, _indexToPrice(toIndex_))), rate);
+        lpbAmountTo_                 = Maths.wrdivr(Maths.wmul(amount_, _indexToPrice(toIndex_)), rate);
         toBucket.lpAccumulator       += lpbAmountTo_;
         toBucket.availableCollateral += amount_;
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -173,7 +173,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         // update "to" bucket accounting
         Bucket storage toBucket      = buckets[toIndex_];
         rate                         = _exchangeRate(_valueAt(toIndex_), toBucket.availableCollateral, toBucket.lpAccumulator, toIndex_);
-        lpbAmountTo_                 = Maths.rdiv((amount_ * _indexToPrice(toIndex_) / 1e9), rate);
+        lpbAmountTo_                 = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, _indexToPrice(toIndex_))), rate);
         toBucket.lpAccumulator       += lpbAmountTo_;
         toBucket.availableCollateral += amount_;
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -161,7 +161,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
 
         // determine amount of amount of LP required
         Bucket storage fromBucket = buckets[fromIndex_];
-        require(fromBucket.availableCollateral >= amount_, "S:MC:INSUF_C");
+        require(fromBucket.availableCollateral >= amount_, "S:MC:INSUF_COL");
         uint256 rate              = _exchangeRate(_valueAt(fromIndex_), fromBucket.availableCollateral, fromBucket.lpAccumulator, fromIndex_);
         lpbAmountFrom_            = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, _indexToPrice(fromIndex_))), rate);
         require(bucketLender.lpBalance != 0 && lpbAmountFrom_ <= bucketLender.lpBalance, "S:MC:INSUF_LPS");

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -153,8 +153,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         emit MoveQuoteToken(msg.sender, fromIndex_, toIndex_, amount, newLup);
     }
 
-    event Debug(string where, uint256 what);
-
     function moveCollateral(uint256 amount_, uint256 fromIndex_, uint256 toIndex_) external returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_) {  // TODO: override
         require(fromIndex_ != toIndex_, "S:MC:SAME_PRICE");
 
@@ -165,9 +163,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         Bucket storage fromBucket = buckets[fromIndex_];
         require(fromBucket.availableCollateral >= amount_, "S:MC:INSUF_C");
         uint256 rate              = _exchangeRate(_valueAt(fromIndex_), fromBucket.availableCollateral, fromBucket.lpAccumulator, fromIndex_);
-        lpbAmountFrom_            = Maths.rdiv((amount_ * _indexToPrice(fromIndex_) / 1e9), rate);
-        emit Debug("moveCollateral lpbAmountFrom_", lpbAmountFrom_);
-        emit Debug("moveCollateral bucketLender.lpBalance", bucketLender.lpBalance);
+        lpbAmountFrom_            = Maths.rdiv(Maths.wadToRay(Maths.wmul(amount_, _indexToPrice(fromIndex_))), rate);
         require(bucketLender.lpBalance != 0 && lpbAmountFrom_ <= bucketLender.lpBalance, "S:MC:INSUF_LPS");
 
         // update "from" bucket accounting

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -153,7 +153,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
         emit MoveQuoteToken(msg.sender, fromIndex_, toIndex_, amount, newLup);
     }
 
-    function moveCollateral(uint256 amount_, uint256 fromIndex_, uint256 toIndex_) external returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_) {  // TODO: override
+    function moveCollateral(uint256 amount_, uint256 fromIndex_, uint256 toIndex_) external override returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_) {
         require(fromIndex_ != toIndex_, "S:MC:SAME_PRICE");
 
         BucketLender storage bucketLender = bucketLenders[fromIndex_][msg.sender];

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -31,6 +31,15 @@ interface IScaledPool {
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
 
     /**
+     *  @notice Emitted when lender moves collateral from a bucket price to another.
+     *  @param  lender_ Recipient that moved collateral.
+     *  @param  from_   Price bucket from which collateral was moved.
+     *  @param  to_     Price bucket where collateral was moved.
+     *  @param  amount_ Amount of collateral moved.
+     */
+    event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
+
+    /**
      *  @notice Emitted when lender removes quote token from the pool.
      *  @param  lender_ Recipient that removed quote tokens.
      *  @param  price_  Price at which quote tokens were removed.
@@ -224,6 +233,16 @@ interface IScaledPool {
      *  @return lpbAmountTo_   The amount of LPs moved to destination bucket.
      */
     function moveQuoteToken(uint256 maxAmount_, uint256 fromIndex_, uint256 toIndex_) external returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_);
+
+    /**
+     *  @notice Called by lenders to move an amount of credit from a specified price bucket to another specified price bucket.
+     *  @param  amount_        The amount of collateral to be moved by a lender.
+     *  @param  fromIndex_     The bucket index from which collateral will be removed.
+     *  @param  toIndex_       The bucket index to which collateral will be added.
+     *  @return lpbAmountFrom_ The amount of LPs moved out from bucket.
+     *  @return lpbAmountTo_   The amount of LPs moved to destination bucket.
+     */
+    function moveCollateral(uint256 amount_, uint256 fromIndex_, uint256 toIndex_) external returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_);
 
     /**
      *  @notice Called by lenders to redeem the maximum amount of LP for quote token.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -287,9 +287,6 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         // Get current swap price
         uint256 quoteTokenReturnAmount = _getQuoteTokenReturnAmount(uint256(liquidation.kickTime), uint256(liquidation.referencePrice), collateralForLiquidation);
 
-        // Pull funds from msg.sender
-        quoteToken().safeTransferFrom(msg.sender, address(this), quoteTokenReturnAmount);
-
         _repayDebt(borrower_, quoteTokenReturnAmount, oldPrev_, newPrev_);
     }
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -277,7 +277,8 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 availableLPs = bucketLender.lpBalance;
 
         // ensure user can actually remove that much
-        lpAmount_ = Maths.rdiv((Maths.wad(tokenIds_.length) * price / 1e9), rate);
+        lpAmount_ = Maths.rdiv((Maths.wad(tokenIds_.length) * price / 1e9), rate);  // TODO: determine if there's a rounding issue here
+//        lpAmount_ = Maths.rdiv(Maths.wadToRay(Maths.wmul(Maths.wad(tokenIds_.length), price)), rate);
         uint256 nftsAvailableForClaiming = Maths.rwdivw(Maths.rmul(lpAmount_, rate), price);
         require(availableLPs != 0 && lpAmount_ <= availableLPs && Maths.wad(tokenIds_.length) >= nftsAvailableForClaiming, "S:RC:INSUF_LPS");
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -277,8 +277,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 availableLPs = bucketLender.lpBalance;
 
         // ensure user can actually remove that much
-        lpAmount_ = Maths.rdiv((Maths.wad(tokenIds_.length) * price / 1e9), rate);  // TODO: determine if there's a rounding issue here
-//        lpAmount_ = Maths.rdiv(Maths.wadToRay(Maths.wmul(Maths.wad(tokenIds_.length), price)), rate);
+        lpAmount_ = Maths.rdiv((Maths.wad(tokenIds_.length) * price / 1e9), rate);
         uint256 nftsAvailableForClaiming = Maths.rwdivw(Maths.rmul(lpAmount_, rate), price);
         require(availableLPs != 0 && lpAmount_ <= availableLPs && Maths.wad(tokenIds_.length) >= nftsAvailableForClaiming, "S:RC:INSUF_LPS");
 


### PR DESCRIPTION
This change allows users to reconstitute an NFT by moving collateral between buckets.