### PR TITLE
ERC721HelperContract rework, _poolMinDebtAmount fix

### DIFF
--- a/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolBorrow.t.sol
@@ -27,7 +27,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         _lender2   = makeAddr("lender2");
 
         // deploy collection pool
-        _collectionPool = _deployCollectionPool();
+        ERC721Pool collectionPool = _deployCollectionPool();
 
         // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](6);
@@ -37,22 +37,20 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
         subsetTokenIds[5] = 73;
-        _subsetPool = _deploySubsetPool(subsetTokenIds);
+        _pool = _deploySubsetPool(subsetTokenIds);
 
-        address[] memory _poolAddresses = _getPoolAddresses();
+        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
 
-        _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
-
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 10);
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower3, 13);
+        _mintAndApproveCollateralTokens(_borrower, 52);
+        _mintAndApproveCollateralTokens(_borrower2, 10);
+        _mintAndApproveCollateralTokens(_borrower3, 13);
 
         // TODO: figure out how to generally approve quote tokens for the borrowers to handle repays
         // TODO: potentially use _approveQuoteMultipleUserMultiplePool()
         vm.prank(_borrower);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
+        _quote.approve(address(collectionPool), 200_000 * 1e18);
         vm.prank(_borrower);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        _quote.approve(address(_pool), 200_000 * 1e18);
     }
 
     /***************************/
@@ -62,9 +60,9 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
     function testBorrowLimitReached() external {
         // lender deposits 10000 Quote into 3 buckets
         changePrank(_lender);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2552);
 
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
@@ -72,56 +70,56 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // should revert if insufficient quote available before limit price
         vm.expectRevert(IScaledPool.BorrowLimitIndexReached.selector);
-        _subsetPool.borrow(21_000 * 1e18, 2551);
+        _pool.borrow(21_000 * 1e18, 2551);
     }
 
     function testBorrowBorrowerUnderCollateralized() external {
         // add initial quote to the pool
         changePrank(_lender);
         assertEq(_indexToPrice(3575), 18.133510183516748631 * 1e18);
-        _subsetPool.addQuoteToken(1_000 * 1e18, 3575);
+        _pool.addQuoteToken(1_000 * 1e18, 3575);
 
         // borrower pledges some collateral
         changePrank(_borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](2);
         tokenIdsToAdd[0] = 5;
         tokenIdsToAdd[1] = 3;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // should revert if borrower did not deposit enough collateral
         vm.expectRevert(IScaledPool.BorrowBorrowerUnderCollateralized.selector);
-        _subsetPool.borrow(40 * 1e18, 4000);
+        _pool.borrow(40 * 1e18, 4000);
     }
 
     function testBorrowPoolUnderCollateralized() external {
         // add initial quote to the pool
         changePrank(_lender);
         assertEq(_indexToPrice(3232), 100.332368143282009890 * 1e18);
-        _subsetPool.addQuoteToken(1_000 * 1e18, 3232);
+        _pool.addQuoteToken(1_000 * 1e18, 3232);
 
         // should revert if borrow would result in pool under collateralization
         changePrank(_borrower);
         vm.expectRevert(IScaledPool.BorrowPoolUnderCollateralized.selector);
-        _subsetPool.borrow(500 * 1e18, 4000);
+        _pool.borrow(500 * 1e18, 4000);
     }
 
     function testBorrowAndRepay() external {
         // lender deposits 10000 Quote into 3 buckets
         vm.startPrank(_lender);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2552);
 
         // check initial token balances
-        assertEq(_subsetPool.pledgedCollateral(), 0);
+        assertEq(_pool.pledgedCollateral(), 0);
         assertEq(_collateral.balanceOf(_borrower),            52);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
+        assertEq(_collateral.balanceOf(address(_pool)), 0);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 30_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 30_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            0);
 
         // check pool state
@@ -129,14 +127,14 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_lup(), BucketMath.MAX_PRICE);
 
         assertEq(_poolSize(),              30_000 * 1e18);
-        assertEq(_subsetPool.borrowerDebt(),          0);
+        assertEq(_pool.borrowerDebt(),          0);
         assertEq(_poolTargetUtilization(), 1 * 1e18);
         assertEq(_poolActualUtilization(), 0);
         assertEq(_poolMinDebtAmount(),     0);
         assertEq(_exchangeRate(2550),      1 * 1e27);
 
         // check initial bucket state
-        (uint256 lpAccumulator, uint256 availableCollateral) = _subsetPool.buckets(2550);
+        (uint256 lpAccumulator, uint256 availableCollateral) = _pool.buckets(2550);
         assertEq(lpAccumulator,       10_000 * 1e27);
         assertEq(availableCollateral, 0);
 
