### PR TITLE
Fenwick tree updates:

### DIFF
--- a/src/_test/FenwickTree.t.sol
+++ b/src/_test/FenwickTree.t.sol
@@ -27,12 +27,6 @@ contract FenwickTreeTest is DSTestPlus {
         assertEq(_tree.get(12), 0);
         assertEq(_tree.get(13), 0);
 
-        assertEq(_tree.rangeSum(8, 8),   0);
-        assertEq(_tree.rangeSum(9, 9),   200 * 1e18);
-        assertEq(_tree.rangeSum(11, 11), 300 * 1e18);
-        assertEq(_tree.rangeSum(12, 12), 0);
-        assertEq(_tree.rangeSum(13, 13), 0);
-
         assertEq(_tree.prefixSum(0),    0);
         assertEq(_tree.prefixSum(5),    0);
         assertEq(_tree.prefixSum(10),   200 * 1e18);
@@ -64,11 +58,6 @@ contract FenwickTreeTest is DSTestPlus {
         assertEq(_tree.get(9),  480 * 1e18);
         assertEq(_tree.get(10), 0);
         assertEq(_tree.get(11), 300 * 1e18);
-
-        assertEq(_tree.rangeSum(5, 5),   132 * 1e18);
-        assertEq(_tree.rangeSum(9, 9),   480 * 1e18);
-        assertEq(_tree.rangeSum(10, 10), 0);
-        assertEq(_tree.rangeSum(11, 11), 300 * 1e18);
 
         assertEq(_tree.prefixSum(0),    0);
         assertEq(_tree.prefixSum(4),    0);
@@ -107,11 +96,6 @@ contract FenwickTreeTest is DSTestPlus {
         assertEq(_tree.get(9),  480 * 1e18);
         assertEq(_tree.get(10), 0);
         assertEq(_tree.get(11), 0);
-
-        assertEq(_tree.rangeSum(5, 5),   132 * 1e18);
-        assertEq(_tree.rangeSum(9, 9),   480 * 1e18);
-        assertEq(_tree.rangeSum(10, 10), 0);
-        assertEq(_tree.rangeSum(11, 11), 0);
     }
 
     /**

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -228,10 +228,6 @@ contract FenwickTreeInstance is FenwickTree, DSTestPlus {
         return _treeSum();
     }
 
-    function rangeSum(uint256 i_, uint256 j_) external view returns (uint256 m_) {
-        return _rangeSum(i_, j_);
-    }
-
     function get(uint256 i_) external view returns (uint256 m_) {
         return _valueAt(i_);
     }

--- a/src/base/FenwickTree.sol
+++ b/src/base/FenwickTree.sol
@@ -12,6 +12,16 @@ abstract contract FenwickTree {
     uint256 public constant SIZE = 8192;
 
     /**
+     *  @notice Not a valid tree index.
+     */
+    error InvalidIndex();
+
+    /**
+     *  @notice Scalilng factor is invalid.
+     */
+    error InvalidScalingFactor();
+
+    /**
      *  @notice Array of values in the FenwickTree.
      */
     uint256[8193] internal values;  // values
@@ -28,7 +38,7 @@ abstract contract FenwickTree {
      *  @param  x_  amount to increase the value by.
     */    
     function _add(uint256 i_, uint256 x_) internal {
-        require(i_ < SIZE, "FW:A:INVALID_INDEX");
+        if (i_ >= SIZE) revert InvalidIndex();
 
         uint256 j     = SIZE;       // Binary index, 1 << 13
         uint256 ii    = 0;          // Binary index offset
@@ -108,8 +118,8 @@ abstract contract FenwickTree {
     */    
     // TODO: add check to ensure scaling factor is at least a WAD? 
     function _mult(uint256 i_, uint256 f_) internal {
-        require(i_ < SIZE, "FW:M:INVALID_INDEX");
-        require(f_ != 0,   "FW:M:FACTOR_ZERO");
+        if (i_ >= SIZE) revert InvalidIndex();
+        if (f_ == 0) revert InvalidScalingFactor();
 
         i_          += 1;
         uint256 sum = 0;
@@ -186,24 +196,13 @@ abstract contract FenwickTree {
     }
 
     /**
-     *  @notice Returns the sum of a given range.
-     *  @param  start_  start of range to sum.
-     *  @param  stop_   end of range to sum.
-    */
-    function _rangeSum(uint256 start_, uint256 stop_) internal view returns (uint256) {
-        require(start_ < SIZE, "FW:R:INVALID_START");
-        require(stop_ >= start_ && stop_ <= SIZE,  "FW:R:INVALID_STOP");
-        return _prefixSum(stop_) - _prefixSum(start_ - 1);
-    }
-
-    /**
      *  @notice Decrease a node in the FenwickTree at an index.
      *  @dev    Starts at tree root and decrements through range parent nodes until index, i_, is reached.
      *  @param  i_  The index pointing to the value
      *  @param  x_  Amount to decrease the value by.
     */    
     function _remove(uint256 i_, uint256 x_) internal {
-        require(i_ < SIZE, "FW:R:INVALID_INDEX");
+        if (i_ >= SIZE) revert InvalidIndex();
 
         uint256 j     = SIZE;       // Binary index, 1 << 13
         uint256 ii    = 0;          // Binary index offset
@@ -232,7 +231,7 @@ abstract contract FenwickTree {
     }
 
     function _scale(uint256 i_) internal view returns (uint256 a_) {
-        require(i_ < SIZE, "FW:S:INVALID_INDEX");
+        if (i_ >= SIZE) revert InvalidIndex();
 
         a_ = Maths.WAD;
         uint256 scaled;
@@ -248,7 +247,7 @@ abstract contract FenwickTree {
     }
 
     function _valueAt(uint256 i_) internal view returns (uint256 s_) {
-        require(i_ < SIZE, "FW:V:INVALID_INDEX");
+        if (i_ >= SIZE) revert InvalidIndex();
 
         uint256 j  =  i_;
         uint256 k  =  1;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -229,7 +229,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         // Calculate exchange rate before new collateral has been accounted for.
         // This is consistent with how lbpChange in addQuoteToken is adjusted before calling _add.
-        uint256 rate = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
 
         uint256 tokensToAdd        = Maths.wad(tokenIds_.length);
         uint256 quoteValue         = Maths.wmul(tokensToAdd, _indexToPrice(index_));
@@ -270,7 +270,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
         uint256 price        = _indexToPrice(index_);
-        uint256 rate         = _exchangeRate(_rangeSum(index_, index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
+        uint256 rate         = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs = bucketLender.lpBalance;
 
         // ensure user can actually remove that much


### PR DESCRIPTION
- Replace all ERC721 occurences of `_rangeSum()` with `_valueAt()`
- Remove unused `_rangeSum()` method
- use custom errors instead requires
- update tests
- results with 200 optimizer runs

```
  ============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,595B  (91.94%)
  ERC20Pool                -  22,396B  (91.13%)

 vs

 ============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,998B  (93.58%)
  ERC20Pool                -  22,610B  (92.00%)
```