### PR TITLE
Move Ajna token address to deployer, RWT improvements

### DIFF
--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -42,6 +42,11 @@ abstract contract PoolDeployer {
     /// @dev SubsetHash => CollateralAddress => QuoteAddress => Pool Address
     mapping(bytes32 => mapping(address => mapping(address => address))) public deployedPools;
 
+    /**
+     *  @notice Address of the Ajna token, needed for Claimable Reserve Auctions.
+     */
+    address internal ajnaTokenAddress = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+
     /*****************/
     /*** Modifiers ***/
     /*****************/

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -72,7 +72,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     /**
      *  @notice Address of the Ajna token, needed for Claimable Reserve Auctions.
      */
-    address internal ajnaTokenAddress = address(0);
+    address internal ajnaTokenAddress;
 
     Heap.Data internal loans;
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -72,7 +72,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     /**
      *  @notice Address of the Ajna token, needed for Claimable Reserve Auctions.
      */
-    address internal ajnaTokenAddress = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+    address internal ajnaTokenAddress = address(0);
 
     Heap.Data internal loans;
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -31,13 +31,13 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
     /*** Initialize Functions ***/
     /****************************/
 
-    function initialize(uint256 rate_) external {
+    function initialize(uint256 rate_, address ajnaTokenAddress_) external {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
         collateralScale = 10**(18 - collateral().decimals());
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        ajnaTokenAddress           = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+        ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -32,6 +32,6 @@ contract ERC20PoolFactory is IPoolFactory, PoolDeployer {
         deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(interestRate_);
+        pool.initialize(interestRate_, ajnaTokenAddress);
     }
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -219,9 +219,10 @@ interface IERC20Pool is IScaledPool {
 
     /**
      *  @notice Initializes a new pool, setting initial state variables.
-     *  @param  interestRate_ Default interest rate of the pool.
+     *  @param  interestRate_     Default interest rate of the pool.
+     *  @param  ajnaTokenAddress_ Address of the Ajna token.
      */
-    function initialize(uint256 interestRate_) external;
+    function initialize(uint256 interestRate_, address ajnaTokenAddress_) external;
 
     /*******************************************/
     /*** ERC20Pool Lender External Functions ***/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -44,12 +44,12 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     /*** Initialize Functions ***/
     /****************************/
 
-    function initialize(uint256 rate_) external {
+    function initialize(uint256 rate_, address ajnaTokenAddress_) external {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
         quoteTokenScale = 10**(18 - quoteToken().decimals());
 
-        ajnaTokenAddress           = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+        ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         lenderInterestFactor       = 0.9 * 10**18;
@@ -63,8 +63,8 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         poolInitializations += 1;
     }
 
-    function initializeSubset(uint256[] memory tokenIds_, uint256 rate_) external override {
-        this.initialize(rate_);
+    function initializeSubset(uint256[] memory tokenIds_, uint256 rate_, address ajnaTokenAddress_) external override {
+        this.initialize(rate_, ajnaTokenAddress_);
 
         // add subset of tokenIds allowed in the pool
         for (uint256 id = 0; id < tokenIds_.length;) {

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -32,7 +32,7 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         deployedPools[ERC721_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(interestRate_);
+        pool.initialize(interestRate_, ajnaTokenAddress);
     }
 
     function deploySubsetPool(
@@ -45,7 +45,7 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         deployedPools[getNFTSubsetHash(tokenIds_)][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initializeSubset(tokenIds_, interestRate_);
+        pool.initializeSubset(tokenIds_, interestRate_, ajnaTokenAddress);
     }
 
     /*********************************/

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -151,9 +151,12 @@ interface IERC721Pool is IScaledPool {
 
     /**
      *  @notice Called by deployNFTSubsetPool()
-     *  @dev Used to initialize pools that only support a subset of tokenIds
+     *  @dev    Used to initialize pools that only support a subset of tokenIds
+     *  @param  tokenIds_         Enumerates tokenIds to be allowed in the pool.
+     *  @param  interestRate_     Initial interest rate of the pool.
+     *  @param  ajnaTokenAddress_ Address of the Ajna token.
      */
-    function initializeSubset(uint256[] memory tokenIds_, uint256 interestRate_) external;
+    function initializeSubset(uint256[] memory tokenIds_, uint256 interestRate_, address ajnaTokenAddress_) external;
 
 
     /***********************************/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,6 +240,7 @@ class TestUtils:
                     lines.append(
                         f"   {prefix} {fn_name} -  avg: {values['avg']}  avg (confirmed):"
                         f" {values['avg_success']}  low: {values['low']}  high: {values['high']}"
+                        f"  tx count: {values['count']}"
                     )
 
             return lines + [""]


### PR DESCRIPTION
Per discussion this morning, moved Ajna token address to `PoolDeployer`, such that it's in one place instead of three.  Will still need a solution to parameterize this for deployment to other chains.

Unrelated, some minor improvements to the real-world test.