### PR TITLE
Fix borrower pendingDebt calculation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
-## Etherscan API Key ##
-## Used for verification of contracts on deployement ##
+## Etherscan API key ##
+## for verification of contracts on deployment ##
 ETHERSCAN_API_KEY=
 
-## Alchemy API Key ##
-## For deployment ##
+## Alchemy API key ##
+## for deployment ##
 ALCHEMY_API_KEY=
 
-## Alchmey API Key URL ##
+## Ethereum node endpoint ##
 ETH_RPC_URL=
 
 ## EOA Contract Deployer ##

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -336,7 +336,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
 
     function _assertPool(PoolState memory state_) internal {
         ( , , uint256 htp, , uint256 lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (uint256 poolSize, uint256 loansCount, address maxBorrower, uint256 pendingInflator) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, uint256 loansCount, address maxBorrower, uint256 pendingInflator, uint256 pendingInterestFactor) = _poolUtils.poolLoansInfo(address(_pool));
         (uint256 poolMinDebtAmount, , uint256 poolActualUtilization, uint256 poolTargetUtilization) = _poolUtils.poolUtilizationInfo(address(_pool));
         assertEq(htp, state_.htp);
         assertEq(lup, state_.lup);
@@ -403,11 +403,11 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     }
 
     function _loansCount() internal view returns (uint256 loansCount_) {
-        ( , loansCount_, , ) = _poolUtils.poolLoansInfo(address(_pool));
+        ( , loansCount_, , , ) = _poolUtils.poolLoansInfo(address(_pool));
     }
 
     function _poolSize() internal view returns (uint256 poolSize_) {
-        (poolSize_, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize_, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
     }
 
     function _exchangeRate(uint256 index_) internal view returns (uint256 exchangeRate_) {

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -156,8 +156,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         uint256 minDebtAmount;
         uint256 loans;
         address maxBorrower;
-        uint256 inflatorSnapshot;
-        uint256 pendingInflator;
         uint256 interestRate;
         uint256 interestRateUpdate;
     }
@@ -352,8 +350,9 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
         assertEq(loansCount,  state_.loans);
         assertEq(maxBorrower, state_.maxBorrower);
 
-        assertEq(_pool.inflatorSnapshot(), state_.inflatorSnapshot);
-        assertEq(pendingInflator,          state_.pendingInflator);
+        uint256 poolInflatorSnapshot = _pool.inflatorSnapshot();
+        assertGe(poolInflatorSnapshot, 1e18);
+        assertGe(pendingInflator,      poolInflatorSnapshot);
 
         assertEq(_pool.interestRate(),       state_.interestRate);
         assertEq(_pool.interestRateUpdate(), state_.interestRateUpdate);

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -66,8 +66,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -101,8 +99,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_102.0192307692307702 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -161,8 +157,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        4_003.846153846153848 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -194,8 +188,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        3_003.846153846153848000 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -229,8 +221,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -275,8 +265,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -307,8 +295,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_102.019230769230770200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
                 interestRateUpdate:   _startTime + 10 days
             })
@@ -347,8 +333,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_108.363638510121338731 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.003018244385218513 * 1e18,
-                pendingInflator:      1.003018244385218513 * 1e18,
                 interestRate:         0.0605 * 1e18,
                 interestRateUpdate:   _startTime + 20 days
             })
@@ -386,8 +370,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_111.861221326057567518 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.004682160092905114 * 1e18,
-                pendingInflator:      1.004682160092905114 * 1e18,
                 interestRate:         0.06655 * 1e18,
                 interestRateUpdate:   _startTime + 30 days
             })
@@ -429,8 +411,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_115.715264301085329867 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.006515655675920014 * 1e18,
-                pendingInflator:      1.006515655675920014 * 1e18,
                 interestRate:         0.073205 * 1e18,
                 interestRateUpdate:   _startTime + 40 days
             })
@@ -469,8 +449,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_119.962835689728444617 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.008536365727696620 * 1e18,
-                pendingInflator:      1.008536365727696620 * 1e18,
                 interestRate:         0.0805255 * 1e18,
                 interestRateUpdate:   _startTime + 50 days
             })
@@ -501,8 +479,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        2_119.962835689728444617 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.008536365727696620 * 1e18,
-                pendingInflator:      1.010763832743848754 * 1e18,
                 interestRate:         0.0805255 * 1e18,
                 interestRateUpdate:   _startTime + 50 days
             })
