### PR TITLE
added MOMP factor

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -139,7 +139,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         uint256 pendingDebt;
         uint256 collateral;
         uint256 collateralization;
-        uint256 lupFactor;
+        uint256 mompFactor;
         uint256 inflator;
     }
 
@@ -361,11 +361,11 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     }
 
     function _assertBorrower(BorrowerState memory state_) internal {
-        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 lupFactor, uint256 inflator) = _pool.borrowerInfo(state_.borrower);
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _pool.borrowerInfo(state_.borrower);
         assertEq(debt,        state_.debt);
         assertEq(pendingDebt, state_.pendingDebt);
         assertEq(col,         state_.collateral);
-        assertEq(lupFactor,   state_.lupFactor);
+        assertEq(mompFactor,   state_.mompFactor);
         assertEq(inflator,    state_.inflator);
 
         assertEq(_pool.borrowerCollateralization(state_.debt, state_.collateral, _pool.lup()), state_.collateralization);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -319,7 +319,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_051.890446235135648008 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.090818626082626625 * 1e18,
-                mompFactor:        2_995.912459898389633881 * 1e18,
+                mompFactor:        2_981.007422784467321543 * 1e18,
                 inflator:          1 * 1e18
             })
         );
@@ -359,7 +359,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_083.636385101213387311 * 1e18,
                 collateral:        60 * 1e18,
                 collateralization: 8.483377444958217435 * 1e18,
-                mompFactor:        2_986.897273971999164870 * 1e18,
+                mompFactor:        2_972.037088529352426932 * 1e18,
                 inflator:          1.003018244385218513 * 1e18
             })
         );
@@ -398,7 +398,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_118.612213260575675180 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.057773002983275249 * 1e18,
-                mompFactor:        2_981.950490313624344276 * 1e18,
+                mompFactor:        2_967.114915734949620331 * 1e18,
                 inflator:          1.004682160092905114 * 1e18
             })
         );
@@ -441,7 +441,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_157.152643010853298669 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.044916376706357985 * 1e18,
-                mompFactor:        2_976.518490302568830134 * 1e18,
+                mompFactor:        2_961.709940599570999250 * 1e18,
                 inflator:          1.006515655675920014 * 1e18
             })
         );
@@ -481,7 +481,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_199.628356897284446170 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.030801136225104189 * 1e18,
-                mompFactor:        2_970.554718407924741286 * 1e18,
+                mompFactor:        2_955.775839211865438160 * 1e18,
                 inflator:          1.008536365727696620 * 1e18
             })
         );
@@ -513,7 +513,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_246.450141935843879765 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.030801136225104189 * 1e18,
-                mompFactor:        2_970.554718407924741286 * 1e18,
+                mompFactor:        2_955.775839211865438160 * 1e18,
                 inflator:          1.008536365727696620 * 1e18
             })
         );
@@ -573,26 +573,26 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
             })
         );
 
-        changePrank(_borrower);
-        // should revert if borrower attempts to borrow more than minimum amount
-        vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
-        _pool.borrow(10 * 1e18, 3000);
+       // changePrank(_borrower);
+       // // should revert if borrower attempts to borrow more than minimum amount
+       // vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
+       // _pool.borrow(10 * 1e18, 3000);
 
-        changePrank(_borrower2);
-        vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
-        _pool.borrow(2_976 * 1e18, 3000);
+       // changePrank(_borrower2);
+       // vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
+       // _pool.borrow(2_976 * 1e18, 3000);
 
-        // should be able to borrow if properly specified
-        _borrow(
-            BorrowSpecs({
-                from:         _borrower2,
-                borrower:     _borrower2,
-                pledgeAmount: 0,
-                borrowAmount: 10 * 1e18,
-                indexLimit:   3_000,
-                price:        2_995.912459898389633881 * 1e18
-            })
-        );
+       // // should be able to borrow if properly specified
+       // _borrow(
+       //     BorrowSpecs({
+       //         from:         _borrower2,
+       //         borrower:     _borrower2,
+       //         pledgeAmount: 0,
+       //         borrowAmount: 10 * 1e18,
+       //         indexLimit:   3_000,
+       //         price:        2_981.007422784467321543 * 1e18
+       //     })
+       // );
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -573,26 +573,26 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
             })
         );
 
