### PR TITLE
Custom errors

### DIFF
--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -5,6 +5,7 @@ import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
 import { IERC20Pool } from "../../erc20/interfaces/IERC20Pool.sol";
+import { IScaledPool } from "../../base/interfaces/IScaledPool.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
@@ -250,7 +251,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
     function testScaledPoolBorrowRequireChecks() external {
         // should revert if borrower attempts to borrow with an out of bounds limitIndex
         changePrank(_borrower);
-        vm.expectRevert(IERC20Pool.BorrowLimitIndexReached.selector);
+        vm.expectRevert(IScaledPool.BorrowLimitIndexReached.selector);
         _pool.borrow(1_000 * 1e18, 5000, address(0), address(0));
 
         // add initial quote to the pool
@@ -260,7 +261,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if borrow would result in pool under collateralization
-        vm.expectRevert(IERC20Pool.BorrowPoolUnderCollateralized.selector);
+        vm.expectRevert(IScaledPool.BorrowPoolUnderCollateralized.selector);
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after adding sufficient collateral
@@ -274,13 +275,13 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if borrower attempts to borrow more than minimum amount
-        vm.expectRevert(IERC20Pool.BorrowAmountLTMinDebt.selector);
+        vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
         _pool.borrow(10 * 1e18, 3000, address(0), _borrower2);
 
         changePrank(_borrower2);
         // should revert if borrow would result in borrower under collateralization
         assertEq(_pool.lup(), 2_995.912459898389633881 * 1e18);
-        vm.expectRevert(IERC20Pool.BorrowBorrowerUnderCollateralized.selector);
+        vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
         _pool.borrow(2_976 * 1e18, 3000, address(0), _borrower);
 
         // should be able to borrow if properly specified
@@ -308,7 +309,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
-        vm.expectRevert(IERC20Pool.RepayNoDebt.selector);
+        vm.expectRevert(IScaledPool.RepayNoDebt.selector);
         _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
@@ -326,7 +327,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
-        vm.expectRevert(IERC20Pool.BorrowAmountLTMinDebt.selector);
+        vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
         _pool.repay(_borrower, 750 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
+import { IERC20Pool } from "../../erc20/interfaces/IERC20Pool.sol";
+
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
 import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
@@ -248,7 +250,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
     function testScaledPoolBorrowRequireChecks() external {
         // should revert if borrower attempts to borrow with an out of bounds limitIndex
         changePrank(_borrower);
-        vm.expectRevert("S:B:LIMIT_REACHED");
+        vm.expectRevert(IERC20Pool.BorrowLimitIndexReached.selector);
         _pool.borrow(1_000 * 1e18, 5000, address(0), address(0));
 
         // add initial quote to the pool
@@ -258,7 +260,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if borrow would result in pool under collateralization
-        vm.expectRevert("S:B:PUNDER_COLLAT");
+        vm.expectRevert(IERC20Pool.BorrowPoolUnderCollateralized.selector);
         _pool.borrow(500 * 1e18, 3000, address(0), address(0));
 
         // borrower 1 borrows 500 quote from the pool after adding sufficient collateral
@@ -272,13 +274,13 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if borrower attempts to borrow more than minimum amount
-        vm.expectRevert("S:B:AMT_LT_MIN_DEBT");
+        vm.expectRevert(IERC20Pool.BorrowAmountLTMinDebt.selector);
         _pool.borrow(10 * 1e18, 3000, address(0), _borrower2);
 
         changePrank(_borrower2);
         // should revert if borrow would result in borrower under collateralization
         assertEq(_pool.lup(), 2_995.912459898389633881 * 1e18);
-        vm.expectRevert("S:B:BUNDER_COLLAT");
+        vm.expectRevert(IERC20Pool.BorrowBorrowerUnderCollateralized.selector);
         _pool.borrow(2_976 * 1e18, 3000, address(0), _borrower);
 
         // should be able to borrow if properly specified
@@ -302,14 +304,11 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
         _pool.addQuoteToken(10_000 * 1e18, 2550);
         _pool.addQuoteToken(10_000 * 1e18, 2551);
 
-        // should revert if borrower has insufficient quote to repay desired amount
         changePrank(_borrower);
-        vm.expectRevert("S:R:INSUF_BAL");
-        _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
-        vm.expectRevert("S:R:NO_DEBT");
+        vm.expectRevert(IERC20Pool.RepayNoDebt.selector);
         _pool.repay(_borrower, 10_000 * 1e18, address(0), address(0));
 
         // borrower 1 borrows 1000 quote from the pool
@@ -327,7 +326,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
-        vm.expectRevert("R:B:AMT_LT_MIN_DEBT");
+        vm.expectRevert(IERC20Pool.BorrowAmountLTMinDebt.selector);
         _pool.repay(_borrower, 750 * 1e18, address(0), address(0));
 
         // should be able to repay loan if properly specified

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
+import { IERC20Pool } from "../../erc20/interfaces/IERC20Pool.sol";
+
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
@@ -151,7 +153,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if trying to remove more collateral than is available
-        vm.expectRevert("S:PC:NOT_ENOUGH_COLLATERAL");
+        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
         _pool.pullCollateral(testCollateralAmount, address(0), address(0));
 
         // borrower deposits 100 collateral
@@ -223,9 +225,9 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         // should revert if no collateral in the bucket
         changePrank(_lender);
-        vm.expectRevert("S:RAC:NO_COL");
+        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeAllCollateral(testIndex);
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeCollateral(3.50 * 1e18, testIndex);
 
         // another actor deposits some collateral
@@ -236,13 +238,13 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         // should revert if insufficient collateral in the bucket
         changePrank(_lender);
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeCollateral(1.25 * 1e18, testIndex);
 
         // should revert if actor does not have LP
-        vm.expectRevert("S:RAC:NO_CLAIM");
+        vm.expectRevert(IERC20Pool.RemoveCollateralNoClaim.selector);
         _pool.removeAllCollateral(testIndex);
-        vm.expectRevert("S:RC:INSUF_LPS");
+        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientLP.selector);
         _pool.removeCollateral(0.32 * 1e18, testIndex);
     }
 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -5,6 +5,7 @@ import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
 import { IERC20Pool } from "../../erc20/interfaces/IERC20Pool.sol";
+import { IScaledPool } from "../../base/interfaces/IScaledPool.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
@@ -158,7 +159,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         changePrank(_borrower);
         // should revert if trying to remove more collateral than is available
-        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _pool.pullCollateral(testCollateralAmount, address(0), address(0));
 
         // borrower deposits 100 collateral
@@ -230,9 +231,9 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         // should revert if no collateral in the bucket
         changePrank(_lender);
-        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeAllCollateral(testIndex);
-        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeCollateral(3.50 * 1e18, testIndex);
 
         // another actor deposits some collateral
@@ -243,13 +244,13 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
 
         // should revert if insufficient collateral in the bucket
         changePrank(_lender);
-        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientCollateral.selector);
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _pool.removeCollateral(1.25 * 1e18, testIndex);
 
         // should revert if actor does not have LP
         vm.expectRevert(IERC20Pool.RemoveCollateralNoClaim.selector);
         _pool.removeAllCollateral(testIndex);