@@ -146,20 +144,20 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // borrower borrows from the pool
         uint256 borrowAmount = 3_000 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit Borrow(_borrower, _indexToPrice(2550), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 2551);
+        _pool.borrow(borrowAmount, 2551);
 
         // check token balances after borrow
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_pool.pledgedCollateral(), Maths.wad(3));
         assertEq(_collateral.balanceOf(_borrower),            49);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_collateral.balanceOf(address(_pool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 27_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            borrowAmount);
 
         // check pool state after borrow
@@ -167,20 +165,20 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_lup(), _indexToPrice(2550));
 
         assertEq(_poolSize(),              30_000 * 1e18);
-        assertEq(_subsetPool.borrowerDebt(),          3_002.88461538461538600 * 1e18);
+        assertEq(_pool.borrowerDebt(),          3_002.88461538461538600 * 1e18);
         assertEq(_poolTargetUtilization(), 1 * 1e18);
         assertEq(_poolActualUtilization(), .100096153846153846 * 1e18);
         assertEq(_poolMinDebtAmount(),     300.288461538461538600 * 1e18);
-        assertEq(_poolMinDebtAmount(), _subsetPool.borrowerDebt() / 10);
+        assertEq(_poolMinDebtAmount(), _pool.borrowerDebt() / 10);
         assertEq(_exchangeRate(2550),      1 * 1e27);
 
         // check bucket state after borrow
-        (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
+        (lpAccumulator, availableCollateral) = _pool.buckets(2550);
         assertEq(lpAccumulator,       10_000 * 1e27);
         assertEq(availableCollateral, 0);
 
         // check borrower info after borrow
-        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        3_002.884615384615386000 * 1e18);
         assertEq(pendingDebt, 3_002.884615384615386000 * 1e18);
         assertEq(col       ,  3 * 1e18);
@@ -193,14 +191,14 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // borrower partially repays half their loan
         vm.expectEmit(true, true, false, true);
         emit Repay(_borrower, _indexToPrice(2550), borrowAmount / 2);
-        _subsetPool.repay(_borrower, borrowAmount / 2);
+        _pool.repay(_borrower, borrowAmount / 2);
 
         // check token balances after partial repay
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_pool.pledgedCollateral(), Maths.wad(3));
         assertEq(_collateral.balanceOf(_borrower),            49);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_collateral.balanceOf(address(_pool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 28_500 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            borrowAmount / 2);
 
         // check pool state after partial repay
@@ -209,20 +207,20 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // check utilization changes make sense
         assertEq(_poolSize(),                30_003.520235392247040000 * 1e18);
-        assertEq(_subsetPool.borrowerDebt(), 1507.000974734143274062 * 1e18);
+        assertEq(_pool.borrowerDebt(), 1507.000974734143274062 * 1e18);
         assertEq(_poolTargetUtilization(),   .166838815388013307 * 1e18);
         assertEq(_poolActualUtilization(),   .050227472073642885 * 1e18);
         assertEq(_poolMinDebtAmount(),       150.700097473414327406 * 1e18);
-        assertEq(_poolMinDebtAmount(),       _subsetPool.borrowerDebt() / 10);
+        assertEq(_poolMinDebtAmount(),       _pool.borrowerDebt() / 10);
         assertEq(_exchangeRate(2550),        1.000117341179741568000000000 * 1e27);
 
         // check bucket state after partial repay
-        (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
+        (lpAccumulator, availableCollateral) = _pool.buckets(2550);
         assertEq(lpAccumulator,       10_000 * 1e27);
         assertEq(availableCollateral, 0);
 
         // check borrower info after partial repay
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        1_507.000974734143274062 * 1e18);
         assertEq(pendingDebt, 1_507.000974734143274062 * 1e18);
         assertEq(col,         3 * 1e18);
@@ -233,7 +231,7 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         skip(10 days);
 
         // find pending debt after interest accumulation
-        (, pendingDebt, , , ) = _subsetPool.borrowerInfo(_borrower);
+        (, pendingDebt, , , ) = _pool.borrowerInfo(_borrower);
 
         // mint additional quote to allow borrower to repay their loan plus interest
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 1_000 * 1e18);
@@ -241,14 +239,14 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // borrower repays their remaining loan balance
         vm.expectEmit(true, true, false, true);
         emit Repay(_borrower, BucketMath.MAX_PRICE, pendingDebt);
