### PR TITLE
Claimable Reserve Auction

### DIFF
--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -2,6 +2,10 @@ name: Forge Tests
 
 on: [push]
 
+env:
+  ## Loads environment from secrets
+  ETH_RPC_URL: ${{secrets.ETH_RPC_URL}}
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -20,7 +20,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: make test-with-gas-report
+        run: echo "DEBUG ${{env.ETH_RPC_URL}}"; make test-with-gas-report
 
       - name: Run coverage
         continue-on-error: true

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -5,6 +5,7 @@ on: [push]
 env:
   ## Loads environment from secrets
   ETH_RPC_URL: ${{secrets.ETH_RPC_URL}}
+  FOO: bar
 
 jobs:
   tests:
@@ -20,7 +21,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: echo "DEBUG ${{env.ETH_RPC_URL}}"; make test-with-gas-report
+        run: echo "DEBUG ${{env.ETH_RPC_URL}} ${{env.FOO}}"; make test-with-gas-report
 
       - name: Run coverage
         continue-on-error: true

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -5,7 +5,6 @@ on: [push]
 env:
   ## Loads environment from secrets
   ETH_RPC_URL: ${{secrets.ETH_RPC_URL}}
-  FOO: bar
 
 jobs:
   tests:
@@ -21,7 +20,7 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: echo "DEBUG ${{env.ETH_RPC_URL}} ${{env.FOO}}"; make test-with-gas-report
+        run: echo "ENV ${{env.ETH_RPC_URL}} SECRET ${{secrets.ETH_RPC_URL}}"; make test-with-gas-report
 
       - name: Run coverage
         continue-on-error: true

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -10,19 +10,18 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          submodules: recursive
-#
-#      - name: Install Foundry
-#        uses: foundry-rs/foundry-toolchain@v1
-#        with:
-#          version: nightly
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
 
       - name: Run tests
-        run: echo "ENV ${{env.ETH_RPC_URL}}\n; echo SECRET ${{secrets.ETH_RPC_URL}}"
-#        run: make test-with-gas-report
+        run: make test-with-gas-report
 
-#      - name: Run coverage
-#        continue-on-error: true
-#        run: make coverage
+      - name: Run coverage
+        continue-on-error: true
+        run: make coverage

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -10,18 +10,19 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+#      - uses: actions/checkout@v2
+#        with:
+#          submodules: recursive
+#
+#      - name: Install Foundry
+#        uses: foundry-rs/foundry-toolchain@v1
+#        with:
+#          version: nightly
 
       - name: Run tests
-        run: echo "ENV ${{env.ETH_RPC_URL}} SECRET ${{secrets.ETH_RPC_URL}}"; make test-with-gas-report
+        run: echo "ENV ${{env.ETH_RPC_URL}}\n; echo SECRET ${{secrets.ETH_RPC_URL}}"
+#        run: make test-with-gas-report
 
-      - name: Run coverage
-        continue-on-error: true
-        run: make coverage
+#      - name: Run coverage
+#        continue-on-error: true
+#        run: make coverage

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -176,7 +176,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
     function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
         ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
-        (uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.reserveAuction();
+        (, uint256 auctionPrice, ) = pool.reserveAuction();
         assertEq(auctionPrice, expectedPrice);
     }
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -44,6 +44,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     struct ReserveAuctionState {
         uint256 claimableReservesRemaining;
         uint256 auctionPrice;
+        uint256 timeRemaining;
     }
 }
 
@@ -167,14 +168,15 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     function _assertReserveAuction(ReserveAuctionState memory state_) internal {
         ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
 
-        (uint256 claimableReservesRemaining, uint256 auctionPrice) = pool.reserveAuction();
+        (uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.reserveAuction();
         assertEq(claimableReservesRemaining, state_.claimableReservesRemaining);
         assertEq(auctionPrice, state_.auctionPrice);
+        assertEq(timeRemaining, state_.timeRemaining);
     }
 
     function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
         ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
-        (uint256 claimableReservesRemaining, uint256 auctionPrice) = pool.reserveAuction();
+        (uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.reserveAuction();
         assertEq(auctionPrice, expectedPrice);
     }
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -171,4 +171,10 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
         assertEq(claimableReservesRemaining, state_.claimableReservesRemaining);
         assertEq(auctionPrice, state_.auctionPrice);
     }
+
+    function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        (uint256 claimableReservesRemaining, uint256 auctionPrice) = pool.reserveAuction();
+        assertEq(auctionPrice, expectedPrice);
+    }
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -19,6 +19,24 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     event PullCollateralNFT(address indexed borrower_, uint256[] tokenIds_);
     event RemoveCollateralNFT(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_);
     event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