-        vm.expectRevert(IERC20Pool.RemoveCollateralInsufficientLP.selector);
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
         _pool.removeCollateral(0.32 * 1e18, testIndex);
     }
 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolFactory.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
+import { PoolDeployer } from "../../base/PoolDeployer.sol";
+
 import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
 
 contract ERC20ScaledPoolFactoryTest is ERC20HelperContract {
@@ -15,21 +17,21 @@ contract ERC20ScaledPoolFactoryTest is ERC20HelperContract {
 
     function testDeployERC20PoolWithZeroAddress() external {
         // should revert if trying to deploy with zero address as collateral
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _poolFactory.deployPool(address(0), address(_quote), 0.05 * 10**18);
 
         // should revert if trying to deploy with zero address as quote token
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _poolFactory.deployPool(address(_collateral), address(0), 0.05 * 10**18);
     }
 
     function testDeployERC20PoolWithInvalidRate() external {
         // should revert if trying to deploy with interest rate lower than accepted
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _poolFactory.deployPool(address(_collateral), address(_quote), 10**18);
 
         // should revert if trying to deploy with interest rate higher than accepted
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _poolFactory.deployPool(address(_collateral), address(_quote), 2 * 10**18);
     }
 
@@ -37,7 +39,7 @@ contract ERC20ScaledPoolFactoryTest is ERC20HelperContract {
         _poolFactory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
 
         // should revert if trying to deploy same pool one more time
-        vm.expectRevert("PF:DP:POOL_EXISTS");
+        vm.expectRevert(PoolDeployer.PoolAlreadyExists.selector);
         _poolFactory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
 
         // should deploy different pool

--- a/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC20Pool }        from "../../erc20/ERC20Pool.sol";
 import { ERC20PoolFactory } from "../../erc20/ERC20PoolFactory.sol";
 
+import { IScaledPool } from "../../base/interfaces/IScaledPool.sol";
+
 import { BucketMath } from "../../libraries/BucketMath.sol";
 
 import { ERC20HelperContract } from "./ERC20DSTestPlus.sol";
@@ -36,7 +38,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
 
         // should fail if allowed owner is not set
         changePrank(_lender);
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // should fail if allowed owner is set to 0x
@@ -44,7 +46,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.approveLpOwnership(address(0), indexes[0], 1_000 * 1e18);
 
         changePrank(_lender);
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
@@ -61,7 +63,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.approveLpOwnership(_lender2, indexes[2], 1_000 * 1e27);
 
         changePrank(_lender);
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender, indexes);
     }
 