@@ -646,8 +622,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        100.096153846153846200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -678,8 +652,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        300.288461538461538600 * 1e18,
                 loans:                2,
                 maxBorrower:          _borrower2,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -713,8 +685,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        300.288456538461538600 * 1e18,
                 loans:                2,
                 maxBorrower:          _borrower2,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -757,8 +727,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        100.096153846153846200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -787,8 +755,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        100.096143846153846200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -843,8 +809,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        50.048076923076923100 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -894,8 +858,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        50.048076923076923100 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -930,8 +892,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -63,8 +63,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -96,8 +94,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        2_102.019230769230770200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -139,8 +135,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        2_104.900682313900291843 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.001370801704613834 * 1e18,
-                pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
                 interestRateUpdate:   _startTime + 10 days
             })
@@ -179,8 +173,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        2_104.900682313900291843 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.001370801704613834 * 1e18,
-                pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.055 * 1e18,
                 interestRateUpdate:   _startTime + 10 days
             })
@@ -566,8 +558,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -598,8 +588,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -57,8 +57,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -85,8 +83,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        4_604.423076923076925200 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.001507985182953253 * 1e18,
                 interestRate:         0.055 * 1e18,
                 interestRateUpdate:   _startTime + 10 days
             })
@@ -129,8 +125,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        500.480769230769231 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.000017123434275559 * 1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -204,8 +198,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        1_501.442307692307693000 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.000005707778846384 * 1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -227,8 +219,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        1_501.442307692307693000 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1.000011415590271509 * 1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -261,8 +251,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -295,8 +283,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        50.048076923076923100 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -328,8 +314,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        50.048076923076923100 * 1e18,
                 loans:                2,
                 maxBorrower:          address(_borrower),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -364,8 +348,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        50.617163681466490465 * 1e18,
                 loans:                2,
                 maxBorrower:          address(_borrower),
-                inflatorSnapshot:     1.001370801704613834 * 1e18,
-                pendingInflator:      1.001370801704613834 * 1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -151,8 +151,6 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 minDebtAmount:        500.523620446054562664 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                inflatorSnapshot:     1.000085620103548021 * 1e18,
-                pendingInflator:      1.000085620103548021 * 1e18,
                 interestRate:         0.045 * 1e18,
                 interestRateUpdate:   54000
             })

--- a/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -97,7 +97,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(lup, BucketMath.MAX_PRICE);
 
         (uint256 lpBalance, ) = _pool.lenders(2549, _lender);
