### PR TITLE
Code reorg

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -346,7 +346,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
 
     function _assertLPs(LenderLPs memory specs_) internal {
         for (uint256 i = 0; i < specs_.bucketLPs.length; ++i) {
-            (uint256 lpBalance, uint256 time) = _pool.bucketLenders(specs_.bucketLPs[i].index, specs_.lender);
+            (uint256 lpBalance, uint256 time) = _pool.lenders(specs_.bucketLPs[i].index, specs_.lender);
             assertEq(lpBalance, specs_.bucketLPs[i].balance);
             assertEq(time,      specs_.bucketLPs[i].time);
         }

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -36,7 +36,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         address from;
         uint256 amount;
         uint256 index;
-        uint256 price;
     }
 
     struct BorrowSpecs {
@@ -215,7 +214,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     function _addCollateral(AddCollateralSpecs memory specs_) internal {
         changePrank(specs_.from);
         vm.expectEmit(true, true, false, true);
-        emit AddCollateral(specs_.from, specs_.price, specs_.amount);
+        emit AddCollateral(specs_.from, specs_.index, specs_.amount);
         vm.expectEmit(true, true, false, true);
         emit Transfer(specs_.from, address(_pool), specs_.amount);
         _pool.addCollateral(specs_.amount, specs_.index);

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -88,8 +88,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
     struct RemoveCollateralSpecs {
         address from;
         uint256 amount;
-        uint256 index; 
-        uint256 price;
+        uint256 index;
         uint256 lpRedeem;
     }
 
@@ -223,7 +222,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     function _removeAllCollateral(RemoveCollateralSpecs memory specs_) internal {
         changePrank(specs_.from);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(specs_.from, specs_.price, specs_.amount);
+        emit RemoveCollateral(specs_.from, specs_.index, specs_.amount);
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), specs_.from, specs_.amount);
         (uint256 collateralRemoved, uint256 lpAmount) = _pool.removeAllCollateral(specs_.index);
@@ -246,7 +245,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     function _removeCollateral(RemoveCollateralSpecs memory specs_) internal {
         changePrank(specs_.from);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(specs_.from, specs_.price, specs_.amount);
+        emit RemoveCollateral(specs_.from, specs_.index, specs_.amount);
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), specs_.from, specs_.amount);
         uint256 lpRedeemed = _pool.removeCollateral(specs_.amount, specs_.index);

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -21,7 +21,7 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
     }
 
     function testLoadERC20PoolFuzzyPartialRepay(uint256 borrowerId_) public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         address borrower = _borrowers[borrowerId_];
@@ -29,11 +29,11 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.repay(borrower, 100 * 1e18);
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasFuzzyFullRepay(uint256 borrowerId_) public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         skip(15 hours);
@@ -42,11 +42,11 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.repay(borrower, pendingDebt);
 
-        assertEq(_pool.loansCount(), LOANS_COUNT - 1);
+        assertEq(_loansCount(), LOANS_COUNT - 1);
     }
 
     function testLoadERC20PoolGasFuzzyBorrowExisting(uint256 borrowerId_) public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         skip(15 hours);
@@ -54,13 +54,13 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.borrow(1_000 * 1e18, 5_000);
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasBorrowNew() public {
         uint256 snapshot = vm.snapshot();
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         address newBorrower = makeAddr("newBorrower");
 
@@ -74,68 +74,68 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         _pool.borrow(1_000 * 1e18, 5_000);
         vm.stopPrank();
 
-        assertEq(_pool.loansCount(), LOANS_COUNT + 1);
+        assertEq(_loansCount(), LOANS_COUNT + 1);
 
         vm.revertTo(snapshot);
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExercisePartialRepayForAllBorrowers() public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.loansCount(), LOANS_COUNT);
+            assertEq(_loansCount(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             vm.prank(borrower);
             _pool.repay(borrower, 100 * 1e18);
 
-            assertEq(_pool.loansCount(), LOANS_COUNT);
+            assertEq(_loansCount(), LOANS_COUNT);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExerciseRepayAllForAllBorrowers() public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.loansCount(), LOANS_COUNT);
+            assertEq(_loansCount(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             (, uint256 pendingDebt, , , ) = _pool.borrowerInfo(borrower);
             vm.prank(borrower);
             _pool.repay(borrower, pendingDebt);
 
-            assertEq(_pool.loansCount(), LOANS_COUNT - 1);
+            assertEq(_loansCount(), LOANS_COUNT - 1);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExerciseBorrowMoreForAllBorrowers() public {
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.loansCount(), LOANS_COUNT);
+            assertEq(_loansCount(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             vm.prank(borrower);
             _pool.borrow(1_000 * 1e18, 5_000);
 
-            assertEq(_pool.loansCount(), LOANS_COUNT);
+            assertEq(_loansCount(), LOANS_COUNT);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.loansCount(), LOANS_COUNT);
+        assertEq(_loansCount(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasFuzzyAddRemoveQuoteToken(uint256 index_) public {

--- a/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -22,7 +22,7 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
     }
 
     function testMulticallDepostQuoteToken() external {
-        assertEq(_pool.poolSize(), 0);
+        assertEq(_poolSize(), 0);
 
         bytes[] memory callsToExecute = new bytes[](3);
 
@@ -59,27 +59,33 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
         emit Transfer(_lender, address(_pool), 10_000 * 1e18);                
         _pool.multicall(callsToExecute);
 
-        assertEq(_pool.htp(), 0);
-        assertEq(_pool.lup(), BucketMath.MAX_PRICE);
-        assertEq(_pool.hpb(), _pool.indexToPrice(2550));
+
+        _assertPoolPrices(
+            PoolPricesInfo({
+                htp: 0,
+                hpb: 3_010.892022197881557845 * 1e18,
+                lup: BucketMath.MAX_PRICE,
+                lupIndex: 0
+            })
+        );
 
         // check balances
         assertEq(_quote.balanceOf(address(_pool)), 30_000 * 1e18);
         assertEq(_quote.balanceOf(_lender),        170_000 * 1e18);
-        assertEq(_pool.poolSize(),                 30_000 * 1e18);
+        assertEq(_poolSize(),                      30_000 * 1e18);
 
         // check buckets
         (uint256 lpBalance, ) = _pool.lenders(2550, _lender);
-        assertEq(lpBalance,                10_000 * 1e27);
-        assertEq(_pool.exchangeRate(2550), 1 * 1e27);
+        assertEq(lpBalance,           10_000 * 1e27);
+        assertEq(_exchangeRate(2550), 1 * 1e27);
 
         (lpBalance, ) = _pool.lenders(2551, _lender);
-        assertEq(lpBalance,                10_000 * 1e27);
-        assertEq(_pool.exchangeRate(2551), 1 * 1e27);
+        assertEq(lpBalance,           10_000 * 1e27);
+        assertEq(_exchangeRate(2551), 1 * 1e27);
 
         (lpBalance, ) = _pool.lenders(2552, _lender);
-        assertEq(lpBalance,                10_000 * 1e27);
-        assertEq(_pool.exchangeRate(2552), 1 * 1e27);
+        assertEq(lpBalance,           10_000 * 1e27);
+        assertEq(_exchangeRate(2552), 1 * 1e27);
     }
 
     function testMulticallRevertString() public {

--- a/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -69,15 +69,15 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
         assertEq(_pool.poolSize(),                 30_000 * 1e18);
 
         // check buckets
-        (uint256 lpBalance, ) = _pool.bucketLenders(2550, _lender);
+        (uint256 lpBalance, ) = _pool.lenders(2550, _lender);
         assertEq(lpBalance,                10_000 * 1e27);
         assertEq(_pool.exchangeRate(2550), 1 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(2551, _lender);
+        (lpBalance, ) = _pool.lenders(2551, _lender);
         assertEq(lpBalance,                10_000 * 1e27);
         assertEq(_pool.exchangeRate(2551), 1 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(2552, _lender);
+        (lpBalance, ) = _pool.lenders(2552, _lender);
         assertEq(lpBalance,                10_000 * 1e27);
         assertEq(_pool.exchangeRate(2552), 1 * 1e27);
     }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -238,8 +238,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _bidder,
                 amount: 4 * 1e18,
-                index:  2550,
-                price: _pool.indexToPrice(2550)
+                index:  2550
             })
         );
 
@@ -320,8 +319,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _bidder,
                 amount: 1 * 1e18,
-                index:  1530,
-                price: _pool.indexToPrice(1530)
+                index:  1530
             })
         );
 
@@ -412,16 +410,14 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _lender,
                 amount: 16.3 * 1e18,
-                index:  3333,
-                price: _pool.indexToPrice(3333)
+                index:  3333
             })
         );
         _addCollateral(
             AddCollateralSpecs({
                 from:   _lender,
                 amount: 3.7 * 1e18,
-                index:  3334,
-                price: _pool.indexToPrice(3334)
+                index:  3334
             })
         );
 
@@ -439,8 +435,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _borrower,
                 amount: 1.3 * 1e18,
-                index:  3334,
-                price: _pool.indexToPrice(3334)
+                index:  3334
             })
         );
         // should revert if actor doesn't have enough LP to move specified amount
@@ -487,8 +482,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _lender,
                 amount: 1 * 1e18,
-                index:  fromBucket,
-                price: _pool.indexToPrice(1369)
+                index:  fromBucket
             })
         );
         skip(2 hours);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -265,7 +265,6 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   1.53 * 1e18,
                 index:    2550,
-                price:    _pool.indexToPrice(2550),
                 lpRedeem: 4_606.664793962758783502850000000 * 1e27
             })
         );
@@ -290,7 +289,6 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   2.47 * 1e18,
                 index:    2550,
-                price:    _pool.indexToPrice(2550),
                 lpRedeem: 7_436.90329482876744787715 * 1e27
             })
         );
@@ -328,7 +326,6 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   0.5 * 1e18,
                 index:    1530,
-                price:    _pool.indexToPrice(1530),
                 lpRedeem: 243_808.1263305875209909205 * 1e27
             })
         );
@@ -355,7 +352,6 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   0.5 * 1e18,
                 index:    1530,
-                price:    _pool.indexToPrice(1530),
                 lpRedeem: 243_808.1263305875209909205 * 1e27
             })
         );
@@ -450,19 +446,19 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
                 amount:       3.7 * 1e18,
                 fromIndex:    3334,
                 toIndex:      3333,
-                lpRedeemFrom: 223.205292406408929929926000068 * 1e27,
-                lpRedeemTo:   224.321318868440972760613496942 * 1e27
+                lpRedeemFrom: 223.2052924064089299299 * 1e27,
+                lpRedeemTo:   224.3213188684409727605 * 1e27
             })
         );
 
         // check bucket state and bidder's LPs
         BucketState[] memory bucketStates = new BucketState[](2);
-        bucketStates[0] = BucketState({index: 3333, LPs: 1_212.547669559140393300613496942 * 1e27, collateral: 20 * 1e18});
-        bucketStates[1] = BucketState({index: 3334, LPs: 78.423481115765299705109135142 * 1e27, collateral: 1.3 * 1e18});
+        bucketStates[0] = BucketState({index: 3333, LPs: 1_212.5476695591403933 * 1e27, collateral: 20 * 1e18});
+        bucketStates[1] = BucketState({index: 3334, LPs: 78.4234811157652997051 * 1e27, collateral: 1.3 * 1e18});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 3334, balance: 73999932, time: 0}); // FIXME: optimized LP calculation leaves 73999932 LP here
-        lps[1] = BucketLP({index: 3333, balance: 1_212.547669559140393300613496942 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 3334, balance: 0, time: 0});
+        lps[1] = BucketLP({index: 3333, balance: 1_212.5476695591403933 * 1e27, time: 0});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,

--- a/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolCollateral.t.sol
@@ -160,7 +160,7 @@ contract ERC20ScaledCollateralTest is ERC20HelperContract {
         _pullCollateral(
             PullSpecs({
                 from:   _borrower,
-                amount: 50 * 1e18 - _pool.encumberedCollateral(21_049.006823139002918431 * 1e18, _pool.lup())
+                amount: 50 * 1e18 - _pool.encumberedCollateral(21_049.006823139002918431 * 1e18, _lup())
             })
         );
 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolLiquidations.t.sol
@@ -67,8 +67,8 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
 
         assertEq(borrowerDebt,         10_009.615384615384620000 * 1e18);
         assertEq(borrowerPendingDebt,  10_030.204233142901661009 * 1e18);
-        assertEq(_pool.encumberedCollateral(borrowerPendingDebt, _pool.lup()), 1.001368006956135433 * 1e18);
-        assertEq(_pool.borrowerCollateralization(borrowerPendingDebt, collateralDeposited, _pool.lup()), 0.998633861930247030 * 1e18);
+        assertEq(_pool.encumberedCollateral(borrowerPendingDebt, _lup()), 1.001368006956135433 * 1e18);
+        assertEq(_pool.borrowerCollateralization(borrowerPendingDebt, collateralDeposited, _lup()), 0.998633861930247030 * 1e18);
         assertEq(borrowerInflator,     1e18);
 
         ( uint256 kickTime, uint256 referencePrice, uint256 remainingCollateral, uint256 remainingDebt ) = _pool.liquidations(_borrower2);
@@ -98,8 +98,8 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
         assertEq(borrowerDebt,         10_030.204233142901661009 * 1e18);  // Updated to reflect debt
         assertEq(borrowerPendingDebt,  10_030.204233142901661009 * 1e18);  // Pending debt is unchanged
         assertEq(collateralDeposited,  1e18);                              // Unchanged
-        assertEq(_pool.encumberedCollateral(borrowerDebt, _pool.lup()), 1.001368006956135433 * 1e18);  // Unencumbered collateral is unchanged because based off pending debt
-        assertEq(_pool.borrowerCollateralization(borrowerDebt, collateralDeposited, _pool.lup()), 0.998633861930247030 * 1e18);  // Unchanged because based off pending debt
+        assertEq(_pool.encumberedCollateral(borrowerDebt, _lup()), 1.001368006956135433 * 1e18);  // Unencumbered collateral is unchanged because based off pending debt
+        assertEq(_pool.borrowerCollateralization(borrowerDebt, collateralDeposited, _lup()), 0.998633861930247030 * 1e18);  // Unchanged because based off pending debt
         assertEq(borrowerInflator,     1.002056907057504104 * 1e18);       // Inflator is updated to reflect new debt
 
         ( kickTime, referencePrice, remainingCollateral, remainingDebt ) = _pool.liquidations(_borrower2);
@@ -148,8 +148,8 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
         emit log_named_uint("borrowerPendingDebt ", borrowerPendingDebt);
         emit log_named_uint("collateralDeposited ", collateralDeposited);
         emit log_named_uint("mompFactor ",           mompFactor);
-        emit log_named_uint("collateralEncumbered", _pool.encumberedCollateral(borrowerDebt, _pool.lup()));
-        emit log_named_uint("collateralization   ", _pool.borrowerCollateralization(borrowerDebt, collateralDeposited, _pool.lup()));
+        emit log_named_uint("collateralEncumbered", _pool.encumberedCollateral(borrowerDebt, _lup()));
+        emit log_named_uint("collateralization   ", _pool.borrowerCollateralization(borrowerDebt, collateralDeposited, _lup()));
         emit log_named_uint("borrowerInflator    ", borrowerInflator);
     }
 }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -91,7 +91,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (uint256 lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -116,7 +116,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(),         125_000 * _quotePoolPrecision);
         assertEq(lpBalance,                25_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -161,7 +161,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.maxBorrower(), address(0));
         assertEq(_pool.loansCount(),  0);
 
-        (uint256 lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (uint256 lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -189,7 +189,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -217,7 +217,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
         assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
@@ -277,7 +277,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // check bucket state
         (uint256 lpAccumulatorStateOne, uint256 availableCollateral) = _pool.buckets(2549);
-        (uint256 lpBalance, )                                        = _pool.bucketLenders(2549, _lender);
+        (uint256 lpBalance, )                                        = _pool.lenders(2549, _lender);
         assertEq(availableCollateral,   collateralRequired);
         assertGt(availableCollateral,   0);
         assertEq(lpAccumulatorStateOne, lpBalance);
@@ -293,7 +293,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_pool.htp(), 0);
         assertEq(_pool.lup(), BucketMath.MAX_PRICE);
 
-        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(_pool.poolSize(), 149_500 * _quotePoolPrecision);
         assertEq(lpBalance,        50_000 * _lpPoolPrecision);
 
@@ -307,7 +307,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // check bucket state
         (uint256 lpAccumulatorStateTwo, uint256 availableCollateralStateTwo) = _pool.buckets(2549);
-        (lpBalance, ) = _pool.bucketLenders(2549, _lender);
+        (lpBalance, ) = _pool.lenders(2549, _lender);
         assertEq(availableCollateralStateTwo, 0);
         assertEq(lpAccumulatorStateTwo, lpBalance);
         assertGt(lpAccumulatorStateTwo, 0);

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPrecision.t.sol
@@ -88,13 +88,16 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_lender),        50_000 * _quotePrecision);
 
         // check initial pool state