-       // changePrank(_borrower);
-       // // should revert if borrower attempts to borrow more than minimum amount
-       // vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
-       // _pool.borrow(10 * 1e18, 3000);
+        changePrank(_borrower);
+        // should revert if borrower attempts to borrow more than minimum amount
+        vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
+        _pool.borrow(10 * 1e18, 3000);
 
-       // changePrank(_borrower2);
-       // vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
-       // _pool.borrow(2_976 * 1e18, 3000);
+        changePrank(_borrower2);
+        vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
+        _pool.borrow(2_976 * 1e18, 3000);
 
-       // // should be able to borrow if properly specified
-       // _borrow(
-       //     BorrowSpecs({
-       //         from:         _borrower2,
-       //         borrower:     _borrower2,
-       //         pledgeAmount: 0,
-       //         borrowAmount: 10 * 1e18,
-       //         indexLimit:   3_000,
-       //         price:        2_981.007422784467321543 * 1e18
-       //     })
-       // );
+        // should be able to borrow if properly specified
+        _borrow(
+            BorrowSpecs({
+                from:         _borrower2,
+                borrower:     _borrower2,
+                pledgeAmount: 0,
+                borrowAmount: 10 * 1e18,
+                indexLimit:   3_000,
+                price:        2_981.007422784467321543 * 1e18
+            })
+        );
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -590,7 +590,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pledgeAmount: 0,
                 borrowAmount: 10 * 1e18,
                 indexLimit:   3_000,
-                price:        2_981.007422784467321543 * 1e18
+                price:        2_995.912459898389633881 * 1e18
             })
         );
     }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolBorrow.t.sol
@@ -319,7 +319,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_051.890446235135648008 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.090818626082626625 * 1e18,
-                lupFactor:         2_981.007422784467321543 * 1e18,
+                mompFactor:        2_995.912459898389633881 * 1e18,
                 inflator:          1 * 1e18
             })
         );
@@ -359,7 +359,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_083.636385101213387311 * 1e18,
                 collateral:        60 * 1e18,
                 collateralization: 8.483377444958217435 * 1e18,
-                lupFactor:         2_972.037088529352426932 * 1e18,
+                mompFactor:        2_986.897273971999164870 * 1e18,
                 inflator:          1.003018244385218513 * 1e18
             })
         );
@@ -398,7 +398,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_118.612213260575675180 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.057773002983275249 * 1e18,
-                lupFactor:         2_967.114915734949620331 * 1e18,
+                mompFactor:        2_981.950490313624344276 * 1e18,
                 inflator:          1.004682160092905114 * 1e18
             })
         );
@@ -441,7 +441,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_157.152643010853298669 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.044916376706357985 * 1e18,
-                lupFactor:         2_961.709940599570999250 * 1e18,
+                mompFactor:        2_976.518490302568830134 * 1e18,
                 inflator:          1.006515655675920014 * 1e18
             })
         );
@@ -481,7 +481,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_199.628356897284446170 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.030801136225104189 * 1e18,
-                lupFactor:         2_955.775839211865438160 * 1e18,
+                mompFactor:        2_970.554718407924741286 * 1e18,
                 inflator:          1.008536365727696620 * 1e18
             })
         );
@@ -513,7 +513,7 @@ contract ERC20ScaledBorrowTest is ERC20HelperContract {
                 pendingDebt:       21_246.450141935843879765 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.030801136225104189 * 1e18,
-                lupFactor:         2_955.775839211865438160 * 1e18,
+                mompFactor:        2_970.554718407924741286 * 1e18,
                 inflator:          1.008536365727696620 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -107,7 +107,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_020.192307692307702000 * 1e18,
                 collateral:        100 * 1e18,
                 collateralization: 14.181637252165253251 * 1e18,
-                mompFactor:        2_995.912459898389633881 * 1e18,
+                mompFactor:        2_981.007422784467321543 * 1e18,
                 inflator:          1 * 1e18
             })
         );
@@ -150,7 +150,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_049.006823139002918431 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.081111825921092812 * 1e18,
-                mompFactor:        2_991.811279896025266018 * 1e18,
+                mompFactor:        2_976.926646662711731597 * 1e18,
                 inflator:          1.001370801704613834 * 1e18
             })
         );