-        _subsetPool.repay(_borrower, pendingDebt);
+        _pool.repay(_borrower, pendingDebt);
 
         // check token balances after fully repay
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_pool.pledgedCollateral(), Maths.wad(3));
         assertEq(_collateral.balanceOf(_borrower),            49);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_collateral.balanceOf(address(_pool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 30_008.860066921599064643 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 30_008.860066921599064643 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            991.139933078400935357 * 1e18);
 
         // check pool state after fully repay
@@ -259,16 +257,16 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         uint256[] memory tokenIdsToRemove = tokenIdsToAdd;
         vm.expectEmit(true, true, false, true);
         emit PullCollateralNFT(_borrower, tokenIdsToRemove);
-        _subsetPool.pullCollateral(tokenIdsToRemove);
-        assertEq(_subsetPool.pledgedCollateral(), 0);
+        _pool.pullCollateral(tokenIdsToRemove);
+        assertEq(_pool.pledgedCollateral(), 0);
         assertEq(_collateral.balanceOf(_borrower),            52);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 0);
+        assertEq(_collateral.balanceOf(address(_pool)), 0);
 
         // check utilization changes make sense
         assertEq(_poolSize(),                30_005.105213052294392423 * 1e18);
-        assertEq(_subsetPool.borrowerDebt(), 0);
-        assertEq(_subsetPool.debtEma(),      116.548760023014994270 * 1e18);
-        assertEq(_subsetPool.lupColEma(),    257_438_503.676217090117659874 * 1e18);
+        assertEq(_pool.borrowerDebt(), 0);
+        assertEq(_pool.debtEma(),      116.548760023014994270 * 1e18);
+        assertEq(_pool.lupColEma(),    257_438_503.676217090117659874 * 1e18);
         // TODO: LUP=MAX_PRICE is causing a technically correct yet undesirable target utilization
         assertEq(_poolTargetUtilization(),   .000000452724663788 * 1e18);
         assertEq(_poolActualUtilization(),   0);
@@ -276,12 +274,12 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         assertEq(_exchangeRate(2550),        1.000170173768409813000000000 * 1e27);
 
         // check bucket state after fully repay
-        (lpAccumulator, availableCollateral) = _subsetPool.buckets(2550);
+        (lpAccumulator, availableCollateral) = _pool.buckets(2550);
         assertEq(lpAccumulator,       10_000 * 1e27);
         assertEq(availableCollateral, 0);
 
         // check borrower info after fully repay
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(col,         0);
@@ -292,22 +290,22 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // add initial quote to the pool
         changePrank(_lender);
         assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
 
         // should revert if borrower has no debt
         deal(address(_quote), _borrower, _quote.balanceOf(_borrower) + 10_000 * 1e18);
         changePrank(_borrower);
         vm.expectRevert(IScaledPool.RepayNoDebt.selector);
-        _subsetPool.repay(_borrower, 10_000 * 1e18);
+        _pool.repay(_borrower, 10_000 * 1e18);
 
         // borrower 1 borrows 1000 quote from the pool
         uint256[] memory tokenIdsToAdd = new uint256[](3);
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-        _subsetPool.borrow(1_000 * 1e18, 3000);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.borrow(1_000 * 1e18, 3000);
 
         assertEq(_maxBorrower(), _borrower);
         assertEq(_loansCount(),  1);
@@ -316,8 +314,8 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd);
-        _subsetPool.borrow(3_000 * 1e18, 3000);
+        _pool.pledgeCollateral(_borrower2, tokenIdsToAdd);
+        _pool.borrow(3_000 * 1e18, 3000);
 
         assertEq(_maxBorrower(), _borrower2);
         assertEq(_loansCount(),  2);
@@ -325,19 +323,19 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         // should revert if amount left after repay is less than the average debt
         changePrank(_borrower);
         vm.expectRevert(IScaledPool.BorrowAmountLTMinDebt.selector);
-        _subsetPool.repay(_borrower, 900 * 1e18);
+        _pool.repay(_borrower, 900 * 1e18);
 
         // should be able to repay loan if properly specified
         vm.expectEmit(true, true, false, true);
         emit Repay(_borrower, _lup(), 1_000.961538461538462000 * 1e18);
-        _subsetPool.repay(_borrower, 1_100 * 1e18);
+        _pool.repay(_borrower, 1_100 * 1e18);
     }
 
     function testRepayLoanFromDifferentActor() external {
         changePrank(_lender);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2552);
 
         // borrower deposits three NFTs into the subset pool
         changePrank(_borrower);
@@ -345,17 +343,17 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
 
         // borrower borrows from the pool
