### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -1,6 +1,6 @@
 name: Forge Tests
 
-on: [push]
+on: [fork]
 
 env:
   ## Loads environment from secrets

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -1,6 +1,6 @@
 name: Forge Tests
 
-on: [fork]
+on: [push]
 
 env:
   ## Loads environment from secrets

--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -55,3 +55,4 @@ jobs:
       - name: Run coverage
         continue-on-error: true
         run: make coverage
+    timeout-minutes: 10

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -47,7 +47,9 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Run check-size script
-        run: ./check-size.sh
+        run: |
+          ./check-size.sh >> ${{github.run_id}}/.size-check
+          echo $(cat size-check | tail -1) >> $GITHUB_STEP_SUMMARY
         id: check-size
 
       - name: Send size report to Discord
@@ -56,6 +58,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.message }}```
+          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.core.summary }}```
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p size-reports-${{ github.run_id }}
           ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
-          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g'))"
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1))"
         id: check-size
 
       - name: Send size report to Discord
@@ -59,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
+          message: ${{ steps.check-size.outputs.size-report }}
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -48,8 +48,9 @@ jobs:
 
       - name: Run check-size script
         run: |
-          ./check-size.sh >> ${{github.run_id}}/.size-check
-          echo $(cat ${{github.run_id}}/.size-check | tail -1) >> $GITHUB_STEP_SUMMARY
+          mkdir -p size-reports-${{ github.run_id }}
+          ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1))"
         id: check-size
 
       - name: Send size report to Discord
@@ -58,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.core.summary }}```
+          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -59,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
+          message: "https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```"
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run check-size script
         run: |
           ./check-size.sh >> ${{github.run_id}}/.size-check
-          echo $(cat size-check | tail -1) >> $GITHUB_STEP_SUMMARY
+          echo $(cat ${{github.run_id}}/.size-check | tail -1) >> $GITHUB_STEP_SUMMARY
         id: check-size
 
       - name: Send size report to Discord

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -48,4 +48,14 @@ jobs:
 
       - name: Run check-size script
         run: ./check-size.sh
+        id: check-size
+
+      - name: Send size report to Discord
+        uses: appleboy/discord-action@master
+        with:
+          webhook_id: ${{ secrets.DISCORD_ID }}
+          webhook_token: ${{ secrets.DISCORD_TOKEN }}
+          username: "Contract Size Reporter"
+          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.message }}```
+
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p size-reports-${{ github.run_id }}
           ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
-          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g)')"
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g'))"
         id: check-size
 
       - name: Send size report to Discord

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p size-reports-${{ github.run_id }}
           ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
-          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1|sed -e 's/\x1b\[[0-9;]*m//g'))"
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g))"
         id: check-size
 
       - name: Send size report to Discord

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p size-reports-${{ github.run_id }}
           ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
-          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g))"
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1| sed -e 's/, /\…/g)')"
         id: check-size
 
       - name: Send size report to Discord

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -59,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: ${{ steps.check-size.outputs.size-report }}
+          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -59,5 +59,5 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: ${{ github.ref }}  ```${{ steps.check-size.outputs.size-report }}```
+          message: Largest contract size for `${{ github.ref }}`  ```${{ steps.check-size.outputs.size-report }}```
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -59,6 +59,5 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: ${{ github.base_ref }}  ```${{ steps.check-size.outputs.size-report }}```
-
+          message: ${{ github.ref }}  ```${{ steps.check-size.outputs.size-report }}```
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p size-reports-${{ github.run_id }}
           ./check-size.sh | tee size-reports-${{github.run_id}}/size-report
-          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1))"
+          echo "##[set-output name=size-report;]$(echo $(cat size-reports-${{github.run_id}}/size-report|tail -1|sed -e 's/\x1b\[[0-9;]*m//g'))"
         id: check-size
 
       - name: Send size report to Discord
@@ -59,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: "https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```"
+          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -59,6 +59,6 @@ jobs:
           webhook_id: ${{ secrets.DISCORD_ID }}
           webhook_token: ${{ secrets.DISCORD_TOKEN }}
           username: "Contract Size Reporter"