@@ -78,7 +80,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.approveLpOwnership(_lender2, indexes[2], 1_000 * 1e27);
 
         changePrank(_lender);
-        vm.expectRevert("S:TLT:INVALID_INDEX");
+        vm.expectRevert(IScaledPool.TransferLPInvalidIndex.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
@@ -95,7 +97,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.approveLpOwnership(_lender2, indexes[1], 30_000 * 1e27);
 
         changePrank(_lender2);
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
     }
 
@@ -139,7 +141,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check that old token ownership was removed - a new transfer should fail
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance
@@ -200,7 +202,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, transferIndexes);
 
         // check that old token ownership was removed - transfer with same indexes should fail
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, transferIndexes);
 
         // check lenders lp balance
@@ -267,7 +269,7 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check that old token ownership was removed - transfer with same indexes should fail
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -359,7 +359,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // add three tokens to a single bucket
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateralNFT(_borrower, _subsetPool.indexToPrice(1530), tokenIds);
+        emit AddCollateralNFT(_borrower, 1530, tokenIds);
         _subsetPool.addCollateral(tokenIds, 1530);
 
         // should revert if the actor does not have any LP to remove a token
@@ -408,7 +408,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // add three tokens to a single bucket
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateralNFT(_borrower, _subsetPool.indexToPrice(1530), tokenIds);
+        emit AddCollateralNFT(_borrower, 1530, tokenIds);
         _subsetPool.addCollateral(tokenIds, 1530);
 
         // move half of collateral to another bucket, splitting up the tokens

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -5,6 +5,7 @@ import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
 import { IERC721Pool } from "../../erc721/interfaces/IERC721Pool.sol";
+import { IScaledPool } from "../../base/interfaces/IScaledPool.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
@@ -341,7 +342,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         tokenIdsToRemove[0] = 3;
         tokenIdsToRemove[1] = 5;
 
-        vm.expectRevert("S:PC:NOT_ENOUGH_COLLATERAL");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
     }
 
@@ -365,13 +366,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         changePrank(_borrower2);
         tokenIds = new uint256[](1);
         tokenIds[0] = 1;
-        vm.expectRevert("S:RC:INSUF_LPS");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
         _subsetPool.removeCollateral(tokenIds, 1530);
 
         // should revert if we try to remove a token from a bucket with no collateral
         changePrank(_borrower);
         tokenIds[0] = 1;
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _subsetPool.removeCollateral(tokenIds, 1692);
 
         // remove one token
@@ -433,9 +434,9 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // should revert if we try to remove a token from either bucket (both with 0.5 collateral)
         tokenIds[0] = 1;
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _subsetPool.removeCollateral(tokenIds, 1530);
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         _subsetPool.removeCollateral(tokenIds, 1447);
 
         // move LP from old to new bucket, reconstituting the last token

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
+import { IERC721Pool } from "../../erc721/interfaces/IERC721Pool.sol";
+
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
@@ -88,7 +90,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // should revert if borrower attempts to add tokens not in the pool subset
         changePrank(_borrower);
-        vm.expectRevert("P:ONLY_SUBSET");
+        vm.expectRevert(IERC721Pool.OnlySubset.selector);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd, address(0), address(0));
     }
 