-        assertEq(_pool.htp(), 0);
-        assertEq(_pool.lup(), BucketMath.MAX_PRICE);
+        ( , uint256 htp, uint256 lup, ) = _pool.poolPricesInfo();
+        assertEq(htp, 0);
+        assertEq(lup, BucketMath.MAX_PRICE);
 
         (uint256 lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
+        (uint256 poolSize, , , ) = _pool.poolLoansInfo();
+        ( , , , , , uint256 exchangeRate, ) = _pool.bucketAt(2549);
+        assertEq(poolSize,         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
-        assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
+        assertEq(exchangeRate, 1 * _lpPoolPrecision);
 
         // check bucket balance
         (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(2549);
@@ -113,13 +116,16 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_lender),        75_000 * _quotePrecision);
 
         // check pool state
-        assertEq(_pool.htp(), 0);
-        assertEq(_pool.lup(), BucketMath.MAX_PRICE);
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        assertEq(htp, 0);
+        assertEq(lup, BucketMath.MAX_PRICE);
 
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(),         125_000 * _quotePoolPrecision);
-        assertEq(lpBalance,                25_000 * _lpPoolPrecision);
-        assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
+        (poolSize, , , ) = _pool.poolLoansInfo();
+        ( , , , , , exchangeRate, ) = _pool.bucketAt(2549);
+        assertEq(poolSize,     125_000 * _quotePoolPrecision);
+        assertEq(lpBalance,    25_000 * _lpPoolPrecision);
+        assertEq(exchangeRate, 1 * _lpPoolPrecision);
 
         // check bucket balance
         (lpAccumulator, availableCollateral) = _pool.buckets(2549);
@@ -156,19 +162,23 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_borrower), 0);
 
         // check pool state
-        assertEq(_pool.htp(), 0);
-        assertEq(_pool.lup(), BucketMath.MAX_PRICE);
-        assertEq(_pool.maxBorrower(), address(0));
-        assertEq(_pool.loansCount(),  0);
+        ( , uint256 htp, uint256 lup, ) = _pool.poolPricesInfo();
+        (uint256 poolSize, uint256 loansCount, address maxBorrower, ) = _pool.poolLoansInfo();
+        assertEq(htp, 0);
+        assertEq(lup, BucketMath.MAX_PRICE);
+        assertEq(maxBorrower, address(0));
+        assertEq(loansCount,  0);
 
         (uint256 lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
+        ( , , , , , uint256 exchangeRate, ) = _pool.bucketAt(2549);
+        assertEq(poolSize,         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
-        assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
+        assertEq(exchangeRate, 1 * _lpPoolPrecision);
 
         // borrower borrows
         vm.expectEmit(true, true, false, true);
-        emit Borrow(_borrower, _pool.indexToPrice(2549), 10_000 * _quotePoolPrecision);
+        (uint256 price, , , , , , ) = _pool.bucketAt(2549);
+        emit Borrow(_borrower, price, 10_000 * _quotePoolPrecision);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_pool), _borrower, 10_000 * _quotePrecision);
         _pool.borrow(10_000 * _quotePoolPrecision, 3000);
@@ -181,22 +191,25 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // check pool state
         (uint256 debt, , uint256 col, , ) = _pool.borrowerInfo(_borrower);
-        assertEq(_pool.htp(), Maths.wdiv(debt, col));
-        assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(_pool.maxBorrower(), _borrower);
-        assertEq(_pool.loansCount(),  1);
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        (poolSize, loansCount, maxBorrower, ) = _pool.poolLoansInfo();
+        assertEq(htp, Maths.wdiv(debt, col));
+        assertEq(lup, price);
+        assertEq(maxBorrower, _borrower);
+        assertEq(loansCount,  1);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
+        ( , , , , , exchangeRate, ) = _pool.bucketAt(2549);
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
+        assertEq(poolSize,         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
-        assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
+        assertEq(exchangeRate, 1 * _lpPoolPrecision);
 
         // borrower repays half of loan
         vm.expectEmit(true, true, false, true);
-        emit Repay(_borrower, _pool.indexToPrice(2549), 5_000 * _quotePoolPrecision);
+        emit Repay(_borrower, price, 5_000 * _quotePoolPrecision);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_pool), 5_000 * _quotePrecision);
         _pool.repay(_borrower, 5_000 * _quotePoolPrecision);
@@ -209,21 +222,25 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // check pool state
         (debt, , col, , ) = _pool.borrowerInfo(_borrower);
-        assertEq(_pool.htp(), Maths.wdiv(debt, col));
-        assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(_pool.maxBorrower(), _borrower);
-        assertEq(_pool.loansCount(),  1);
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        (poolSize, loansCount, maxBorrower, ) = _pool.poolLoansInfo();
+        assertEq(htp, Maths.wdiv(debt, col));
+        assertEq(lup, price);
+        assertEq(maxBorrower, _borrower);
+        assertEq(loansCount,  1);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
+        ( , , , , , exchangeRate, ) = _pool.bucketAt(2549);
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(),         150_000 * _quotePoolPrecision);
+        assertEq(poolSize,         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
-        assertEq(_pool.exchangeRate(2549), 1 * _lpPoolPrecision);
+        assertEq(exchangeRate, 1 * _lpPoolPrecision);
 
         // remove all of the remaining unencumbered collateral
-        uint256 unencumberedCollateral = col - _pool.encumberedCollateral(debt, _pool.lup());
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        uint256 unencumberedCollateral = col - _pool.encumberedCollateral(debt, lup);
         vm.expectEmit(true, true, false, true);
         emit PullCollateral(_borrower, unencumberedCollateral);
         vm.expectEmit(true, true, false, true);
@@ -238,10 +255,12 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // check pool state
         (debt, , col, , ) = _pool.borrowerInfo(_borrower);
-        assertEq(_pool.htp(), Maths.wdiv(debt, col));
-        assertEq(_pool.lup(), _pool.indexToPrice(2549));
-        assertEq(_pool.maxBorrower(), _borrower);
-        assertEq(_pool.loansCount(),  1);
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        (poolSize, loansCount, maxBorrower, ) = _pool.poolLoansInfo();
+        assertEq(htp, Maths.wdiv(debt, col));
+        assertEq(lup, price);
+        assertEq(maxBorrower, _borrower);
+        assertEq(loansCount,  1);
 
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
@@ -264,8 +283,9 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
 
         // bidder purchases quote with collateral
         changePrank(_bidder);
+        (uint256 price, , , , , , ) = _pool.bucketAt(2549);
         uint256 quoteToPurchase = 500 * _quotePoolPrecision;
-        uint256 collateralRequired = Maths.wdiv(quoteToPurchase, _pool.indexToPrice(2549));
+        uint256 collateralRequired = Maths.wdiv(quoteToPurchase, price);
         uint256 adjustedCollateralReq = collateralRequired / _pool.collateralScale();
     //     vm.expectEmit(true, true, false, true);
     //     emit Transfer(address(_bidder), address(_pool), adjustedCollateralReq);
@@ -290,11 +310,13 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_bidder),             500 * _quotePrecision);
 
         // check pool state
-        assertEq(_pool.htp(), 0);
-        assertEq(_pool.lup(), BucketMath.MAX_PRICE);
+        ( , uint256 htp, uint256 lup, ) = _pool.poolPricesInfo();
+        assertEq(htp, 0);
+        assertEq(lup, BucketMath.MAX_PRICE);
 
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        assertEq(_pool.poolSize(), 149_500 * _quotePoolPrecision);
+        (uint256 poolSize, , , ) = _pool.poolLoansInfo();
+        assertEq(poolSize, 149_500 * _quotePoolPrecision);
         assertEq(lpBalance,        50_000 * _lpPoolPrecision);
 
         // lender claims newly available collateral from bucket
@@ -302,7 +324,7 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         vm.expectEmit(true, true, true, true);
         emit Transfer(address(_pool), address(_lender), adjustedCollateralReq);
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateral(address(_lender), _pool.indexToPrice(2549), availableCollateral);
+        emit RemoveCollateral(address(_lender), price, availableCollateral);
        _pool.removeCollateral(availableCollateral, 2549);
 
         // check bucket state
@@ -321,8 +343,10 @@ contract ERC20ScaledPoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_bidder),             500 * _quotePrecision);
 
         // check pool state
-        assertEq(_pool.htp(),      0);
-        assertEq(_pool.lup(),      BucketMath.MAX_PRICE);
-        assertEq(_pool.poolSize(), 149_500 * _quotePoolPrecision);
+        ( , htp, lup, ) = _pool.poolPricesInfo();
+        (poolSize, , , ) = _pool.poolLoansInfo();
+        assertEq(htp,      0);
+        assertEq(lup,      BucketMath.MAX_PRICE);
+        assertEq(poolSize, 149_500 * _quotePoolPrecision);
     }
 }

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -54,8 +54,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _bidder,
                 amount: collateralToPurchaseWith,
-                index:  testIndex,
-                price:  priceAtTestIndex
+                index:  testIndex
             })
         );
 
@@ -245,8 +244,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
             AddCollateralSpecs({
                 from:   _bidder,
                 amount: collateralToPurchaseWith,
-                index:  2550,
-                price:  3_010.892022197881557845 * 1e18
+                index:  2550
             })
         );
 

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -125,7 +125,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from: _lender,
                 amount: 3.321274866808485288 * 1e18,
                 index: testIndex,
-                price: priceAtTestIndex,
                 lpRedeem: 10_000 * 1e27
             })
         );
@@ -155,7 +154,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from: _bidder,
                 amount: 0.678725133191514712 * 1e18,
                 index: testIndex,
-                price: priceAtTestIndex,
                 lpRedeem: 2_043.56808879152623138 * 1e27
             })
         );
@@ -254,7 +252,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 index:    2550,
                 amount:   amountWithInterest,
                 newLup:   _pool.indexToPrice(2552),
-                lpRedeem: 10_000.000000000000000000030608033 * 1e27
+                lpRedeem: 10_000 * 1e27
             })
         );
 
@@ -265,8 +263,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   expectedCollateral,
                 index:    2550,
-                price:    p2550,
-                lpRedeem: 200.344335561364860742267847549 * 1e27
+                lpRedeem: 200.344335561364860742236645388 * 1e27
             })
         );
         BucketLP[] memory lps = new BucketLP[](1);
@@ -287,7 +284,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from:     _lender,
                 amount:   expectedCollateral,
                 index:    2550,
-                price:    p2550,
                 lpRedeem: 6_000 * 1e27
             })
         );
@@ -308,7 +304,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from:     _lender1,
                 amount:   expectedCollateral,
                 index:    2550,
-                price:    p2550,
                 lpRedeem: 4_000 * 1e27
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolPurchaseQuote.t.sol
@@ -35,8 +35,6 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
     function testPurchaseQuote() external {
         // test setup
         uint256 testIndex = 2550;
-        uint256 priceAtTestIndex = _pool.indexToPrice(testIndex);
-        assertEq(priceAtTestIndex, 3_010.892022197881557845 * 1e18);
 
         // lender adds initial quote to pool
         Liquidity[] memory amounts = new Liquidity[](1);
@@ -88,7 +86,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 index:    testIndex,
                 amount:   10_000 * 1e18,
                 penalty:  0,
-                newLup:   _pool.lup(),
+                newLup:   _lup(),
                 lpRedeem: 10_000 * 1e27
             })
         );
@@ -186,8 +184,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
      *  @notice 2 lenders, 1 borrower, 1 bidder tests purchasing quote token with collateral.
      */
     function testPurchaseQuoteWithDebt() external {
-        uint256 p2550 = _pool.indexToPrice(2550);
-        assertEq(p2550, 3_010.892022197881557845 * 1e18);
+        uint256 p2550 = 3_010.892022197881557845 * 1e18;
 
         // lenders add liquidity
         Liquidity[] memory amounts = new Liquidity[](3);
@@ -219,7 +216,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 pledgeAmount: 100 * 1e18,
                 borrowAmount: 15_000 * 1e18,
                 indexLimit:   3000,
-                price:        _pool.indexToPrice(2551)
+                price:        _indexToPrice(2551)
             })
         );
 
@@ -251,7 +248,7 @@ contract ERC20ScaledPurchaseQuoteTokenTest is ERC20HelperContract {
                 from:     _bidder,
                 index:    2550,
                 amount:   amountWithInterest,
-                newLup:   _pool.indexToPrice(2552),
+                newLup:   _indexToPrice(2552),
                 lpRedeem: 10_000 * 1e27
             })
         );

--- a/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolQuoteToken.t.sol
@@ -37,7 +37,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
      *              attempts to addQuoteToken at invalid price.
      */
     function testScaledPoolDepositQuoteToken() external {
-        assertEq(_pool.hpb(), BucketMath.MIN_PRICE);
+        assertEq(_hpb(), BucketMath.MIN_PRICE);
 
         // test 10_000 deposit at price of 3_010.892022197881557845
         Liquidity[] memory amounts = new Liquidity[](1);
@@ -417,7 +417,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 index:    4990,
                 amount:   10_000 * 1e18,
                 penalty:  0,
-                newLup:   _pool.indexToPrice(4551),
+                newLup:   _indexToPrice(4551),
                 lpRedeem: 10_000 * 1e27
             })
         );
@@ -452,7 +452,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 bucketLPs: lps
             })
         );
-        uint256 exchangeRateBefore = _pool.exchangeRate(1606);
+        uint256 exchangeRateBefore = _exchangeRate(1606);
 
         skip(59 minutes);
 
@@ -462,7 +462,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 bucketLPs: lps
             })
         );
-        assertEq(exchangeRateBefore, _pool.exchangeRate(1606));
+        assertEq(exchangeRateBefore, _exchangeRate(1606));
         uint256 lenderBalanceBefore = _quote.balanceOf(_lender);
 
         // borrower takes a loan of 3000 quote token
@@ -486,7 +486,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 bucketLPs: lps
             })
         );
-        assertEq(exchangeRateBefore, _pool.exchangeRate(1606));
+        assertEq(exchangeRateBefore, _exchangeRate(1606));
 
         // lender makes a partial withdrawal, paying an early withdrawal penalty
         uint256 penalty = Maths.WAD - Maths.wdiv(_pool.interestRate(), _pool.WAD_WEEKS_PER_YEAR());
@@ -498,21 +498,21 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 index:    1606,
                 amount:   1_700 * 1e18,
                 penalty:  penalty,
-                newLup:   _pool.indexToPrice(1663),
+                newLup:   _indexToPrice(1663),
                 lpRedeem: 1_699.988430646832348876473462074 * 1e27
             })
         );
 
         // lender removes all quote token, including interest, from the bucket
         skip(1 days);
-        assertGt(_pool.indexToPrice(1606), _pool.htp());
+        assertGt(_indexToPrice(1606), _htp());
         uint256 expectedWithdrawal2 = 1_700.146556206967894132 * 1e18;
         _removeAllLiquidity(
             RemoveAllLiquiditySpecs({
                 from:     _lender,
                 index:    1606,
                 amount:   expectedWithdrawal2,
-                newLup:   _pool.indexToPrice(1663),
+                newLup:   _indexToPrice(1663),
                 lpRedeem: 1_700.011569353167651123526537926 * 1e27
             })
         );
@@ -678,7 +678,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 amount:       10_000 * 1e18,
                 fromIndex:    4549,
                 toIndex:      4550,
-                newLup:       _pool.indexToPrice(4551),
+                newLup:       _indexToPrice(4551),
                 lpRedeemFrom: 10_000 * 1e27,
                 lpRedeemTo:   10_000 * 1e27
             })
@@ -721,7 +721,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 amount:       2_500 * 1e18,
                 fromIndex:    2873,
                 toIndex:      2954,
-                newLup:       _pool.lup(),
+                newLup:       _lup(),
                 lpRedeemFrom: 2_499.877878608019467246904020519 * 1e27,
                 lpRedeemTo:   2_497.596153846153845 * 1e27
             })
@@ -745,7 +745,7 @@ contract ERC20ScaledQuoteTokenTest is ERC20HelperContract {
                 amount:       2_500 * 1e18,
                 fromIndex:    2873,
                 toIndex:      2954,
-                newLup:       _pool.lup(),
+                newLup:       _lup(),
                 lpRedeemFrom: 2_499.778568979414622058441434089 * 1e27,
                 lpRedeemTo:   2_500 * 1e27
             })

--- a/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20ScaledPoolTransferLPTokens.t.sol
@@ -114,19 +114,19 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.addQuoteToken(30_000 * 1e18, indexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender1);
+        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
         assertEq(lpBalance, 0);
 
         // set allowed owner to lender2 address
@@ -145,19 +145,19 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
+        (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
     }
 