@@ -190,7 +190,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_049.006823139002918431 * 1e18,
                 collateral:        7.061038044473493202 * 1e18,
                 collateralization: 1 * 1e18,
-                mompFactor:         2_991.811279896025266018 * 1e18,
+                mompFactor:        2_976.926646662711731597 * 1e18,
                 inflator:          1.001370801704613834 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -107,7 +107,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_020.192307692307702000 * 1e18,
                 collateral:        100 * 1e18,
                 collateralization: 14.181637252165253251 * 1e18,
-                lupFactor:         2_981.007422784467321543 * 1e18,
+                mompFactor:        2_995.912459898389633881 * 1e18,
                 inflator:          1 * 1e18
             })
         );
@@ -150,7 +150,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_049.006823139002918431 * 1e18,
                 collateral:        50 * 1e18,
                 collateralization: 7.081111825921092812 * 1e18,
-                lupFactor:         2_976.926646662711731597 * 1e18,
+                mompFactor:        2_991.811279896025266018 * 1e18,
                 inflator:          1.001370801704613834 * 1e18
             })
         );
@@ -190,7 +190,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 pendingDebt:       21_049.006823139002918431 * 1e18,
                 collateral:        7.061038044473493202 * 1e18,
                 collateralization: 1 * 1e18,
-                lupFactor:         2_976.926646662711731597 * 1e18,
+                mompFactor:         2_991.811279896025266018 * 1e18,
                 inflator:          1.001370801704613834 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
@@ -142,7 +142,7 @@ contract ERC20ScaledInterestRateTestAndEMAs is ERC20HelperContract {
                 pendingDebt:       0,
                 collateral:        100 * 1e18,
                 collateralization: 1e18,
-                mompFactor:        2_981.007422784467321543 * 1e18,
+                mompFactor:        0 * 1e18,
                 inflator:          1.001507985182953253 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
@@ -142,7 +142,7 @@ contract ERC20ScaledInterestRateTestAndEMAs is ERC20HelperContract {
                 pendingDebt:       0,
                 collateral:        100 * 1e18,
                 collateralization: 1e18,
-                mompFactor:         1_003_455_791.141722003295902974 * 1e18,
+                mompFactor:        2_981.007422784467321543 * 1e18,
                 inflator:          1.001507985182953253 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolInterestRateAndEMAs.t.sol
@@ -142,7 +142,7 @@ contract ERC20ScaledInterestRateTestAndEMAs is ERC20HelperContract {
                 pendingDebt:       0,
                 collateral:        100 * 1e18,
                 collateralization: 1e18,
-                lupFactor:         1_003_455_791.141722003295902974 * 1e18,
+                mompFactor:         1_003_455_791.141722003295902974 * 1e18,
                 inflator:          1.001507985182953253 * 1e18
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolLiquidations.t.sol
@@ -62,7 +62,7 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
             uint256 borrowerDebt,
             uint256 borrowerPendingDebt,
             uint256 collateralDeposited,
-            uint256 lupFactor,
+            uint256 mompFactor,
             uint256 borrowerInflator
         ) = _pool.borrowerInfo(_borrower2);
 
@@ -92,7 +92,7 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
             borrowerDebt,
             borrowerPendingDebt,
             collateralDeposited,
-            lupFactor,
+            mompFactor,
             borrowerInflator
         ) = _pool.borrowerInfo(_borrower2);
 
@@ -116,7 +116,7 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
             uint256 borrowerDebt,
             uint256 borrowerPendingDebt,
             uint256 collateralDeposited,
-            uint256 lupFactor,
+            uint256 mompFactor,
             uint256 borrowerInflator
 
         ) = _pool.borrowerInfo(address(borrower_));
@@ -124,7 +124,7 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
         emit log_named_uint("borrowerDebt        ", borrowerDebt);
         emit log_named_uint("borrowerPendingDebt ", borrowerPendingDebt);
         emit log_named_uint("collateralDeposited ", collateralDeposited);
-        emit log_named_uint("lupFactor ",           lupFactor);
+        emit log_named_uint("mompFactor ",           mompFactor);
         emit log_named_uint("collateralEncumbered", _pool.encumberedCollateral(borrowerDebt, _pool.lup()));
         emit log_named_uint("collateralization   ", _pool.borrowerCollateralization(borrowerDebt, collateralDeposited, _pool.lup()));
         emit log_named_uint("borrowerInflator    ", borrowerInflator);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -97,7 +97,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        5_017.163540992622874208 * 1e18);
         assertEq(pendingDebt, 5_017.163540992622874208 * 1e18);
         assertEq(col.length,  4);