-        _subsetPool.borrow(3_000 * 1e18, 2551);
+        _pool.borrow(3_000 * 1e18, 2551);
 
         // check token balances after borrow
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_pool.pledgedCollateral(), Maths.wad(3));
         assertEq(_collateral.balanceOf(_borrower),            49);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_collateral.balanceOf(address(_pool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 27_000 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 27_000 * 1e18);
         assertEq(_quote.balanceOf(_lender),              170_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
 
@@ -364,14 +362,14 @@ contract ERC721ScaledBorrowTest is ERC721HelperContract {
 
         // lender partially repays borrower's loan
         changePrank(_lender);
-        _subsetPool.repay(_borrower, 1_500 * 1e18);
+        _pool.repay(_borrower, 1_500 * 1e18);
 
         // check token balances after partial repay
-        assertEq(_subsetPool.pledgedCollateral(), Maths.wad(3));
+        assertEq(_pool.pledgedCollateral(), Maths.wad(3));
         assertEq(_collateral.balanceOf(_borrower),            49);
-        assertEq(_collateral.balanceOf(address(_subsetPool)), 3);
+        assertEq(_collateral.balanceOf(address(_pool)), 3);
 
-        assertEq(_quote.balanceOf(address(_subsetPool)), 28_500 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)), 28_500 * 1e18);
         assertEq(_quote.balanceOf(_lender),              168_500 * 1e18);
         assertEq(_quote.balanceOf(_borrower),            3_000 * 1e18);
     }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolInterest.t.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolInterest.t.sol
@@ -12,14 +12,15 @@ import { Maths }      from "../../libraries/Maths.sol";
 import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
 import "forge-std/Test.sol";
 
-contract ERC721ScaledInterestTest is ERC721HelperContract {
-    using stdStorage for StdStorage;
-
+abstract contract ERC721ScaledInterestTest is ERC721HelperContract {
     address internal _borrower;
     address internal _borrower2;
     address internal _borrower3;
     address internal _lender;
     address internal _lender2;
+
+    // Called by setUp method to set the _pool which tests will use
+    function createPool() external virtual returns (ERC721Pool);
 
     function setUp() external {
         _borrower  = makeAddr("borrower");
@@ -28,8 +29,24 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
+        _pool = this.createPool();
+        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
+
+        _mintAndApproveCollateralTokens(_borrower, 52);
+        _mintAndApproveCollateralTokens(_borrower2, 10);
+        _mintAndApproveCollateralTokens(_borrower3, 13);
+
+        // TODO: figure out how to generally approve quote tokens for the borrowers to handle repays
+        // TODO: potentially use _approveQuoteMultipleUserMultiplePool()
+        vm.prank(_borrower);
+        _quote.approve(address(_pool), 200_000 * 1e18);
+    }
+}
+
+contract ERC721ScaledSubsetInterestTest is ERC721ScaledInterestTest {
+    function createPool() external override returns (ERC721Pool) {
         // deploy collection pool
-        _collectionPool = _deployCollectionPool();
+        ERC721Pool collectionPool = _deployCollectionPool();
 
         // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](6);
@@ -39,32 +56,17 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
         subsetTokenIds[5] = 73;
-        _subsetPool = _deploySubsetPool(subsetTokenIds);
-
-        address[] memory _poolAddresses = _getPoolAddresses();
-
-        _mintAndApproveQuoteTokens(_poolAddresses, _lender, 200_000 * 1e18);
-
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower, 52);
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower2, 10);
-        _mintAndApproveCollateralTokens(_poolAddresses, _borrower3, 13);
-
-        // TODO: figure out how to generally approve quote tokens for the borrowers to handle repays
-        // TODO: potentially use _approveQuoteMultipleUserMultiplePool()
-        vm.prank(_borrower);
-        _quote.approve(address(_collectionPool), 200_000 * 1e18);
-        vm.prank(_borrower);
-        _quote.approve(address(_subsetPool), 200_000 * 1e18);
+        return _deploySubsetPool(subsetTokenIds);
     }
 
     // TODO: skip block number ahead as well
     function testBorrowerInterestAccumulation() external {
         changePrank(_lender);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2553);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2554);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2552);
+        _pool.addQuoteToken(10_000 * 1e18, 2553);
+        _pool.addQuoteToken(10_000 * 1e18, 2554);
 
         skip(864000);
 
@@ -74,11 +76,11 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-        _subsetPool.borrow(5_000 * 1e18, 2551);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.borrow(5_000 * 1e18, 2551);
 
-        assertEq(_subsetPool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
-        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _subsetPool.borrowerInfo(_borrower);
+        assertEq(_pool.borrowerDebt(), 5_004.807692307692310000 * 1e18);
+        (uint256 debt, uint256 pendingDebt, uint256 col, uint256 mompFactor, uint256 inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        5_004.807692307692310000 * 1e18);
         assertEq(pendingDebt, 5_012.354868151222773335 * 1e18);
         assertEq(col       ,  3 * 1e18);
@@ -89,9 +91,9 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         skip(864000);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 51;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-        assertEq(_subsetPool.borrowerDebt(), 5_019.913425024098425550 * 1e18);
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        assertEq(_pool.borrowerDebt(), 5_019.913425024098425550 * 1e18);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        5_019.913425024098425550 * 1e18);
         assertEq(pendingDebt, 5_019.913425024098425550 * 1e18);
         assertEq(col,         4 * 1e18);