-          message: https://github.com/ajna-finance/contracts/commit/${{ github.sha }}  ```${{ steps.check-size.outputs.size-report }}```
+          message: ${{ github.base_ref }}  ```${{ steps.check-size.outputs.size-report }}```
 
     timeout-minutes: 2

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,0 +1,51 @@
+name: Size Check
+on: [push]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Cache compiler installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: ${{ runner.os }}-compiler-cache
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      - name: Install ganache
+        run: npm install -g ganache-cli@6.12.1
+
+      - name: Set up python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Set pip cache directory path
+        id: pip-cache-dir-path
+        run: |
+            echo "::set-output name=dir::$(pip cache dir)"
+      - name: Restore pip cache
+        uses: actions/cache@v2
+        id: pip-cache
+        with:
+            path: |
+                ${{ steps.pip-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-dev.txt') }}
+            restore-keys: |
+                ${{ runner.os }}-pip-${{ hashFiles('**/requirements-dev.txt') }}
+                ${{ runner.os }}-pip-
+      - name: Install python dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run check-size script
+        run: ./check-size.sh
+    timeout-minutes: 2

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -41,3 +41,4 @@ jobs:
           slither src/erc721/.
         continue-on-error: true
         id: erc721-pool-analyzer
+    timeout-minutes: 5

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,5 +1,5 @@
 name: Slither Analysis
-on: [fork]
+on: [push]
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,5 +1,5 @@
 name: Slither Analysis
-on: [push]
+on: [fork]
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ build   :; forge clean && forge build
 test                 :; forge clean && forge test -v --no-match-test testLoad # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-with-gas-report :; forge clean && forge build && forge test -v --no-match-test testLoad --gas-report # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-load            :; forge clean && forge build && forge test -vv --match-test testLoad --gas-report
-# TODO: should be able to fork from block 15478978, a block after Ajna token contract was created
-test-with-cache      :; forge clean && forge test -vv --no-match-test testLoad --fork-url $(ETH_RPC_URL) --fork-block-number 15576176
+test-with-cache      :; forge clean && forge test -vv --no-match-test testLoad --fork-url $(ETH_RPC_URL) --fork-block-number 15478978
 coverage             :; forge coverage --no-match-test testLoad
 
 # Generate Gas Snapshots

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,21 @@
 all: clean install build
 
 # Clean the repo
-clean  :; forge clean
+clean   :; forge clean
 
 # Install the Modules
 install :; git submodule update --init --recursive
 
 # Builds
-build  :; forge clean && forge build
+build   :; forge clean && forge build
 
 # Tests
-test   :; forge clean && forge test -v --no-match-test testLoad # --ffi # enable if you need the `ffi` cheat code on HEVM
-test-with-gas-report   :; forge clean && forge build && forge test -v --no-match-test testLoad --gas-report # --ffi # enable if you need the `ffi` cheat code on HEVM
-test-load   :; forge clean && forge build && forge test -vv --match-test testLoad --gas-report
-coverage   :; forge coverage --no-match-test testLoad
+test                 :; forge clean && forge test -v --no-match-test testLoad # --ffi # enable if you need the `ffi` cheat code on HEVM
+test-with-gas-report :; forge clean && forge build && forge test -v --no-match-test testLoad --gas-report # --ffi # enable if you need the `ffi` cheat code on HEVM
+test-load            :; forge clean && forge build && forge test -vv --match-test testLoad --gas-report
+# TODO: should be able to fork from block 15478978, a block after Ajna token contract was created
+test-with-cache      :; forge clean && forge test -vv --no-match-test testLoad --fork-url $(ETH_RPC_URL) --fork-block-number 15576176
+coverage             :; forge coverage --no-match-test testLoad
 
 # Generate Gas Snapshots
 snapshot :; forge clean && forge snapshot

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ build   :; forge clean && forge build
 test                 :; forge clean && forge test -v --no-match-test testLoad # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-with-gas-report :; forge clean && forge build && forge test -v --no-match-test testLoad --gas-report # --ffi # enable if you need the `ffi` cheat code on HEVM
 test-load            :; forge clean && forge build && forge test -vv --match-test testLoad --gas-report
-test-with-cache      :; forge clean && forge test -vv --no-match-test testLoad --fork-url $(ETH_RPC_URL) --fork-block-number 15478978
 coverage             :; forge coverage --no-match-test testLoad
 
 # Generate Gas Snapshots

--- a/check-size.sh
+++ b/check-size.sh
@@ -7,14 +7,9 @@ largest_contract=${BASH_REMATCH[1]}
 largest_size=$(echo "${BASH_REMATCH[2]}" | sed -e 's/,//g' -e 's/B//g')
 
 limit=24576
-exitcode=0
-message=    # to make shellcheck happy
 if (( largest_size > limit)); then
-  message="$largest_contract is $largest_size bytes, over size limit of $limit bytes."
-  exitcode=1
+  echo "$largest_contract is $largest_size bytes (over size limit of $limit bytes)."
+  exit 1
 else
-  message="$largest_contract is $largest_size bytes, under size limit of $limit bytes."
+  echo "$largest_contract is $largest_size bytes, (under size limit of $limit bytes)."
 fi;
-
-echo "$message"
-exit $exitcode

--- a/check-size.sh
+++ b/check-size.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-s=`brownie compile --size`
+s=$(brownie compile --size)
 echo "${s}"
 regex='============ Deployment Bytecode Sizes ============\s*(\w+)\s+-\s+([0-9,B]+)\s+\('
 [[ "$s" =~ $regex ]]
 largest_contract=${BASH_REMATCH[1]}
-largest_size=`echo ${BASH_REMATCH[2]} | sed -e 's/,//g' -e 's/B//g'`
+largest_size=$(echo "${BASH_REMATCH[2]}" | sed -e 's/,//g' -e 's/B//g')
 
 limit=24576
-if (( $largest_size > $limit)); then
-  echo $largest_contract is $largest_size bytes, over size limit of $limit bytes.
+if (( largest_size > limit)); then
+  echo "$largest_contract" is "$largest_size" bytes, over size limit of $limit bytes.
   exit 1
 else
-  echo $largest_contract is $largest_size bytes, under size limit of $limit bytes.
+  echo "$largest_contract" is "$largest_size" bytes, under size limit of $limit bytes.
 fi;

--- a/check-size.sh
+++ b/check-size.sh
@@ -7,9 +7,14 @@ largest_contract=${BASH_REMATCH[1]}
 largest_size=$(echo "${BASH_REMATCH[2]}" | sed -e 's/,//g' -e 's/B//g')
 
 limit=24576
+exitcode=0
+message=    # to make shellcheck happy
 if (( largest_size > limit)); then
-  echo "$largest_contract" is "$largest_size" bytes, over size limit of $limit bytes.
-  exit 1
+  message="$largest_contract is $largest_size bytes, over size limit of $limit bytes."
+  exitcode=1
 else
-  echo "$largest_contract" is "$largest_size" bytes, under size limit of $limit bytes.
+  message="$largest_contract is $largest_size bytes, under size limit of $limit bytes."
 fi;
+
+echo "$message"
+exit $exitcode

--- a/check-size.sh
+++ b/check-size.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+s=`brownie compile --size`
+echo "${s}"
+regex='============ Deployment Bytecode Sizes ============\s*(\w+)\s+-\s+([0-9,B]+)\s+\('
+[[ "$s" =~ $regex ]]
+largest_contract=${BASH_REMATCH[1]}
+largest_size=`echo ${BASH_REMATCH[2]} | sed -e 's/,//g' -e 's/B//g'`
+
+limit=24576
+if (( $largest_size > $limit)); then
+  echo $largest_contract is $largest_size bytes, over size limit of $limit bytes.
+  exit 1
+else
+  echo $largest_contract is $largest_size bytes, under size limit of $limit bytes.
+fi;

--- a/check-size.sh
+++ b/check-size.sh
@@ -11,5 +11,5 @@ if (( largest_size > limit)); then
   echo "$largest_contract is $largest_size bytes (over size limit of $limit bytes)."
   exit 1
 else
-  echo "$largest_contract is $largest_size bytes, (under size limit of $limit bytes)."
+  echo "$largest_contract is $largest_size bytes (under size limit of $limit bytes)."
 fi;

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -184,12 +184,14 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     Token         internal _quote;
     ERC20Pool     internal _pool;
     PoolInfoUtils internal _poolUtils;
+    uint256       internal _startTime;
 
     constructor() {
         _collateral = new Token("Collateral", "C");
         _quote      = new Token("Quote", "Q");
         _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
         _poolUtils  = new PoolInfoUtils();
+        _startTime  = block.timestamp;
     }
 
     function _mintQuoteAndApproveTokens(address operator_, uint256 mintAmount_) internal {

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -282,7 +282,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _borrow(
             BorrowSpecs({
                 from:         _borrower,
@@ -310,7 +310,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
         _assertBorrower(
@@ -325,7 +325,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _pledgeCollateral(
             PledgeSpecs({
                 from:     _borrower,
@@ -350,7 +350,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.003018244385218513 * 1e18,
                 pendingInflator:      1.003018244385218513 * 1e18,
                 interestRate:         0.0605 * 1e18,
-                interestRateUpdate:   _startTime + 1728000
+                interestRateUpdate:   _startTime + 20 days
             })
         );
         _assertBorrower(
@@ -365,7 +365,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _pullCollateral(
             PullSpecs({
                 from:    _borrower,
@@ -389,7 +389,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.004682160092905114 * 1e18,
                 pendingInflator:      1.004682160092905114 * 1e18,
                 interestRate:         0.06655 * 1e18,
-                interestRateUpdate:   _startTime + 2592000
+                interestRateUpdate:   _startTime + 30 days
             })
         );
         _assertBorrower(
@@ -404,7 +404,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _borrow(
             BorrowSpecs({
                 from:         _borrower,
@@ -432,7 +432,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.006515655675920014 * 1e18,
                 pendingInflator:      1.006515655675920014 * 1e18,
                 interestRate:         0.073205 * 1e18,
-                interestRateUpdate:   _startTime + 3456000
+                interestRateUpdate:   _startTime + 40 days
             })
         );
         _assertBorrower(
@@ -447,7 +447,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _repay(
             RepaySpecs({
                 from:        _borrower,
@@ -472,7 +472,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.008536365727696620 * 1e18,
                 pendingInflator:      1.008536365727696620 * 1e18,
                 interestRate:         0.0805255 * 1e18,
-                interestRateUpdate:   _startTime + 4320000
+                interestRateUpdate:   _startTime + 50 days
             })
         );
         _assertBorrower(
@@ -487,7 +487,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
         _assertPool(
             PoolState({
                 htp:                  423.992567137945688924 * 1e18,
@@ -504,7 +504,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.008536365727696620 * 1e18,
                 pendingInflator:      1.010763832743848754 * 1e18,
                 interestRate:         0.0805255 * 1e18,
-                interestRateUpdate:   _startTime + 4320000
+                interestRateUpdate:   _startTime + 50 days
             })
         );
         _assertBorrower(

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -69,7 +69,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -104,7 +104,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -113,11 +113,11 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_lender),        150_000 * 1e18);
 
         BucketLP[] memory lps = new BucketLP[](5);
-        lps[0] = BucketLP({index: highest, balance: 10_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: high,    balance: 10_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: med,     balance: 10_000 * 1e27, time: 0});
-        lps[3] = BucketLP({index: low,     balance: 10_000 * 1e27, time: 0});
-        lps[4] = BucketLP({index: lowest,  balance: 10_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: highest, balance: 10_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: high,    balance: 10_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: med,     balance: 10_000 * 1e27, time: _startTime});
+        lps[3] = BucketLP({index: low,     balance: 10_000 * 1e27, time: _startTime});
+        lps[4] = BucketLP({index: lowest,  balance: 10_000 * 1e27, time: _startTime});
 
         _assertLPs(
             LenderLPs({
@@ -164,7 +164,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         // check balances
@@ -197,7 +197,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -232,7 +232,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -278,7 +278,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -310,7 +310,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
         _assertBorrower(
@@ -350,7 +350,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.003018244385218513 * 1e18,
                 pendingInflator:      1.003018244385218513 * 1e18,
                 interestRate:         0.0605 * 1e18,
-                interestRateUpdate:   1728000
+                interestRateUpdate:   _startTime + 1728000
             })
         );
         _assertBorrower(
@@ -389,7 +389,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.004682160092905114 * 1e18,
                 pendingInflator:      1.004682160092905114 * 1e18,
                 interestRate:         0.06655 * 1e18,
-                interestRateUpdate:   2592000
+                interestRateUpdate:   _startTime + 2592000
             })
         );
         _assertBorrower(
@@ -432,7 +432,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.006515655675920014 * 1e18,
                 pendingInflator:      1.006515655675920014 * 1e18,
                 interestRate:         0.073205 * 1e18,
-                interestRateUpdate:   3456000
+                interestRateUpdate:   _startTime + 3456000
             })
         );
         _assertBorrower(
@@ -472,7 +472,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.008536365727696620 * 1e18,
                 pendingInflator:      1.008536365727696620 * 1e18,
                 interestRate:         0.0805255 * 1e18,
-                interestRateUpdate:   4320000
+                interestRateUpdate:   _startTime + 4320000
             })
         );
         _assertBorrower(
@@ -504,7 +504,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1.008536365727696620 * 1e18,
                 pendingInflator:      1.010763832743848754 * 1e18,
                 interestRate:         0.0805255 * 1e18,
-                interestRateUpdate:   4320000
+                interestRateUpdate:   _startTime + 4320000
             })
         );
         _assertBorrower(
@@ -649,7 +649,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -681,7 +681,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -716,7 +716,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
     }
@@ -760,7 +760,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -790,7 +790,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
     }
@@ -846,7 +846,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
     }
@@ -897,7 +897,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -933,7 +933,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -116,7 +116,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         assertEq(_collateral.balanceOf(_borrower), 50 * 1e18);
 
         // pass time to allow interest to accrue
-        skip(864000);
+        skip(10 days);
 
         // remove some of the collateral
         _pullCollateral(
@@ -142,7 +142,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
         _assertBorrower(
@@ -182,7 +182,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
         _assertBorrower(

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -66,7 +66,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_collateral.balanceOf(_borrower), 150 * 1e18);
@@ -99,7 +99,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         _assertBorrower(
@@ -142,7 +142,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
         _assertBorrower(
@@ -182,7 +182,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
         _assertBorrower(
@@ -569,7 +569,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_collateral.balanceOf(_borrower),  150 * 1e18);
@@ -601,7 +601,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_collateral.balanceOf(_borrower),  150 * 1e18);

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -61,9 +61,10 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(address(pool.quoteToken()),        address(_quote));
         assertEq(pool.quoteTokenScale(),            1);
         assertEq(pool.inflatorSnapshot(),           10**18);
-        assertEq(pool.lastInflatorSnapshotUpdate(), 333);
+        assertEq(pool.lastInflatorSnapshotUpdate(), _startTime + 333);
+        assertEq(pool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(pool.interestRate(),               0.0543 * 10**18);
-        assertEq(pool.interestRateUpdate(),         333);
+        assertEq(pool.interestRateUpdate(),         _startTime + 333);
         assertEq(pool.minFee(),                     0.0005 * 10**18);
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -62,7 +62,6 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(pool.quoteTokenScale(),            1);
         assertEq(pool.inflatorSnapshot(),           10**18);
         assertEq(pool.lastInflatorSnapshotUpdate(), _startTime + 333);
-        assertEq(pool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(pool.interestRate(),               0.0543 * 10**18);
         assertEq(pool.interestRateUpdate(),         _startTime + 333);
         assertEq(pool.minFee(),                     0.0005 * 10**18);

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -60,7 +60,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         // enforce EMA and target utilization update
@@ -192,7 +192,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.000005707778846384 * 1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
 
@@ -215,7 +215,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.000011415590271509 * 1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
     }
@@ -249,7 +249,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_pool.debtEma(),   0);
@@ -283,7 +283,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_pool.debtEma(),   0);
@@ -316,7 +316,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         assertEq(_pool.debtEma(),   0);

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -42,7 +42,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
 
         _assertPool(
             PoolState({
@@ -90,7 +90,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
 
@@ -105,7 +105,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
 
-        skip(864000);
+        skip(10 days);
 
         // enforce EMA and target utilization update
         amounts = new Liquidity[](1);
@@ -132,7 +132,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1.001507985182953253 * 1e18,
                 pendingInflator:      1.003018244385218513 * 1e18,
                 interestRate:         0.055 * 1e18, // FIXME here it should decrease
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
         _assertBorrower(
@@ -352,7 +352,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   _startTime + 864000
+                interestRateUpdate:   _startTime + 10 days
             })
         );
         assertEq(_pool.debtEma(),   95.440014344854493304 * 1e18);

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -90,7 +90,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
 
@@ -132,7 +132,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1.001507985182953253 * 1e18,
                 pendingInflator:      1.003018244385218513 * 1e18,
                 interestRate:         0.055 * 1e18, // FIXME here it should decrease
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
         _assertBorrower(
@@ -352,7 +352,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 inflatorSnapshot:     1.001370801704613834 * 1e18,
                 pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   864000
+                interestRateUpdate:   _startTime + 864000
             })
         );
         assertEq(_pool.debtEma(),   95.440014344854493304 * 1e18);

--- a/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -62,7 +62,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         bucketStates[0] = BucketState({index: testIndex, LPs: 22_043.56808879152623138 * 1e27, collateral: collateralToPurchaseWith});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](1);
-        lps[0] = BucketLP({index: testIndex, balance: 10_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: testIndex, balance: 10_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -98,7 +98,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         bucketStates[0] = BucketState({index: testIndex, LPs: 12_043.56808879152623138 * 1e27, collateral: collateralToPurchaseWith});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](1);
-        lps[0] = BucketLP({index: testIndex, balance: 10_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: testIndex, balance: 10_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -131,7 +131,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         bucketStates[0] = BucketState({index: testIndex, LPs: 2_043.56808879152623138 * 1e27, collateral: 0.678725133191514712 * 1e18});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](1);
-        lps[0] = BucketLP({index: testIndex, balance: 0, time: 0});
+        lps[0] = BucketLP({index: testIndex, balance: 0, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -165,7 +165,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         bucketStates[0] = BucketState({index: testIndex, LPs: 0, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](1);
-        lps[0] = BucketLP({index: testIndex, balance: 0, time: 0});
+        lps[0] = BucketLP({index: testIndex, balance: 0, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -265,6 +265,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
             })
         );
         BucketLP[] memory lps = new BucketLP[](1);
+
         lps[0] = BucketLP({index: 2550, balance: 0 * 1e27, time: 0});
         _assertLPs(
             LenderLPs({
@@ -285,7 +286,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lpRedeem: 6_000 * 1e27
             })
         );
-        lps[0] = BucketLP({index: 2550, balance: 0 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2550, balance: 0 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -305,7 +306,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lpRedeem: 4_000 * 1e27
             })
         );
-        lps[0] = BucketLP({index: 2550, balance: 0 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2550, balance: 0 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender1,

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -446,8 +446,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[1] = BucketState({index: 1663, LPs: 3_400 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
+        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 1 minutes});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 1 minutes});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -480,8 +480,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         );
 
         skip(2 hours);
-        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
+        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 1 minutes});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 1 minutes});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -525,8 +525,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[1] = BucketState({index: 1663, LPs: 3_400 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 1606, balance: 0, time: _startTime + 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
+        lps[0] = BucketLP({index: 1606, balance: 0, time: _startTime + 1 minutes});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 1 minutes});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -66,14 +66,14 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         BucketState[] memory bucketStates = new BucketState[](1);
         bucketStates[0] = BucketState({index: 2550, LPs: 10_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](1);
-        lps[0] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -113,7 +113,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         bucketStates = new BucketState[](2);
@@ -121,8 +121,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[0] = BucketState({index: 2551, LPs: 20_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -157,7 +157,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         bucketStates = new BucketState[](3);
@@ -166,9 +166,9 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[2] = BucketState({index: 2551, LPs: 20_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](3);
-        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -207,7 +207,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         BucketState[] memory bucketStates = new BucketState[](3);
@@ -216,9 +216,9 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[2] = BucketState({index: 2551, LPs: 20_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](3);
-        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -255,7 +255,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         bucketStates = new BucketState[](3);
@@ -264,9 +264,9 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[2] = BucketState({index: 2551, LPs: 20_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](3);
-        lps[0] = BucketLP({index: 2549, balance: 35_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 35_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -303,7 +303,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 inflatorSnapshot:     1e18,
                 pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         bucketStates = new BucketState[](3);
@@ -312,9 +312,9 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[2] = BucketState({index: 2551, LPs: 20_000 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](3);
-        lps[0] = BucketLP({index: 2549, balance: 0,             time: 0});
-        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 0,             time: _startTime});
+        lps[1] = BucketLP({index: 2550, balance: 10_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: 2551, balance: 20_000 * 1e27, time: _startTime});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -446,8 +446,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[1] = BucketState({index: 1663, LPs: 3_400 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         BucketLP[] memory lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: 60});
+        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 60});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -480,8 +480,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         );
 
         skip(2 hours);
-        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: 60});
+        lps[0] = BucketLP({index: 1606, balance: 3_400 * 1e27, time: _startTime + 60});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -525,8 +525,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         bucketStates[1] = BucketState({index: 1663, LPs: 3_400 * 1e27, collateral: 0});
         _assertBuckets(bucketStates);
         lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 1606, balance: 0, time: 60});