-        assertEq(mompFactor,   3_003.477050385824310983 * 1e18);
+        assertEq(mompFactor,  3_003.477050385824310983 * 1e18);
         assertEq(inflator,    1.002468795894779594 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -80,11 +80,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.borrow(5_000 * 1e18, 2551);
 
         assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 lupFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_010.981808341113791532 * 1e18);
         assertEq(col.length,  3);
-        assertEq(lupFactor,   3_010.892022197881557845 * 1e18);
+        assertEq(mompFactor,   3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
         // borrower pledge additional collateral after some time has passed
@@ -93,11 +93,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 51;
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
         assertEq(_subsetPool.borrowerDebt(), 5_017.163540992622874208 * 1e18);
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_017.163540992622874208 * 1e18);
         assertEq(pendingDebt, 5_017.163540992622874208 * 1e18);
         assertEq(col.length,  4);
-        assertEq(lupFactor,   3_003.477050385824310983 * 1e18);
+        assertEq(mompFactor,   3_003.477050385824310983 * 1e18);
         assertEq(inflator,    1.002468795894779594 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed
@@ -106,22 +106,22 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToRemove[0] = 1;
         _subsetPool.pullCollateral(tokenIdsToRemove);
         assertEq(_subsetPool.borrowerDebt(), 5_022.733620353117867729 * 1e18);
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_022.733620353117867729 * 1e18);
         assertEq(pendingDebt, 5_022.733620353117867729 * 1e18);
         assertEq(col.length,  3);
-        assertEq(lupFactor,   3_000.146273404086167746 * 1e18);
+        assertEq(mompFactor,   3_000.146273404086167746 * 1e18);
         assertEq(inflator,    1.003581741626751696 * 1e18);
 
         // borrower borrows some additional quote after some time has passed
         skip(864000);
         _subsetPool.borrow(1_000 * 1e18, 3000);
         assertEq(_subsetPool.borrowerDebt(), 6_028.452940379879069654 * 1e18);
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        6_028.452940379879069654 * 1e18);
         assertEq(pendingDebt, 6_028.452940379879069654 * 1e18);
         assertEq(col.length,  3);
-        assertEq(lupFactor,   2_997.151732388411916563 * 1e18);
+        assertEq(mompFactor,   2_997.151732388411916563 * 1e18);
         assertEq(inflator,    1.004584449182531072 * 1e18);
 
         // mint additional quote to borrower to enable repayment
@@ -129,13 +129,13 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // borrower repays their loan after some additional time
         skip(864000);
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         _subsetPool.repay(_borrower, pendingDebt);
         assertEq(_subsetPool.borrowerDebt(), 0);
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
-        assertEq(lupFactor,   999_484_076.340322579760520204 * 1e18);
+        assertEq(mompFactor,   999_484_076.340322579760520204 * 1e18);
         assertEq(col.length,  3);
         assertEq(inflator,    1.005487742522395296 * 1e18);
 
@@ -324,11 +324,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after borrow
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 lupFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col.length,  3);
-        assertEq(lupFactor,   3_010.892022197881557845 * 1e18);
+        assertEq(mompFactor,   3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
         // pass time to allow interest to accumulate
@@ -366,11 +366,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after partial repay
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
         assertEq(col.length,  3);
-        assertEq(lupFactor,   3_006.770336295505368176 * 1e18);
+        assertEq(mompFactor,   3_006.770336295505368176 * 1e18);
         assertEq(inflator,    1.001370801704613834 * 1e18);
 
         // pass time to allow additional interest to accumulate
@@ -425,11 +425,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after fully repay
-        (debt, pendingDebt, col, lupFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  0);
-        assertEq(lupFactor,   1_002_356_715.905391712168567717 * 1e18);
+        assertEq(mompFactor,   1_002_356_715.905391712168567717 * 1e18);
     }
 
     function testScaledPoolRepayRequireChecks() external {

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -84,7 +84,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_010.981808341113791532 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,   3_010.892022197881557845 * 1e18);
+        assertEq(mompFactor,  0 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
         // borrower pledge additional collateral after some time has passed
@@ -135,7 +135,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
-        assertEq(mompFactor,   999_484_076.340322579760520204 * 1e18);
+        assertEq(mompFactor,  0 * 1e18);
         assertEq(col.length,  3);
         assertEq(inflator,    1.005487742522395296 * 1e18);
 
@@ -328,7 +328,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,   3_010.892022197881557845 * 1e18);
+        assertEq(mompFactor,  0);
         assertEq(inflator,    1 * 1e18);
 
         // pass time to allow interest to accumulate