@@ -102,9 +104,9 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         skip(864000);
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 1;
-        _subsetPool.pullCollateral(tokenIdsToRemove);
-        assertEq(_subsetPool.borrowerDebt(), 5_028.241003157279922662 * 1e18);
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        _pool.pullCollateral(tokenIdsToRemove);
+        assertEq(_pool.borrowerDebt(), 5_028.241003157279922662 * 1e18);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        5_028.241003157279922662 * 1e18);
         assertEq(pendingDebt, 5_028.241003157279922662 * 1e18);
         assertEq(col,         3 * 1e18);
@@ -113,9 +115,9 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
 
         // borrower borrows some additional quote after some time has passed
         skip(864000);
-        _subsetPool.borrow(1_000 * 1e18, 3000);
-        assertEq(_subsetPool.borrowerDebt(), 6_038.697103647272763112 * 1e18);
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        _pool.borrow(1_000 * 1e18, 3000);
+        assertEq(_pool.borrowerDebt(), 6_038.697103647272763112 * 1e18);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        6_038.697103647272763112 * 1e18);
         assertEq(pendingDebt, 6_038.697103647272763112 * 1e18);
         assertEq(col       ,  3 * 1e18);
@@ -127,10 +129,10 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
 
         // borrower repays their loan after some additional time
         skip(864000);
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
-        _subsetPool.repay(_borrower, pendingDebt);
-        assertEq(_subsetPool.borrowerDebt(), 0);
-        (debt, pendingDebt, col, mompFactor, inflator) = _subsetPool.borrowerInfo(_borrower);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
+        _pool.repay(_borrower, pendingDebt);
+        assertEq(_pool.borrowerDebt(), 0);
+        (debt, pendingDebt, col, mompFactor, inflator) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        0);
         assertEq(pendingDebt, 0);
         assertEq(mompFactor,  0 * 1e18);
@@ -143,10 +145,10 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         // lender deposits 10000 Quote into 3 buckets
         changePrank(_lender);
         assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2550);
+        _pool.addQuoteToken(10_000 * 1e18, 2550);
         assertEq(_indexToPrice(2551), 2_995.912459898389633881 * 1e18);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2551);
-        _subsetPool.addQuoteToken(10_000 * 1e18, 2552);
+        _pool.addQuoteToken(10_000 * 1e18, 2551);
+        _pool.addQuoteToken(10_000 * 1e18, 2552);
         skip(2 hours);
 
         // borrower pledges three NFTs and takes out a loan with TP around 2666