-        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: 60});
+        lps[0] = BucketLP({index: 1606, balance: 0, time: _startTime + 60});
+        lps[1] = BucketLP({index: 1663, balance: 3_400 * 1e27, time: _startTime + 60});
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -548,7 +548,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         );
 
         BucketLP[] memory lps = new BucketLP[](2);
-        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 40_000 * 1e27, time: _startTime});
         lps[1] = BucketLP({index: 2552, balance: 0, time: 0});
         _assertLPs(
             LenderLPs({
@@ -569,8 +569,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             })
         );
 
-        lps[0] = BucketLP({index: 2549, balance: 35_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2552, balance: 5_000 * 1e27, time: 0});
+        lps[0] = BucketLP({index: 2549, balance: 35_000 * 1e27, time: _startTime});
+        lps[1] = BucketLP({index: 2552, balance: 5_000 * 1e27, time: 0});  // FIXME: This doesn't seem right
         _assertLPs(
             LenderLPs({
                 lender:    _lender,
@@ -592,7 +592,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         lps = new BucketLP[](3);
         lps[0] = BucketLP({index: 2540, balance: 5_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2549, balance: 30_000 * 1e27, time: 0});
+        lps[1] = BucketLP({index: 2549, balance: 30_000 * 1e27, time: _startTime});
         lps[2] = BucketLP({index: 2552, balance: 5_000 * 1e27, time: 0});
         _assertLPs(
             LenderLPs({
@@ -615,8 +615,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         lps = new BucketLP[](5);
         lps[0] = BucketLP({index: 2540, balance: 5_000 * 1e27, time: 0});
-        lps[1] = BucketLP({index: 2549, balance: 30_000 * 1e27, time: 0});
-        lps[2] = BucketLP({index: 2551, balance: 5_000 * 1e27, time: 0});
+        lps[1] = BucketLP({index: 2549, balance: 30_000 * 1e27, time: _startTime});
+        lps[2] = BucketLP({index: 2551, balance: 5_000 * 1e27, time: _startTime});
         lps[3] = BucketLP({index: 2552, balance: 5_000 * 1e27, time: 0});
         lps[4] = BucketLP({index: 2777, balance: 15_000 * 1e27, time: 0});
         _assertLPs(

--- a/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
@@ -117,7 +117,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         // check lenders lp balance
         (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, _startTime + 3600);
+        assertEq(lastQuoteDeposit, _startTime + 1 hours);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
@@ -155,7 +155,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, _startTime + 3600);
+        assertEq(lastQuoteDeposit, _startTime + 1 hours);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
@@ -243,7 +243,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         // check lenders lp balance
         (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, _startTime + 3600);
+        assertEq(lastQuoteDeposit, _startTime + 1 hours);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
@@ -251,7 +251,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 5_000 * 1e27);
-        assertEq(lastQuoteDeposit, _startTime + 7200);
+        assertEq(lastQuoteDeposit, _startTime + 2 hours);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
@@ -283,7 +283,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
-        assertEq(lastQuoteDeposit, _startTime + 7200);
+        assertEq(lastQuoteDeposit, _startTime + 2 hours);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);

--- a/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
@@ -117,7 +117,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         // check lenders lp balance
         (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, 3600);
+        assertEq(lastQuoteDeposit, _startTime + 3600);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
@@ -155,7 +155,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, 3600);
+        assertEq(lastQuoteDeposit, _startTime + 3600);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
@@ -243,7 +243,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         // check lenders lp balance
         (uint256 lpBalance, uint256 lastQuoteDeposit) = _pool.lenders(indexes[0], _lender1);
         assertEq(lpBalance, 10_000 * 1e27);
-        assertEq(lastQuoteDeposit, 3600);
+        assertEq(lastQuoteDeposit, _startTime + 3600);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender1);
         assertEq(lpBalance, 20_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender1);
@@ -251,7 +251,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 5_000 * 1e27);
-        assertEq(lastQuoteDeposit, 7200);
+        assertEq(lastQuoteDeposit, _startTime + 7200);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 10_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);
@@ -283,7 +283,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
 
         (lpBalance, lastQuoteDeposit) = _pool.lenders(indexes[0], _lender2);
         assertEq(lpBalance, 15_000 * 1e27);