@@ -429,7 +429,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col.length,  0);
-        assertEq(mompFactor,   1_002_356_715.905391712168567717 * 1e18);
+        assertEq(mompFactor,  0 * 1e18);
     }
 
     function testScaledPoolRepayRequireChecks() external {

--- a/src/_test/FenwickTree.t.sol
+++ b/src/_test/FenwickTree.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.14;
 import { DSTestPlus, FenwickTreeInstance }  from "./utils/DSTestPlus.sol";
 
 import { Maths } from "../libraries/Maths.sol";
-import "forge-std/console.sol";
 
 contract FenwickTreeTest is DSTestPlus {
 

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -637,7 +637,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         return _getArgAddress(0x14);
     }
  
-    function _updateMompFactor(uint256 inflator) internal view returns (uint256) {
+    function _mompFactor(uint256 inflator) internal view returns (uint256) {
         uint256 numLoans = (loans.count - 1) * 1e18;
         if (numLoans != 0) {
             return Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, numLoans))), inflator);

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -636,4 +636,12 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     function quoteTokenAddress() external pure returns (address) {
         return _getArgAddress(0x14);
     }
+ 
+    function _updateMompFactor(uint256 inflator) internal view returns (uint256) {
+        uint256 numLoans = (loans.count - 1) * 1e18;
+        if (numLoans != 0) {
+            return Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, numLoans))), inflator);
+        }
+        return 0;
+    }
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -71,7 +71,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         pledgedCollateral += amount_;
 
         uint256 lup = _lup();
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
         _updateInterestRateAndEMAs(curDebt, lup);
 
@@ -109,7 +109,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         loans.upsert(msg.sender, thresholdPrice);
 
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);
@@ -134,7 +134,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(msg.sender, thresholdPrice);
 
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         // update pool state
@@ -388,7 +388,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         borrowerDebt = curDebt;
 
         uint256 newLup = _lup();
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -71,7 +71,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         pledgedCollateral += amount_;
 
         uint256 lup = _lup();
-        borrower.lupFactor    = Maths.wdiv(lup, borrower.inflatorSnapshot);
+        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
+        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
         _updateInterestRateAndEMAs(curDebt, lup);
 
@@ -109,7 +110,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         loans.upsert(msg.sender, thresholdPrice);
 
-        borrower.lupFactor    = Maths.wdiv(newLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(borrowerDebt /  loans.count - 1)), borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);
@@ -134,7 +135,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(msg.sender, thresholdPrice);
 
-        borrower.lupFactor    = Maths.wdiv(curLup, borrower.inflatorSnapshot);
+        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
+        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         // update pool state
@@ -388,7 +390,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         borrowerDebt = curDebt;
 
         uint256 newLup = _lup();
-        borrower.lupFactor    = Maths.wdiv(newLup, borrower.inflatorSnapshot);
+        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
+        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);
@@ -409,7 +412,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
             borrowers[borrower_].debt,            // accrued debt (WAD)
             pendingDebt,                          // current debt, accrued and pending accrual (WAD)
             borrowers[borrower_].collateral,      // deposited collateral including encumbered (WAD)
-            borrowers[borrower_].lupFactor,       // LUP / inflator, used in neutralPrice calc (WAD)
+            borrowers[borrower_].mompFactor,      // MOMP / inflator, used in neutralPrice calc (WAD)
             borrowers[borrower_].inflatorSnapshot // used to calculate pending interest (WAD)
         );
     }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -71,10 +71,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         pledgedCollateral += amount_;
 
         uint256 lup = _lup();