@@ -155,100 +157,107 @@ contract ERC721ScaledInterestTest is ERC721HelperContract {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _subsetPool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
         uint256 borrowAmount = 8_000 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit Borrow(_borrower, _indexToPrice(2550), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 2551);
+        _pool.borrow(borrowAmount, 2551);
         skip(4 hours);
 
         // borrower 2 pledges one NFT and takes out a loan with TP around 2750
         changePrank(_borrower2);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
-        _subsetPool.pledgeCollateral(_borrower2, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower2, tokenIdsToAdd);
         borrowAmount = 2_750 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit Borrow(_borrower2, _indexToPrice(2551), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 3000);
+        _pool.borrow(borrowAmount, 3000);
         skip(4 hours);
 
         // borrower 3 pledges one NFT and takes out a loan with TP around 2500
         changePrank(_borrower3);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 73;
-        _subsetPool.pledgeCollateral(_borrower3, tokenIdsToAdd);
+        _pool.pledgeCollateral(_borrower3, tokenIdsToAdd);
         borrowAmount = 2_500 * 1e18;
         vm.expectEmit(true, true, false, true);
         emit Borrow(_borrower3, _indexToPrice(2551), borrowAmount);
-        _subsetPool.borrow(borrowAmount, 3000);
+        _pool.borrow(borrowAmount, 3000);
         skip(4 hours);
 
         // trigger an interest accumulation
         changePrank(_lender);
-        _subsetPool.addQuoteToken(1 * 1e18, 2550);
+        _pool.addQuoteToken(1 * 1e18, 2550);
 
         // check pool and borrower debt to confirm interest has accumulated
-        assertEq(_subsetPool.borrowerDebt(), 13_263.563121817930264782 * 1e18);
-        (uint256 debt, uint256 pendingDebt, , , ) = _subsetPool.borrowerInfo(_borrower);
+        assertEq(_pool.borrowerDebt(), 13_263.563121817930264782 * 1e18);
+        (uint256 debt, uint256 pendingDebt, , , ) = _pool.borrowerInfo(_borrower);
         assertEq(debt,        8_007.692307692307696000 * 1e18);
         assertEq(pendingDebt, 8_007.692307692307696000 * 1e18);
-        (debt, pendingDebt, , , ) = _subsetPool.borrowerInfo(_borrower2);
+        (debt, pendingDebt, , , ) = _pool.borrowerInfo(_borrower2);
         assertEq(debt,        2_752.644230769230770500 * 1e18);
         assertEq(pendingDebt, 2_752.644230769230770500 * 1e18);
-        (debt, pendingDebt, , , ) = _subsetPool.borrowerInfo(_borrower3);
+        (debt, pendingDebt, , , ) = _pool.borrowerInfo(_borrower3);
         assertEq(debt,        2_502.403846153846155000 * 1e18);
         assertEq(pendingDebt, 2_502.403846153846155000 * 1e18);
+    }
+}
+
+contract ERC721ScaledCollectionInterestTest is ERC721ScaledInterestTest {
+    using stdStorage for StdStorage;
+
+    function createPool() external override returns (ERC721Pool) {
+        return _deployCollectionPool();
     }
 
     function testLenderInterestMargin() external {
         // check empty pool
-        assertEq(_collectionPool.lenderInterestMargin(),           0.85 * 1e18);
+        assertEq(_pool.lenderInterestMargin(), 0.85 * 1e18);
 
         // lender adds liquidity
         changePrank(_lender);
-        _collectionPool.addQuoteToken(10_000 * 1e18, 0);  // all deposit above the PTP
-        // TODO: Convenience methods look at _subsetPool and ignore _collectionPool.  Plan to rework this in another PR.
-//        assertEq(_poolActualUtilization(), 0);
+        _pool.addQuoteToken(10_000 * 1e18, 0);  // all deposit above the PTP
+        assertEq(_poolActualUtilization(), 0);
 
         // borrower pledges a single NFT
         changePrank(_borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 1;
-        _collectionPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-//        assertEq(_poolActualUtilization(), 0);
-        assertEq(_collectionPool.pledgedCollateral(), 1 * 1e18);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        assertEq(_poolActualUtilization(), 0);
+        assertEq(_pool.pledgedCollateral(), 1 * 1e18);
 
         // to minimize test complexity and maintenance cost, manipulate utilization by writing debt to storage
         uint256 slotBorrowerDebt = stdstore
-            .target(address(_collectionPool))
+            .target(address(_pool))
             .sig("borrowerDebt()")
             .find();
         assertEq(slotBorrowerDebt, 16391);
 
         // test lender interest margin for various amounts of utilization
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(100 * 1e18)));
-//        assertEq(_poolActualUtilization(), 0.01 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  0.850501675988110546 * 1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(100 * 1e18)));
+        assertEq(_poolActualUtilization(), 0.01 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  0.850501675988110546 * 1e18);
 
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(2_300 * 1e18)));
-//        assertEq(_poolActualUtilization(), 0.23 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  0.862515153185046657 * 1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(2_300 * 1e18)));
+        assertEq(_poolActualUtilization(), 0.23 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  0.862515153185046657 * 1e18);
 
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(6_700 * 1e18)));
-//        assertEq(_poolActualUtilization(), 0.67 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  0.896343651549832236 * 1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(6_700 * 1e18)));
+        assertEq(_poolActualUtilization(), 0.67 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  0.896343651549832236 * 1e18);
 
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(8_800 * 1e18)));
-//        assertEq(_poolActualUtilization(), 0.88 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  0.926013637770085897 * 1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(8_800 * 1e18)));
+        assertEq(_poolActualUtilization(), 0.88 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  0.926013637770085897 * 1e18);
 
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(10_000 * 1e18)));
-//        assertEq(_poolActualUtilization(), 1 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(10_000 * 1e18)));
+        assertEq(_poolActualUtilization(), 1 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  1e18);
 
-        vm.store(address(_collectionPool), bytes32(slotBorrowerDebt), bytes32(uint256(10_300 * 1e18)));
-//        assertEq(_poolActualUtilization(), 1.03 * 1e18);
-        assertEq(_collectionPool.lenderInterestMargin(),  1e18);
+        vm.store(address(_pool), bytes32(slotBorrowerDebt), bytes32(uint256(10_300 * 1e18)));
+        assertEq(_poolActualUtilization(), 1.03 * 1e18);
+        assertEq(_pool.lenderInterestMargin(),  1e18);
     }
 }

--- a/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
+++ b/src/_test/ERC721Pool/ERC721ScaledPoolReserveAuction.sol
@@ -23,28 +23,27 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         _lender    = makeAddr("lender");
 
         // deploy collection pool, mint, and approve tokens
