### PR TITLE
Chores:

### DIFF
--- a/src/_test/Heap.t.sol
+++ b/src/_test/Heap.t.sol
@@ -57,6 +57,72 @@ contract HeapTest is DSTestPlus {
         assertEq(_loans.getTotalTps(),    1);
     }
 
+    function testHeapInsertMultipleLoansWithSameTp() public {
+        // assert initial state
+        assertEq(_loans.getMaxBorrower(), address(0));
+        assertEq(_loans.getMaxTp(), 0);
+
+        address b1 = makeAddr("b1");
+        address b2 = makeAddr("b2");
+        address b3 = makeAddr("b3");
+        address b4 = makeAddr("b4");
+        address b5 = makeAddr("b5");
+        address b6 = makeAddr("b6");
+
+        _loans.upsertTp(b1, 100 * 1e18);
+        _loans.upsertTp(b2, 200 * 1e18);
+        _loans.upsertTp(b3, 200 * 1e18);
+        _loans.upsertTp(b4, 300 * 1e18);
+        _loans.upsertTp(b5, 400 * 1e18);
+        _loans.upsertTp(b6, 400 * 1e18);
+
+        assertEq(_loans.getMaxBorrower(), b5);
+        assertEq(_loans.getMaxTp(),       400 * 1e18);
+        assertEq(_loans.getTotalTps(),    7);
+
+        assertEq(_loans.getTp(b1), 100 * 1e18);
+        assertEq(_loans.getTp(b2), 200 * 1e18);
+        assertEq(_loans.getTp(b3), 200 * 1e18);
+        assertEq(_loans.getTp(b4), 300 * 1e18);
+        assertEq(_loans.getTp(b5), 400 * 1e18);
+        assertEq(_loans.getTp(b6), 400 * 1e18);
+
+        _loans.removeTp(b5);
+        assertEq(_loans.getMaxBorrower(), b6);
+        assertEq(_loans.getMaxTp(),       400 * 1e18);
+        assertEq(_loans.getTotalTps(),    6);
+
+        _loans.removeTp(b6);
+        assertEq(_loans.getMaxBorrower(), b4);
+        assertEq(_loans.getMaxTp(),       300 * 1e18);
+        assertEq(_loans.getTotalTps(),    5);
+
+        _loans.removeTp(b4);
+        assertEq(_loans.getMaxBorrower(), b2);
+        assertEq(_loans.getMaxTp(),       200 * 1e18);
+        assertEq(_loans.getTotalTps(),    4);
+
+        _loans.upsertTp(b1, 200 * 1e18);
+        assertEq(_loans.getMaxBorrower(), b2);
+        assertEq(_loans.getMaxTp(),       200 * 1e18);
+        assertEq(_loans.getTotalTps(),    4);
+
+        _loans.removeTp(b2);
+        assertEq(_loans.getMaxBorrower(), b3);
+        assertEq(_loans.getMaxTp(),       200 * 1e18);
+        assertEq(_loans.getTotalTps(),    3);
+
+        _loans.removeTp(b3);
+        assertEq(_loans.getMaxBorrower(), b1);
+        assertEq(_loans.getMaxTp(),       200 * 1e18);
+        assertEq(_loans.getTotalTps(),    2);
+
+        _loans.removeTp(b1);
+        assertEq(_loans.getMaxBorrower(), address(0));
+        assertEq(_loans.getMaxTp(),       0);
+        assertEq(_loans.getTotalTps(),    1);
+    }
+
     function testHeapInsertAndRemoveHeadByMaxTp() public {
         // assert initial state
         assertEq(_loans.getMaxBorrower(), address(0));

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -508,10 +508,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         );
     }
 
-    function bucketCount() external view override returns (uint256) {
-        return this.SIZE();
-    }
-
     function reserves() external view override returns (uint256) {
         return borrowerDebt + quoteToken().balanceOf(address(this)) - this.poolSize() - liquidationBondEscrowed - reserveAuctionUnclaimed;
     }

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -222,12 +222,6 @@ interface IScaledPool {
     function buckets(uint256 index_) external view returns (uint256 lpAccumulator, uint256 availableCollateral);
 
     /**
-     *  @notice Returns the `SIZE` constant, equivalent to the maximum number of price indices in the pool.
-     *  @return Number of price buckets in the pool, a constant.
-     */
-    function bucketCount() external view returns (uint256);
-
-    /**
      *  @notice Mapping of buckets indexes and owner addresses to {BucketLender} structs.
      *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
      *  @param  index_           Bucket index.


### PR DESCRIPTION
- Remove total size external function and reduce contract compiled size
```
  ERC721Pool               -  24,316B  (98.94%)
  ERC20Pool                -  23,679B  (96.35%)
```
vs
```
  ERC721Pool               -  24,435B  (99.42%)
  ERC20Pool                -  23,798B  (96.83%)
```
- Add heap test with multiple borrowers having same TPs