-        uint256 loansCount = (loans.count - 1) * 1e18;
-        if (loansCount != 0) {
-            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
-        }
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
         _updateInterestRateAndEMAs(curDebt, lup);
 
@@ -112,10 +109,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         loans.upsert(msg.sender, thresholdPrice);
 
-        uint256 loansCount = (loans.count - 1) * 1e18;
-        if (loansCount != 0) {
-            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
-        }
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);
@@ -140,10 +134,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(msg.sender, thresholdPrice);
 
-        uint256 loansCount = (loans.count - 1) * 1e18;
-        if (loansCount != 0) {
-            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
-        }
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         // update pool state
@@ -397,10 +388,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         borrowerDebt = curDebt;
 
         uint256 newLup = _lup();
-        uint256 loansCount = (loans.count - 1) * 1e18;
-        if (loansCount != 0) {
-            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
-        }
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
         borrowers[borrower_] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -71,8 +71,10 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         pledgedCollateral += amount_;
 
         uint256 lup = _lup();
-        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
-        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
+        uint256 loansCount = (loans.count - 1) * 1e18;
+        if (loansCount != 0) {
+            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
+        }
         borrowers[borrower_] = borrower;
         _updateInterestRateAndEMAs(curDebt, lup);
 
@@ -110,8 +112,10 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         loans.upsert(msg.sender, thresholdPrice);
 
-        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0;
-        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
+        uint256 loansCount = (loans.count - 1) * 1e18;
+        if (loansCount != 0) {
+            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
+        }
         borrowers[msg.sender] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);
@@ -136,8 +140,10 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(msg.sender, thresholdPrice);
 
-        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
-        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
+        uint256 loansCount = (loans.count - 1) * 1e18;
+        if (loansCount != 0) {
+            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
+        }
         borrowers[msg.sender] = borrower;
 
         // update pool state
@@ -391,8 +397,10 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         borrowerDebt = curDebt;
 
         uint256 newLup = _lup();
-        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0; 
-        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
+        uint256 loansCount = (loans.count - 1) * 1e18;
+        if (loansCount != 0) {
+            borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, loansCount))), borrower.inflatorSnapshot);
+        }
         borrowers[borrower_] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -110,7 +110,8 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, borrower.collateral, borrower.inflatorSnapshot);
         loans.upsert(msg.sender, thresholdPrice);
 
-        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(borrowerDebt /  loans.count - 1)), borrower.inflatorSnapshot);
+        uint256 avgLoan = loans.count - 1 != 0 ? borrowerDebt / loans.count - 1 : 0;
+        borrower.mompFactor = Maths.wdiv(_indexToPrice(_findIndexOfSum(avgLoan)), borrower.inflatorSnapshot);
         borrowers[msg.sender] = borrower;
 
         _updateInterestRateAndEMAs(curDebt, newLup);

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -156,13 +156,13 @@ interface IERC20Pool is IScaledPool {
      *  @notice Struct holding borrower related info.
      *  @param  debt             Borrower debt, WAD units.
      *  @param  collateral       Collateral deposited by borrower, WAD units.
-     *  @return lupFactor        LUP / inflator, used in neutralPrice calc (WAD)
+     *  @return mompFactor       Most Optimistic Matching Price (MOMP) / inflator, used in neutralPrice calc, WAD units.
      *  @param  inflatorSnapshot Current borrower inflator snapshot, WAD units.
      */
     struct Borrower {
         uint256 debt;             // [WAD]
         uint256 collateral;       // [WAD]
-        uint256 lupFactor;        // [WAD]
+        uint256 mompFactor;       // [WAD]
         uint256 inflatorSnapshot; // [WAD]
     }
 

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -119,10 +119,10 @@ interface IERC20Pool is IScaledPool {
      *  @param  borrower_  Address of the borrower.
      *  @return debt       Amount of debt that the borrower has, in quote token.
      *  @return collateral Amount of collateral that the borrower has deposited, in collateral token.
-     *  @return lupFactor  The LUP / inflator snapshot factor used.
+     *  @return mompFactor Momp / borrowerInflatorSnapshot factor used.
      *  @return inflator   Snapshot of inflator value used to track interest on loans.
      */
-    function borrowers(address borrower_) external view returns (uint256 debt, uint256 collateral, uint256 lupFactor, uint256 inflator);
+    function borrowers(address borrower_) external view returns (uint256 debt, uint256 collateral, uint256 mompFactor, uint256 inflator);
 
     /**
      *  @notice Returns the `collateralScale` state variable.
@@ -286,7 +286,7 @@ interface IERC20Pool is IScaledPool {
      *  @return debt_             Borrower accrued debt (WAD)
      *  @return pendingDebt_      Borrower current debt, accrued and pending accrual (WAD)
      *  @return collateral_       Deposited collateral including encumbered (WAD)
-     *  @return lupFactor_        LUP / inflator, used in neutralPrice calc (WAD)
+     *  @return mompFactor_        LUP / inflator, used in neutralPrice calc (WAD)
      *  @return inflatorSnapshot_ Inflator used to calculate pending interest (WAD)
      */
     function borrowerInfo(address borrower_)
@@ -296,7 +296,7 @@ interface IERC20Pool is IScaledPool {
             uint256 debt_,
             uint256 pendingDebt_,
             uint256 collateral_,
-            uint256 lupFactor_,
+            uint256 mompFactor_,
             uint256 inflatorSnapshot_
         );
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -105,7 +105,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         // accrue interest to borrower
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-        borrower.lupFactor = Maths.wdiv(lup, borrower.inflatorSnapshot);
+        borrower.mompFactor = Maths.wdiv(lup, borrower.inflatorSnapshot);
 
         // update loan queue
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), borrower.inflatorSnapshot);
@@ -137,7 +137,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         if (_borrowerCollateralization(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), newLup) < Maths.WAD) revert BorrowBorrowerUnderCollateralized();
         if (_poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral, newLup) < Maths.WAD) revert BorrowPoolUnderCollateralized();
 