@@ -188,7 +190,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // should revert if borrower attempts to remove collateral not in pool
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 51;
-        vm.expectRevert("P:T_NOT_IN_P");
+        vm.expectRevert(IERC721Pool.TokenNotDeposited.selector);
         _subsetPool.pullCollateral(tokenIdsToRemove, address(0), address(0));
 
         // borrower should be able to remove collateral in the pool

--- a/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
+import { PoolDeployer } from "../../base/PoolDeployer.sol";
+
 import { DSTestPlus }                     from "../utils/DSTestPlus.sol";
 import { NFTCollateralToken, Token } from "../utils/Tokens.sol";
 
@@ -69,27 +71,27 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
 
     function testDeployERC721CollectionPoolWithZeroAddress() external {
         // should revert if trying to deploy with zero address as collateral
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _factory.deployPool(address(0), address(_quote), 0.05 * 10**18);
 
         // should revert if trying to deploy with zero address as quote token
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _factory.deployPool(address(_collateral), address(0), 0.05 * 10**18);
     }
 
     function testDeployERC721CollectionPoolWithInvalidRate() external {
         // should revert if trying to deploy with interest rate lower than accepted
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _factory.deployPool(address(_quote), address(_quote), 10**18);
 
         // should revert if trying to deploy with interest rate higher than accepted
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _factory.deployPool(address(_quote), address(_quote), 2 * 10**18);
     }
 
     function testDeployERC20PoolMultipleTimes() external {
         // should revert if trying to deploy same pool one more time
-        vm.expectRevert("PF:DP:POOL_EXISTS");
+        vm.expectRevert(PoolDeployer.PoolAlreadyExists.selector);
         _factory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
     }
 
@@ -121,11 +123,11 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
         tokenIdsTestSubset[2] = 3;
 
         // should revert if trying to deploy with zero address as collateral
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _factory.deploySubsetPool(address(0), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
 
         // should revert if trying to deploy with zero address as quote token
-        vm.expectRevert("PF:DP:ZERO_ADDR");
+        vm.expectRevert(PoolDeployer.DeployWithZeroAddress.selector);
         _factory.deploySubsetPool(address(_collateral), address(0), tokenIdsTestSubset, 0.05 * 10**18);
     }
 
@@ -135,10 +137,10 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
         tokenIdsTestSubset[1] = 2;
         tokenIdsTestSubset[2] = 3;
 
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.11 * 10**18);
 
-        vm.expectRevert("PF:DP:INVALID_RATE");
+        vm.expectRevert(PoolDeployer.PoolInterestRateInvalid.selector);
         _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.009 * 10**18);
     }
 
@@ -150,7 +152,7 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
 
         _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
 
-        vm.expectRevert("PF:DP:POOL_EXISTS");
+        vm.expectRevert(PoolDeployer.PoolAlreadyExists.selector);
         _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
     }
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -5,6 +5,7 @@ import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
 import { IERC721Pool } from "../../erc721/interfaces/IERC721Pool.sol";
+import { IScaledPool } from "../../base/interfaces/IScaledPool.sol";
 
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
@@ -227,7 +228,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToRemove[1] = 3;
         tokenIdsToRemove[2] = 5;
         tokenIdsToRemove[3] = 51;
-        vm.expectRevert("S:RC:INSUF_COL");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientCollateral.selector);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
 
         // should revert if lender attempts to remove collateral not available in the bucket
@@ -256,7 +257,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         changePrank(_lender2);
         tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 74;
-        vm.expectRevert("S:RC:INSUF_LPS");
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
     }
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 import { ERC721Pool }        from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory } from "../../erc721/ERC721PoolFactory.sol";
 
+import { IERC721Pool } from "../../erc721/interfaces/IERC721Pool.sol";
+
 import { BucketMath } from "../../libraries/BucketMath.sol";
 import { Maths }      from "../../libraries/Maths.sol";
 
@@ -231,7 +233,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // should revert if lender attempts to remove collateral not available in the bucket
         tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 1;
-        vm.expectRevert("S:RC:T_NOT_IN_B");
+        vm.expectRevert(IERC721Pool.TokenNotDeposited.selector);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
 
         // lender exchanges their lp for collateral

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -91,7 +91,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, false, true);
         emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateralNFT(_bidder, priceAtTestIndex, tokenIdsToAdd);
+        emit AddCollateralNFT(_bidder, testIndex, tokenIdsToAdd);
         uint256 lpBalanceChange = _subsetPool.addCollateral(tokenIdsToAdd, testIndex);
 
         // check bucket state