-        assertEq(lastQuoteDeposit, 7200);
+        assertEq(lastQuoteDeposit, _startTime + 7200);
         (lpBalance, ) = _pool.lenders(indexes[1], _lender2);
         assertEq(lpBalance, 30_000 * 1e27);
         (lpBalance, ) = _pool.lenders(indexes[2], _lender2);

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -62,9 +62,11 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     ERC20              internal _ajna;
     ERC721Pool         internal _pool;
     PoolInfoUtils      internal _poolUtils;
+    uint256            internal _startTime;
 
     // TODO: bool for pool type
     constructor() {
+        _startTime  = block.timestamp;
         vm.createSelectFork(vm.envString("ETH_RPC_URL"));
 
         _collateral = new NFTCollateralToken();

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -110,7 +110,7 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime + 0);
         assertEq(_NFTCollectionPool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
-        assertEq(_NFTCollectionPool.interestRateUpdate(),         0);
+        assertEq(_NFTCollectionPool.interestRateUpdate(),         _startTime);
         assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);
         assertEq(_NFTCollectionPool.isSubset(),                   false);
     }
@@ -175,7 +175,7 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), _startTime);
         assertEq(_NFTSubsetOnePool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRate(),               0.05 * 10**18);
-        assertEq(_NFTSubsetOnePool.interestRateUpdate(),         0);
+        assertEq(_NFTSubsetOnePool.interestRateUpdate(),         _startTime);
         assertEq(_NFTSubsetOnePool.minFee(),                     0.0005 * 10**18);
         assertEq(_NFTSubsetOnePool.isSubset(),                   true);
 

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -108,7 +108,6 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTCollectionPool.quoteTokenScale(),            1);
         assertEq(_NFTCollectionPool.inflatorSnapshot(),           10**18);
         assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime + 0);