@@ -177,18 +177,18 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.addQuoteToken(30_000 * 1e18, depositIndexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender1);
+        (uint256 lpBalance, ) = _pool.lenders(depositIndexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(depositIndexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(depositIndexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[0], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[2], _lender2);
         assertEq(lpBalance, 0);
 
         // set allowed owner to lender2 address
@@ -206,18 +206,18 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, transferIndexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender1);
+        (lpBalance, ) = _pool.lenders(depositIndexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(depositIndexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(depositIndexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[0], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[1], _lender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(depositIndexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(depositIndexes[2], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
     }
 
@@ -240,20 +240,20 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.addQuoteToken(15_000 * 1e18, indexes[2]);
 
         // check lenders lp balance
-        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender1);
+        (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
         assertEq(lastQuoteDeposit, 3600);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
         assertEq(lpBalance, 30_000 * 1e27);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
+        (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 5_000 * 1e27);
         assertEq(lastQuoteDeposit, 7200);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
 
         // set allowed owner to lender2 address
@@ -273,19 +273,19 @@ contract ERC20ScaledPoolTransferLPTokensTest is ERC20HelperContract {
         _pool.transferLPTokens(_lender1, _lender2, indexes);
 
         // check lenders lp balance
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender1);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
         assertEq(lpBalance, 0);
 
-        (lpBalance, lastQuoteDeposit) = _pool.bucketLenders(indexes[0], _lender2);
+        (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
         assertEq(lastQuoteDeposit, 7200);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], _lender2);
+        (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
         assertEq(lpBalance, 45_000 * 1e27);
     }
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -147,7 +147,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     // TODO: implement _pullCollateral()
     
     function _assertPool(PoolState memory state_) internal {
-        ERC721Pool pool = _subsetPool;
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
         ( , uint256 htp, uint256 lup, ) = pool.poolPricesInfo();
         (uint256 poolSize, uint256 loansCount, address maxBorrower, ) = pool.poolLoansInfo();
         (uint256 poolMinDebtAmount, , uint256 poolActualUtilization, uint256 poolTargetUtilization) = pool.poolUtilizationInfo();
@@ -168,7 +168,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _assertReserveAuction(ReserveAuctionState memory state_) internal {
-        ERC721Pool pool = _subsetPool;
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
 
         ( , , uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.poolReservesInfo();
         assertEq(claimableReservesRemaining, state_.claimableReservesRemaining);
@@ -177,13 +177,14 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
-        ERC721Pool pool = _subsetPool;
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
         ( , , , uint256 auctionPrice, ) = pool.poolReservesInfo();
         assertEq(auctionPrice, expectedPrice);
     }
 
     function _indexToPrice(uint256 index_) internal view returns (uint256 price_) {
-        ( price_, , , , , , ) = _subsetPool.bucketAt(index_);
+        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        ( price_, , , , , , ) = pool.bucketAt(index_);
     }
 
     function _htp() internal view returns (uint256 htp_) {

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -148,19 +148,21 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     
     function _assertPool(PoolState memory state_) internal {
         ERC721Pool pool = _subsetPool;
-        
-        assertEq(pool.htp(), state_.htp);
-        assertEq(pool.lup(), state_.lup);
+        ( , uint256 htp, uint256 lup, ) = pool.poolPricesInfo();
+        (uint256 poolSize, uint256 loansCount, address maxBorrower, ) = pool.poolLoansInfo();
+        (uint256 poolMinDebtAmount, , uint256 poolActualUtilization, uint256 poolTargetUtilization) = pool.poolUtilizationInfo();
+        assertEq(htp, state_.htp);
+        assertEq(lup, state_.lup);
 
-        assertEq(pool.poolSize(),              state_.poolSize);
-        assertEq(pool.pledgedCollateral(),     state_.pledgedCollateral);
-        assertEq(pool.borrowerDebt(),          state_.borrowerDebt);
-        assertEq(pool.poolActualUtilization(), state_.actualUtilization);
-        assertEq(pool.poolTargetUtilization(), state_.targetUtilization);
-        assertEq(pool.poolMinDebtAmount(),     state_.minDebtAmount);
+        assertEq(poolSize,                 state_.poolSize);
+        assertEq(pool.pledgedCollateral(), state_.pledgedCollateral);
+        assertEq(pool.borrowerDebt(),      state_.borrowerDebt);
+        assertEq(poolActualUtilization,    state_.actualUtilization);
+        assertEq(poolTargetUtilization,    state_.targetUtilization);
+        assertEq(poolMinDebtAmount,        state_.minDebtAmount);
 
-        assertEq(pool.loansCount(),  state_.loans);
-        assertEq(pool.maxBorrower(), state_.maxBorrower);
+        assertEq(loansCount,  state_.loans);
+        assertEq(maxBorrower, state_.maxBorrower);
 
         assertEq(pool.encumberedCollateral(state_.borrowerDebt, state_.lup), state_.encumberedCollateral);
     }
@@ -168,7 +170,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     function _assertReserveAuction(ReserveAuctionState memory state_) internal {
         ERC721Pool pool = _subsetPool;
 
-        (uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.reserveAuction();
+        ( , , uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.poolReservesInfo();
         assertEq(claimableReservesRemaining, state_.claimableReservesRemaining);
         assertEq(auctionPrice, state_.auctionPrice);
         assertEq(timeRemaining, state_.timeRemaining);
@@ -176,7 +178,47 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
     function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
         ERC721Pool pool = _subsetPool;
-        (, uint256 auctionPrice, ) = pool.reserveAuction();
+        ( , , , uint256 auctionPrice, ) = pool.poolReservesInfo();
         assertEq(auctionPrice, expectedPrice);
+    }
+
+    function _indexToPrice(uint256 index_) internal view returns (uint256 price_) {
+        ( price_, , , , , , ) = _subsetPool.bucketAt(index_);
+    }
+
+    function _htp() internal view returns (uint256 htp_) {
+        (, htp_, , ) = _subsetPool.poolPricesInfo();
+    }
+
+    function _exchangeRate(uint256 index_) internal view returns (uint256 exchangeRate_) {
+        ( , , , , , exchangeRate_, ) = _subsetPool.bucketAt(index_);
+    }
+
+    function _lup() internal view returns (uint256 lup_) {
+        (, , lup_, ) = _subsetPool.poolPricesInfo();
+    }
+
+    function _poolSize() internal view returns (uint256 poolSize_) {
+        (poolSize_, , , ) = _subsetPool.poolLoansInfo();
+    }
+
+    function _poolTargetUtilization() internal view returns (uint256 utilization_) {
+        ( , , , utilization_) = _subsetPool.poolUtilizationInfo();
+    }
+
+    function _poolActualUtilization() internal view returns (uint256 utilization_) {
+        ( , , utilization_, ) = _subsetPool.poolUtilizationInfo();
+    }
+
+    function _poolMinDebtAmount() internal view returns (uint256 minDebt_) {
+        ( minDebt_, , , ) = _subsetPool.poolUtilizationInfo();
+    }
+
+    function _loansCount() internal view returns (uint256 loansCount_) {
+        ( , loansCount_, , ) = _subsetPool.poolLoansInfo();
+    }
+
+    function _maxBorrower() internal view returns (address maxBorrower_) {
+        ( , , maxBorrower_, ) = _subsetPool.poolLoansInfo();
     }
 }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -147,7 +147,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     // TODO: implement _pullCollateral()
     
     function _assertPool(PoolState memory state_) internal {
-        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        ERC721Pool pool = _subsetPool;
         
         assertEq(pool.htp(), state_.htp);
         assertEq(pool.lup(), state_.lup);
@@ -166,7 +166,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _assertReserveAuction(ReserveAuctionState memory state_) internal {
-        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        ERC721Pool pool = _subsetPool;
 
         (uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 timeRemaining) = pool.reserveAuction();
         assertEq(claimableReservesRemaining, state_.claimableReservesRemaining);
@@ -175,7 +175,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _assertReserveAuctionPrice(uint256 expectedPrice) internal {
-        ERC721Pool pool = address(_collectionPool) == address(0) ? _subsetPool : _collectionPool;
+        ERC721Pool pool = _subsetPool;
         (, uint256 auctionPrice, ) = pool.reserveAuction();
         assertEq(auctionPrice, expectedPrice);
     }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -144,9 +144,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testMultipleBorrowerInterestAccumulation() external {
         // lender deposits 10000 Quote into 3 buckets
         changePrank(_lender);
-        assertEq(_subsetPool.indexToPrice(2550), 3_010.892022197881557845 * 1e18);
+        assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        assertEq(_subsetPool.indexToPrice(2551), 2_995.912459898389633881 * 1e18);
+        assertEq(_indexToPrice(2551), 2_995.912459898389633881 * 1e18);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
         skip(2 hours);
@@ -160,7 +160,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
         uint256 borrowAmount = 8_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551);
         skip(4 hours);
 
@@ -171,7 +171,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd);
         borrowAmount = 2_750 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(_borrower2, _subsetPool.indexToPrice(2551), borrowAmount);
+        emit Borrow(_borrower2, _indexToPrice(2551), borrowAmount);
         _subsetPool.borrow(borrowAmount, 3000);
         skip(4 hours);
 
@@ -182,7 +182,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.pledgeCollateral(_borrower3, tokenIdsToAdd);
         borrowAmount = 2_500 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(_borrower3, _subsetPool.indexToPrice(2551), borrowAmount);
+        emit Borrow(_borrower3, _indexToPrice(2551), borrowAmount);
         _subsetPool.borrow(borrowAmount, 3000);
         skip(4 hours);
 
@@ -226,7 +226,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testBorrowBorrowerUnderCollateralized() external {
         // add initial quote to the pool
         changePrank(_lender);
-        assertEq(_subsetPool.indexToPrice(3575), 18.133510183516748631 * 1e18);
+        assertEq(_indexToPrice(3575), 18.133510183516748631 * 1e18);
         _subsetPool.addQuoteToken(1_000 * 1e18, 3575);
 
         // borrower pledges some collateral
@@ -244,7 +244,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testBorrowPoolUnderCollateralized() external {
         // add initial quote to the pool
         changePrank(_lender);
-        assertEq(_subsetPool.indexToPrice(3232), 100.332368143282009890 * 1e18);
+        assertEq(_indexToPrice(3232), 100.332368143282009890 * 1e18);
         _subsetPool.addQuoteToken(1_000 * 1e18, 3232);
 
         // should revert if borrow would result in pool under collateralization
@@ -269,15 +269,15 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower),            0);
 
         // check pool state
-        assertEq(_subsetPool.htp(), 0);
-        assertEq(_subsetPool.lup(), BucketMath.MAX_PRICE);
+        assertEq(_htp(), 0);
+        assertEq(_lup(), BucketMath.MAX_PRICE);
 
-        assertEq(_subsetPool.poolSize(),              30_000 * 1e18);
+        assertEq(_poolSize(),              30_000 * 1e18);
         assertEq(_subsetPool.borrowerDebt(),          0);
-        assertEq(_subsetPool.poolTargetUtilization(), 1 * 1e18);
-        assertEq(_subsetPool.poolActualUtilization(), 0);
-        assertEq(_subsetPool.poolMinDebtAmount(),     0);
-        assertEq(_subsetPool.exchangeRate(2550),      1 * 1e27);
+        assertEq(_poolTargetUtilization(), 1 * 1e18);
+        assertEq(_poolActualUtilization(), 0);
+        assertEq(_poolMinDebtAmount(),     0);
+        assertEq(_exchangeRate(2550),      1 * 1e27);
 
         // check initial bucket state
         (uint256 lpAccumulator, uint256 availableCollateral) = _subsetPool.buckets(2550);
@@ -295,7 +295,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // borrower borrows from the pool
         uint256 borrowAmount = 3_000 * 1e18;
         vm.expectEmit(true, true, false, true);
-        emit Borrow(_borrower, _subsetPool.indexToPrice(2550), borrowAmount);
+        emit Borrow(_borrower, _indexToPrice(2550), borrowAmount);
         _subsetPool.borrow(borrowAmount, 2551);
 
         // check token balances after borrow
@@ -307,16 +307,16 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower),            borrowAmount);
 
         // check pool state after borrow
-        assertEq(_subsetPool.htp(), 1_000.961538461538462000 * 1e18);
-        assertEq(_subsetPool.lup(), _subsetPool.indexToPrice(2550));
+        assertEq(_htp(), 1_000.961538461538462000 * 1e18);
+        assertEq(_lup(), _indexToPrice(2550));
 
-        assertEq(_subsetPool.poolSize(),              30_000 * 1e18);
+        assertEq(_poolSize(),              30_000 * 1e18);
         assertEq(_subsetPool.borrowerDebt(),          3_002.88461538461538600 * 1e18);
-        assertEq(_subsetPool.poolTargetUtilization(), 1 * 1e18);
-        assertEq(_subsetPool.poolActualUtilization(), .100096153846153846 * 1e18);
-        assertEq(_subsetPool.poolMinDebtAmount(),     300.288461538461538600 * 1e18);
-        assertEq(_subsetPool.poolMinDebtAmount(), _subsetPool.borrowerDebt() / 10);
-        assertEq(_subsetPool.exchangeRate(2550),      1 * 1e27);
+        assertEq(_poolTargetUtilization(), 1 * 1e18);
+        assertEq(_poolActualUtilization(), .100096153846153846 * 1e18);
+        assertEq(_poolMinDebtAmount(),     300.288461538461538600 * 1e18);
+        assertEq(_poolMinDebtAmount(), _subsetPool.borrowerDebt() / 10);
+        assertEq(_exchangeRate(2550),      1 * 1e27);
 
         // check bucket state after borrow
         (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
@@ -336,7 +336,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // borrower partially repays half their loan
         vm.expectEmit(true, true, false, true);
-        emit Repay(_borrower, _subsetPool.indexToPrice(2550), borrowAmount / 2);
+        emit Repay(_borrower, _indexToPrice(2550), borrowAmount / 2);
         _subsetPool.repay(_borrower, borrowAmount / 2);
 
         // check token balances after partial repay
@@ -348,17 +348,17 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower),            borrowAmount / 2);
 
         // check pool state after partial repay
-        assertEq(_subsetPool.htp(), 502.333658244714424687 * 1e18); // HTP should be different than t0 TP recorded in TP queue
-        assertEq(_subsetPool.lup(), _subsetPool.indexToPrice(2550));
+        assertEq(_htp(), 502.333658244714424687 * 1e18); // HTP should be different than t0 TP recorded in TP queue
+        assertEq(_lup(), _indexToPrice(2550));
 
         // check utilization changes make sense
-        assertEq(_subsetPool.poolSize(),              30_003.704723414575110000 * 1e18);
+        assertEq(_poolSize(),              30_003.704723414575110000 * 1e18);
         assertEq(_subsetPool.borrowerDebt(),          1507.000974734143274062 * 1e18);
-        assertEq(_subsetPool.poolTargetUtilization(), .166838815388013307 * 1e18);
-        assertEq(_subsetPool.poolActualUtilization(), .050227163232882224 * 1e18);
-        assertEq(_subsetPool.poolMinDebtAmount(),     150.700097473414327406 * 1e18);
-        assertEq(_subsetPool.poolMinDebtAmount(),     _subsetPool.borrowerDebt() / 10);
-        assertEq(_subsetPool.exchangeRate(2550),      1.000123490780485837000000000 * 1e27);
+        assertEq(_poolTargetUtilization(), .166838815388013307 * 1e18);
+        assertEq(_poolActualUtilization(), .050227163232882224 * 1e18);
+        assertEq(_poolMinDebtAmount(),     150.700097473414327406 * 1e18);
+        assertEq(_poolMinDebtAmount(),     _subsetPool.borrowerDebt() / 10);
+        assertEq(_exchangeRate(2550),      1.000123490780485837000000000 * 1e27);
 
         // check bucket state after partial repay
         (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
@@ -396,8 +396,8 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower),            991.139933078400935357 * 1e18);
 
         // check pool state after fully repay
-        assertEq(_subsetPool.htp(), 0);
-        assertEq(_subsetPool.lup(), BucketMath.MAX_PRICE);
+        assertEq(_htp(), 0);
+        assertEq(_lup(), BucketMath.MAX_PRICE);
 
         // borrower pulls collateral
         uint256[] memory tokenIdsToRemove = tokenIdsToAdd;
@@ -409,15 +409,15 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
         // check utilization changes make sense
-        assertEq(_subsetPool.poolSize(),              30_005.377906383285317363 * 1e18);
+        assertEq(_poolSize(),              30_005.377906383285317363 * 1e18);
         assertEq(_subsetPool.borrowerDebt(),          0);
         // TODO: LUP=MAX_PRICE is causing a technically correct yet undesirable target utilization
         assertEq(_subsetPool.debtEma(),               116.548760023014994270 * 1e18);
         assertEq(_subsetPool.lupColEma(),             257_438_503.676217090117659874 * 1e18);
-        assertEq(_subsetPool.poolTargetUtilization(), .000000452724663788 * 1e18);
-        assertEq(_subsetPool.poolActualUtilization(), 0);
-        assertEq(_subsetPool.poolMinDebtAmount(),     0);
-        assertEq(_subsetPool.exchangeRate(2550),      1.000179263546109511000000000 * 1e27);
+        assertEq(_poolTargetUtilization(), .000000452724663788 * 1e18);
+        assertEq(_poolActualUtilization(), 0);
+        assertEq(_poolMinDebtAmount(),     0);
+        assertEq(_exchangeRate(2550),      1.000179263546109511000000000 * 1e27);
 
         // check bucket state after fully repay
         (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
@@ -435,7 +435,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testScaledPoolRepayRequireChecks() external {
         // add initial quote to the pool
         changePrank(_lender);
-        assertEq(_subsetPool.indexToPrice(2550), 3_010.892022197881557845 * 1e18);
+        assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
         _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
 
@@ -453,8 +453,8 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
         _subsetPool.borrow(1_000 * 1e18, 3000);
 
-        assertEq(_subsetPool.maxBorrower(), _borrower);
-        assertEq(_subsetPool.loansCount(),  1);
+        assertEq(_maxBorrower(), _borrower);
+        assertEq(_loansCount(),  1);
 
         // borrower 2 borrows 3k quote from the pool and becomes new queue HEAD
         changePrank(_borrower2);
@@ -463,8 +463,8 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd);
         _subsetPool.borrow(3_000 * 1e18, 3000);
 
-        assertEq(_subsetPool.maxBorrower(), _borrower2);
-        assertEq(_subsetPool.loansCount(),  2);
+        assertEq(_maxBorrower(), _borrower2);
+        assertEq(_loansCount(),  2);
 
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
@@ -473,7 +473,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
-        emit Repay(_borrower, _subsetPool.lup(), 1_000.961538461538462000 * 1e18);
+        emit Repay(_borrower, _lup(), 1_000.961538461538462000 * 1e18);
         _subsetPool.repay(_borrower, 1_100 * 1e18);
     }
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -80,10 +80,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.borrow(5_000 * 1e18, 2551);
 
         assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_012.354868151222773335 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col       ,  3 * 1e18);
         assertEq(mompFactor,  3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
@@ -96,7 +96,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_019.913425024098425550 * 1e18);
         assertEq(pendingDebt, 5_019.913425024098425550 * 1e18);
-        assertEq(col.length,  4);
+        assertEq(col,         4 * 1e18);
         assertEq(mompFactor,  3_001.831760341859136562 * 1e18);
         assertEq(inflator,    1.003018244385218513 * 1e18);
 
@@ -109,7 +109,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_028.241003157279922662 * 1e18);
         assertEq(pendingDebt, 5_028.241003157279922662 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col,         3 * 1e18);
         assertEq(mompFactor,  2_996.860242765192441905 * 1e18);
         assertEq(inflator,    1.004682160092905114 * 1e18);
 
@@ -120,7 +120,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        6_038.697103647272763112 * 1e18);
         assertEq(pendingDebt, 6_038.697103647272763112 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col       ,  3 * 1e18);
         assertEq(mompFactor,  2_991.401082754081650235 * 1e18);
         assertEq(inflator,    1.006515655675920014 * 1e18);
 
@@ -136,7 +136,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(mompFactor,  0 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col       ,  3 * 1e18);
         assertEq(inflator,    1.008536365727696620 * 1e18);
 
     }
@@ -324,10 +324,10 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(availableCollateral, 0);
 
         // check borrower info after borrow
-        (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col       ,  3 * 1e18);
         assertEq(mompFactor,  3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
@@ -369,7 +369,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
-        assertEq(col.length,  3);
+        assertEq(col,         3 * 1e18);
         assertEq(mompFactor,  3_006.770336295505368176 * 1e18);
         assertEq(inflator,    1.001370801704613834 * 1e18);
 
@@ -428,7 +428,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
-        assertEq(col.length,  0);
+        assertEq(col,         0);
         assertEq(mompFactor,  0 * 1e18);
     }
 

--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -82,9 +82,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
         (uint256 debt, uint256 pendingDebt, uint256[] memory col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
-        assertEq(pendingDebt, 5_010.981808341113791532 * 1e18);
+        assertEq(pendingDebt, 5_012.354868151222773335 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,  0 * 1e18);
+        assertEq(mompFactor,  3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
         // borrower pledge additional collateral after some time has passed
@@ -92,37 +92,37 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 51;
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-        assertEq(_subsetPool.borrowerDebt(), 5_017.163540992622874208 * 1e18);
+        assertEq(_subsetPool.borrowerDebt(), 5_019.913425024098425550 * 1e18);
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
-        assertEq(debt,        5_017.163540992622874208 * 1e18);
-        assertEq(pendingDebt, 5_017.163540992622874208 * 1e18);
+        assertEq(debt,        5_019.913425024098425550 * 1e18);
+        assertEq(pendingDebt, 5_019.913425024098425550 * 1e18);
         assertEq(col.length,  4);
-        assertEq(mompFactor,  3_003.477050385824310983 * 1e18);
-        assertEq(inflator,    1.002468795894779594 * 1e18);
+        assertEq(mompFactor,  3_001.831760341859136562 * 1e18);
+        assertEq(inflator,    1.003018244385218513 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed
         skip(864000);
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 1;
         _subsetPool.pullCollateral(tokenIdsToRemove);
-        assertEq(_subsetPool.borrowerDebt(), 5_022.733620353117867729 * 1e18);
+        assertEq(_subsetPool.borrowerDebt(), 5_028.241003157279922662 * 1e18);
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
-        assertEq(debt,        5_022.733620353117867729 * 1e18);
-        assertEq(pendingDebt, 5_022.733620353117867729 * 1e18);
+        assertEq(debt,        5_028.241003157279922662 * 1e18);
+        assertEq(pendingDebt, 5_028.241003157279922662 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,   3_000.146273404086167746 * 1e18);
-        assertEq(inflator,    1.003581741626751696 * 1e18);
+        assertEq(mompFactor,  2_996.860242765192441905 * 1e18);
+        assertEq(inflator,    1.004682160092905114 * 1e18);
 
         // borrower borrows some additional quote after some time has passed
         skip(864000);
         _subsetPool.borrow(1_000 * 1e18, 3000);
-        assertEq(_subsetPool.borrowerDebt(), 6_028.452940379879069654 * 1e18);
+        assertEq(_subsetPool.borrowerDebt(), 6_038.697103647272763112 * 1e18);
         (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
-        assertEq(debt,        6_028.452940379879069654 * 1e18);
-        assertEq(pendingDebt, 6_028.452940379879069654 * 1e18);
+        assertEq(debt,        6_038.697103647272763112 * 1e18);
+        assertEq(pendingDebt, 6_038.697103647272763112 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,   2_997.151732388411916563 * 1e18);
-        assertEq(inflator,    1.004584449182531072 * 1e18);
+        assertEq(mompFactor,  2_991.401082754081650235 * 1e18);
+        assertEq(inflator,    1.006515655675920014 * 1e18);
 
         // mint additional quote to borrower to enable repayment
         deal(address(_quote), _borrower, 20_000 * 1e18);
@@ -137,7 +137,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(pendingDebt, 0);
         assertEq(mompFactor,  0 * 1e18);
         assertEq(col.length,  3);
-        assertEq(inflator,    1.005487742522395296 * 1e18);
+        assertEq(inflator,    1.008536365727696620 * 1e18);
 
     }
 
@@ -328,7 +328,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,  0);
+        assertEq(mompFactor,  3_010.892022197881557845 * 1e18);
         assertEq(inflator,    1 * 1e18);
 
         // pass time to allow interest to accumulate
@@ -370,7 +370,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
         assertEq(col.length,  3);
-        assertEq(mompFactor,   3_006.770336295505368176 * 1e18);
+        assertEq(mompFactor,  3_006.770336295505368176 * 1e18);
         assertEq(inflator,    1.001370801704613834 * 1e18);
 
         // pass time to allow additional interest to accumulate

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -347,7 +347,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         _subsetPool.pullCollateral(tokenIdsToRemove);
     }
 
-    function _testAddRemoveCollateral() external {
+    function testAddRemoveCollateral() external {
         vm.startPrank(_lender);
         // lender adds some liquidity
         _subsetPool.addQuoteToken(10_000 * 1e18, 1530);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -389,7 +389,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         _subsetPool.removeCollateral(tokenIds, 1530);
         (, collateral, , ) = _subsetPool.bucketAt(1530);
         assertEq(collateral, 0);
-        (uint256 lpb, ) = _subsetPool.bucketLenders(1530, _borrower);
+        (uint256 lpb, ) = _subsetPool.lenders(1530, _borrower);
         assertEq(lpb, 0);
 
         // lender removes quote token

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -68,13 +68,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 5);
-        vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // check token balances after add
@@ -114,9 +114,9 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         changePrank(_borrower2);
         _collateral.setApprovalForAll(address(_subsetPool), true);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(_borrower2, address(_subsetPool), 53);
-        vm.expectEmit(true, true, false, true);
         emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(_borrower2, address(_subsetPool), 53);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // check token balances after add
@@ -145,13 +145,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 5);
-        vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // check token balances after add
@@ -165,11 +165,11 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // borrower removes some of their deposted NFTS from the pool
         vm.expectEmit(true, true, false, true);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 5);
-        vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove);
 
         // check token balances after remove