-        _collectionPool = _deployCollectionPool();
-        address[] memory poolAddresses_ = new address[](1);
-        poolAddresses_[0] = address(_collectionPool);
-        _mintAndApproveQuoteTokens(poolAddresses_, _lender,   250_000 * 1e18);
-        _mintAndApproveQuoteTokens(poolAddresses_, _borrower, 5_000 * 1e18);
-        _mintAndApproveAjnaTokens( poolAddresses_, _bidder,   40_000 * 1e18);
+        _pool = _deployCollectionPool();
+
+        _mintAndApproveQuoteTokens(_lender,   250_000 * 1e18);
+        _mintAndApproveQuoteTokens(_borrower, 5_000 * 1e18);
+        _mintAndApproveAjnaTokens( _bidder,   40_000 * 1e18);
         assertEq(_ajna.balanceOf(_bidder), 40_000 * 1e18);
-        _mintAndApproveCollateralTokens(poolAddresses_, _borrower, 12);
+        _mintAndApproveCollateralTokens(_borrower, 12);
 
         // lender adds liquidity and borrower draws debt
         changePrank(_lender);
         uint16 bucketId = 1663;
         uint256 bucketPrice = _indexToPrice(bucketId);
         assertEq(bucketPrice, 251_183.992399245533703810 * 1e18);
-        _collectionPool.addQuoteToken(200_000 * 1e18, bucketId);
+        _pool.addQuoteToken(200_000 * 1e18, bucketId);
 
         // borrower draws debt
         changePrank(_borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 1;
-        _collectionPool.pledgeCollateral(_borrower, tokenIdsToAdd);
-        _collectionPool.borrow(175_000 * 1e18, bucketId);
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.borrow(175_000 * 1e18, bucketId);
 
         _assertPool(
             PoolState({
@@ -76,33 +75,33 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
 
         // ensure cannot take when no auction was started
         vm.expectRevert(IScaledPool.NoAuction.selector);
-        _collectionPool.takeReserves(555 * 1e18);
-        (uint256 reserves, , , , ) = _collectionPool.poolReservesInfo();
+        _pool.takeReserves(555 * 1e18);
+        (uint256 reserves, , , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 168.26923076923085 * 1e18);
     }
 
     function testUnclaimableReserves() external {
         // borrower repays partial debt, ensure cannot kick when there are no claimable reserves
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 50_000 * 1e18);
-        (uint256 reserves, uint256 claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        _pool.repay(_borrower, 50_000 * 1e18);
+        (uint256 reserves, uint256 claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 499.181304561658553626 * 1e18);
         changePrank(_bidder);
         assertEq(claimableReserves, 0);
         vm.expectRevert(IScaledPool.KickNoReserves.selector);
-        _collectionPool.startClaimableReserveAuction();
+        _pool.startClaimableReserveAuction();
     }
 
     function testReserveAuctionPricing() external {
         // borrower repays all debt (auction for full reserves)
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 205_000 * 1e18);
-        (uint256 reserves, , , , ) = _collectionPool.poolReservesInfo();
+        _pool.repay(_borrower, 205_000 * 1e18);
+        (uint256 reserves, , , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 499.181304561658553626 * 1e18);
 
         // kick off a new auction
         changePrank(_bidder);
-        _collectionPool.startClaimableReserveAuction();
+        _pool.startClaimableReserveAuction();
         _assertReserveAuctionPrice(1_000_000_000 * 1e18);
 
         // check prices
@@ -143,8 +142,8 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
     function testClaimableReserveAuction() external {
         // borrower repays all debt (auction for full reserves)
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 205_000 * 1e18);
-        (uint256 reserves, uint256 claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        _pool.repay(_borrower, 205_000 * 1e18);
+        (uint256 reserves, uint256 claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 499.181304561658553626 * 1e18);
 
         // kick off a new auction
@@ -158,7 +157,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         changePrank(_bidder);
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(expectedReserves, expectedPrice);
-        _collectionPool.startClaimableReserveAuction();
+        _pool.startClaimableReserveAuction();
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
@@ -166,7 +165,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
                 timeRemaining:              3 days
             })
         );
-        (reserves, claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        (reserves, claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 0);
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
 
@@ -182,7 +181,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         );
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(194.189491516041968090 * 1e18, expectedPrice);
-        _collectionPool.takeReserves(300 * 1e18);
+        _pool.takeReserves(300 * 1e18);
         expectedQuoteBalance += 300 * 1e18;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
         assertEq(_ajna.balanceOf(_bidder), 22_118.6065673828125 * 1e18);
@@ -207,7 +206,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         );
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(0, expectedPrice);
-        _collectionPool.takeReserves(400 * 1e18);
+        _pool.takeReserves(400 * 1e18);
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
         assertEq(_ajna.balanceOf(_bidder), 11_193.643043356438691840 * 1e18);