-        assertEq(_NFTCollectionPool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTCollectionPool.interestRateUpdate(),         _startTime);
         assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);
@@ -173,7 +172,6 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTSubsetOnePool.quoteTokenScale(),            1);
         assertEq(_NFTSubsetOnePool.inflatorSnapshot(),           10**18);
         assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), _startTime);
-        assertEq(_NFTSubsetOnePool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRateUpdate(),         _startTime);
         assertEq(_NFTSubsetOnePool.minFee(),                     0.0005 * 10**18);

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -21,8 +21,10 @@ contract ERC721PoolFactoryTest is DSTestPlus {
     Token              internal _quote;
     uint256[]          internal _tokenIdsSubsetOne;
     uint256[]          internal _tokenIdsSubsetTwo;
+    uint256            internal _startTime;
 
     function setUp() external {
+        _startTime   = block.timestamp;
         _collateral  = new NFTCollateralToken();
         _quote       = new Token("Quote", "Q");
 
@@ -105,7 +107,8 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(address(_NFTCollectionPool.quoteToken()),        address(_quote));
         assertEq(_NFTCollectionPool.quoteTokenScale(),            1);
         assertEq(_NFTCollectionPool.inflatorSnapshot(),           10**18);
-        assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), 0);
+        assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime + 0);
+        assertEq(_NFTCollectionPool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTCollectionPool.interestRateUpdate(),         0);
         assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);