@@ -202,13 +202,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         tokenIdsToRemove[2] = 5;
 
         vm.expectEmit(true, true, false, true);
+        vm.expectEmit(true, true, false, true);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         emit Transfer(address(_subsetPool), _borrower, 1);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 5);
-        vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove);
     }
 
@@ -242,13 +242,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 5);
-        vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // TODO: determine how to handle checking both token types of Transfer
@@ -279,11 +279,11 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
 
         // borrower removes some of their deposted NFTS from the pool
         vm.expectEmit(true, true, false, true);
+        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _borrower, 5);
-        vm.expectEmit(true, true, false, true);
-        emit PullCollateralNFT(_borrower, tokenIdsToRemove);
         _subsetPool.pullCollateral(tokenIdsToRemove);
 
         // check token balances after remove
@@ -318,13 +318,13 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
         vm.expectEmit(true, true, false, true);
+        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 1);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 3);
         vm.expectEmit(true, true, false, true);
         emit Transfer(_borrower, address(_subsetPool), 5);
-        vm.expectEmit(true, true, false, true);
-        emit PledgeCollateralNFT(_borrower, tokenIdsToAdd);
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // check collateralization after pledge

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -102,10 +102,10 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(_borrower2),           53);
         assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
 
-        (, , uint256[] memory col, , ) = _subsetPool.borrowerInfo(_borrower);
-        assertEq(col.length,  0);
+        (, , uint256 col, , ) = _subsetPool.borrowerInfo(_borrower);
+        assertEq(col,  0);
         (, , col, , ) = _subsetPool.borrowerInfo(_borrower2);
-        assertEq(col.length,  0);
+        assertEq(col,  0);
 
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
@@ -126,9 +126,9 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(address(_subsetPool)), 1);
 
         (, , col, , ) = _subsetPool.borrowerInfo(_borrower);
-        assertEq(col.length,  1);
+        assertEq(col,  1 * 1e18);
         (, , col, , ) = _subsetPool.borrowerInfo(_borrower2);
-        assertEq(col.length,  0);
+        assertEq(col,  0);
     }
 
     function testPullCollateral() external {

--- a/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolCollateral.t.sol
@@ -347,7 +347,7 @@ contract ERC721ScaledCollateralTest is ERC721HelperContract {
         _subsetPool.pullCollateral(tokenIdsToRemove);
     }
 
-    function testAddRemoveCollateral() external {
+    function _testAddRemoveCollateral() external {
         vm.startPrank(_lender);
         // lender adds some liquidity
         _subsetPool.addQuoteToken(10_000 * 1e18, 1530);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolFactory.t.sol
@@ -110,6 +110,7 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
         assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTCollectionPool.interestRateUpdate(),         0);
         assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);
+        assertEq(_NFTCollectionPool.isSubset(),                   false);
     }
 
     /**************************************/
@@ -174,6 +175,7 @@ contract ERC721ScaledPoolFactoryTest is DSTestPlus {
         assertEq(_NFTSubsetOnePool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRateUpdate(),         0);
         assertEq(_NFTSubsetOnePool.minFee(),                     0.0005 * 10**18);
+        assertEq(_NFTSubsetOnePool.isSubset(),                   true);
 
         assertTrue(_NFTSubsetOnePool.isTokenIdAllowed(1));
         assertTrue(_NFTSubsetOnePool.isTokenIdAllowed(5));

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -125,7 +125,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256[] memory tokenIdsToRemove = new uint256[](2);
         tokenIdsToRemove = tokenIdsToAdd;
         vm.expectEmit(true, true, false, true);
-        emit RemoveCollateralNFT(_lender, priceAtTestIndex, tokenIdsToRemove);
+        emit RemoveCollateralNFT(_lender, testIndex, tokenIdsToRemove);
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _lender, tokenIdsToRemove[0]);
         vm.expectEmit(true, true, false, true);
@@ -215,7 +215,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 65;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
+        emit RemoveCollateralNFT(_bidder, 2350, tokenIdsToRemove);
         (uint256 amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
         (uint256 lpBalance, ) = _subsetPool.lenders(2350, _bidder);
         assertEq(lpBalance, 490.713717393968418590429839925 * 1e27);
@@ -241,7 +241,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 73;
         vm.expectEmit(true, true, true, true);
-        emit RemoveCollateralNFT(_lender, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
+        emit RemoveCollateralNFT(_lender, 2350, tokenIdsToRemove);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
         (lpBalance, ) = _subsetPool.lenders(2350, _lender);
         assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -53,7 +53,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 13);   
     }
 
-    function _testSubsetPurchaseQuote() external {
+    function testSubsetPurchaseQuote() external {
         // test setup
         uint256 testIndex = 2550;
         uint256 priceAtTestIndex = _subsetPool.indexToPrice(testIndex);
@@ -243,22 +243,22 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateralNFT(_lender, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        // (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
-        // assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
-        // skip(3600);
+        (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
+        assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
+        skip(3600);
 
-        // // check bucket state
-        // (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
-        // assertEq(quote,      0);
-        // assertEq(collateral, Maths.wad(2));
-        // assertEq(lpb,        16_327.142478262645612393619885284 * 1e27);
+        // check bucket state
+        (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
+        assertEq(quote,      0);
+        assertEq(collateral, Maths.wad(2));
+        assertEq(lpb,        16_327.142478262645612393619885284 * 1e27);
 
-        // // should revert if lender2 attempts to remove more collateral than lp is available for
-        // changePrank(_lender2);
-        // tokenIdsToRemove = new uint256[](1);
-        // tokenIdsToRemove[0] = 74;
-        // vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
-        // (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
+        // should revert if lender2 attempts to remove more collateral than lp is available for
+        changePrank(_lender2);
+        tokenIdsToRemove = new uint256[](1);
+        tokenIdsToRemove[0] = 74;
+        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
+        (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
     }
 
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -89,9 +89,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 70;
         tokenIdsToAdd[2] = 73;
         vm.expectEmit(true, true, false, true);
-        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
-        vm.expectEmit(true, true, false, true);
         emit AddCollateralNFT(_bidder, testIndex, tokenIdsToAdd);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         uint256 lpBalanceChange = _subsetPool.addCollateral(tokenIdsToAdd, testIndex);
 
         // check bucket state
@@ -195,9 +195,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertGt(_quote.balanceOf(address(_subsetPool)), amountToPurchase);
         uint256 amountWithInterest = 24_001.511204352939432000 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
-        vm.expectEmit(true, true, true, true);
         emit AddCollateralNFT(_bidder, 2350, tokenIdsToAdd);
+        vm.expectEmit(true, true, true, true);
+        emit Transfer(_bidder, address(_subsetPool), tokenIdsToAdd[0]);
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         
         vm.expectEmit(true, true, false, true);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -53,7 +53,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _mintAndApproveCollateralTokens(_poolAddresses, _bidder, 13);   
     }
 
-    function testSubsetPurchaseQuote() external {
+    function _testSubsetPurchaseQuote() external {
         // test setup
         uint256 testIndex = 2550;
         uint256 priceAtTestIndex = _subsetPool.indexToPrice(testIndex);
@@ -243,22 +243,22 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateralNFT(_lender, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
-        assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
-        skip(3600);
+        // (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
+        // assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
+        // skip(3600);
 
-        // check bucket state
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
-        assertEq(quote,      0);
-        assertEq(collateral, Maths.wad(2));
-        assertEq(lpb,        16_327.142478262645612393619885284 * 1e27);
+        // // check bucket state
+        // (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
+        // assertEq(quote,      0);
+        // assertEq(collateral, Maths.wad(2));
+        // assertEq(lpb,        16_327.142478262645612393619885284 * 1e27);
 
-        // should revert if lender2 attempts to remove more collateral than lp is available for
-        changePrank(_lender2);
-        tokenIdsToRemove = new uint256[](1);
-        tokenIdsToRemove[0] = 74;
-        vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
-        (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
+        // // should revert if lender2 attempts to remove more collateral than lp is available for
+        // changePrank(_lender2);
+        // tokenIdsToRemove = new uint256[](1);
+        // tokenIdsToRemove[0] = 74;
+        // vm.expectRevert(IScaledPool.RemoveCollateralInsufficientLP.selector);
+        // (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
     }
 
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -56,11 +56,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testSubsetPurchaseQuote() external {
         // test setup
         uint256 testIndex = 2550;
-        uint256 priceAtTestIndex = _subsetPool.indexToPrice(testIndex);
+        uint256 priceAtTestIndex = _indexToPrice(testIndex);
         assertEq(priceAtTestIndex, 3_010.892022197881557845 * 1e18);
 
         // check bucket state
-        (uint256 quote, uint256 collateral, uint256 lpb, ) = _subsetPool.bucketAt(2550);
+        ( , uint256 quote, uint256 collateral, uint256 lpb, , , ) = _subsetPool.bucketAt(2550);
         assertEq(quote,      0);
         assertEq(collateral, 0);
         assertEq(lpb,        0);
@@ -77,7 +77,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.addQuoteToken(10_000 * 1e18, testIndex);
 
         // check bucket state
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
+        (, quote, collateral, lpb, , , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18);
         assertEq(collateral, 0);
         assertEq(lpb,        10_000 * 1e27);
@@ -95,7 +95,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256 lpBalanceChange = _subsetPool.addCollateral(tokenIdsToAdd, testIndex);
 
         // check bucket state
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
+        (, quote, collateral, lpb, , , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18);
         assertEq(collateral, Maths.wad(3));
         (uint256 lpBalance, ) = _subsetPool.lenders(testIndex, _bidder);
@@ -111,12 +111,12 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // bidder removes quote token from bucket
         uint256 qtToRemove = Maths.wmul(priceAtTestIndex, 3 * 1e18);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, testIndex, qtToRemove, _subsetPool.lup());
+        emit RemoveQuoteToken(_bidder, testIndex, qtToRemove, _lup());
         _subsetPool.removeAllQuoteToken(testIndex);
         assertEq(_quote.balanceOf(_bidder), qtToRemove);
         (lpBalance, ) = _subsetPool.lenders(testIndex, _bidder);
         assertEq(lpBalance, 0);
-        (quote, collateral, , ) = _subsetPool.bucketAt(testIndex);
+        (, quote, collateral, lpb, , , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18 - qtToRemove);
         assertEq(collateral, 3 * 1e18);
 
@@ -133,15 +133,15 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, false, true);
         emit Transfer(address(_subsetPool), _lender, tokenIdsToRemove[2]);
         _subsetPool.removeCollateral(tokenIdsToRemove, testIndex);
-        (quote, collateral, , ) = _subsetPool.bucketAt(testIndex);
+        (, quote, collateral, lpb, , , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      967.323933406355326465 * 1e18);
         assertEq(collateral, 0);
 
         // lender removes remaining quote token to empty the bucket
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_lender, testIndex, quote, _subsetPool.lup());
+        emit RemoveQuoteToken(_lender, testIndex, quote, _lup());
         _subsetPool.removeAllQuoteToken(testIndex);
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
+        (, quote, collateral, lpb, , , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      0);
         assertEq(collateral, 0);
         assertEq(lpb,        0);
@@ -175,11 +175,11 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[3] = 51;
         _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
         _subsetPool.borrow(24_000 * 1e18, 2351);
-        assertEq(_subsetPool.lup(), _subsetPool.indexToPrice(2351));
+        assertEq(_lup(), _indexToPrice(2351));
         skip(86400);
 
         // check bucket state
-        (uint256 quote, uint256 collateral, uint256 lpb, ) = _subsetPool.bucketAt(2350);
+        ( , uint256 quote, uint256 collateral, uint256 lpb, , , ) = _subsetPool.bucketAt(2350);
         assertEq(quote,      24_000 * 1e18);
         assertEq(collateral, 0);
         assertEq(lpb,        24_000 * 1e27);
@@ -201,12 +201,12 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _subsetPool.addCollateral(tokenIdsToAdd, 2350);
         
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(_bidder, 2350, amountWithInterest, _subsetPool.indexToPrice(2352));
+        emit RemoveQuoteToken(_bidder, 2350, amountWithInterest, _indexToPrice(2352));
         _subsetPool.removeAllQuoteToken(2350);
         assertEq(_quote.balanceOf(_bidder), amountWithInterest);
 
         // check bucket state
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
+        ( , quote, collateral, lpb, , , ) = _subsetPool.bucketAt(2350);
         assertEq(quote,      0);
         assertEq(collateral, Maths.wad(4));
         assertEq(lpb,        32_654.284956525291224787239794566 * 1e27);
@@ -248,7 +248,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         skip(3600);
 
         // check bucket state
-        (quote, collateral, lpb, ) = _subsetPool.bucketAt(2350);
+        ( , quote, collateral, lpb, , , ) = _subsetPool.bucketAt(2350);
         assertEq(quote,      0);
         assertEq(collateral, Maths.wad(2));
         assertEq(lpb,        16_327.142478262645612393619885284 * 1e27);

--- a/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolPurchaseQuote.t.sol
@@ -98,7 +98,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         (quote, collateral, lpb, ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18);
         assertEq(collateral, Maths.wad(3));
-        (uint256 lpBalance, ) = _subsetPool.bucketLenders(testIndex, _bidder);
+        (uint256 lpBalance, ) = _subsetPool.lenders(testIndex, _bidder);
         assertEq(lpBalance, lpBalanceChange);
 
         // check pool state
@@ -114,7 +114,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         emit RemoveQuoteToken(_bidder, testIndex, qtToRemove, _subsetPool.lup());
         _subsetPool.removeAllQuoteToken(testIndex);
         assertEq(_quote.balanceOf(_bidder), qtToRemove);
-        (lpBalance, ) = _subsetPool.bucketLenders(testIndex, _bidder);
+        (lpBalance, ) = _subsetPool.lenders(testIndex, _bidder);
         assertEq(lpBalance, 0);
         (quote, collateral, , ) = _subsetPool.bucketAt(testIndex);
         assertEq(quote,      10_000 * 1e18 - qtToRemove);
@@ -217,7 +217,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateralNFT(_bidder, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (uint256 amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        (uint256 lpBalance, ) = _subsetPool.bucketLenders(2350, _bidder);
+        (uint256 lpBalance, ) = _subsetPool.lenders(2350, _bidder);
         assertEq(lpBalance, 490.713717393968418590429839925 * 1e27);
         skip(7200);
 
@@ -243,7 +243,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateralNFT(_lender, _subsetPool.indexToPrice(2350), tokenIdsToRemove);
         (amount) = _subsetPool.removeCollateral(tokenIdsToRemove, 2350);
-        (lpBalance, ) = _subsetPool.bucketLenders(2350, _lender);
+        (lpBalance, ) = _subsetPool.lenders(2350, _lender);
         assertEq(lpBalance, 11_836.428760868677193803190045359 * 1e27);
         skip(3600);
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -180,17 +180,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         uint256 tokenId = _mintNFT(testAddress, address(_pool));
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(indexes[0], testAddress);
+        (uint256 lpBalance, ) = _pool.lenders(indexes[0], testAddress);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[1], testAddress);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[2], testAddress);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -222,17 +222,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[0], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[1], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[2], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
 
         // check position manager state
@@ -252,17 +252,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _pool.addQuoteToken(3_000 * 1e18, indexes[2]);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[0], testAddress);
         assertEq(lpBalance, 1_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[1], testAddress);
         assertEq(lpBalance, 2_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[2], testAddress);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
 
         // check position manager state
@@ -290,17 +290,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[0], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[1], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], testAddress);
+        (lpBalance, ) = _pool.lenders(indexes[2], testAddress);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 4_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 5_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 6_000 * 1e27);
 
         // check position manager state
@@ -348,25 +348,25 @@ contract PositionManagerTest is PositionManagerHelperContract {
         uint256 tokenId2 = _mintNFT(testLender2, address(_pool));
 
         // check lender, position manager, and pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(indexes[0], testLender1);
+        (uint256 lpBalance, ) = _pool.lenders(indexes[0], testLender1);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], testLender1);
+        (lpBalance, ) = _pool.lenders(indexes[1], testLender1);
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], testLender1);
-        assertEq(lpBalance, 3_000 * 1e27);
-
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], testLender2);
-        assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[3], testLender2);
+        (lpBalance, ) = _pool.lenders(indexes[2], testLender1);
         assertEq(lpBalance, 3_000 * 1e27);
 
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], testLender2);
+        assertEq(lpBalance, 3_000 * 1e27);
+        (lpBalance, ) = _pool.lenders(indexes[3], testLender2);
+        assertEq(lpBalance, 3_000 * 1e27);
+
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[3], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[3], address(_positionManager));
         assertEq(lpBalance, 0);
 
         assertEq(_positionManager.getLPTokens(indexes[0], tokenId1), 0);