+
+    /*****************/
+    /*** Utilities ***/
+    /*****************/
+
+    struct PoolState {
+        uint256 htp;
+        uint256 lup;
+        uint256 poolSize;
+        uint256 pledgedCollateral;
+        uint256 encumberedCollateral;
+        uint256 borrowerDebt;
+        uint256 actualUtilization;
+        uint256 targetUtilization;
+        uint256 minDebtAmount;
+        uint256 loans;
+        address maxBorrower;
+    }
 }
 
 abstract contract ERC721HelperContract is ERC721DSTestPlus {
@@ -97,5 +115,23 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     // TODO: implement _pullCollateral()
+    
+    function _assertPool(PoolState memory state_) internal {
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        
+        assertEq(pool.htp(), state_.htp);
+        assertEq(pool.lup(), state_.lup);
 
+        assertEq(pool.poolSize(),              state_.poolSize);
+        assertEq(pool.pledgedCollateral(),     state_.pledgedCollateral);
+        assertEq(pool.borrowerDebt(),          state_.borrowerDebt);
+        assertEq(pool.poolActualUtilization(), state_.actualUtilization);
+        assertEq(pool.poolTargetUtilization(), state_.targetUtilization);
+        assertEq(pool.poolMinDebtAmount(),     state_.minDebtAmount);
+
+        assertEq(pool.loansCount(),  state_.loans);
+        assertEq(pool.maxBorrower(), state_.maxBorrower);
+
+        assertEq(pool.encumberedCollateral(state_.borrowerDebt, state_.lup), state_.encumberedCollateral);
+    }
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -69,7 +69,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: 0,
-                auctionPrice:               0
+                auctionPrice:               0,
+                timeRemaining:              0
             })
         );
 
@@ -104,29 +105,29 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // check prices
         skip(37 minutes);
-        _assertReserveAuctionPrice(652176034.882778815 * 1e18);
+        _assertReserveAuctionPrice(652176034.882782114 * 1e18);
         skip(23 hours);     // 23 hours 37 minutes
-        _assertReserveAuctionPrice(77.745441781 * 1e18);
+        _assertReserveAuctionPrice(77.74544178 * 1e18);
         skip(1400);         // 24 hours 0 minutes 20 seconds
         _assertReserveAuctionPrice(59.604644775 * 1e18);
         skip(100);          // 24 hours 2 minutes
         _assertReserveAuctionPrice(58.243272807 * 1e18);
         skip(58 minutes);   // 25 hours
-        _assertReserveAuctionPrice(29.802322388 * 1e18);
+        _assertReserveAuctionPrice(29.802322387 * 1e18);
         skip(5 hours);      // 30 hours
-        _assertReserveAuctionPrice(0.931322575 * 1e18);
+        _assertReserveAuctionPrice(0.931322574 * 1e18);
         skip(121 minutes);  // 32 hours 1 minute
-        _assertReserveAuctionPrice(0.230156356 * 1e18);
+        _assertReserveAuctionPrice(0.230156355 * 1e18);
         skip(7700 seconds); // 34 hours 9 minutes 20 seconds
         _assertReserveAuctionPrice(0.052459681 * 1e18);
         skip(8 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000204921 * 1e18);
+        _assertReserveAuctionPrice(0.000204920 * 1e18);
         skip(6 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000003202 * 1e18);
+        _assertReserveAuctionPrice(0.000003201 * 1e18);
         skip(3100 seconds); // 43 hours
         _assertReserveAuctionPrice(0.000001756 * 1e18);
         skip(5 hours);      // 48 hours
-        _assertReserveAuctionPrice(0.000000055 * 1e18);
+        _assertReserveAuctionPrice(0.000000054 * 1e18);
         skip(12 hours);     // 60 hours
         _assertReserveAuctionPrice(0);
     }
@@ -152,7 +153,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              3 days
             })
         );
         assertEq(_collectionPool.reserves(), 0);
@@ -164,7 +166,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              2 days
             })
         );
         vm.expectEmit(true, true, true, true);
@@ -177,7 +180,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              2 days
             })
         );
 
@@ -187,7 +191,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              2875 minutes
             })
         );
         vm.expectEmit(true, true, true, true);
@@ -200,7 +205,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              2875 minutes
             })
         );
 
@@ -211,7 +217,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: 0,
-                auctionPrice:               0
+                auctionPrice:               0,
+                timeRemaining:              0
             })
         );
         assertEq(_collectionPool.reserves(), 0);
@@ -236,7 +243,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              3 days
             })
         );
         assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18);
@@ -250,7 +258,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              2 days
             })
         );
 
@@ -260,7 +269,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              0
             })
         );
 
@@ -289,7 +299,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              44 hours
             })
         );
         expectedReserves = 0;
