### PR TITLE
pass curDebt to interest rate update method to save a storage read

### DIFF
--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -157,7 +157,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
     /*********************************/
 
     function addCollateral(uint256 amount_, uint256 index_) external override returns (uint256 lpbChange_) {
-        _accruePoolInterest();
+        uint256 curDebt = _accruePoolInterest();
 
         // Calculate exchange rate before new collateral has been accounted for.
         // This is consistent with how lbpChange in addQuoteToken is adjusted before calling _add.
@@ -171,7 +171,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         bucketLenders[index_][msg.sender].lpBalance += lpbChange_;
 
-        _updateInterestRateAndEMAs(borrowerDebt, _lup());
+        _updateInterestRateAndEMAs(curDebt, _lup());
 
         // move required collateral from sender to pool
         emit AddCollateral(msg.sender, _indexToPrice(index_), amount_);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -223,7 +223,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
     // TODO: does pool state need to be updated with collateral deposited as well?
     function addCollateral(uint256[] calldata tokenIds_, uint256 index_) external override returns (uint256 lpbChange_) {
-        _accruePoolInterest();
+        uint256 curDebt = _accruePoolInterest();
 
         Bucket memory bucket = buckets[index_];
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
@@ -241,7 +241,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         buckets[index_] = bucket;
         bucketLenders[index_][msg.sender] = bucketLender;
 
-        _updateInterestRateAndEMAs(borrowerDebt, _lup());
+        _updateInterestRateAndEMAs(curDebt, _lup());
 
         // move required collateral from sender to pool
         for (uint256 i = 0; i < tokenIds_.length;) {
@@ -266,7 +266,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         Bucket memory bucket = buckets[index_];
         if (Maths.wad(tokenIds_.length) > bucket.availableCollateral) revert RemoveCollateralInsufficientCollateral();
 
-        _accruePoolInterest();
+        uint256 curDebt = _accruePoolInterest();
 
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         uint256 price        = _indexToPrice(index_);
@@ -290,7 +290,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         bucketLender.lpBalance -= lpAmount_;
         bucketLenders[index_][msg.sender] = bucketLender;
 
-        _updateInterestRateAndEMAs(borrowerDebt, _lup());
+        _updateInterestRateAndEMAs(curDebt, _lup());
 
         emit RemoveCollateralNFT(msg.sender, price, tokenIds_);
 


### PR DESCRIPTION
Saves 92 gas on average.

Note that the `removeCollateral` methods don't do this because they share a helper method which reads it from `borrowerDebt`.