-        borrower.lupFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
         curDebt += debt;
 
         borrowerDebt = curDebt;
@@ -166,7 +166,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 curLup = _lup();
         if (Maths.wad(borrower.collateralDeposited.length()) - _encumberedCollateral(borrower.debt, curLup) < Maths.wad(tokenIds_.length)) revert RemoveCollateralInsufficientCollateral();
 
-        borrower.lupFactor = Maths.wdiv(curLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = Maths.wdiv(curLup, borrower.inflatorSnapshot);
 
         // update pool state
         pledgedCollateral -= Maths.wad(tokenIds_.length);
@@ -218,7 +218,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         // update pool state
         borrowerDebt = curDebt;
         uint256 newLup = _lup();
-        borrower.lupFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
 
         _updateInterestRateAndEMAs(curDebt, newLup);
 
@@ -373,7 +373,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
             borrowers[borrower_].debt,                         // accrued debt (WAD)
             pendingDebt,                                       // current debt, accrued and pending accrual (WAD)
             borrowers[borrower_].collateralDeposited.values(), // deposited collateral including encumbered (WAD)
-            borrowers[borrower_].lupFactor,                    // LUP / inflator, used in neutralPrice calc (WAD)
+            borrowers[borrower_].mompFactor,                    // LUP / inflator, used in neutralPrice calc (WAD)
             borrowers[borrower_].inflatorSnapshot              // used to calculate pending interest (WAD)
         );
     }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -105,8 +105,8 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         // accrue interest to borrower
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-        borrower.mompFactor = Maths.wdiv(lup, borrower.inflatorSnapshot);
 
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
         // update loan queue
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(borrower_, thresholdPrice);
@@ -137,9 +137,9 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         if (_borrowerCollateralization(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), newLup) < Maths.WAD) revert BorrowBorrowerUnderCollateralized();
         if (_poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral, newLup) < Maths.WAD) revert BorrowPoolUnderCollateralized();
 
-        borrower.mompFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
-        curDebt += debt;
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
 
+        curDebt += debt;
         borrowerDebt = curDebt;
 
         // update loan queue
@@ -166,7 +166,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 curLup = _lup();
         if (Maths.wad(borrower.collateralDeposited.length()) - _encumberedCollateral(borrower.debt, curLup) < Maths.wad(tokenIds_.length)) revert RemoveCollateralInsufficientCollateral();
 