@@ -299,7 +310,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice
+                auctionPrice:               expectedPrice,
+                timeRemaining:              44 hours
             })
         );
     }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -69,14 +69,18 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18);
     }
 
-    function testClaimableReserveAuction() external {
+    function testClaimableReserveNoAuction() external {
+        // ensure empty state is returned
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: 0,
                 auctionPrice:               0
             })
         );
-//        _collectionPool.startClaimableReserveAuction();
+
+        // ensure cannot take when no auction was started
+        vm.expectRevert(IScaledPool.NoAuction.selector);
+        _collectionPool.takeReserves(555 * 1e18);
     }
 
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -99,7 +99,6 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // kick off a new auction
         changePrank(_bidder);
-        uint256 expectedReserves = 604.374905327857838090 * 1e18;
         _collectionPool.startClaimableReserveAuction();
         _assertReserveAuctionPrice(1_000_000_000 * 1e18);
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.14;
 
 import { ERC721Pool }           from "../../erc721/ERC721Pool.sol";
 import { ERC721PoolFactory }    from "../../erc721/ERC721PoolFactory.sol";
-
 import { IERC721Pool }          from "../../erc721/interfaces/IERC721Pool.sol";
 import { IScaledPool }          from "../../base/interfaces/IScaledPool.sol";
 
@@ -19,6 +18,9 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        // TODO: consider moving this into helper contract deployPool methods
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"));
+
         _borrower  = makeAddr("borrower");
         _bidder    = makeAddr("bidder");
         _lender    = makeAddr("lender");
@@ -68,7 +70,12 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
     }
 
     function testClaimableReserveAuction() external {
-        // TODO: implement
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: 0,
+                auctionPrice:               0
+            })
+        );
 //        _collectionPool.startClaimableReserveAuction();
     }
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -90,6 +90,47 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _collectionPool.startClaimableReserveAuction();
     }
 
