### PR TITLE
Gas optimizations

### DIFF
--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -23,6 +23,4 @@ compiler:
       - "@prb-math=lib/prb-math/"
       - "@clones=lib/clones-with-immutable-args/src/"
       - "@base64-sol=lib/base64/"
-    optimizer:
-      enabled: false
 

--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -23,4 +23,6 @@ compiler:
       - "@prb-math=lib/prb-math/"
       - "@clones=lib/clones-with-immutable-args/src/"
       - "@base64-sol=lib/base64/"
+    optimizer:
+      enabled: false
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -240,10 +240,9 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, Queue, IScaledPoo
             delete _lpTokenAllowances[owner_][newOwner_][indexes_[i]];
 
             // move lp tokens to the new owner address
-            BucketLender memory bucketLenderNewOwner = bucketLenders[indexes_[i]][newOwner_];
-            bucketLenderNewOwner.lpBalance           += balanceToTransfer;
-            bucketLenderNewOwner.lastQuoteDeposit    = Maths.max(bucketLenderOwner.lastQuoteDeposit, bucketLenderNewOwner.lastQuoteDeposit);
-            bucketLenders[indexes_[i]][newOwner_]  = bucketLenderNewOwner;
+            BucketLender storage bucketLenderNewOwner = bucketLenders[indexes_[i]][newOwner_];
+            bucketLenderNewOwner.lpBalance            += balanceToTransfer;
+            bucketLenderNewOwner.lastQuoteDeposit     = Maths.max(bucketLenderOwner.lastQuoteDeposit, bucketLenderNewOwner.lastQuoteDeposit);
 
             // delete owner lp balance for this bucket
             delete bucketLenders[indexes_[i]][owner_];

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -208,7 +208,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         lpAmount_     = Maths.rdiv((amount_ * price / 1e9), rate);
 
         BucketLender storage bucketLender = bucketLenders[index_][msg.sender];
-        if (availableLPs == 0 || lpAmount_ > availableLPs) revert RemoveCollateralInsufficientLP(); // ensure user can actually remove that much
+        if (bucketLender.lpBalance == 0 || lpAmount_ > bucketLender.lpBalance) revert RemoveCollateralInsufficientLP(); // ensure user can actually remove that much
 
         _redeemLPForCollateral(bucket, bucketLender, lpAmount_, amount_, price, index_);
     }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -123,7 +123,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 curDebt = _accruePoolInterest();
 
         // borrower accounting
-        Borrower storage borrower = borrowers[msg.sender];
+        Borrower memory borrower = borrowers[msg.sender];
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
 
         uint256 curLup = _lup();
@@ -133,6 +133,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         // update loan queue
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         if (borrower.debt != 0) _updateLoanQueue(msg.sender, thresholdPrice, oldPrev_, newPrev_);
+
+        borrowers[msg.sender] = borrower;
 
         // update pool state
         pledgedCollateral -= amount_;


### PR DESCRIPTION
- ERC20Pool `addCollateral`: do not fetch entire bucketLender struct from storage, just change the lpBalance
- ERC20Pool `removeCollateral` and `removeAllCollateral`: load `bucketLender` storage instead memory. Removed `_redeemLPForCollateral` function
- ERC20Pool `pullCollateral`: load borrower struct in memory, then save to storage
- ScaledPool `moveQuoteToken`: not loading entire to bucket lender from storage, only update balance with `lpbAmountTo` 
- ScaledPool `transferLPTokens`: new owner BucketLender struct in storage instead memory

```
    │ addCollateral                              ┆ 97397           ┆ 215370 ┆ 226725 ┆ 447818 ┆ 7       │
    vs
    │ addCollateral                              ┆ 99822           ┆ 217795 ┆ 229150 ┆ 450241 ┆ 7       │
  
    │ removeCollateral                           ┆ 847             ┆ 22677  ┆ 17154  ┆ 55554  ┆ 4       │
    vs
    │ removeCollateral                           ┆ 847             ┆ 23295  ┆ 18238  ┆ 55856  ┆ 4       │

    │ removeAllCollateral                        ┆ 4748            ┆ 55298  ┆ 46995  ┆ 107595 ┆ 8       │
    vs
    │ removeAllCollateral                        ┆ 4748            ┆ 55819  ┆ 47315  ┆ 107995 ┆ 8       │
    
    │ pullCollateral                             ┆ 24328           ┆ 116087 ┆ 39712  ┆ 391312 ┆ 7       │
    vs
    │ pullCollateral                             ┆ 24603           ┆ 119242 ┆ 40056  ┆ 391655 ┆ 7       │
    
    │ moveQuoteToken                             ┆ 488             ┆ 192248 ┆ 184820 ┆ 673855 ┆ 10      │
    vs
    │ moveQuoteToken                             ┆ 488             ┆ 192262 ┆ 184839 ┆ 673873 ┆ 10      │

    │ transferLPTokens                           ┆ 2807            ┆ 24461  ┆ 21617  ┆ 107648 ┆ 29      │
    vs
    │ transferLPTokens                           ┆ 2807            ┆ 24801  ┆ 21899  ┆ 108493 ┆ 29      │
```