@@ -405,20 +405,20 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(testLender1));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(testLender1));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(testLender1));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(testLender1));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(testLender1));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(testLender1));
         assertEq(lpBalance, 0);
 
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[3], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[3], address(_positionManager));
         assertEq(lpBalance, 0);
 
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[0]), 3_000 * 1e27);
@@ -450,18 +450,18 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], testLender2);
+        (lpBalance, ) = _pool.lenders(indexes[0], testLender2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(indexes[3], testLender2);
+        (lpBalance, ) = _pool.lenders(indexes[3], testLender2);
         assertEq(lpBalance, 0);
 
-        (lpBalance, ) = _pool.bucketLenders(indexes[0], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[0], address(_positionManager));
         assertEq(lpBalance, 6_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[1], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[1], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[2], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[2], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(indexes[3], address(_positionManager));
+        (lpBalance, ) = _pool.lenders(indexes[3], address(_positionManager));
         assertEq(lpBalance, 3_000 * 1e27);
 
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[0]), 3_000 * 1e27);
@@ -514,11 +514,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _pool.addQuoteToken(15_000 * 1e18, testIndexPrice);
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (uint256 lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -537,11 +537,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 15_000 * 1e27);
 
         // check position manager state
@@ -569,11 +569,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -604,11 +604,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _pool.addQuoteToken(15_000 * 1e18, testIndexPrice);
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (uint256 lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -627,11 +627,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 15_000 * 1e27);
 
         // check position manager state
@@ -676,11 +676,11 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -806,17 +806,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.ownerOf(tokenId2), testAddress2);
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress1);
+        (uint256 lpBalance, ) = _pool.lenders(mintIndex, testAddress1);
         assertEq(lpBalance, 2_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress2);
         assertEq(lpBalance, 5_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(mintIndex, address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(moveIndex, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -843,17 +843,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress2);
         assertEq(lpBalance, 5_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(mintIndex, address(_positionManager));
         assertEq(lpBalance, 2_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(moveIndex, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -878,17 +878,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress2);
         assertEq(lpBalance, 5_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(mintIndex, address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(moveIndex, address(_positionManager));
         assertEq(lpBalance, 2_500 * 1e27);
 
         // check position manager state
@@ -913,17 +913,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(mintIndex, address(_positionManager));
         assertEq(lpBalance, 5_500 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(moveIndex, address(_positionManager));
         assertEq(lpBalance, 2_500 * 1e27);
 
         // check position manager state
@@ -948,17 +948,17 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress1);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress1);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(mintIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, testAddress2);
+        (lpBalance, ) = _pool.lenders(moveIndex, testAddress2);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(mintIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(mintIndex, address(_positionManager));
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(moveIndex, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(moveIndex, address(_positionManager));
         assertEq(lpBalance, 8_000 * 1e27);
 
         // check position manager state
@@ -988,9 +988,9 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _pool.addQuoteToken(15_000 * 1e18, testIndexPrice);
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (uint256 lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -1009,9 +1009,9 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 15_000 * 1e27);
 
         // check position manager state
@@ -1035,9 +1035,9 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -1089,13 +1089,13 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _pool.addQuoteToken(15_000 * 1e18, testIndexPrice);
 
         // check pool state
-        (uint256 lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (uint256 lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 25_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2551, testReceiver);
+        (lpBalance, ) = _pool.lenders(2551, testReceiver);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state
@@ -1114,13 +1114,13 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 25_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2551, testReceiver);
+        (lpBalance, ) = _pool.lenders(2551, testReceiver);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 15_000 * 1e27);
 
         // check position manager state
@@ -1159,13 +1159,13 @@ contract PositionManagerTest is PositionManagerHelperContract {
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testMinter);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testMinter);
         assertEq(lpBalance, 0);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, testReceiver);
+        (lpBalance, ) = _pool.lenders(testIndexPrice, testReceiver);
         assertEq(lpBalance, 40_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(2551, testReceiver);
+        (lpBalance, ) = _pool.lenders(2551, testReceiver);
         assertEq(lpBalance, 15_000 * 1e27);
-        (lpBalance, ) = _pool.bucketLenders(testIndexPrice, address(_positionManager));
+        (lpBalance, ) = _pool.lenders(testIndexPrice, address(_positionManager));
         assertEq(lpBalance, 0);
 
         // check position manager state

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -376,7 +376,8 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(indexes[0], tokenId2), 0);
         assertEq(_positionManager.getLPTokens(indexes[3], tokenId2), 0);
 
-        assertEq(_pool.poolSize(), 15_000 * 1e18);
+        (uint256 poolSize, , , ) = _pool.poolLoansInfo();
+        assertEq(poolSize, 15_000 * 1e18);
 
         // construct memorialize lender 1 params struct
         uint256[] memory lender1Indexes = new uint256[](3);
@@ -425,7 +426,8 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[1]), 3_000 * 1e27);
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[2]), 3_000 * 1e27);
 
-        assertEq(_pool.poolSize(), 15_000 * 1e18);
+        (poolSize, , , ) = _pool.poolLoansInfo();
+        assertEq(poolSize, 15_000 * 1e18);
 
         // allow position manager to take ownership of lender 2's position
         vm.prank(testLender2);
@@ -471,7 +473,8 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(tokenId2, indexes[0]), 3_000 * 1e27);
         assertEq(_positionManager.getLPTokens(tokenId2, indexes[3]), 3_000 * 1e27);
 
-        assertEq(_pool.poolSize(), 15_000 * 1e18);
+        (poolSize, , , ) = _pool.poolLoansInfo();
+        assertEq(poolSize, 15_000 * 1e18);
     }
 
     function testMemorializeMultipleAndModifyLiquidity() external {

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -79,7 +79,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
             if (!positionPrice.contains(params_.indexes[i])) require(positionPrice.add(params_.indexes[i]), "PM:ME:ADD_FAIL");
 
             // update PositionManager accounting
-            (uint256 lpBalance, ) = pool.bucketLenders(params_.indexes[i], params_.owner);
+            (uint256 lpBalance, ) = pool.lenders(params_.indexes[i], params_.owner);
             lps[params_.tokenId][params_.indexes[i]] += lpBalance;
 
             // increment call counter in gas efficient way by skipping safemath checks

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -106,8 +106,9 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     function moveLiquidity(MoveLiquidityParams calldata params_) external override mayInteract(params_.pool, params_.tokenId) {
 
         IScaledPool pool = IScaledPool(params_.pool);
+        ( , uint256 bucketDeposit, , , , , ) = pool.bucketAt(params_.fromIndex);
         uint256 maxQuote = pool.lpsToQuoteTokens(
-            pool.depositAt(params_.fromIndex),  lps[params_.tokenId][params_.fromIndex], params_.fromIndex
+            bucketDeposit, lps[params_.tokenId][params_.fromIndex], params_.fromIndex
         );
 
         // update prices set at which a position has liquidity

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -439,12 +439,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         return Maths.max(Maths.wdiv(interestRate, WAD_WEEKS_PER_YEAR), minFee);
     }
 
-    function _exchangeRate(uint256 quoteToken_, uint256 availableCollateral_, uint256 lpAccumulator_, uint256 index_) internal pure returns (uint256) {
-        uint256 colValue   = Book.indexToPrice(index_) * availableCollateral_;             // 10^36
-        uint256 bucketSize = quoteToken_ * 10**18 + colValue;                          // 10^36
-        return lpAccumulator_ != 0 ? bucketSize * 10**18 / lpAccumulator_ : Maths.RAY; // 10^27
-    }
-
     function _lpsToQuoteTokens(uint256 deposit_, uint256 lpTokens_, uint256 index_) internal view returns (uint256 quoteAmount_) {
         uint256 rate = buckets.getExchangeRate(index_, deposit_);
         quoteAmount_ = Maths.min(deposit_, Maths.rayToWad(Maths.rmul(lpTokens_, rate))); // TODO optimize to calculate bucket size only once

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -738,11 +738,6 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         return Maths.max(Maths.wdiv(interestRate, WAD_WEEKS_PER_YEAR), minFee);
     }
 
-    function _lpsToQuoteTokens(uint256 deposit_, uint256 lpTokens_, uint256 index_) internal view returns (uint256 quoteAmount_) {
-        uint256 rate = buckets.getExchangeRate(index_, deposit_);
-        quoteAmount_ = Maths.min(deposit_, Maths.rayToWad(Maths.rmul(lpTokens_, rate))); // TODO optimize to calculate bucket size only once
-    }
-
     function _pendingInterestFactor(uint256 elapsed_) internal view returns (uint256) {
         return PRBMathUD60x18.exp((interestRate * elapsed_) / 365 days);
     }
@@ -843,8 +838,13 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         uint256 deposit_,
         uint256 lpTokens_,
         uint256 index_
-    ) external view override returns (uint256) {
-        return _lpsToQuoteTokens(deposit_, lpTokens_, index_);
+    ) external view override returns (uint256 quoteTokenAmount_) {
+        (quoteTokenAmount_, , ) = buckets.lpsToQuoteToken(
+            index_,
+            deposit_,
+            lpTokens_,
+            deposit_
+        );
     }
 
     function poolLoansInfo()

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -82,17 +82,17 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
 
     Heap.Data internal loans;
 
-    uint256 internal poolInitializations = 0;
+    uint256 internal poolInitializations;
 
     /**
      *  @notice Time a Claimable Reserve Auction was last kicked.
      */
-    uint256 internal reserveAuctionKicked = 0;
+    uint256 internal reserveAuctionKicked;
 
     /**
      *  @notice Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
      */
-    uint256 internal reserveAuctionUnclaimed = 0;
+    uint256 internal reserveAuctionUnclaimed;
 
 
     /*********************************/

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -761,8 +761,8 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         price_             = Book.indexToPrice(index_);
         quoteTokens_       = _valueAt(index_);           // quote token in bucket, deposit + interest (WAD)
         collateral_        = buckets[index_].collateral; // unencumbered collateral in bucket (WAD)
-        bucketLPs_         = buckets[index_].lps;       // outstanding LP balance (WAD)
-        scale_             = _scale(index_);            // lender interest multiplier (WAD)
+        bucketLPs_         = buckets[index_].lps;        // outstanding LP balance (WAD)
+        scale_             = _scale(index_);             // lender interest multiplier (WAD)
         exchangeRate_      = buckets.getExchangeRate(index_, quoteTokens_);
         liquidityToPrice_  = _prefixSum(index_);
     }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -621,7 +621,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     function _mompFactor(uint256 inflator) internal view returns (uint256) {
         uint256 numLoans = (loans.count - 1) * 1e18;
         if (numLoans != 0) {
-            return Maths.wdiv(_indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, numLoans))), inflator);
+            return Maths.wdiv(Book.indexToPrice(_findIndexOfSum(Maths.wdiv(borrowerDebt, numLoans))), inflator);
         }
         return 0;
     }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -495,6 +495,18 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
         );
     }
 
+    function borrowerInfo(address borrower_) external view override returns (uint256, uint256, uint256, uint256, uint256) {
+        uint256 pendingDebt = Maths.wmul(borrowers[borrower_].debt, Maths.wdiv(_pendingInflator(), inflatorSnapshot));
+
+        return (
+            borrowers[borrower_].debt,            // accrued debt (WAD)
+            pendingDebt,                          // current debt, accrued and pending accrual (WAD)
+            borrowers[borrower_].collateral,      // deposited collateral including encumbered (WAD)
+            borrowers[borrower_].mompFactor,      // MOMP / inflator, used in neutralPrice calc (WAD)
+            borrowers[borrower_].inflatorSnapshot // used to calculate pending interest (WAD)
+        );
+    }
+
     function claimableReserves() external view override returns (uint256) {
         return _claimableReserves();
     }

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -515,7 +515,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
             msg.sender,
             bucketLPs_
         );