+    function testReserveAuctionPricing() external {
+        // borrower repays all debt (auction for full reserves)
+        changePrank(_borrower);
+        _collectionPool.repay(_borrower, 205_000 * 1e18);
+        assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18);
+
+        // kick off a new auction
+        changePrank(_bidder);
+        uint256 expectedReserves = 604.374905327857838090 * 1e18;
+        _collectionPool.startClaimableReserveAuction();
+        _assertReserveAuctionPrice(1_000_000_000 * 1e18);
+
+        // check prices
+        skip(37 minutes);
+        _assertReserveAuctionPrice(652176034.882778815 * 1e18);
+        skip(23 hours);     // 23 hours 37 minutes
+        _assertReserveAuctionPrice(77.745441781 * 1e18);
+        skip(1400);         // 24 hours 0 minutes 20 seconds
+        _assertReserveAuctionPrice(59.604644775 * 1e18);
+        skip(100);          // 24 hours 2 minutes
+        _assertReserveAuctionPrice(58.243272807 * 1e18);
+        skip(58 minutes);   // 25 hours
+        _assertReserveAuctionPrice(29.802322388 * 1e18);
+        skip(5 hours);      // 30 hours
+        _assertReserveAuctionPrice(0.931322575 * 1e18);
+        skip(121 minutes);  // 32 hours 1 minute
+        _assertReserveAuctionPrice(0.230156356 * 1e18);
+        skip(7700 seconds); // 34 hours 9 minutes 20 seconds
+        _assertReserveAuctionPrice(0.052459681 * 1e18);
+        skip(8 hours);      // 42 hours 9 minutes 20 seconds
+        _assertReserveAuctionPrice(0.000204921 * 1e18);
+        skip(6 hours);      // 42 hours 9 minutes 20 seconds
+        _assertReserveAuctionPrice(0.000003202 * 1e18);
+        skip(3100 seconds); // 43 hours
+        _assertReserveAuctionPrice(0.000001756 * 1e18);
+        skip(5 hours);      // 48 hours
+        _assertReserveAuctionPrice(0.000000055 * 1e18);
+        skip(12 hours);     // 60 hours
+        _assertReserveAuctionPrice(0);
+    }
+
     function testClaimableReserveAuction() external {
         // borrower repays all debt (auction for full reserves)
         changePrank(_borrower);
@@ -142,7 +183,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // bid max amount
         skip(5 minutes);
-//        expectedPrice = 12_222 * 1e18;    // FIXME: price won't update until an hour passes
+        expectedPrice = 56.25929312 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
@@ -154,7 +195,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _collectionPool.takeReserves(400 * 1e18);
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajna.balanceOf(_bidder), 3_976.448457008778648946 * 1e18);
+        assertEq(_ajna.balanceOf(_bidder), 4_994.689550287796185205 * 1e18);
         expectedReserves = 0;
         _assertReserveAuction(
             ReserveAuctionState({

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -105,31 +105,37 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // check prices
         skip(37 minutes);
-        _assertReserveAuctionPrice(652176034.882782114 * 1e18);
+        _assertReserveAuctionPrice(652176034.882782126826643053 * 1e18);
         skip(23 hours);     // 23 hours 37 minutes
-        _assertReserveAuctionPrice(77.74544178 * 1e18);
+        _assertReserveAuctionPrice(77.745441780421987394 * 1e18);
         skip(1400);         // 24 hours 0 minutes 20 seconds
-        _assertReserveAuctionPrice(59.604644775 * 1e18);
+        _assertReserveAuctionPrice(59.604644775390625 * 1e18);
         skip(100);          // 24 hours 2 minutes
-        _assertReserveAuctionPrice(58.243272807 * 1e18);
+        _assertReserveAuctionPrice(58.243272807255146201 * 1e18);
         skip(58 minutes);   // 25 hours
-        _assertReserveAuctionPrice(29.802322387 * 1e18);
+        _assertReserveAuctionPrice(29.8023223876953125 * 1e18);
         skip(5 hours);      // 30 hours
-        _assertReserveAuctionPrice(0.931322574 * 1e18);
+        _assertReserveAuctionPrice(0.931322574615478515 * 1e18);
         skip(121 minutes);  // 32 hours 1 minute
-        _assertReserveAuctionPrice(0.230156355 * 1e18);
+        _assertReserveAuctionPrice(0.230156355619639189 * 1e18);
         skip(7700 seconds); // 34 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.052459681 * 1e18);
+        _assertReserveAuctionPrice(0.052459681325756842 * 1e18);
         skip(8 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000204920 * 1e18);
+        _assertReserveAuctionPrice(0.000204920630178738 * 1e18);
         skip(6 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000003201 * 1e18);
+        _assertReserveAuctionPrice(0.000003201884846542 * 1e18);
         skip(3100 seconds); // 43 hours
-        _assertReserveAuctionPrice(0.000001756 * 1e18);
+        _assertReserveAuctionPrice(0.000001755953640897 * 1e18);
         skip(5 hours);      // 48 hours
-        _assertReserveAuctionPrice(0.000000054 * 1e18);
+        _assertReserveAuctionPrice(0.000000054873551278 * 1e18);
         skip(12 hours);     // 60 hours
-        _assertReserveAuctionPrice(0);
+        _assertReserveAuctionPrice(0.000000000013396863 * 1e18);
+        skip(11 hours);     // 71 hours
+        _assertReserveAuctionPrice(0.000000000000006541 * 1e18);
+        skip(3599 seconds); // 71 hours 59 minutes 59 seconds
+        _assertReserveAuctionPrice(0.000000000000003308 * 1e18);
+        skip(1 seconds);    // 72 hours
+        _assertReserveAuctionPrice(0.000000000000003270 * 1e18);
     }
 
     function testClaimableReserveAuction() external {
@@ -162,7 +168,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // bid once the price becomes attractive
         skip(24 hours);
-        expectedPrice = 59.604644775 * 1e18;
+        expectedPrice = 59.604644775390625 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
@@ -175,7 +181,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _collectionPool.takeReserves(300 * 1e18);
         expectedQuoteBalance += 300 * 1e18;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajna.balanceOf(_bidder), 22_118.6065675 * 1e18);
+        assertEq(_ajna.balanceOf(_bidder), 22_118.6065673828125 * 1e18);
         expectedReserves -= 300 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
@@ -187,7 +193,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // bid max amount
         skip(5 minutes);
-        expectedPrice = 56.25929312 * 1e18;
+        expectedPrice = 56.259293120008319416 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
@@ -200,7 +206,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _collectionPool.takeReserves(400 * 1e18);
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajna.balanceOf(_bidder), 4_994.689550287796185205 * 1e18);
+        assertEq(_ajna.balanceOf(_bidder), 4_994.689550168076463748 * 1e18);
         expectedReserves = 0;
         _assertReserveAuction(
             ReserveAuctionState({
@@ -252,7 +258,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         // partial take
         skip(1 days);
         changePrank(_bidder);
-        expectedPrice = 59.604644775 * 1e18;
+        expectedPrice = 59.604644775390625 * 1e18;
         _collectionPool.takeReserves(100 * 1e18);
         expectedReserves -= 100 * 1e18;
         _assertReserveAuction(
@@ -295,7 +301,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         // take everything
         skip(28 hours);
         assertEq(expectedReserves, 538.990762002892312075 * 1e18);
-        expectedPrice = 3.725290298 * 1e18;
+        expectedPrice = 3.725290298461914062 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import { ERC721Pool }           from "../../erc721/ERC721Pool.sol";
+import { ERC721PoolFactory }    from "../../erc721/ERC721PoolFactory.sol";
+
+import { IERC721Pool }          from "../../erc721/interfaces/IERC721Pool.sol";
+import { IScaledPool }          from "../../base/interfaces/IScaledPool.sol";
+
+import { BucketMath }           from "../../libraries/BucketMath.sol";
+import { Maths }                from "../../libraries/Maths.sol";
+
+import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
+
+contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
+
+    address internal _borrower;
+    address internal _bidder;
+    address internal _lender;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _bidder    = makeAddr("bidder");
+        _lender    = makeAddr("lender");
+
+        // deploy collection pool, mint, and approve tokens
+        _collectionPool = _deployCollectionPool();
+        address[] memory poolAddresses_ = new address[](1);
+        poolAddresses_[0] = address(_collectionPool);
+        _mintAndApproveQuoteTokens(poolAddresses_, _lender, 250_000 * 1e18);
+        _mintAndApproveQuoteTokens(poolAddresses_, _borrower, 5_000 * 1e18);
+        _mintAndApproveCollateralTokens(poolAddresses_, _borrower, 12);
+
+        // lender adds liquidity and borrower draws debt
+        changePrank(_lender);
+        uint16 bucketId = 1663;
+        uint256 bucketPrice = _collectionPool.indexToPrice(bucketId);
+        assertEq(bucketPrice, 251_183.992399245533703810 * 1e18);
+        _collectionPool.addQuoteToken(200_000 * 1e18, bucketId);
+
+        // borrower draws debt
+        changePrank(_borrower);
+        uint256[] memory tokenIdsToAdd = new uint256[](1);
+        tokenIdsToAdd[0] = 1;
+        _collectionPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _collectionPool.borrow(175_000 * 1e18, bucketId);
+
+        _assertPool(
+            PoolState({
+                htp:                  175_168.269230769230850000 * 1e18,
+                lup:                  bucketPrice,
+                poolSize:             200_000 * 1e18,
+                pledgedCollateral:    1 * 1e18,
+                encumberedCollateral: 0.697370352137516918 * 1e18,
+                borrowerDebt:         175_168.269230769230850000 * 1e18,
+                actualUtilization:    0.875841346153846154 * 1e18,
+                targetUtilization:    1 * 1e18,
+                minDebtAmount:        17_516.826923076923085000 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower
+            })
+        );
+        skip(26 weeks);
+
+        // borrower repays debt
+        _collectionPool.repay(_borrower, 205_000 * 1e18);
+        assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18);
+    }
+
+    function testClaimableReserveAuction() external {
+        // TODO: implement
+//        _collectionPool.startClaimableReserveAuction();
+    }
+
+}

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -79,6 +79,17 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         assertEq(_collectionPool.reserves(), 168.26923076923085 * 1e18);
     }
 
+    function testUnclaimableReserves() external {
+        // borrower repays partial debt, ensure cannot kick when there are no claimable reserves
+        changePrank(_borrower);
+        _collectionPool.repay(_borrower, 50_000 * 1e18);
+        assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18);
+        changePrank(_bidder);
+        assertEq(_collectionPool.claimableReserves(), 0);
+        vm.expectRevert(IScaledPool.KickNoReserves.selector);
+        _collectionPool.startClaimableReserveAuction();
+    }
+
     function testClaimableReserveAuction() external {
         // borrower repays all debt (auction for full reserves)
         changePrank(_borrower);
@@ -87,9 +98,12 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // kick off a new auction
         uint256 expectedPrice = 1_000_000_000 * 1e18;
-        uint256 expectedReserves = _collectionPool.reserves();
+        uint256 expectedReserves = _collectionPool.claimableReserves();
+        assertEq(expectedReserves, _collectionPool.reserves());
         assertEq(expectedReserves, 610.479702351371553626 * 1e18);
-        uint256 expectedQuoteBalance = _quote.balanceOf(_bidder);
+        uint256 kickAward = Maths.wmul(expectedReserves, 0.01 * 1e18);
+        uint256 expectedQuoteBalance = _quote.balanceOf(_bidder) + kickAward;
+        expectedReserves -= kickAward;
         changePrank(_bidder);
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(expectedReserves, expectedPrice);
@@ -101,6 +115,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
             })
         );
         assertEq(_collectionPool.reserves(), 0);