@@ -223,7 +222,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         // ensure take reverts after auction ends
         skip(72 hours);
         vm.expectRevert(IScaledPool.NoAuction.selector);
-        _collectionPool.takeReserves(777 * 1e18);
+        _pool.takeReserves(777 * 1e18);
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: 0,
@@ -231,15 +230,15 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
                 timeRemaining:              0
             })
         );
-        (reserves, claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        (reserves, claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 0);
     }
 
     function testReserveAuctionPartiallyTaken() external {
         // borrower repays partial debt (auction for full reserves)
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 100_000 * 1e18);
-        (uint256 reserves, uint256 claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        _pool.repay(_borrower, 100_000 * 1e18);
+        (uint256 reserves, uint256 claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 499.181304561658553626 * 1e18);
         uint256 expectedReserves = claimableReserves;
         assertEq(expectedReserves, 101.229434828705361858 * 1e18);
@@ -251,7 +250,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         changePrank(_bidder);
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(expectedReserves, expectedPrice);
-        _collectionPool.startClaimableReserveAuction();
+        _pool.startClaimableReserveAuction();
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,
@@ -259,14 +258,14 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
                 timeRemaining:              3 days
             })
         );
-        (reserves, claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        (reserves, claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18);
 
         // partial take
         skip(1 days);
         changePrank(_bidder);
         expectedPrice = 59.604644775390625 * 1e18;
-        _collectionPool.takeReserves(100 * 1e18);
+        _pool.takeReserves(100 * 1e18);
         expectedReserves -= 100 * 1e18;
         _assertReserveAuction(
             ReserveAuctionState({
@@ -290,12 +289,12 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         // after more interest accumulates, borrower repays remaining debt
         skip(4 weeks);
         changePrank(_borrower);
-        _collectionPool.repay(_borrower, 105_000 * 1e18);
+        _pool.repay(_borrower, 105_000 * 1e18);
 
         // start an auction, confirm old claimable reserves are included alongside new claimable reserves
         skip(1 days);
         changePrank(_bidder);
-        (reserves, claimableReserves, , , ) = _collectionPool.poolReservesInfo();
+        (reserves, claimableReserves, , , ) = _pool.poolReservesInfo();
         assertEq(reserves, 442.433476150631408531 * 1e18);
         uint256 newClaimableReserves = claimableReserves;
         assertEq(newClaimableReserves, 442.433476150631408531 * 1e18);
@@ -304,7 +303,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         expectedReserves += newClaimableReserves - kickAward;
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(expectedReserves, expectedPrice);
-        _collectionPool.startClaimableReserveAuction();
+        _pool.startClaimableReserveAuction();
 
         // take everything
         skip(28 hours);
@@ -320,7 +319,7 @@ contract ERC721ScaledReserveAuctionTest is ERC721HelperContract {
         expectedReserves = 0;
         vm.expectEmit(true, true, true, true);
         emit ReserveAuction(expectedReserves, expectedPrice);
-        _collectionPool.takeReserves(600 * 1e18);
+        _pool.takeReserves(600 * 1e18);
         _assertReserveAuction(
             ReserveAuctionState({
                 claimableReservesRemaining: expectedReserves,

--- a/src/base/ScaledPool.sol
+++ b/src/base/ScaledPool.sol
@@ -687,7 +687,7 @@ abstract contract ScaledPool is Clone, FenwickTree, Multicall, IScaledPool {
     }
 
     function _poolMinDebtAmount(uint256 debt_) internal view returns (uint256) {
-        return Maths.wdiv(Maths.wdiv(debt_, Maths.wad(loans.count - 1)), 10**19);
+        return loans.count == 1 ? 0 : Maths.wdiv(Maths.wdiv(debt_, Maths.wad(loans.count - 1)), 10**19);
     }
 
     function _lup() internal view returns (uint256) {


### PR DESCRIPTION
**Changes**
- Per discussion in 2022.09.22 standup, reworked `ERC721HelperContract` such that it only holds a reference to a single pool.  This cleaned up the interface, obviating annoyances passing pool addresses around, and making it behave more consistently with `ERC20HelperContract`.
- Made `ERC721ScaledInterestTest` an abstract base used for testing both the collection pool (`ERC721ScaledCollectionInterestTest`) and subset pool (`ERC721ScaledSubsetInterestTest`).
- Uncommented the MAU checks in `testLenderInterestMargin`.
- Fixed a divide-by-zero bug in `_poolMinDebtAmount`.