-        (uint256 poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         ( , , , , , uint256 exchangeRate) = _poolUtils.bucketInfo(address(_pool), 2549);
         assertEq(poolSize,         150_000 * _quotePoolPrecision);
         assertEq(lpBalance,                50_000 * _lpPoolPrecision);
@@ -125,7 +125,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(lup, BucketMath.MAX_PRICE);
 
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        (poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         ( , , , , , exchangeRate) = _poolUtils.bucketInfo(address(_pool), 2549);
         assertEq(poolSize,     125_000 * _quotePoolPrecision);
         assertEq(lpBalance,    25_000 * _lpPoolPrecision);
@@ -167,7 +167,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // check pool state
         ( , , uint256 htp, , uint256 lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (uint256 poolSize, uint256 loansCount, address maxBorrower, ) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, uint256 loansCount, address maxBorrower, , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(htp, 0);
         assertEq(lup, BucketMath.MAX_PRICE);
         assertEq(maxBorrower, address(0));
@@ -196,7 +196,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         // check pool state
         (uint256 debt, , uint256 col, , ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         ( , , htp, , lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (poolSize, loansCount, maxBorrower, ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, loansCount, maxBorrower, , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(htp, Maths.wdiv(debt, col));
         assertEq(lup, price);
         assertEq(maxBorrower, _borrower);
@@ -227,7 +227,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         // check pool state
         (debt, , col, , ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         ( , , htp, , lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (poolSize, loansCount, maxBorrower, ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, loansCount, maxBorrower, , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(htp, Maths.wdiv(debt, col));
         assertEq(lup, price);
         assertEq(maxBorrower, _borrower);
@@ -260,7 +260,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         // check pool state
         (debt, , col, , ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         ( , , htp, , lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (poolSize, loansCount, maxBorrower, ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, loansCount, maxBorrower, , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(htp, Maths.wdiv(debt, col));
         assertEq(lup, price);
         assertEq(maxBorrower, _borrower);
@@ -319,7 +319,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(lup, BucketMath.MAX_PRICE);
 
         (lpBalance, ) = _pool.lenders(2549, _lender);
-        (uint256 poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 149_500 * _quotePoolPrecision);
         assertEq(lpBalance,        50_000 * _lpPoolPrecision);
 
@@ -348,7 +348,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // check pool state
         ( , , htp, , lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(htp,      0);
         assertEq(lup,      BucketMath.MAX_PRICE);
         assertEq(poolSize, 149_500 * _quotePoolPrecision);

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -63,8 +63,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -110,8 +108,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -154,8 +150,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -204,8 +198,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -252,8 +244,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })
@@ -300,8 +290,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                inflatorSnapshot:     1e18,
-                pendingInflator:      1e18,
                 interestRate:         0.05 * 1e18,
                 interestRateUpdate:   _startTime
             })

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -133,7 +133,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     
     function _assertPool(PoolState memory state_) internal {
         ( , , uint256 htp, , uint256 lup, ) = _poolUtils.poolPricesInfo(address(_pool));
-        (uint256 poolSize, uint256 loansCount, address maxBorrower, ) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, uint256 loansCount, address maxBorrower, , ) = _poolUtils.poolLoansInfo(address(_pool));
         (uint256 poolMinDebtAmount, , uint256 poolActualUtilization, uint256 poolTargetUtilization) = _poolUtils.poolUtilizationInfo(address(_pool));
         assertEq(htp, state_.htp);
         assertEq(lup, state_.lup);
@@ -180,7 +180,7 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _poolSize() internal view returns (uint256 poolSize_) {
-        (poolSize_, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize_, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
     }
 
     function _poolTargetUtilization() internal view returns (uint256 utilization_) {
@@ -196,10 +196,10 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
     }
 
     function _loansCount() internal view returns (uint256 loansCount_) {
-        ( , loansCount_, , ) = _poolUtils.poolLoansInfo(address(_pool));
+        ( , loansCount_, , , ) = _poolUtils.poolLoansInfo(address(_pool));
     }
 
     function _maxBorrower() internal view returns (address maxBorrower_) {
-        ( , , maxBorrower_, ) = _poolUtils.poolLoansInfo(address(_pool));
+        ( , , maxBorrower_, , ) = _poolUtils.poolLoansInfo(address(_pool));
     }
 }

--- a/src/_test/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolInterest.t.sol
@@ -191,13 +191,13 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         assertEq(_pool.borrowerDebt(), 13_263.563121817930264782 * 1e18);
         (uint256 debt, uint256 pendingDebt, , , ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         assertEq(debt,        8_007.692307692307696000 * 1e18);
-        assertEq(pendingDebt, 8_007.692307692307696000 * 1e18);
+        assertEq(pendingDebt, 8_008.332217347647994785 * 1e18);
         (debt, pendingDebt, , , ) = _poolUtils.borrowerInfo(address(_pool), _borrower2);
         assertEq(debt,        2_752.644230769230770500 * 1e18);
-        assertEq(pendingDebt, 2_752.644230769230770500 * 1e18);
+        assertEq(pendingDebt, 2_752.769925156330518889 * 1e18);
         (debt, pendingDebt, , , ) = _poolUtils.borrowerInfo(address(_pool), _borrower3);
         assertEq(debt,        2_502.403846153846155000 * 1e18);
-        assertEq(pendingDebt, 2_502.403846153846155000 * 1e18);
+        assertEq(pendingDebt, 2_502.460979313951752502 * 1e18);
     }
 }
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -379,7 +379,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(indexes[0], tokenId2), 0);
         assertEq(_positionManager.getLPTokens(indexes[3], tokenId2), 0);
 
-        (uint256 poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (uint256 poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
 
         // construct memorialize lender 1 params struct
@@ -429,7 +429,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[1]), 3_000 * 1e27);
         assertEq(_positionManager.getLPTokens(tokenId1, indexes[2]), 3_000 * 1e27);
 
-        (poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
 
         // allow position manager to take ownership of lender 2's position
@@ -476,7 +476,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
         assertEq(_positionManager.getLPTokens(tokenId2, indexes[0]), 3_000 * 1e27);
         assertEq(_positionManager.getLPTokens(tokenId2, indexes[3]), 3_000 * 1e27);
 
-        (poolSize, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -599,10 +599,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** Pool Helper Functions ***/
     /*****************************/
 
+    // TODO: This is not a view; it mutates state.  Recommend renaming back to _accruePoolInterest.
     function _getPoolState() internal returns (PoolState memory poolState_) {
-        poolState_.accruedDebt  = borrowerDebt;
-        poolState_.collateral   = pledgedCollateral;
-        poolState_.inflator = inflatorSnapshot;
+        poolState_.accruedDebt = borrowerDebt;
+        poolState_.collateral  = pledgedCollateral;
+        poolState_.inflator    = inflatorSnapshot;
 
         if (poolState_.accruedDebt != 0) {
             uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -79,7 +79,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
     ) external override returns (uint256 bucketLPs_) {
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         bucketLPs_ = buckets.quoteTokensToLPs(
             index_,
@@ -115,7 +115,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     ) external override returns (uint256 fromBucketLPs_, uint256 toBucketLPs_) {
         if (fromIndex_ == toIndex_) revert MoveQuoteToSamePrice();
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 lenderLpBalance, uint256 lenderLastDepositTime) = lenders.getLenderInfo(
             fromIndex_,
@@ -169,7 +169,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     function removeAllQuoteToken(
         uint256 index_
     ) external returns (uint256 quoteTokenAmountRemoved_, uint256 redeemedLenderLPs_) {
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 lenderLPsBalance, ) = lenders.getLenderInfo(
             index_,
@@ -198,7 +198,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 index_
     ) external override returns (uint256 bucketLPs_) {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         uint256 deposit = deposits.valueAt(index_);
         if (quoteTokenAmountToRemove_ > deposit) revert RemoveQuoteInsufficientQuoteAvailable();
@@ -270,7 +270,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 limitIndex_
     ) external override {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         uint256 lupId = _lupIndex(poolState.accruedDebt + amountToBorrow_);
         if (lupId > limitIndex_) revert BorrowLimitIndexReached();
@@ -388,7 +388,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateralAmountToPledge_
     ) internal {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         // borrower accounting
         (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
@@ -423,7 +423,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateralAmountToPull_
     ) internal {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         // borrower accounting
         (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
@@ -467,7 +467,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 maxQuoteTokenAmountToRepay_
     ) internal {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
             borrower_,
@@ -522,7 +522,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateralAmountToAdd_,
         uint256 index_
     ) internal returns (uint256 bucketLPs_) {
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (bucketLPs_, ) = buckets.collateralToLPs(
             index_,
@@ -541,7 +541,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 index_
     ) internal returns (uint256 bucketLPs_) {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         uint256 bucketCollateral;
         (bucketLPs_, bucketCollateral) = buckets.collateralToLPs(
@@ -599,8 +599,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** Pool Helper Functions ***/
     /*****************************/
 
-    // TODO: This is not a view; it mutates state.  Recommend renaming back to _accruePoolInterest.
-    function _getPoolState() internal returns (PoolState memory poolState_) {
+    function _accruePoolInterest() internal returns (PoolState memory poolState_) {
         poolState_.accruedDebt = borrowerDebt;
         poolState_.collateral  = pledgedCollateral;
         poolState_.inflator    = inflatorSnapshot;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -103,7 +103,7 @@ contract ERC20Pool is IERC20Pool, Pool {
     ) external override returns (uint256 fromBucketLPs_, uint256 toBucketLPs_) {
         if (fromIndex_ == toIndex_) revert MoveCollateralToSamePrice();
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         uint256 fromBucketCollateral;
         (fromBucketLPs_, fromBucketCollateral) = buckets.collateralToLPs(
@@ -141,7 +141,7 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 index_
     ) external override returns (uint256 collateralAmountRemoved_, uint256 redeemedLenderLPs_) {
 
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 lenderLPsBalance, ) = lenders.getLenderInfo(index_, msg.sender);
         (collateralAmountRemoved_, redeemedLenderLPs_) = buckets.lpsToCollateral(
@@ -195,7 +195,7 @@ contract ERC20Pool is IERC20Pool, Pool {
     }
 
     function kick(address borrower_) external override {
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
             borrower_,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -222,7 +222,7 @@ contract ERC721Pool is IERC721Pool, Pool {
     }
 
     function kick(address borrower_) external override {
-        PoolState memory poolState = _getPoolState();
+        PoolState memory poolState = _accruePoolInterest();
 
         (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
             borrower_,


### PR DESCRIPTION
**Changes**
- Fix bug Matt found in `PoolInfoUtils.borrowerInfo`; it was calculating pending borrower debt using the pool inflator snapshot rather than the borrower inflator snapshot.
- Expose `pendingInterestFactor` in `poolLoansInfo`, needed so real-world test can calculate pending pool debt.
- Rename `_getPoolState()` back to `_accruePoolInterest()` to better reflect purpose.
- Eliminate inflators from `PoolState` in `ERC20DSTestPlus`; these were not useful fields to validate.  ERC721 tests were not looking at them, so no change was needed there.

**TODO**
- Continue investigating the "pool has debt with no loans" problem, which could continue in a new branch.