+        assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
 
         // bid once the price becomes attractive
         skip(24 hours);
@@ -112,7 +127,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
             })
         );
         vm.expectEmit(true, true, true, true);
-        emit ReserveAuction(310.479702351371553626 * 1e18, expectedPrice);
+        emit ReserveAuction(304.374905327857838090 * 1e18, expectedPrice);
         _collectionPool.takeReserves(300 * 1e18);
         expectedQuoteBalance += 300 * 1e18;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
@@ -139,7 +154,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _collectionPool.takeReserves(400 * 1e18);
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajna.balanceOf(_bidder), 3_612.574198998766312082 * 1e18);
+        assertEq(_ajna.balanceOf(_bidder), 3_976.448457008778648946 * 1e18);
         expectedReserves = 0;
         _assertReserveAuction(
             ReserveAuctionState({
@@ -162,36 +177,89 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
     }
 
     function testReserveAuctionPartiallyTaken() external {
-        // borrower repays partial debt (auction leaves small buffer in reserves)
+        // borrower repays partial debt (auction for full reserves)
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 50_000 * 1e18);
+        _collectionPool.repay(_borrower, 100_000 * 1e18);
         assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18);
-        uint256 expectedReserves = _collectionPool.reserves();
+        uint256 expectedReserves = _collectionPool.claimableReserves();
+        assertEq(expectedReserves, 212.527832618418361858 * 1e18);
 
+        // kick off a new auction
+        uint256 expectedPrice = 1_000_000_000 * 1e18;
+        uint256 kickAward = Maths.wmul(expectedReserves, 0.01 * 1e18);
+        expectedReserves -= kickAward;
         changePrank(_bidder);
-        // _collectionPool.startClaimableReserveAuction();  // FIXME: underflow because CR formula returns negative value
-        //assertEq(_collectionPool.reserves(), 5.555 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit ReserveAuction(expectedReserves, expectedPrice);
+        _collectionPool.startClaimableReserveAuction();
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: expectedReserves,
+                auctionPrice:               expectedPrice
+            })
+        );
+        assertEq(_collectionPool.reserves(), 610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18);
 