@@ -169,7 +172,8 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(address(_NFTSubsetOnePool.quoteToken()),        address(_quote));
         assertEq(_NFTSubsetOnePool.quoteTokenScale(),            1);
         assertEq(_NFTSubsetOnePool.inflatorSnapshot(),           10**18);
-        assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), 0);
+        assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), _startTime);
+        assertEq(_NFTSubsetOnePool.lenderInterestFactor(),       0.9 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRateUpdate(),         0);
         assertEq(_NFTSubsetOnePool.minFee(),                     0.0005 * 10**18);

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -107,7 +107,7 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(address(_NFTCollectionPool.quoteToken()),        address(_quote));
         assertEq(_NFTCollectionPool.quoteTokenScale(),            1);
         assertEq(_NFTCollectionPool.inflatorSnapshot(),           10**18);
-        assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime + 0);
+        assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime);
         assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
         assertEq(_NFTCollectionPool.interestRateUpdate(),         _startTime);
         assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);

--- a/src/_test/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolInterest.t.sol
@@ -65,7 +65,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         _pool.addQuoteToken(10_000 * 1e18, 2553);
         _pool.addQuoteToken(10_000 * 1e18, 2554);
 
-        skip(864000);
+        skip(10 days);
 
         // borrower adds collateral and borrows initial amount
         changePrank(_borrower);