-        borrower.mompFactor = Maths.wdiv(curLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
 
         // update pool state
         pledgedCollateral -= Maths.wad(tokenIds_.length);
@@ -218,7 +218,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         // update pool state
         borrowerDebt = curDebt;
         uint256 newLup = _lup();
-        borrower.mompFactor = Maths.wdiv(newLup, borrower.inflatorSnapshot);
+        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
 
         _updateInterestRateAndEMAs(curDebt, newLup);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -106,7 +106,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         // accrue interest to borrower
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
 
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
         // update loan queue
         uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), borrower.inflatorSnapshot);
         if (borrower.debt != 0) loans.upsert(borrower_, thresholdPrice);
@@ -137,7 +137,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         if (_borrowerCollateralization(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), newLup) < Maths.WAD) revert BorrowBorrowerUnderCollateralized();
         if (_poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral, newLup) < Maths.WAD) revert BorrowPoolUnderCollateralized();
 
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
 
         curDebt += debt;
         borrowerDebt = curDebt;
@@ -166,7 +166,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 curLup = _lup();
         if (Maths.wad(borrower.collateralDeposited.length()) - _encumberedCollateral(borrower.debt, curLup) < Maths.wad(tokenIds_.length)) revert RemoveCollateralInsufficientCollateral();
 
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
 
         // update pool state
         pledgedCollateral -= Maths.wad(tokenIds_.length);
@@ -218,7 +218,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         // update pool state
         borrowerDebt = curDebt;
         uint256 newLup = _lup();
-        borrower.mompFactor = _updateMompFactor(borrower.inflatorSnapshot);
+        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
 
         _updateInterestRateAndEMAs(curDebt, newLup);
 
@@ -373,7 +373,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
             borrowers[borrower_].debt,                         // accrued debt (WAD)
             pendingDebt,                                       // current debt, accrued and pending accrual (WAD)
             borrowers[borrower_].collateralDeposited.values(), // deposited collateral including encumbered (WAD)
-            borrowers[borrower_].mompFactor,                    // LUP / inflator, used in neutralPrice calc (WAD)
+            borrowers[borrower_].mompFactor,                   // MOMP / inflator, used in neutralPrice calc (WAD)
             borrowers[borrower_].inflatorSnapshot              // used to calculate pending interest (WAD)
         );
     }

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -120,13 +120,13 @@ interface IERC721Pool is IScaledPool {
      *  @notice Struct holding borrower related info per price bucket, for borrowers using NFTs as collateral.
      *  @param  debt                Borrower debt, WAD units.
      *  @param  collateralDeposited OZ Enumberable Set tracking the tokenIds of collateral that have been deposited
-     *  @param  lupFactor           LUP / inflator, used in neutralPrice calc (WAD)
+     *  @param  mompFactor          Momp / borrower.inflatorSnapshot, used in neutralPrice calc (WAD)
      *  @param  inflatorSnapshot    Current borrower inflator snapshot, RAY units.
      */
     struct NFTBorrower {
         uint256               debt;                // [WAD]
         EnumerableSet.UintSet collateralDeposited;
-        uint256               lupFactor;
+        uint256               mompFactor;
         uint256               inflatorSnapshot;    // [WAD]
     }
 
@@ -235,7 +235,7 @@ interface IERC721Pool is IScaledPool {
      *  @return debt_                Borrower accrued debt (WAD)
      *  @return pendingDebt_         Borrower current debt, accrued and pending accrual (WAD)
      *  @return collateralDeposited_ Array of deposited collateral IDs including encumbered
-     *  @return lupFactor_           LUP / inflator, used in neutralPrice calc (WAD)
+     *  @return mompFactor_          Momp / borrower.inflatorSnapshot, used in neutralPrice calc (WAD)
      *  @return inflatorSnapshot_    Inflator used to calculate pending interest (WAD)
      */
     function borrowerInfo(address borrower_)
@@ -245,7 +245,7 @@ interface IERC721Pool is IScaledPool {
             uint256 debt_,
             uint256 pendingDebt_,
             uint256[] memory collateralDeposited_,
-            uint256 lupFactor_,
+            uint256 mompFactor_,
             uint256 inflatorSnapshot_
         );
 


### PR DESCRIPTION
`MOMP` is used to calculate the neutral price used in liquidations, it stands for "Most Optimistic Matching Price".
* updated anytime borrower updates their position -> `borrower`, `pledgeCollateral`, `_repayDebt`, `pullCollateral`
* updated corresponding tests.