@@ -197,7 +197,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, true, true);
         emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         vm.expectEmit(true, true, true, true);
-        emit AddCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToAdd);        
+        emit AddCollateralNFT(_bidder, 2350, tokenIdsToAdd);
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         
         vm.expectEmit(true, true, false, true);

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -12,6 +12,7 @@ import { ERC20PoolFactory} from "../erc20/ERC20PoolFactory.sol";
 import { PositionManager } from "../base/PositionManager.sol";
 
 import { IPositionManager } from "../base/interfaces/IPositionManager.sol";
+import { IScaledPool }      from "../base/interfaces/IScaledPool.sol";
 
 // TODO: test this against ERC721Pool
 abstract contract PositionManagerHelperContract is DSTestPlus {
@@ -123,7 +124,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
         );
 
         // should revert if access hasn't been granted to transfer LP tokens
-        vm.expectRevert("S:TLT:NO_ALLOWANCE");
+        vm.expectRevert(IScaledPool.TransferLPNoAllowance.selector);
         vm.prank(testAddress);
         _positionManager.memorializePositions(memorializeParams);
 

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -16,6 +16,25 @@ abstract contract PoolDeployer {
      */
     event PoolCreated(address pool_);
 
+    /**************/
+    /*** Errors ***/
+    /**************/
+
+    /**
+     *  @notice Can't deploy with one of the args pointing to the 0x0 address.
+     */
+    error DeployWithZeroAddress();
+
+    /**
+     *  @notice Pool with this combination of quote and collateral already exists.
+     */
+    error PoolAlreadyExists();
+
+    /**
+     *  @notice Pool starting interest rate is invalid.
+     */
+    error PoolInterestRateInvalid();
+
     /***********************/
     /*** State Variables ***/
     /***********************/
@@ -28,9 +47,9 @@ abstract contract PoolDeployer {
     /*****************/
 
     modifier canDeploy(bytes32 subsetHash_, address collateral_, address quote_, uint256 interestRate_) {
-        require(collateral_ != address(0) && quote_ != address(0),             "PF:DP:ZERO_ADDR");
-        require(deployedPools[subsetHash_][collateral_][quote_] == address(0), "PF:DP:POOL_EXISTS");
-        require(MIN_RATE <= interestRate_ && interestRate_ <= MAX_RATE,        "PF:DP:INVALID_RATE");
+        if (collateral_ == address(0) || quote_ == address(0))              revert DeployWithZeroAddress();
+        if (deployedPools[subsetHash_][collateral_][quote_] != address(0)) revert PoolAlreadyExists();
+        if (MIN_RATE >= interestRate_ || interestRate_ >= MAX_RATE)         revert PoolInterestRateInvalid();
         _;
     }
 }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -76,7 +76,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Queue, IScaledPool {
     /*** Lender External Functions ***/
     /*********************************/
 
-    // TODO: check index incoming index_ is valid?
     function addQuoteToken(uint256 amount_, uint256 index_) external override returns (uint256 lpbChange_) {
         uint256 curDebt = _accruePoolInterest();
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -104,9 +104,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, Queue, IScaledPoo
     }
 
     function moveQuoteToken(uint256 maxAmount_, uint256 fromIndex_, uint256 toIndex_) external override returns (uint256 lpbAmountFrom_, uint256 lpbAmountTo_) {
-        if (fromIndex_ == toIndex_) {
-            revert MoveQuoteToSamePrice();
-        }
+        if (fromIndex_ == toIndex_) revert MoveQuoteToSamePrice();
 
         BucketLender storage bucketLender = bucketLenders[fromIndex_][msg.sender];
         uint256 availableLPs              = bucketLender.lpBalance;

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -66,7 +66,7 @@ interface IScaledPool {
     event UpdateInterestRate(uint256 oldRate_, uint256 newRate_);
 
     /*********************/
-    /*** Custom Errors ***/
+    /*** Shared Errors ***/
     /*********************/
 
     // TODO: add a test for this
@@ -74,6 +74,26 @@ interface IScaledPool {
      *  @notice Pool already initialized.
      */
     error AlreadyInitialized();
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than is available before the supplied limitIndex.
+     */
+    error BorrowLimitIndexReached();
+
+    /**
+     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
+     */
+    error BorrowAmountLTMinDebt();
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than they have collateral for.
+     */
+    error BorrowBorrowerUnderCollateralized();
+
+    /**
+     *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
+     */
+    error BorrowPoolUnderCollateralized();
 
     /**
      *  @notice FromIndex_ and toIndex_ arguments to moveQuoteToken() are the same.
@@ -104,6 +124,21 @@ interface IScaledPool {
      *  @notice When removing quote token HTP must stay below LUP.
      */
     error RemoveQuoteLUPBelowHTP();
+
+    /**
+     *  @notice User is attempting to pull more collateral than is available.
+     */
+    error RemoveCollateralInsufficientCollateral();
+
+    /**
+     *  @notice Lender is attempting to remove more collateral they have claim to in the bucket.
+     */
+    error RemoveCollateralInsufficientLP();
+
+    /**
+     *  @notice Borrower is attempting to repay when they have no outstanding debt.
+     */
+    error RepayNoDebt();
 
     /**
      *  @notice When transferring LP tokens between indices, the new index must be a valid index.

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -56,6 +56,57 @@ interface IScaledPool {
      */
     event UpdateInterestRate(uint256 oldRate_, uint256 newRate_);
 
+    /*********************/
+    /*** Custom Errors ***/
+    /*********************/
+
+    // TODO: add a test for this
+    /**
+     *  @notice Pool already initialized.
+     */
+    error AlreadyInitialized();
+
+    /**
+     *  @notice FromIndex_ and toIndex_ arguments to moveQuoteToken() are the same.
+     */
+    error MoveQuoteToSamePrice();
+
+    /**
+     *  @notice When moving quote token HTP must stay below LUP.
+     */
+    error MoveQuoteLUPBelowHTP();
+
+    /**
+     *  @notice Lender must have non-zero LPB when attemptign to remove quote token from the pool.
+     */
+    error RemoveQuoteNoClaim();
+
+    /**
+     *  @notice Lender must have enough LP tokens to claim the desired amount of quote from the bucket.
+     */
+    error RemoveQuoteInsufficientLPB();
+
+    /**
+     *  @notice Bucket must have more quote available in the bucket than the lender is attempting to claim.
+     */
+    error RemoveQuoteInsufficientQuoteAvailable();
+
+    /**
+     *  @notice When removing quote token HTP must stay below LUP.
+     */
+    error RemoveQuoteLUPBelowHTP();
+
+    /**
+     *  @notice When transferring LP tokens between indices, the new index must be a valid index.
+     */
+    error TransferLPInvalidIndex();
+
+    /**
+     *  @notice Owner of the LP tokens must have approved the new owner prior to transfer.
+     */
+    error TransferLPNoAllowance();
+
+
     /***********************/
     /*** State Variables ***/
     /***********************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,9 +37,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
     /****************************/
 
     function initialize(uint256 rate_) external {
-        if (poolInitializations != 0) {
-            revert AlreadyInitialized();
-        }
+        if (poolInitializations != 0) revert AlreadyInitialized();
+
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,7 +37,9 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
     /****************************/
 
     function initialize(uint256 rate_) external {
-        require(poolInitializations == 0, "P:INITIALIZED");
+        if (poolInitializations != 0) {
+            revert AlreadyInitialized();
+        }
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -63,26 +63,6 @@ interface IERC20Pool is IScaledPool {
     /*********************/
 
     /**
-     *  @notice Borrower is attempting to borrow more quote token than is available before the supplied limitIndex.
-     */
-    error BorrowLimitIndexReached();
-
-    /**
-     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
-     */
-    error BorrowAmountLTMinDebt();
-
-    /**
-     *  @notice Borrower is attempting to borrow more quote token than they have collateral for.
-     */
-    error BorrowBorrowerUnderCollateralized();
-
-    /**
-     *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
-     */
-    error BorrowPoolUnderCollateralized();
-
-    /**
      *  @notice Borrower has no debt to liquidate.
      */
     error LiquidateNoDebt();
@@ -98,24 +78,9 @@ interface IERC20Pool is IScaledPool {
     error LiquidateLUPGreaterThanTP();
 
     /**
-     *  @notice User is attempting to pull more collateral than is available.
-     */
-    error RemoveCollateralInsufficientCollateral();
-
-    /**
-     *  @notice Lender is attempting to remove more collateral they have claim to in the bucket.
-     */
-    error RemoveCollateralInsufficientLP();
-
-    /**
      *  @notice Lender is attempting to remove collateral when they have no claim to collateral in the bucket.
      */
     error RemoveCollateralNoClaim();
-
-    /**
-     *  @notice Borrower is attempting to repay when they have no outstanding debt.
-     */
-    error RepayNoDebt();
 
     /**
      *  @notice Take was called before 1 hour had passed from kick time.

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -83,6 +83,21 @@ interface IERC20Pool is IScaledPool {
     error BorrowPoolUnderCollateralized();
 
     /**
+     *  @notice Borrower has no debt to liquidate.
+     */
+    error LiquidateNoDebt();
+
+    /**
+     *  @notice Borrower has a healthy over-collateralized position.
+     */
+    error LiquidateBorrowerOk();
+
+    /**
+     *  @notice Liquidation must result in LUP below the borrowers threshold price.
+     */
+    error LiquidateLUPGreaterThanTP();
+
+    /**
      *  @notice User is attempting to pull more collateral than is available.
      */
     error RemoveCollateralInsufficientCollateral();
@@ -101,6 +116,11 @@ interface IERC20Pool is IScaledPool {
      *  @notice Borrower is attempting to repay when they have no outstanding debt.
      */
     error RepayNoDebt();
+
+    /**
+     *  @notice Take was called before 1 hour had passed from kick time.
+     */
+    error TakeNotPastCooldown();
 
 
     /*********************************/

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -58,6 +58,51 @@ interface IERC20Pool is IScaledPool {
      */
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
 
+    /*********************/
+    /*** Custom Errors ***/
+    /*********************/
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than is available before the supplied limitIndex.
+     */
+    error BorrowLimitIndexReached();
+
+    /**
+     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
+     */
+    error BorrowAmountLTMinDebt();
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than they have collateral for.
+     */
+    error BorrowBorrowerUnderCollateralized();
+
+    /**
+     *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
+     */
+    error BorrowPoolUnderCollateralized();
+
+    /**
+     *  @notice User is attempting to pull more collateral than is available.
+     */
+    error RemoveCollateralInsufficientCollateral();
+
+    /**
+     *  @notice Lender is attempting to remove more collateral they have claim to in the bucket.
+     */
+    error RemoveCollateralInsufficientLP();
+
+    /**
+     *  @notice Lender is attempting to remove collateral when they have no claim to collateral in the bucket.
+     */
+    error RemoveCollateralNoClaim();
+
+    /**
+     *  @notice Borrower is attempting to repay when they have no outstanding debt.
+     */
+    error RepayNoDebt();
+
+
     /*********************************/
     /*** ERC20Pool State Variables ***/
     /*********************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -41,9 +41,8 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     /****************************/
 
     function initialize(uint256 rate_) external {
-        if (poolInitializations != 0) {
-            revert AlreadyInitialized();
-        }
+        if (poolInitializations != 0) revert AlreadyInitialized();
+
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
         inflatorSnapshot           = 10**18;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -259,7 +259,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
             }
         }
 
-        emit AddCollateralNFT(msg.sender, _indexToPrice(index_), tokenIds_);
+        emit AddCollateralNFT(msg.sender, index_, tokenIds_);
     }
 
     // TODO: finish implementing

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -60,6 +60,30 @@ interface IERC721Pool is IScaledPool {
      */
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
 
+    /*************************/
+    /*** ERC721Pool Errors ***/
+    /*************************/
+
+    /**
+     *  @notice Failed to add tokenId to an EnumerableSet.
+     */
+    error AddTokenFailed();
+
+    /**
+     *  @notice Failed to remove a tokenId from an EnumerableSet.
+     */
+    error RemoveTokenFailed();
+
+    /**
+     *  @notice User attempted to add an NFT to the pool with a tokenId outsde of the allowed subset.
+     */
+    error OnlySubset();
+
+    /**
+     *  @notice User attempted to interact with a tokenId that hasn't been deposited into the pool or bucket.
+     */
+    error TokenNotDeposited();
+
     /**************************/
     /*** ERC721Pool Structs ***/
     /**************************/


### PR DESCRIPTION
- Switch from require string to `revert error()`. Use common errors where possible for borrow repay, and collateral interactions between both pool types.
- Remove balance checks of users before interacting with methods
- Emit index instead of price to save gas in `ERC721Pool.addCollateral()`