-//        // partial take
-//        skip(1 days);
-//        uint256 expectedPrice = 59.604644775 * 1e18;
-//        _collectionPool.takeReserves(200 * 1e18);
-//        expectedReserves -= 200 * 1e18;
-//        _assertReserveAuction(
-//            ReserveAuctionState({
-//                claimableReservesRemaining: expectedReserves,
-//                auctionPrice:               expectedPrice
-//            })
-//        );
-//
-//        // wait until auction ends
-//        skip(3 days);
-//        expectedPrice = 0;
-//        _assertReserveAuction(
-//            ReserveAuctionState({
-//                claimableReservesRemaining: expectedReserves,
-//                auctionPrice:               expectedPrice
-//            })
-//        );
+        // partial take
+        skip(1 days);
+        changePrank(_bidder);
+        expectedPrice = 59.604644775 * 1e18;
+        _collectionPool.takeReserves(100 * 1e18);
+        expectedReserves -= 100 * 1e18;
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: expectedReserves,
+                auctionPrice:               expectedPrice
+            })
+        );
+
+        // wait until auction ends
+        skip(3 days);
+        expectedPrice = 0;
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: expectedReserves,
+                auctionPrice:               expectedPrice
+            })
+        );
+
+        // after more interest accumulates, borrower repays remaining debt
+        skip(4 weeks);
+        changePrank(_borrower);
+        _collectionPool.repay(_borrower, 105_000 * 1e18);
+
+        // start an auction, confirm old claimable reserves are included alongside new claimable reserves
+        skip(1 days);
+        changePrank(_bidder);
+        assertEq(_collectionPool.reserves(), 432.917381525917306905 * 1e18);
+        uint256 newClaimableReserves = _collectionPool.claimableReserves();
+        assertEq(newClaimableReserves, 432.917381525917306905 * 1e18);
+        expectedPrice = 1_000_000_000 * 1e18;
+        kickAward = Maths.wmul(newClaimableReserves, 0.01 * 1e18);
+        expectedReserves += newClaimableReserves - kickAward;
+        vm.expectEmit(true, true, true, true);
+        emit ReserveAuction(expectedReserves, expectedPrice);
+        _collectionPool.startClaimableReserveAuction();
+
+        // take everything
+        skip(28 hours);
+        assertEq(expectedReserves, 538.990762002892312075 * 1e18);
+        expectedPrice = 3.725290298 * 1e18;
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: expectedReserves,
+                auctionPrice:               expectedPrice
+            })
+        );
+        expectedReserves = 0;
+        vm.expectEmit(true, true, true, true);
+        emit ReserveAuction(expectedReserves, expectedPrice);
+        _collectionPool.takeReserves(600 * 1e18);
+        _assertReserveAuction(
+            ReserveAuctionState({
+                claimableReservesRemaining: expectedReserves,
+                auctionPrice:               expectedPrice
+            })
+        );
     }
 }

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -54,6 +54,8 @@ contract MathTest is DSTestPlus {
         uint256 claimableCollateral2 = lpBalance * 1e36 / exchangeRate / price;                  // truncates
         assertEq(claimableCollateral1, 33.726184963566645999 * 1e18);
         assertEq(claimableCollateral2, 33.726184963566645998 * 1e18);
+
+        assertEq(Maths.wdiv(1 * 1e18, 60 * 1e18), 0.016666666666666667 * 1e18);
     }
 
     function testWadToIntRoundingDown() external {
@@ -70,7 +72,9 @@ contract MathTest is DSTestPlus {
         assertEq(PRBMathUD60x18.exp(1.53 * 1e18), 4.618176822299780807 * 1e18);
     }
 
-    function testWpow() external {
+    function testPow() external {
         assertEq(Maths.wpow(3 * 1e18, 3), 27 * 1e18);
+        assertEq(Maths.rpow(0.5 * 1e27, 60), 0.000000000000000000867361738 * 1e27);
+        assertEq(Maths.rpow(0.5 * 1e27, 80), 0.000000000000000000000000827 * 1e27);  // FIXME: not much precision
     }
 }

--- a/src/_test/MathTest.t.sol
+++ b/src/_test/MathTest.t.sol
@@ -69,4 +69,8 @@ contract MathTest is DSTestPlus {
     function testExp() external {
         assertEq(PRBMathUD60x18.exp(1.53 * 1e18), 4.618176822299780807 * 1e18);
     }
+
+    function testWpow() external {
+        assertEq(Maths.wpow(3 * 1e18, 3), 27 * 1e18);
+    }
 }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -255,9 +255,9 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         reserveAuctionUnclaimed -= amount_;
 
         emit ReserveAuction(reserveAuctionUnclaimed, price);
-        quoteToken().safeTransfer(msg.sender, amount_ / quoteTokenScale);
         ERC20(ajnaTokenAddress).safeTransferFrom(msg.sender, address(this), ajnaRequired);
         ERC20Burnable(ajnaTokenAddress).burn(ajnaRequired);
+        quoteToken().safeTransfer(msg.sender, amount_ / quoteTokenScale);
     }
 
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -506,8 +506,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
             _price = 0;
         } else {
             uint256 secondsElapsed = block.timestamp - reserveAuctionKicked;
-            // uint256 hoursComponent = Maths.wpow(0.5 * 1e18, secondsElapsed / 3600);   // worst gas 7256
-            uint256 hoursComponent = 1e18 >> secondsElapsed / 3600;                      // worst gas 4405
+            uint256 hoursComponent = 1e18 >> secondsElapsed / 3600;
             uint256 minutesComponent = Maths.wpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
             _price = 1_000_000_000 * Maths.wmul(hoursComponent, minutesComponent);
         }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -25,7 +25,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     int256  public constant INDEX_OFFSET = 3232;
 
     uint256 public constant WAD_WEEKS_PER_YEAR  = 52 * 10**18;