@@ -85,7 +85,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         assertEq(inflator,    1 * 1e18);
 
         // borrower pledge additional collateral after some time has passed
-        skip(864000);
+        skip(10 days);
         tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 51;
         _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
@@ -98,7 +98,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         assertEq(inflator,    1.003018244385218513 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed
-        skip(864000);
+        skip(10 days);
         uint256[] memory tokenIdsToRemove = new uint256[](1);
         tokenIdsToRemove[0] = 1;
         _pool.pullCollateral(tokenIdsToRemove);
@@ -111,7 +111,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         assertEq(inflator,    1.004682160092905114 * 1e18);
 
         // borrower borrows some additional quote after some time has passed
-        skip(864000);
+        skip(10 days);
         _pool.borrow(1_000 * 1e18, 3000);
         assertEq(_pool.borrowerDebt(), 6_038.697103647272763112 * 1e18);
         (debt, pendingDebt, col, mompFactor, inflator) = _poolUtils.borrowerInfo(address(_pool), _borrower);
@@ -125,7 +125,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         deal(address(_quote), _borrower, 20_000 * 1e18);
 
         // borrower repays their loan after some additional time
-        skip(864000);
+        skip(10 days);
         (debt, pendingDebt, col, mompFactor, inflator) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         _pool.repay(_borrower, pendingDebt);
         assertEq(_pool.borrowerDebt(), 0);

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -645,25 +645,28 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // approve and transfer NFT by permit to different address
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-            minterPrivateKey,
-            keccak256(
-                abi.encodePacked(
-                    "\x19\x01",
-                    _positionManager.DOMAIN_SEPARATOR(),
-                    keccak256(
-                        abi.encode(
-                            _positionManager.PERMIT_TYPEHASH(),
-                            testReceiver,
-                            tokenId,
-                            0,
-                            1 days
+        {
+            uint256 deadline = block.timestamp + 1 days;
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+                minterPrivateKey,
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        _positionManager.DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                _positionManager.PERMIT_TYPEHASH(),
+                                testReceiver,
+                                tokenId,
+                                0,
+                                deadline
+                            )
                         )
                     )
                 )
-            )
-        );
-        _positionManager.safeTransferFromWithPermit(testMinter, testReceiver, testReceiver, tokenId, 1 days, v, r, s );
+            );
+            _positionManager.safeTransferFromWithPermit(testMinter, testReceiver, testReceiver, tokenId, deadline, v, r, s );
+        }
 
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testReceiver);


### PR DESCRIPTION
**Changes**
- Set timeouts on GitHub actions to avoid unnecessary resource spend.
- Implemented an action which checks contract size and fails if the largest contract is above the maximum size.  As requested in 2022.09.27 meeting, added Discord notification for the largest contract size.
- ~Added a `Makefile` target to cache chain from the block after our Ajna token was deployed.~  Updated tests to consider the start time of the test rather than counting from block 0.

Regarding the latter, tests take noticeably longer with the cache, even after the cache has synced.  As such, I didn't adjust CI to use the cache.  Some timings:
_Without cache:_
```
real	0m32.149s
user	0m46.797s
sys	0m0.725s
```

_With cache, after seeding the cache and confirming data is present:_
```
real	0m35.536s
user	0m48.770s
sys	0m0.797s
```

~Happy to discuss whether it's worth keeping the `Makefile` target, and whether we should revert test changes.~
Per our discussion in 2022.09.27 standup, I have eliminated the cache config from the Makefile.