-        buckets.addToBucket(
+        buckets.addCollateral(
             index_,
             bucketLPs_,
             collateralAmountToAdd_
@@ -549,7 +549,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
             msg.sender,
             bucketLPs_
         );
-        buckets.removeFromBucket(
+        buckets.removeCollateral(
             index_,
             bucketLPs_,
             collateralAmountToRemove_

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -329,16 +329,6 @@ interface IScaledPool {
     /*** Structs ***/
     /***************/
 
-    /**
-     *  @notice struct holding bucket info
-     *  @param lpAccumulator       Bucket LP accumulator, RAY
-     *  @param availableCollateral Available collateral tokens deposited in the bucket, WAD
-     */
-    struct Bucket {
-        uint256 lpAccumulator;       // [RAY]
-        uint256 availableCollateral; // [WAD]
-    }
-
     struct BucketLender {
         uint256 lpBalance;           // [RAY]
         uint256 lastQuoteDeposit;    // timestamp

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -524,6 +524,26 @@ interface IScaledPool {
         );
 
     /**
+     *  @notice Get a borrower info struct for a given address.
+     *  @param  borrower_         The borrower address.
+     *  @return debt_             Borrower accrued debt (WAD)
+     *  @return pendingDebt_      Borrower current debt, accrued and pending accrual (WAD)
+     *  @return collateral_       Deposited collateral including encumbered (WAD)
+     *  @return mompFactor_        LUP / inflator, used in neutralPrice calc (WAD)
+     *  @return inflatorSnapshot_ Inflator used to calculate pending interest (WAD)
+     */
+    function borrowerInfo(address borrower_)
+        external
+        view
+        returns (
+            uint256 debt_,
+            uint256 pendingDebt_,
+            uint256 collateral_,
+            uint256 mompFactor_,
+            uint256 inflatorSnapshot_
+        );
+
+    /**
      *  @notice Calculates the amount of reserves which can be claimed through a Claimable Reserve Auction.
      *  @return _claimableReserves Denominated in quote token, or 0 if no reserves can be auctioned.
      */

--- a/src/base/interfaces/IScaledPool.sol
+++ b/src/base/interfaces/IScaledPool.sol
@@ -239,14 +239,14 @@ interface IScaledPool {
     function buckets(uint256 index_) external view returns (uint256 lpAccumulator, uint256 availableCollateral);
 
     /**
-     *  @notice Mapping of buckets indexes and owner addresses to {BucketLender} structs.
+     *  @notice Mapping of buckets indexes and owner addresses to {Lender} structs.
      *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
      *  @param  index_           Bucket index.
      *  @param  lp_              Address of the liquidity provider.
      *  @return lpBalance        Amount of LPs owner has in current bucket.
      *  @return lastQuoteDeposit Time the user last deposited quote token.
      */
-    function bucketLenders(uint256 index_, address lp_) external view returns (uint256 lpBalance, uint256 lastQuoteDeposit);
+    function lenders(uint256 index_, address lp_) external view returns (uint256 lpBalance, uint256 lastQuoteDeposit);
 
     /**
      *  @notice Returns the `debtEma` state variable.
@@ -324,15 +324,6 @@ interface IScaledPool {
      *  @notice Returns the amount of excess quote tokens.
      */
     function reserves() external view returns (uint256 reserves_);
-
-    /***************/
-    /*** Structs ***/
-    /***************/
-
-    struct BucketLender {
-        uint256 lpBalance;           // [RAY]
-        uint256 lastQuoteDeposit;    // timestamp
-    }
 
 
     /*********************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -141,16 +141,15 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         _updateInterestRateAndEMAs(borrowerDebt, _lup());
 
         // move collateral from pool to lender
-        emit RemoveCollateral(msg.sender, price, amount_);
+        emit RemoveCollateral(msg.sender, index_, amount_);
         collateral().safeTransfer(msg.sender, amount_ / collateralScale);
     }
 
     function removeCollateral(uint256 amount_, uint256 index_) external override returns (uint256 lpAmount_) {
-        uint256 price;
-        (lpAmount_, price) = _removeCollateral(amount_, index_);
+        lpAmount_ = _removeCollateral(amount_, index_);
 
         // move collateral from pool to lender
-        emit RemoveCollateral(msg.sender, price, amount_);
+        emit RemoveCollateral(msg.sender, index_, amount_);
         collateral().safeTransfer(msg.sender, amount_ / collateralScale);
     }
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -91,16 +91,11 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
 
         uint256 curDebt = _accruePoolInterest();
 
-        // determine amount of amount of LP required
-        uint256 rate   = buckets.getExchangeRate(fromIndex_, _valueAt(fromIndex_));
-        lpbAmountFrom_ = (amount_ * Book.indexToPrice(fromIndex_) * 1e18 + rate / 2) / rate;
-
+        lpbAmountFrom_ = buckets.collateralToLPs(fromIndex_, _valueAt(fromIndex_), amount_);
         (uint256 lpBalance, ) = lenders.getLenderInfo(fromIndex_, msg.sender);
         if (lpbAmountFrom_ > lpBalance) revert MoveCollateralInsufficientLP();
 
-        // update "to" bucket accounting
-        rate         = buckets.getExchangeRate(toIndex_, _valueAt(toIndex_));
-        lpbAmountTo_ = (amount_ * Book.indexToPrice(toIndex_) * 1e18 + rate / 2) / rate;
+        lpbAmountTo_ = buckets.collateralToLPs(toIndex_, _valueAt(toIndex_), amount_);
 
         // update buckets
         buckets.removeFromBucket(fromIndex_, lpbAmountFrom_, amount_);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -135,12 +135,12 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
             toBucketLPs_
         );
         // update buckets
-        buckets.removeFromBucket(
+        buckets.removeCollateral(
             fromIndex_,
             fromBucketLPs_,
             collateralAmountToMove_
         );
-        buckets.addToBucket(
+        buckets.addCollateral(
             toIndex_,
             toBucketLPs_,
             collateralAmountToMove_
@@ -175,7 +175,7 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
             redeemedLenderLPs_
         );
         // update bucket accounting
-        buckets.removeFromBucket(
+        buckets.removeCollateral(
             index_,
             redeemedLenderLPs_,
             collateralAmountRemoved_

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -124,27 +124,11 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         );
 
         // update lender accounting
-        lenders.removeLPs(
-            fromIndex_,
-            msg.sender,
-            fromBucketLPs_
-        );
-        lenders.addLPs(
-            toIndex_,
-            msg.sender,
-            toBucketLPs_
-        );
+        lenders.removeLPs(fromIndex_, msg.sender, fromBucketLPs_);
+        lenders.addLPs(toIndex_, msg.sender, toBucketLPs_);
         // update buckets
-        buckets.removeCollateral(
-            fromIndex_,
-            fromBucketLPs_,
-            collateralAmountToMove_
-        );
-        buckets.addCollateral(
-            toIndex_,
-            toBucketLPs_,
-            collateralAmountToMove_
-        );
+        buckets.removeCollateral(fromIndex_, fromBucketLPs_, collateralAmountToMove_);
+        buckets.addCollateral(toIndex_, toBucketLPs_, collateralAmountToMove_);
 
         _updateInterestRateAndEMAs(curDebt, _lup());
 
@@ -169,17 +153,9 @@ contract ERC20Pool is IERC20Pool, ScaledPool {
         if (collateralAmountRemoved_ == 0) revert RemoveCollateralNoClaim();
 
         // update lender accounting
-        lenders.removeLPs(
-            index_,
-            msg.sender,
-            redeemedLenderLPs_
-        );
+        lenders.removeLPs(index_, msg.sender, redeemedLenderLPs_);
         // update bucket accounting
-        buckets.removeCollateral(
-            index_,
-            redeemedLenderLPs_,
-            collateralAmountRemoved_
-        );
+        buckets.removeCollateral(index_, redeemedLenderLPs_, collateralAmountRemoved_);
 
         _updateInterestRateAndEMAs(borrowerDebt, _lup());
 

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -219,28 +219,4 @@ interface IERC20Pool is IScaledPool {
      */
     function take(address borrower_, uint256 amount_, bytes memory swapCalldata_) external;
 
-
-    /**********************/
-    /*** View Functions ***/
-    /**********************/
-
-    /**
-     *  @notice Get a borrower info struct for a given address.
-     *  @param  borrower_         The borrower address.
-     *  @return debt_             Borrower accrued debt (WAD)
-     *  @return pendingDebt_      Borrower current debt, accrued and pending accrual (WAD)
-     *  @return collateral_       Deposited collateral including encumbered (WAD)
-     *  @return mompFactor_        LUP / inflator, used in neutralPrice calc (WAD)
-     *  @return inflatorSnapshot_ Inflator used to calculate pending interest (WAD)
-     */
-    function borrowerInfo(address borrower_)
-        external
-        view
-        returns (
-            uint256 debt_,
-            uint256 pendingDebt_,
-            uint256 collateral_,
-            uint256 mompFactor_,
-            uint256 inflatorSnapshot_
-        );
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -21,14 +21,6 @@ interface IERC20Pool is IScaledPool {
     event AddCollateral(address indexed actor_, uint256 indexed price_, uint256 amount_);
 
     /**
-     *  @notice Emitted when borrower borrows quote tokens from pool.
-     *  @param  borrower_ `msg.sender`.
-     *  @param  lup_      LUP after borrow.
-     *  @param  amount_   Amount of quote tokens borrowed from the pool.
-     */
-    event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-
-    /**
      *  @notice Emitted when an actor settles debt in a completed liquidation
      *  @param  borrower_           Identifies the loan under liquidation.
      *  @param  hpbIndex_           The index of the Highest Price Bucket where debt was cleared.
@@ -76,14 +68,6 @@ interface IERC20Pool is IScaledPool {
     event RemoveCollateral(address indexed claimer_, uint256 indexed price_, uint256 amount_);
 
     /**
-     *  @notice Emitted when borrower repays quote tokens to the pool.
-     *  @param  borrower_ `msg.sender`.
-     *  @param  lup_      LUP after repay.
-     *  @param  amount_   Amount of quote tokens repayed to the pool.
-     */
-    event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
-
-    /**
      *  @notice Emitted when an actor uses quote token outside of the book to purchase collateral under liquidation.
      *  @param  borrower_   Identifies the loan being liquidated.
      *  @param  amount_     Amount of quote token used to purchase collateral.
@@ -114,17 +98,6 @@ interface IERC20Pool is IScaledPool {
     /*********************************/
 
     /**
-     *  @notice Mapping of borrower addresses to {Borrower} structs.
-     *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
-     *  @param  borrower_  Address of the borrower.
-     *  @return debt       Amount of debt that the borrower has, in quote token.
-     *  @return collateral Amount of collateral that the borrower has deposited, in collateral token.
-     *  @return mompFactor Momp / borrowerInflatorSnapshot factor used.
-     *  @return inflator   Snapshot of inflator value used to track interest on loans.
-     */
-    function borrowers(address borrower_) external view returns (uint256 debt, uint256 collateral, uint256 mompFactor, uint256 inflator);
-
-    /**
      *  @notice Returns the `collateralScale` state variable.
      *  @return collateralScale_ The precision of the collateral ERC-20 token based on decimals.
      */
@@ -153,20 +126,6 @@ interface IERC20Pool is IScaledPool {
     /*************************/
 
     /**
-     *  @notice Struct holding borrower related info.
-     *  @param  debt             Borrower debt, WAD units.
-     *  @param  collateral       Collateral deposited by borrower, WAD units.
-     *  @return mompFactor       Most Optimistic Matching Price (MOMP) / inflator, used in neutralPrice calc, WAD units.
-     *  @param  inflatorSnapshot Current borrower inflator snapshot, WAD units.
-     */
-    struct Borrower {
-        uint256 debt;             // [WAD]
-        uint256 collateral;       // [WAD]
-        uint256 mompFactor;       // [WAD]
-        uint256 inflatorSnapshot; // [WAD]
-    }
-
-    /**
      *  @notice Maintains the state of a liquidation.
      *  @param  kickTime            Time the liquidation was initiated.
      *  @param  referencePrice      Highest Price Bucket at time of liquidation.
@@ -186,14 +145,6 @@ interface IERC20Pool is IScaledPool {
     /*********************************************/
 
     /**
-     *  @notice Called by a borrower to open or expand a position.
-     *  @dev    Can only be called if quote tokens have already been added to the pool.
-     *  @param  amount_     The amount of quote token to borrow.
-     *  @param  limitIndex_ Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
-     */
-    function borrow(uint256 amount_, uint256 limitIndex_) external;
-
-    /**
      *  @notice Called by borrowers to add collateral to the pool.
      *  @param  borrower_ The address of borrower to pledge collateral for.
      *  @param  amount_   The amount of collateral in deposit tokens to be added to the pool.
@@ -205,13 +156,6 @@ interface IERC20Pool is IScaledPool {
      *  @param  amount_ The amount of collateral in deposit tokens to be removed from a position.
      */
     function pullCollateral(uint256 amount_) external;
-
-    /**
-     *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
-     *  @param  borrower_  The address of borrower to repay quote token amount for.
-     *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
-     */
-    function repay(address borrower_, uint256 maxAmount_) external;
 
     /*****************************/
     /*** Initialize Functions ***/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -32,7 +32,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     BitMaps.BitMap private _poolCollateralTokenIds;
 
     /// @dev Set of NFT Token Ids that have been deposited into any bucket
-    BitMaps.BitMap private _bucketCollateralTokenIds; // TODO do we really need this one?
+    BitMaps.BitMap private _bucketCollateralTokenIds;
 
     /// @dev Set of tokenIds that can be used for a given NFT Subset type pool
     /// @dev Defaults to length 0 if the whole collection is to be used
@@ -111,6 +111,9 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         for (uint256 i = 0; i < tokenIds_.length;) {
             //slither-disable-next-line calls-loop
             if (collateral().ownerOf(tokenIds_[i]) != address(this)) revert TokenNotDeposited();
+            if (!_poolCollateralTokenIds.get(tokenIds_[i]))          revert RemoveTokenFailed(); // check if NFT token id in pool
+            if (!lockedNFTs[msg.sender].get(tokenIds_[i]))           revert RemoveTokenFailed(); // check if caller is the one that locked NFT token id
+
             _poolCollateralTokenIds.unset(tokenIds_[i]);
             lockedNFTs[msg.sender].unset(tokenIds_[i]);
 
@@ -155,7 +158,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         emit RemoveCollateralNFT(msg.sender, index_, tokenIds_);
         // move collateral from pool to lender
         for (uint256 i = 0; i < tokenIds_.length;) {
-            if (!_bucketCollateralTokenIds.get(tokenIds_[i])) revert TokenNotDeposited();
+            if (!_bucketCollateralTokenIds.get(tokenIds_[i])) revert TokenNotDeposited(); // check if NFT token deposited in buckets
 
             _bucketCollateralTokenIds.unset(tokenIds_[i]);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -150,10 +150,9 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     // TODO: finish implementing
     // TODO: check for reentrancy
     function removeCollateral(uint256[] calldata tokenIds_, uint256 index_) external override returns (uint256 lpAmount_) {
-        uint256 price;
-        (lpAmount_, price) = _removeCollateral(Maths.wad(tokenIds_.length), index_);
+        lpAmount_ = _removeCollateral(Maths.wad(tokenIds_.length), index_);
 
-        emit RemoveCollateralNFT(msg.sender, price, tokenIds_);
+        emit RemoveCollateralNFT(msg.sender, index_, tokenIds_);
         // move collateral from pool to lender
         for (uint256 i = 0; i < tokenIds_.length;) {
             if (!_bucketCollateralTokenIds.get(tokenIds_[i])) revert TokenNotDeposited();

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -38,6 +38,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     /// @dev Defaults to length 0 if the whole collection is to be used
     BitMaps.BitMap private _tokenIdsAllowed;
 
+    /// @dev pledged collateral: borrower address -> Set of NFT Token Ids pledged by the borrower
     mapping(address => BitMaps.BitMap) private lockedNFTs;
 
     mapping(address => NFTLiquidationInfo) private liquidations;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -43,6 +43,8 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
     mapping(address => NFTLiquidationInfo) private liquidations;
 
+    bool public isSubset;
+
     /****************************/
     /*** Initialize Functions ***/
     /****************************/
@@ -75,6 +77,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         address ajnaTokenAddress_
     ) external override {
         this.initialize(rate_, ajnaTokenAddress_);
+        isSubset = true;
 
         // add subset of tokenIds allowed in the pool
         for (uint256 id = 0; id < tokenIds_.length;) {
@@ -99,7 +102,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         emit PledgeCollateralNFT(borrower_, tokenIdsToPledge_);
         for (uint256 i = 0; i < tokenIdsToPledge_.length;) {
             uint256 tokenId = tokenIdsToPledge_[i];
-            if (!_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
+            if (isSubset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
 
             _poolCollateralTokenIds.set(tokenId);
             lockedNFTs[borrower_].set(tokenId);
@@ -156,7 +159,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_);
         for (uint256 i = 0; i < tokenIdsToAdd_.length;) {
             uint256 tokenId = tokenIdsToAdd_[i];
-            if (!_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
+            if (isSubset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
 
             _bucketCollateralTokenIds.set(tokenId);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -38,9 +38,6 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     /// @dev Defaults to length 0 if the whole collection is to be used
     EnumerableSet.UintSet private _tokenIdsAllowed;
 
-    /// @dev Internal visibility is required as it contains a nested struct
-    // borrowers book: borrower address -> NFTBorrower
-    mapping(address => NFTBorrower) private borrowers;
     mapping(address => EnumerableSet.UintSet) private lockedNFTs;
 
     mapping(address => NFTLiquidationInfo) private liquidations;
@@ -85,9 +82,11 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     /***********************************/
 
     function pledgeCollateral(address borrower_, uint256[] calldata tokenIds_) external override {
-        EnumerableSet.UintSet storage collateralDeposited = lockedNFTs[borrower_];
+        _pledgeCollateral(borrower_, Maths.wad(tokenIds_.length));
 
-        // add tokenIds to the pool
+        // move collateral from sender to pool
+        emit PledgeCollateralNFT(borrower_, tokenIds_);
+        EnumerableSet.UintSet storage collateralDeposited = lockedNFTs[borrower_];
         for (uint256 i = 0; i < tokenIds_.length;) {
             if (_tokenIdsAllowed.length() != 0) if(!_tokenIdsAllowed.contains(tokenIds_[i])) revert OnlySubset();
 
@@ -101,86 +100,16 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
                 ++i;
             }
         }
-
-        // update pool state
-        uint256 curDebt = _accruePoolInterest();
-        uint256 lup = _lup();
-        _updateInterestRateAndEMAs(curDebt, lup);
-        pledgedCollateral += Maths.wad(tokenIds_.length);
-
-        // accrue interest to borrower
-        NFTBorrower storage borrower = borrowers[borrower_];
-        (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-
-        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
-        // update loan queue
-        uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(collateralDeposited.length()), borrower.inflatorSnapshot);
-        if (borrower.debt != 0) loans.upsert(borrower_, thresholdPrice);
-
-        emit PledgeCollateralNFT(borrower_, tokenIds_);
-    }
-
-    function borrow(uint256 amount_, uint256 limitIndex_) external override {
-        uint256 lupId = _lupIndex(amount_);
-        if (lupId > limitIndex_) revert BorrowLimitIndexReached();
-
-        // update pool interest
-        uint256 curDebt = _accruePoolInterest();
-
-        // borrower accounting
-        NFTBorrower storage borrower = borrowers[msg.sender];
-        if (loans.count - 1 != 0) if (borrower.debt + amount_ < _poolMinDebtAmount(curDebt)) revert BorrowAmountLTMinDebt();
-
-        (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-
-        uint256 debt  = Maths.wmul(amount_, _calculateFeeRate() + Maths.WAD);
-        borrower.debt += debt;
-
-        // pool accounting
-        uint256 newLup = Book.indexToPrice(lupId);
-
-        // check borrow won't push borrower or pool into a state of under-collateralization
-        uint256 noOfNFTs = Maths.wad(lockedNFTs[msg.sender].length());
-        if (_borrowerCollateralization(borrower.debt, noOfNFTs, newLup) < Maths.WAD) revert BorrowBorrowerUnderCollateralized();
-        if (_poolCollateralizationAtPrice(curDebt, debt, pledgedCollateral, newLup) < Maths.WAD) revert BorrowPoolUnderCollateralized();
-
-        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
-
-        curDebt += debt;
-        borrowerDebt = curDebt;
-
-        // update loan queue
-        uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, noOfNFTs, borrower.inflatorSnapshot);
-        loans.upsert(msg.sender, thresholdPrice);
-
-        _updateInterestRateAndEMAs(curDebt, newLup);
-
-        // move borrowed amount from pool to sender
-        emit Borrow(msg.sender, newLup, amount_);
-        quoteToken().safeTransfer(msg.sender, amount_ / quoteTokenScale);
     }
 
     // TODO: check for reentrancy
     // TODO: check for whole units of collateral
     function pullCollateral(uint256[] calldata tokenIds_) external override {
-        uint256 curDebt = _accruePoolInterest();
+        _pullCollateral(Maths.wad(tokenIds_.length));
 
-        // borrower accounting
-        NFTBorrower storage borrower = borrowers[msg.sender];
-        (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-
-        // check collateralization for sufficient unenecumbered collateral
-        uint256 curLup = _lup();
+        // move collateral from pool to sender
+        emit PullCollateralNFT(msg.sender, tokenIds_);
         EnumerableSet.UintSet storage collateralDeposited = lockedNFTs[msg.sender];
-        if (Maths.wad(collateralDeposited.length()) - _encumberedCollateral(borrower.debt, curLup) < Maths.wad(tokenIds_.length)) revert RemoveCollateralInsufficientCollateral();
-
-        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
-
-        // update pool state
-        pledgedCollateral -= Maths.wad(tokenIds_.length);
-        _updateInterestRateAndEMAs(curDebt, curLup);
-
-        // remove tokenIds and transfer to caller
         for (uint256 i = 0; i < tokenIds_.length;) {
             //slither-disable-next-line calls-loop
             if (collateral().ownerOf(tokenIds_[i]) != address(this)) revert TokenNotDeposited();
@@ -194,45 +123,6 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
                 ++i;
             }
         }
-
-        // update loan queue
-        uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(collateralDeposited.length()), borrower.inflatorSnapshot);
-        if (borrower.debt != 0) loans.upsert(msg.sender, thresholdPrice);
-
-        emit PullCollateralNFT(msg.sender, tokenIds_);
-    }
-
-    function repay(address borrower_, uint256 maxAmount_) external override {
-        NFTBorrower storage borrower = borrowers[borrower_];
-        if (borrower.debt == 0) revert RepayNoDebt();
-
-        uint256 curDebt = _accruePoolInterest();
-
-        // update borrower accounting
-        (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);
-        uint256 amount = Maths.min(borrower.debt, maxAmount_);
-        borrower.debt -= amount;
-        curDebt       -= amount;
-
-        // update loan queue
-        if (borrower.debt == 0) {
-            loans.remove(borrower_);
-        } else {
-            if (loans.count - 1 != 0) if (borrower.debt < _poolMinDebtAmount(curDebt)) revert BorrowAmountLTMinDebt();
-            uint256 thresholdPrice = _t0ThresholdPrice(borrower.debt, Maths.wad(lockedNFTs[borrower_].length()), borrower.inflatorSnapshot);
-            loans.upsert(borrower_, thresholdPrice);
-        }
-
-        // update pool state
-        borrowerDebt = curDebt;
-        uint256 newLup = _lup();
-        borrower.mompFactor = _mompFactor(borrower.inflatorSnapshot);
-
-        _updateInterestRateAndEMAs(curDebt, newLup);
-
-        // move amount to repay from sender to pool
-        emit Repay(borrower_, newLup, amount);
-        quoteToken().safeTransferFrom(msg.sender, address(this), amount / quoteTokenScale);
     }
 
     /*********************************/
@@ -241,23 +131,10 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
     // TODO: does pool state need to be updated with collateral deposited as well?
     function addCollateral(uint256[] calldata tokenIds_, uint256 index_) external override returns (uint256 lpbChange_) {
-        uint256 curDebt = _accruePoolInterest();
-
-        // Calculate exchange rate before new collateral has been accounted for.
-        // This is consistent with how lbpChange in addQuoteToken is adjusted before calling _add.
-        uint256 rate = buckets.getExchangeRate(index_, _valueAt(index_));
-
-        uint256 tokensToAdd        = Maths.wad(tokenIds_.length);
-        uint256 quoteValue         = Maths.wmul(tokensToAdd, Book.indexToPrice(index_));
-        lpbChange_                 = Maths.rdiv(Maths.wadToRay(quoteValue), rate);
-
-        buckets.addToBucket(index_, lpbChange_, tokensToAdd);
-
-        lenders.addLPs(index_, msg.sender, lpbChange_);
-
-        _updateInterestRateAndEMAs(curDebt, _lup());
+        lpbChange_ = _addCollateral(Maths.wad(tokenIds_.length), index_);
 
         // move required collateral from sender to pool
+        emit AddCollateralNFT(msg.sender, index_, tokenIds_);
         for (uint256 i = 0; i < tokenIds_.length;) {
             if (_tokenIdsAllowed.length() != 0) if(!_tokenIdsAllowed.contains(tokenIds_[i])) revert OnlySubset();
 
@@ -270,39 +147,15 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
                 ++i;
             }
         }
-
-        emit AddCollateralNFT(msg.sender, index_, tokenIds_);
     }
 
     // TODO: finish implementing
     // TODO: check for reentrancy
     function removeCollateral(uint256[] calldata tokenIds_, uint256 index_) external override returns (uint256 lpAmount_) {
-        uint256 availableCollateral = buckets.getCollateral(index_);
-        if (Maths.wad(tokenIds_.length) > availableCollateral) revert RemoveCollateralInsufficientCollateral();
-
-        uint256 curDebt = _accruePoolInterest();
-
-        uint256 price         = Book.indexToPrice(index_);
-        uint256 rate          = buckets.getExchangeRate(index_, _valueAt(index_));
-        (uint256 lpBalance, ) = lenders.getLenderInfo(index_, msg.sender);
-
-        // ensure user can actually remove that much
-        lpAmount_ = Maths.rdiv((Maths.wad(tokenIds_.length) * price / 1e9), rate);
-        uint256 nftsAvailableForClaiming = Maths.rwdivw(Maths.rmul(lpAmount_, rate), price);
-
-        if (lpBalance == 0 || lpAmount_ > lpBalance || Maths.wad(tokenIds_.length) < nftsAvailableForClaiming) {
-            revert RemoveCollateralInsufficientLP();
-        }
-
-        // update bucket accounting
-        buckets.removeFromBucket(index_, lpAmount_, Maths.wad(tokenIds_.length));
-        // update lender accounting
-        lenders.removeLPs(index_, msg.sender, lpAmount_);
-
-        _updateInterestRateAndEMAs(curDebt, _lup());
+        uint256 price;
+        (lpAmount_, price) = _removeCollateral(Maths.wad(tokenIds_.length), index_);
 
         emit RemoveCollateralNFT(msg.sender, price, tokenIds_);
-
         // move collateral from pool to lender
         for (uint256 i = 0; i < tokenIds_.length;) {
             if (!_bucketCollateralTokenIds.contains(tokenIds_[i])) revert TokenNotDeposited();
@@ -341,7 +194,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
     function kick(address borrower_) external override {
         (uint256 curDebt) = _accruePoolInterest();
 
-        NFTBorrower storage borrower = borrowers[borrower_];
+        Borrower storage borrower = borrowers[borrower_];
         if (borrower.debt == 0) revert KickNoDebt();
 
         (borrower.debt, borrower.inflatorSnapshot) = _accrueBorrowerInterest(borrower.debt, borrower.inflatorSnapshot, inflatorSnapshot);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -292,7 +292,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         }
 
         // update bucket accounting
-        buckets.removeFromBucket(index_, lpAmount_, tokenIds_.length);
+        buckets.removeFromBucket(index_, lpAmount_, Maths.wad(tokenIds_.length));
 
         // update lender accounting
         bucketLender.lpBalance -= lpAmount_;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -100,9 +100,10 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         // move collateral from sender to pool
         emit PledgeCollateralNFT(borrower_, tokenIdsToPledge_);
+        bool subset = isSubset;
         for (uint256 i = 0; i < tokenIdsToPledge_.length;) {
             uint256 tokenId = tokenIdsToPledge_[i];
-            if (isSubset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
+            if (subset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
 
             _poolCollateralTokenIds.set(tokenId);
             lockedNFTs[borrower_].set(tokenId);
@@ -157,9 +158,10 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
 
         // move required collateral from sender to pool
         emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_);
+        bool subset = isSubset;
         for (uint256 i = 0; i < tokenIdsToAdd_.length;) {
             uint256 tokenId = tokenIdsToAdd_[i];
-            if (isSubset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
+            if (subset && !_tokenIdsAllowed.get(tokenId)) revert OnlySubset();
 
             _bucketCollateralTokenIds.set(tokenId);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -14,6 +14,7 @@ import { ScaledPool } from "../base/ScaledPool.sol";
 
 import { Heap }  from "../libraries/Heap.sol";
 import { Maths } from "../libraries/Maths.sol";
+import '../libraries/Book.sol';
 
 contract ERC721Pool is IERC721Pool, ScaledPool {
     using SafeERC20     for ERC20;
@@ -131,7 +132,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         borrower.debt += debt;
 
         // pool accounting
-        uint256 newLup = _indexToPrice(lupId);
+        uint256 newLup = Book.indexToPrice(lupId);
 
         // check borrow won't push borrower or pool into a state of under-collateralization
         if (_borrowerCollateralization(borrower.debt, Maths.wad(borrower.collateralDeposited.length()), newLup) < Maths.WAD) revert BorrowBorrowerUnderCollateralized();
@@ -242,7 +243,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 rate = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
 
         uint256 tokensToAdd        = Maths.wad(tokenIds_.length);
-        uint256 quoteValue         = Maths.wmul(tokensToAdd, _indexToPrice(index_));
+        uint256 quoteValue         = Maths.wmul(tokensToAdd, Book.indexToPrice(index_));
         lpbChange_                 = Maths.rdiv(Maths.wadToRay(quoteValue), rate);
         bucket.lpAccumulator       += lpbChange_;
         bucketLender.lpBalance     += lpbChange_;
@@ -279,7 +280,7 @@ contract ERC721Pool is IERC721Pool, ScaledPool {
         uint256 curDebt = _accruePoolInterest();
 
         BucketLender memory bucketLender = bucketLenders[index_][msg.sender];
-        uint256 price        = _indexToPrice(index_);
+        uint256 price        = Book.indexToPrice(index_);
         uint256 rate         = _exchangeRate(_valueAt(index_), bucket.availableCollateral, bucket.lpAccumulator, index_);
         uint256 availableLPs = bucketLender.lpBalance;
 

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -186,26 +186,6 @@ interface IERC721Pool is IScaledPool {
     /**********************/
 
     /**
-     *  @notice Get a borrower info struct for a given address.
-     *  @param  borrower_            The borrower address.
-     *  @return debt_                Borrower accrued debt (WAD)
-     *  @return pendingDebt_         Borrower current debt, accrued and pending accrual (WAD)
-     *  @return collateralDeposited_ Array of deposited collateral IDs including encumbered
-     *  @return mompFactor_          Momp / borrower.inflatorSnapshot, used in neutralPrice calc (WAD)
-     *  @return inflatorSnapshot_    Inflator used to calculate pending interest (WAD)
-     */
-    function borrowerInfo(address borrower_)
-        external
-        view
-        returns (
-            uint256 debt_,
-            uint256 pendingDebt_,
-            uint256[] memory collateralDeposited_,
-            uint256 mompFactor_,
-            uint256 inflatorSnapshot_
-        );
-
-    /**
      *  @notice Check if a token id is allowed as collateral in pool.
      *  @param  tokenId_ The token id to check.
      *  @return allowed_ True if token id is allowed in pool

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -125,7 +125,6 @@ interface IERC721Pool is IScaledPool {
      */
     struct NFTBorrower {
         uint256               debt;                // [WAD]
-        EnumerableSet.UintSet collateralDeposited;
         uint256               mompFactor;
         uint256               inflatorSnapshot;    // [WAD]
     }

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -23,14 +23,6 @@ interface IERC721Pool is IScaledPool {
     event AddCollateralNFT(address indexed actor_, uint256 indexed price_, uint256[] tokenIds_);
 
     /**
-     *  @notice Emitted when borrower borrows quote tokens from pool.
-     *  @param  borrower_ `msg.sender`.
-     *  @param  lup_      LUP after borrow.
-     *  @param  amount_   Amount of quote tokens borrowed from the pool.
-     */
-    event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-
-    /**
      *  @notice Emitted when an actor settles debt in a completed liquidation
      *  @param  borrower_           Identifies the loan being liquidated.
      *  @param  hpbIndex_           The index of the Highest Price Bucket where debt was cleared.
@@ -67,14 +59,6 @@ interface IERC721Pool is IScaledPool {
      *  @param  tokenIds_ Array of tokenIds to be removed from the pool.
      */
     event RemoveCollateralNFT(address indexed claimer_, uint256 indexed price_, uint256[] tokenIds_);
-
-    /**
-     *  @notice Emitted when borrower repays quote tokens to the pool.
-     *  @param  borrower_ `msg.sender`.
-     *  @param  lup_      LUP after repay.
-     *  @param  amount_   Amount of quote tokens repayed to the pool.
-     */
-    event Repay(address indexed borrower_, uint256 lup_, uint256 amount_);
 
     /**
      *  @notice Emitted when an actor uses quote token outside of the book to purchase collateral under liquidation.
@@ -117,19 +101,6 @@ interface IERC721Pool is IScaledPool {
     /**************************/
 
     /**
-     *  @notice Struct holding borrower related info per price bucket, for borrowers using NFTs as collateral.
-     *  @param  debt                Borrower debt, WAD units.
-     *  @param  collateralDeposited OZ Enumberable Set tracking the tokenIds of collateral that have been deposited
-     *  @param  mompFactor          Momp / borrower.inflatorSnapshot, used in neutralPrice calc (WAD)
-     *  @param  inflatorSnapshot    Current borrower inflator snapshot, RAY units.
-     */
-    struct NFTBorrower {
-        uint256               debt;                // [WAD]
-        uint256               mompFactor;
-        uint256               inflatorSnapshot;    // [WAD]
-    }
-
-    /**
      *  @notice Maintains the state of a liquidation.
      *  @param  kickTime            Time the liquidation was initiated.
      *  @param  referencePrice      Highest Price Bucket at time of liquidation.
@@ -163,14 +134,6 @@ interface IERC721Pool is IScaledPool {
     /***********************************/
 
     /**
-     *  @notice Called by a borrower to open or expand a position.
-     *  @dev    Can only be called if quote tokens have already been added to the pool.
-     *  @param  amount_     The amount of quote token to borrow.
-     *  @param  limitIndex_ Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
-     */
-    function borrow(uint256 amount_, uint256 limitIndex_) external;
-
-    /**
      *  @notice Emitted when borrower locks collateral in the pool.
      *  @param  borrower_ The address of borrower to pledge collateral for.
      *  @param  tokenIds_ Array of tokenIds to be added to the pool.
@@ -182,13 +145,7 @@ interface IERC721Pool is IScaledPool {
      *  @param  tokenIds_ Array of tokenIds to be removed from the pool.
      */
     function pullCollateral(uint256[] calldata tokenIds_) external;
-
-    /**
-     *  @notice Called by a borrower to repay some amount of their borrowed quote tokens.
-     *  @param  borrower_  The address of borrower to repay quote token amount for.
-     *  @param  maxAmount_ WAD The maximum amount of quote token to repay.
-     */
-    function repay(address borrower_, uint256 maxAmount_) external;
+    
 
     /*********************************/
     /*** Lender External Functions ***/

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -28,7 +28,15 @@ library Book {
         self[index_].lps += amount_;
     }
 
-    function addToBucket(
+    function removeLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 amount_
+    ) internal {
+        self[index_].lps -= amount_;
+    }
+
+    function addCollateral(
         mapping(uint256 => Bucket) storage self,
         uint256 index_,
         uint256 lps_,
@@ -38,7 +46,7 @@ library Book {
         self[index_].collateral += collateral_;
     }
 
-    function removeFromBucket(
+    function removeCollateral(
         mapping(uint256 => Bucket) storage self,
         uint256 index_,
         uint256 lps_,
@@ -47,14 +55,6 @@ library Book {
         Bucket storage bucket = self[index_];
         bucket.lps        -= Maths.min(bucket.lps, lps_);
         bucket.collateral -= Maths.min(bucket.collateral, collateral_);
-    }
-
-    function removeLPs(
-        mapping(uint256 => Bucket) storage self,
-        uint256 index_,
-        uint256 amount_
-    ) internal {
-        self[index_].lps -= amount_;
     }
 
     function getExchangeRate(

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -88,6 +88,24 @@ library Book {
         return Maths.rdiv(Maths.wadToRay(quoteTokens_), rate);
     }
 
+    function lpsToQuoteToken(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 deposit_,
+        uint256 lenderLPsBalance_,
+        uint256 maxQuoteToken_
+    ) internal view returns (uint256 quoteTokenAmount_, uint256 bucketLPs_, uint256 lenderLPs_) {
+        lenderLPs_ = lenderLPsBalance_;
+        uint256 rate  = getExchangeRate(self, index_, deposit_);
+        quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
+        if (quoteTokenAmount_ > deposit_) {
+            quoteTokenAmount_ = deposit_;
+            lenderLPs_        = Maths.wrdivr(quoteTokenAmount_, rate);
+        }
+        if (maxQuoteToken_ != quoteTokenAmount_) quoteTokenAmount_ = Maths.min(maxQuoteToken_,quoteTokenAmount_);
+        bucketLPs_ = Maths.wrdivr(quoteTokenAmount_, rate);
+    }
+
     function getCollateral(
         mapping(uint256 => Bucket) storage self,
         uint256 index_

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -61,11 +61,11 @@ library Book {
         mapping(uint256 => Bucket) storage self,
         uint256 index_,
         uint256 quoteToken_
-    ) internal view returns (uint256 rate) {
+    ) internal view returns (uint256) {
         Bucket memory bucket = self[index_];
-        uint256 bucketSize = quoteToken_ * 10**18;                          // 10^36
-        if (bucket.collateral != 0) bucketSize += indexToPrice(index_) * bucket.collateral; // 10^36 + // 10^36
-        return bucket.lps != 0 ? bucketSize * 10**18 / bucket.lps : Maths.RAY; // 10^27
+        if (bucket.lps == 0) return  Maths.RAY;
+        uint256 bucketSize = quoteToken_ * 10**18 + indexToPrice(index_) * bucket.collateral;  // 10^36 + // 10^36
+        return bucketSize * 10**18 / bucket.lps; // 10^27
     }
 
     function collateralToLPs(

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -68,6 +68,18 @@ library Book {
         return bucket.lps != 0 ? bucketSize * 10**18 / bucket.lps : Maths.RAY; // 10^27
     }
 
+    function collateralToLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 deposit_,
+        uint256 collateral_
+    ) internal view returns (uint256 lps_) {
+        uint256 price = indexToPrice(index_);
+        uint256 rate  = getExchangeRate(self, index_, deposit_);
+        uint256 quote = collateral_ * price / 1e9;
+        lps_          = Maths.rdiv(quote, rate);
+    }
+
     function getCollateral(
         mapping(uint256 => Bucket) storage self,
         uint256 index_

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -106,6 +106,25 @@ library Book {
         bucketLPs_ = Maths.wrdivr(quoteTokenAmount_, rate);
     }
 
+    function lpsToCollateral(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 deposit_,
+        uint256 lenderLPsBalance_,
+        uint256 maxCollateral_
+    ) internal view returns (uint256 collateralAmount_, uint256 lenderLPs_) {
+        // max collateral to lps
+        lenderLPs_        = lenderLPsBalance_;
+        uint256 price      = Book.indexToPrice(index_);
+        uint256 rate       = getExchangeRate(self, index_, deposit_);
+        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), price);
+        if (collateralAmount_ > maxCollateral_) {
+            // user is owed more collateral than is available in the bucket
+            collateralAmount_ = maxCollateral_;
+            lenderLPs_        = Maths.wrdivr(Maths.wmul(collateralAmount_, price), rate);
+        }
+    }
+
     function getCollateral(
         mapping(uint256 => Bucket) storage self,
         uint256 index_

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -74,10 +74,8 @@ library Book {
         uint256 deposit_,
         uint256 collateral_
     ) internal view returns (uint256 lps_) {
-        uint256 price = indexToPrice(index_);
         uint256 rate  = getExchangeRate(self, index_, deposit_);
-        uint256 quote = collateral_ * price / 1e9;
-        lps_          = Maths.rdiv(quote, rate);
+        return (collateral_ * indexToPrice(index_) * 1e18 + rate / 2) / rate;
     }
 
     function getCollateral(

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.14;
+
+import './Maths.sol';
+import './BucketMath.sol';
+
+library Book {
+
+    /***************/
+    /*** Buckets ***/
+    /***************/
+
+    struct Bucket {
+        uint256 lps;       // [RAY]
+        uint256 collateral; // [WAD]
+    }
+
+    function addLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 amount_
+    ) internal {
+        self[index_].lps += amount_;
+    }
+
+    function addToBucket(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 lps_,
+        uint256 collateral_
+    ) internal {
+        self[index_].lps += lps_;
+        self[index_].collateral += collateral_;
+    }
+
+    function removeFromBucket(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 lps_,
+        uint256 collateral_
+    ) internal {
+        Bucket storage bucket = self[index_];
+        bucket.lps        -= Maths.min(bucket.lps, lps_);
+        bucket.collateral -= Maths.min(bucket.collateral, collateral_);
+    }
+
+    function removeLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 amount_
+    ) internal {
+        self[index_].lps -= amount_;
+    }
+
+    function getExchangeRate(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 quoteToken_
+    ) internal view returns (uint256 rate) {
+        Bucket memory bucket = self[index_];
+        uint256 bucketSize = quoteToken_ * 10**18;                          // 10^36
+        if (bucket.collateral != 0) bucketSize += indexToPrice(index_) * bucket.collateral; // 10^36 + // 10^36
+        return bucket.lps != 0 ? bucketSize * 10**18 / bucket.lps : Maths.RAY; // 10^27
+    }
+
+    function getCollateral(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_
+    ) internal view returns (uint256) {
+        return self[index_].collateral;
+    }
+
+    function indexToPrice(uint256 index_) internal pure returns (uint256) {
+        return BucketMath.indexToPrice(indexToBucketIndex(index_));
+    }
+
+    /**
+     *  @dev Fenwick index to bucket index conversion
+     *          1.00      : bucket index 0,     fenwick index 4146: 7388-4156-3232=0
+     *          MAX_PRICE : bucket index 4156,  fenwick index 0:    7388-0-3232=4156.
+     *          MIN_PRICE : bucket index -3232, fenwick index 7388: 7388-7388-3232=-3232.
+     */
+    function indexToBucketIndex(uint256 index_) internal pure returns (int256 bucketIndex_) {
+        bucketIndex_ = (index_ != 8191) ? 4156 - int256(index_) : BucketMath.MIN_PRICE_INDEX;
+    }
+}

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -73,9 +73,19 @@ library Book {
         uint256 index_,
         uint256 deposit_,
         uint256 collateral_
-    ) internal view returns (uint256 lps_) {
+    ) internal view returns (uint256) {
         uint256 rate  = getExchangeRate(self, index_, deposit_);
         return (collateral_ * indexToPrice(index_) * 1e18 + rate / 2) / rate;
+    }
+
+    function quoteTokensToLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 deposit_,
+        uint256 quoteTokens_
+    ) internal view returns (uint256) {
+        uint256 rate  = getExchangeRate(self, index_, deposit_);
+        return Maths.rdiv(Maths.wadToRay(quoteTokens_), rate);
     }
 
     function getCollateral(

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -10,9 +10,14 @@ library Book {
     /*** Buckets ***/
     /***************/
 
+    /**
+     *  @notice struct holding bucket info
+     *  @param lps        Bucket LP accumulator, RAY
+     *  @param collateral Available collateral tokens deposited in the bucket, WAD
+     */
     struct Bucket {
-        uint256 lps;       // [RAY]
-        uint256 collateral; // [WAD]
+        uint256 lps;
+        uint256 collateral;
     }
 
     function addLPs(

--- a/src/libraries/Lenders.sol
+++ b/src/libraries/Lenders.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.14;
+
+import './Maths.sol';
+
+library Lenders {
+
+    /***************/
+    /*** Lenders ***/
+    /***************/
+
+    struct Lender {
+        uint256 lps; // [RAY]
+        uint256 ts;  // timestamp
+    }
+
+    function addLPsWithTime(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address lender_,
+        uint256 amount_
+    ) internal {
+        self[index_][lender_].lps += amount_;
+        self[index_][lender_].ts  = block.timestamp;
+    }
+
+    function addLPs(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address lender_,
+        uint256 amount_
+    ) internal {
+        self[index_][lender_].lps += amount_;
+    }
+
+    function removeLPs(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address lender_,
+        uint256 amount_
+    ) internal {
+        self[index_][lender_].lps -= amount_;
+    }
+
+    function transferLPs(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address owner_,
+        address newOwner_,
+        uint256 amount_,
+        uint256 depositTime
+    ) internal {
+        // move lp tokens to the new owner address
+        Lender storage newOwner = self[index_][newOwner_];
+        newOwner.lps += amount_;
+        newOwner.ts  = Maths.max(depositTime, newOwner.ts);
+
+        // delete owner lp balance for this index
+        delete self[index_][owner_];
+    }
+
+    function getLenderInfo(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address lender_
+    ) internal view returns (uint256, uint256) {
+        return (self[index_][lender_].lps, self[index_][lender_].ts);
+    }
+}

--- a/src/libraries/Lenders.sol
+++ b/src/libraries/Lenders.sol
@@ -65,15 +65,15 @@ library Lenders {
         uint256 depositTime_,
         uint256 curDebt_,
         uint256 col_,
-        uint256 maxIndex_,
-        uint256 minIndex_,
+        uint256 fromIndex_,
+        uint256 toIndex_,
         uint256 amount_
     ) internal view returns (uint256 amountWithPenalty_){
         amountWithPenalty_ = amount_;
         if (col_ != 0 && depositTime_ != 0 && block.timestamp - depositTime_ < 1 days) {
             uint256 ptp = Maths.wdiv(curDebt_, col_);
-            bool applyPenalty = Book.indexToPrice(maxIndex_) > ptp;
-            if (minIndex_ != 0) applyPenalty = applyPenalty && Book.indexToPrice(minIndex_) < ptp;
+            bool applyPenalty = Book.indexToPrice(fromIndex_) > ptp;
+            if (toIndex_ != 0) applyPenalty = applyPenalty && Book.indexToPrice(toIndex_) < ptp;
             if (applyPenalty) amountWithPenalty_ =  Maths.wmul(amountWithPenalty_, Maths.WAD - feeRate_);
         }
     }

--- a/src/libraries/Lenders.sol
+++ b/src/libraries/Lenders.sol
@@ -43,6 +43,23 @@ library Lenders {
         self[index_][lender_].lps -= amount_;
     }
 
+    function transferLPs(
+        mapping(uint256 => mapping(address => Lender)) storage self,
+        uint256 index_,
+        address owner_,
+        address newOwner_,
+        uint256 amount_,
+        uint256 depositTime
+    ) internal {
+        // move lp tokens to the new owner address
+        Lender storage newOwner = self[index_][newOwner_];
+        newOwner.lps += amount_;
+        newOwner.ts  = Maths.max(depositTime, newOwner.ts);
+
+        // delete owner lp balance for this index
+        delete self[index_][owner_];
+    }
+
     function applyEarlyWithdrawalPenalty(
         uint256 feeRate_,
         uint256 depositTime_,
@@ -59,23 +76,6 @@ library Lenders {
             if (minIndex_ != 0) applyPenalty = applyPenalty && Book.indexToPrice(minIndex_) < ptp;
             if (applyPenalty) amountWithPenalty_ =  Maths.wmul(amountWithPenalty_, Maths.WAD - feeRate_);
         }
-    }
-
-    function transferLPs(
-        mapping(uint256 => mapping(address => Lender)) storage self,
-        uint256 index_,
-        address owner_,
-        address newOwner_,
-        uint256 amount_,
-        uint256 depositTime
-    ) internal {
-        // move lp tokens to the new owner address
-        Lender storage newOwner = self[index_][newOwner_];
-        newOwner.lps += amount_;
-        newOwner.ts  = Maths.max(depositTime, newOwner.ts);
-
-        // delete owner lp balance for this index
-        delete self[index_][owner_];
     }
 
     function getLenderInfo(

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -274,7 +274,7 @@ def add_quote_token(lender, lender_index, pool):
 
 def remove_quote_token(lender, lender_index, price, pool):
     price_index = pool.priceToIndex(price)
-    (lp_balance, _) = pool.bucketLenders(price_index, lender)
+    (lp_balance, _) = pool.lenders(price_index, lender)
     if lp_balance > 0:
         exchange_rate = pool.exchangeRate(price_index)
         claimable_quote = lp_balance * exchange_rate / 10**36


### PR DESCRIPTION
- externalize Buckets and Lender functionality in libraries
- Buckets library:
  - `add/remove` LPs in bucket
  - `add/remove` collateral in bucket
  - view function to calculate exchange rate (takes bucket index and bucket deposit as params)
  - view function to calculate LPs for given collateral amount
  - view function to calculate LPs for given quoteTokens amount
  - view function to calculate collateral amount for given LPs
  - view function to calculate quoteTokens amount for given LPs
  - utility functions to calculate price of an index
- Lender library:
  - `add/remove/transfer` LPs
  - view function to calculate amount with early penalty

- Used same `Borrower` struct for both ERC20 and NFT pools:
  - keep number of collateral locked by borrower as `collateral` (already scaled to WAD) - previously this was retrieved as length of `EnumerableSet`
  - replace `EnumerableSet` with `BitMap` library that maps token id -> locked in pool flag. This flag is set when collateral is `pledged / added` and unset when `removed/pulled`
  - reorganize pool code to use same internal functions as ERC20 pool to manage assets. Common functionality was externalized in `ScaledPool` (`pledge/add/remove/pull` collateral, `repay`, `borrow`). Differs from ERC20 pool from the event that raise + collateral transfer

- Reduce number of external functions in `ScaledPool` by grouping them functionality related:
  - loans, prices, reserves and utilization related (e.g. instead exposing `lup`, `hpb`, `htp` we now have `poolPricesInfo` function)

ERC20 pool is now under deployment size

```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,732B  (100.63%)
  ERC20Pool                -  24,307B  (98.90%)
```
vs develop
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  25,769B  (104.85%)
  ERC20Pool                -  25,164B  (102.39%)
```

Gas comparison diff `develop` / `current branch`:


│ Function Name               ┆ min                        ┆ avg                          ┆ median                ┆ max                       ┆
│ addQuoteToken              ┆ 80393 / 72060       ┆ 148687 / 138622    ┆ 123326 / 112896 ┆ 656968 / 646754   ┆
│ borrow                            ┆ 149441 / 149606   ┆ 222148 / 220943    ┆ 173248 / 173421 ┆ 797314 / 783680   ┆
│ moveQuoteToken           ┆ 221626 / 202081   ┆ 221626 / 202081    ┆ 221626 / 202081 ┆ 221626 / 202081   ┆
│ pledgeCollateral             ┆ 123650 / 123852   ┆ 125699 / 125912    ┆ 125811 / 126025 ┆  627481 / 613884  ┆
│ removeAllQuoteToken    ┆ 114396 / 107473   ┆ 118091 / 111121    ┆ 118070 / 111115 ┆ 129305 / 120609   ┆
│ removeQuoteToken        ┆ 140397 / 133356   ┆ 145369 / 138286    ┆ 145330 / 138273 ┆  165694 / 156159  ┆
│ repay                              ┆  568923 / 561219  ┆  615670  / 604978  ┆ 595739 / 585215 ┆  837639 / 823959  ┆


TODO:
- move Borrowers in its own library
- move Pool properties in its own library
- update RW test to use new pool functions
- check if we really need OZ's lib or we can use a mapping directly)
- separate pool interfaces based on their scope
- gas optimization
- group more functionality in view functions / reduce number of external functions
- (as a last resort) consider having `removeAll/remove` and `moveAll/move` quote tokens and collateral functions merged and differentiate by amount passed (that is if max uint passed as param assume all amount)
- cosmetic tests