-    uint256 public constant MINUTE_HALF_LIFE    = 0.988514020352896135 * 1e18;  // 0.5^(1/60)
+    uint256 public constant MINUTE_HALF_LIFE    = 0.988514020352896135_356867505 * 1e27;  // 0.5^(1/60)
 
     uint256 public constant INCREASE_COEFFICIENT = 1.1 * 10**18;
     uint256 public constant DECREASE_COEFFICIENT = 0.9 * 10**18;
@@ -506,9 +506,9 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
             _price = 0;
         } else {
             uint256 secondsElapsed = block.timestamp - reserveAuctionKicked;
-            uint256 hoursComponent = 1e18 >> secondsElapsed / 3600;
-            uint256 minutesComponent = Maths.wpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
-            _price = 1_000_000_000 * Maths.wmul(hoursComponent, minutesComponent);
+            uint256 hoursComponent = 1e27 >> secondsElapsed / 3600;
+            uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
+            _price = Maths.rayToWad(1_000_000_000 * Maths.rmul(hoursComponent, minutesComponent));
         }
     }
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -237,6 +237,12 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
 
     function startClaimableReserveAuction() external override {
         reserveAuctionKicked = block.timestamp;
+        console.log("borrowerDebt:            %s", borrowerDebt);
+        console.log("borrowerDebt less 50bps: %s", Maths.wmul(0.995 * 1e18, borrowerDebt));
+        console.log("pool balance:            %s", quoteToken().balanceOf(address(this)));
+        console.log("pool size:               %s", this.poolSize());
+        console.log("liquidationBondEscrowed: %s", liquidationBondEscrowed);
+        console.log("reserveAuctionUnclaimed: %s", reserveAuctionUnclaimed);
         uint256 claimableReserves = Maths.wmul(0.995 * 1e18, borrowerDebt)
                                         + quoteToken().balanceOf(address(this))
                                         - this.poolSize()
@@ -251,7 +257,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
 
         amount_ = Maths.min(reserveAuctionUnclaimed, maxAmount_);
         uint256 price = _reserveAuctionPrice();
-        uint256 ajnaRequired = Maths.wdiv(amount_, price);
+        uint256 ajnaRequired = Maths.wmul(amount_, price);
         reserveAuctionUnclaimed -= amount_;
 
         emit ReserveAuction(reserveAuctionUnclaimed, price);
@@ -523,7 +529,11 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     }
 
     function reserves() external view override returns (uint256) {
-        return borrowerDebt + quoteToken().balanceOf(address(this)) - this.poolSize() - liquidationBondEscrowed - reserveAuctionUnclaimed;
+        return borrowerDebt
+            + quoteToken().balanceOf(address(this))
+            - this.poolSize()
+            - liquidationBondEscrowed
+            - reserveAuctionUnclaimed;
     }
 
     function depositAt(uint256 index_) external view override returns (uint256) {

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -625,10 +625,11 @@ interface IScaledPool {
      *  @notice Returns the state of the Claimaible Reserve Auction.
      *  @return claimableReservesRemaining_ Amount of claimable reserves which has not yet been taken.
      *  @return auctionPrice_               Current price at which 1 quote token may be purchased, denominated in Ajna.
+     *  @return timeRemaining_              Seconds remaining before takes are no longer allowed.
      */
     function reserveAuction() external view returns (
         uint256 claimableReservesRemaining_,
-        uint256 auctionPrice_
-        // TODO: should I add a timeRemaining_ field?
+        uint256 auctionPrice_,
+        uint256 timeRemaining_
     );
 }

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -134,6 +134,11 @@ interface IScaledPool {
     error KickNoDebt();
 
     /**
+     *  @notice No pool reserves are claimable.
+     */
+    error KickNoReserves();
+
+    /**
      *  @notice Borrower has a healthy over-collateralized position.
      */
     error LiquidateBorrowerOk();
@@ -486,6 +491,12 @@ interface IScaledPool {
             uint256 lpAccumulator_,
             uint256 scale_
         );
+
+    /**
+     *  @notice Calculates the amount of reserves which can be claimed through a Claimable Reserve Auction.
+     *  @return _claimableReserves Denominated in quote token, or 0 if no reserves can be auctioned.
+     */
+    function claimableReserves() external view returns (uint256 _claimableReserves);
 
     /**
      *  @notice Returns the address of the pool's collateral token

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -70,6 +70,13 @@ interface IScaledPool {
     event RemoveQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
 
     /**
+     *  @notice Emitted when a Claimaible Reserve Auction is started or taken.
+     *  @return claimableReservesRemaining_ Amount of claimable reserves which has not yet been taken.
+     *  @return auctionPrice_               Current price at which 1 quote token may be purchased, denominated in Ajna.
+     */
+    event ReserveAuction(uint256 claimableReservesRemaining_, uint256 auctionPrice_);
+
+    /**
      *  @notice Emitted when a lender transfers their LP tokens to a different address.
      *  @dev    Used by PositionManager.memorializePositions().
      *  @param  owner_    The original owner address of the position.
@@ -611,5 +618,6 @@ interface IScaledPool {
     function reserveAuction() external view returns (
         uint256 claimableReservesRemaining_,
         uint256 auctionPrice_
+        // TODO: should I add a timeRemaining_ field?
     );
 }

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -157,6 +157,11 @@ interface IScaledPool {
     error MoveQuoteLUPBelowHTP();
 
     /**
+     *  @notice Actor is attempting to take or clear an inactive auction.
+     */
+    error NoAuction();
+
+    /**
      *  @notice User is attempting to pull more collateral than is available.
      */
     error RemoveCollateralInsufficientCollateral();

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,6 +37,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
+        ajnaTokenAddress           = address(0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079);
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,7 +37,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        ajnaTokenAddress           = address(0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079);
+        ajnaTokenAddress           = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -49,6 +49,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
+        ajnaTokenAddress           = address(0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079);
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -49,7 +49,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        ajnaTokenAddress           = address(0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079);
+        ajnaTokenAddress           = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;


### PR DESCRIPTION
Implemented Claimable Reserve Auctions (CRAs), aka _Ajna Token Burn and Buy_.

Did the unit tests in an NFT collection pool merely to offer some coverage of that deployment use case.

Since the Ajna token address is hardcoded, testing requires testing against a fork with the Ajna token deployed.  CI has already been updated with a `ETH_RPC_URL` secret for this purpose.