### PR TITLE
Kick refactor

### DIFF
--- a/src/_test/AuctionsQueueTest.t.sol
+++ b/src/_test/AuctionsQueueTest.t.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import './utils/DSTestPlus.sol';
+
+import './utils/AuctionsQueueInstance.sol';
+
+contract AuctionsQueueTest is DSTestPlus {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _borrower3;
+    address internal _borrower4;
+    address internal _borrower5;
+    address internal _borrower6;
+    address internal _lender;
+
+    AuctionsQueueInstance private auctions;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _borrower3 = makeAddr("borrower3");
+
+        auctions = new AuctionsQueueInstance();
+    }
+    /**
+     *  @notice With 1 lender and 1 borrower test adding collateral and borrowing.
+     */
+    function testAuctionsQueueKick() public {
+        // Add _borrower
+        skip(100 seconds);
+        auctions.kick(_borrower);
+
+        // Check queue head was set correctly
+        assertEq(_borrower, auctions.getHead());
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            address prev,
+            address next
+        ) = auctions.get(auctions.getHead());
+        assertEq(next, address(0));
+        assertEq(prev, address(0));
+        assertEq(auctions.isActive(_borrower), true);
+
+        // Insert borrower2 -- _borrower -> _borrower2
+        // Check queue head remains, _borrower -> _borrower2
+        skip(100 seconds);
+        auctions.kick(_borrower2);
+        assertEq(auctions.getHead(), _borrower);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower);
+        assertEq(_borrower2, next);
+        assertEq(address(0), prev);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower2);
+        assertEq(address(0), next);
+        assertEq(_borrower, prev);
+
+        // _borrower -> _borrower2 -> _borrower3
+        // Don't adjust time, node should still be inserted at tail
+        auctions.kick(_borrower3);
+
+        assertEq(_borrower, auctions.getHead());
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(auctions.getHead());
+        assertEq(_borrower2, next);
+        assertEq(address(0), prev);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower2);
+        assertEq(_borrower3, next);
+        assertEq(_borrower, prev);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower3);
+        assertEq(address(0), next);
+        assertEq(_borrower2, prev);
+    }
+
+    function testAuctionsQueueRemove() public {
+        // Fill Queue
+        skip(12 seconds);
+        auctions.kick(_borrower);
+        skip(12 seconds);
+        auctions.kick(_borrower2);
+        skip(12 seconds);
+        auctions.kick(_borrower3);
+
+        // Remove _borrower from head
+        auctions.remove(_borrower);
+        assertEq(auctions.isActive(_borrower), false);
+
+        // assert new head
+        assertEq(auctions.getHead(), _borrower2);
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            address prev,
+            address next
+        ) = auctions.get(_borrower2);
+        assertEq(prev, address(0));
+        assertEq(next, _borrower3);
+        assertEq(auctions.isActive(_borrower2), true);
+
+        // Remove _borrower2
+        auctions.remove(_borrower2);
+        assertEq(auctions.isActive(_borrower2), false);
+
+        assertEq(auctions.isActive(_borrower3), true);
+        assertEq(auctions.getHead(), _borrower3);
+
+    }
+
+    function testAuctionsQueueKickRemoveAdd() public {
+        // Fill Queue
+        skip(12 seconds);
+        auctions.kick(_borrower);
+        skip(12 seconds);
+        auctions.kick(_borrower2);
+        skip(12 seconds);
+        auctions.kick(_borrower3);
+
+        // Remove _borrower2
+        auctions.remove(_borrower2);
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            address prev,
+            address next
+        ) = auctions.get(_borrower);
+        assertEq(prev, address(0));
+        assertEq(next, _borrower3);
+        assertEq(auctions.isActive(_borrower), true);
+        assertEq(auctions.getHead(), _borrower);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower3);
+        assertEq(next, address(0));
+        assertEq(prev, _borrower);
+        assertEq(auctions.isActive(_borrower3), true);
+        assertEq(auctions.getHead(), _borrower);
+
+        skip(1 hours);
+
+        // Re-add _borrower by overwriting auctions mapping
+        auctions.kick(_borrower2);
+
+        (
+            ,
+            ,
+            ,
+            ,
+            ,
+            prev,
+            next
+        ) = auctions.get(_borrower2);
+        assertEq(next, address(0));
+        assertEq(prev, _borrower3);
+        assertEq(auctions.isActive(_borrower), true);
+        assertEq(auctions.getHead(), _borrower);
+    }
+}

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -177,6 +177,29 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         }
     }
 
+    function testLoadERC20PoolGasKickAllLoansFromLowestTP() public {
+        address kicker = makeAddr("kicker");
+        _mintQuoteAndApproveTokens(kicker, type(uint256).max); // mint enough to cover bonds
+
+        vm.warp(8640000000);
+        vm.startPrank(kicker);
+        for (uint256 i; i < LOANS_COUNT; i ++) {
+            _pool.kick(_borrowers[i]);
+        }
+        vm.stopPrank();
+    }
+
+    function testLoadERC20PoolGasKickAllLoansFromHighestTP() public {
+        address kicker = makeAddr("kicker");
+        _mintQuoteAndApproveTokens(kicker, type(uint256).max); // mint enough to cover bonds
+
+        vm.warp(8640000000);
+        vm.startPrank(kicker);
+        for (uint256 i; i < LOANS_COUNT; i ++) {
+            _pool.kick(_borrowers[LOANS_COUNT - 1 - i]);
+        }
+        vm.stopPrank();
+    }
 
     /*************************/
     /*** Utility Functions ***/

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -159,13 +159,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         _assertAuction(
             {
-                borrower:   _borrower,
-                active:     false,
-                kicker:     address(0),
-                bondSize:   0,
-                bondFactor: 0,
-                kickTime:   0,
-                hpbIndex:   0
+                borrower:       _borrower,
+                active:         false,
+                kicker:         address(0),
+                bondSize:       0,
+                bondFactor:     0,
+                kickTime:       0,
+                kickPriceIndex: 0
             }
         );
 
@@ -228,13 +228,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
         _assertAuction(
             {
-                borrower:   _borrower,
-                active:     true,
-                kicker:     _lender,
-                bondSize:   0.195342779771472726 * 1e18,
-                bondFactor: 0.01 * 1e18,
-                kickTime:   uint128(block.timestamp),
-                hpbIndex:   3696
+                borrower:       _borrower,
+                active:         true,
+                kicker:         _lender,
+                bondSize:       0.195342779771472726 * 1e18,
+                bondFactor:     0.01 * 1e18,
+                kickTime:       uint128(block.timestamp),
+                kickPriceIndex: 3696
             }
         );
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -10,32 +10,42 @@ import '../../libraries/Actors.sol';
 import '../../libraries/Maths.sol';
 import '../../libraries/PoolUtils.sol';
 
-contract ERC20PoolKickSuccessTest is ERC20HelperContract {
+contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
 
-    uint256 HPB        = 1987;  // _p49910
-    uint256 LEND_PRICE = 2309;  // _p10016
-    uint256 START      = block.timestamp;
+    uint256 internal _i9_91 = 3696;
+    uint256 internal _i9_81 = 3698;
+    uint256 internal _i9_72 = 3700;
+    uint256 internal _i9_62 = 3702;
+    uint256 internal _i9_52 = 3704;
 
     function setUp() external {
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
 
-        _mintQuoteAndApproveTokens(_lender, 21_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender, 120_000 * 1e18);
 
-        _mintCollateralAndApproveTokens(_borrower,  1 * 1e18);
-        _mintCollateralAndApproveTokens(_borrower2, 1 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  2 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2, 1_000 * 1e18);
 
-        // Lender adds quote token in two price buckets
+        // Lender adds Quote token accross 5 prices
         _addLiquidity(
             {
                 from:   _lender,
-                amount: 10_000 * 1e18,
-                index:  HPB,
+                amount: 2_000 * 1e18,
+                index:  _i9_91,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 5_000 * 1e18,
+                index:  _i9_81,
                 newLup: BucketMath.MAX_PRICE
             }
         );
@@ -43,102 +53,206 @@ contract ERC20PoolKickSuccessTest is ERC20HelperContract {
             {
                 from:   _lender,
                 amount: 11_000 * 1e18,
-                index:  LEND_PRICE,
+                index:  _i9_72,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 25_000 * 1e18,
+                index:  _i9_62,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 30_000 * 1e18,
+                index:  _i9_52,
                 newLup: BucketMath.MAX_PRICE
             }
         );
 
-        // Borrower adds collateral token and borrows at HPB
+        // first borrower adds collateral token and borrows
         _pledgeCollateral(
             {
                 from:     _borrower,
                 borrower: _borrower,
-                amount:   1e18
+                amount:   2 * 1e18
             }
         );
         _borrow(
             {
                 from:       _borrower,
-                amount:     10_000 * 1e18,
-                indexLimit: HPB,
-                newLup:     49_910.043670274810022205 * 1e18
+                amount:     19.25 * 1e18,
+                indexLimit: _i9_91,
+                newLup:     9.917184843435912074 * 1e18
             }
         );
 
-        // Borrower adds collateral token and borrows at LEND_PRICE
+        // second borrower adds collateral token and borrows
         _pledgeCollateral(
             {
                 from:     _borrower2,
                 borrower: _borrower2,
-                amount:   1e18
+                amount:   1_000 * 1e18
             }
         );
         _borrow(
             {
                 from:       _borrower2,
-                amount:     10_000e18,
-                indexLimit: LEND_PRICE,
-                newLup:     10_016.501589292607751220 * 1e18
+                amount:     7_980 * 1e18,
+                indexLimit: _i9_72,
+                newLup:     9.721295865031779605 * 1e18
             }
         );
+
+        /*****************************/
+        /*** Assert pre-kick state ***/
+        /*****************************/
+
+        _assertPool(
+            PoolState({
+                htp:                  9.634254807692307697 * 1e18,
+                lup:                  9.721295865031779605 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    1_002 * 1e18,
+                encumberedCollateral: 823.649613971736296163 * 1e18,
+                borrowerDebt:         8_006.941586538461542154 * 1e18,
+                actualUtilization:    0.109684131322444679 * 1e18,
+                targetUtilization:    1e18,
+                minDebtAmount:        400.347079326923077108 * 1e18,
+                loans:                2,
+                maxBorrower:          address(_borrower),
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.268509615384615394 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1 * 1e18,
+                borrowerCollateralization: 1.009034539679184679 * 1e18,
+                borrowerPendingDebt:       19.268509615384615394 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              7_987.673076923076926760 * 1e18,
+                borrowerCollateral:        1_000 * 1e18,
+                borrowerMompFactor:        9.818751856078723036 * 1e18,
+                borrowerInflator:          1 * 1e18,
+                borrowerCollateralization: 1.217037273735858713 * 1e18,
+                borrowerPendingDebt:       7_987.673076923076926760 * 1e18
+            }
+        );
+        assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
 
     }
 
-    function test_liquidate() external {
+    function testKick() external {
 
-        // Warp to make borrower undercollateralized
-        vm.warp(START + 15 days);
-        /**********************/
-        /*** Pre-kick state ***/
-        /**********************/
+        _assertAuction(
+            {
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                hpbIndex:   0
+            }
+        );
 
+        // Skip to make borrower undercollateralized
+        skip(100 days);
+
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower,
+                debt:       19.534277977147272573 * 1e18,
+                collateral: 2 * 1e18,
+                bond:       0.195342779771472726 * 1e18
+            }
+        );
+
+        /******************************/
+        /*** Assert Post-kick state ***/
+        /******************************/
+
+        _assertPool(
+            PoolState({
+                htp:                  8.097846143253778448 * 1e18,
+                lup:                  9.721295865031779605 * 1e18,
+                poolSize:             73_094.502279691716022000 * 1e18,
+                pledgedCollateral:    1_002 * 1e18,
+                encumberedCollateral: 835.010119425512354679 * 1e18,
+                borrowerDebt:         8_117.380421230925720814 * 1e18,
+                actualUtilization:    0.111053227918158028 * 1e18,
+                targetUtilization:    0.833343432560391572 * 1e18,
+                minDebtAmount:        811.738042123092572081 * 1e18,
+                loans:                1,
+                maxBorrower:          address(_borrower2),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   block.timestamp
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.534277977147272573 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1.013792886272348689 * 1e18,
+                borrowerCollateralization: 0.995306391810796636 * 1e18,
+                borrowerPendingDebt:       19.534277977147272573 * 1e18
+            }
+        );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              10_009.615384615384620000 * 1e18,
-                borrowerCollateral:        1 * 1e18,
-                borrowerMompFactor:        10_016.501589292607751220 * 1e18,
+                borrowerDebt:              7_987.673076923076926760 * 1e18,
+                borrowerCollateral:        1_000 * 1e18,
+                borrowerMompFactor:        9.818751856078723036 * 1e18,
                 borrowerInflator:          1 * 1e18,
-                borrowerCollateralization: 1.000687958968713934 * 1e18,
-                borrowerPendingDebt:       10_030.204233142901661009 * 1e18
+                borrowerCollateralization: 1.217037273735858713 * 1e18,
+                borrowerPendingDebt:       8_097.846143253778448241 * 1e18
             }
         );
-        assertEq(PoolUtils.encumberance(10_030.204233142901661009 * 1e18, _lup()), 1.001368006956135433 * 1e18);
-
-        ( uint256 kickTime, uint256 referencePrice, uint256 remainingCollateral, uint256 remainingDebt ) = ERC20Pool(address(_pool)).liquidations(_borrower2);
-
-        assertEq(kickTime,            0);
-        assertEq(referencePrice,      0);
-        assertEq(remainingCollateral, 0);
-
-        /************/
-        /*** Kick ***/
-        /************/
-
-        _pool.kick(_borrower2);
-
-        /***********************/
-        /*** Post-kick state ***/
-        /***********************/
-
-        _assertBorrower(
+        assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
+        _assertAuction(
             {
-                borrower:                  _borrower2,
-                borrowerDebt:              10_030.204233142901661009 * 1e18, // Updated to reflect debt
-                borrowerCollateral:        1 * 1e18,                         // Unchanged
-                borrowerMompFactor:        10_016.501589292607751220 * 1e18,
-                borrowerInflator:          1.002056907057504104 * 1e18,      // Inflator is updated to reflect new deb
-                borrowerCollateralization: 0.998633861930247030 * 1e18,      // Unchanged because based off pending debt
-                borrowerPendingDebt:       10_030.204233142901661009 * 1e18  // Pending debt is unchanged
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   uint128(block.timestamp),
+                hpbIndex:   3696
             }
         );
-        assertEq(PoolUtils.encumberance(10_030.204233142901661009 * 1e18, _lup()), 1.001368006956135433 * 1e18);  // Unencumbered collateral is unchanged because based off pending debt
 
-        ( kickTime, referencePrice, remainingCollateral, remainingDebt ) = ERC20Pool(address(_pool)).liquidations(_borrower2);
+        // kick should fail if borrower in liquidation
+        _assertKickActiveAuctionRevert(
+            {
+                from:       _lender,
+                borrower:   _borrower
+            }
+        );
 
-        assertEq(kickTime,            block.timestamp);
-        assertEq(referencePrice,      HPB);
-        assertEq(remainingCollateral, 1e18);
+        // kick should fail if borrower properly collateralized
+        _assertKickCollateralizedBorrowerRevert(
+            {
+                from:       _lender,
+                borrower:   _borrower2
+            }
+        );
     }
 
     function testAuctionPrice() external {

--- a/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.14;
+
+import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
+
+import '../../erc721/ERC721Pool.sol';
+import '../../erc721/ERC721PoolFactory.sol';
+
+import '../../libraries/Actors.sol';
+import '../../libraries/Maths.sol';
+import '../../libraries/PoolUtils.sol';
+
+contract ERC721PoolLiquidationsTest is ERC721HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+
+    uint256 internal _i9_91 = 3696;
+    uint256 internal _i9_81 = 3698;
+    uint256 internal _i9_72 = 3700;
+    uint256 internal _i9_62 = 3702;
+    uint256 internal _i9_52 = 3704;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+
+        // deploy subset pool
+        uint256[] memory subsetTokenIds = new uint256[](6);
+        subsetTokenIds[0] = 1;
+        subsetTokenIds[1] = 3;
+        subsetTokenIds[2] = 5;
+        subsetTokenIds[3] = 51;
+        subsetTokenIds[4] = 53;
+        subsetTokenIds[5] = 73;
+        _pool = _deploySubsetPool(subsetTokenIds);
+
+       _mintAndApproveQuoteTokens(_lender,    120_000 * 1e18);
+       _mintAndApproveQuoteTokens(_borrower,  100 * 1e18);
+       _mintAndApproveQuoteTokens(_borrower2, 8_000 * 1e18);
+
+       _mintAndApproveCollateralTokens(_borrower,  6);
+       _mintAndApproveCollateralTokens(_borrower2, 74);
+
+        // Lender adds Quote token accross 5 prices
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 2_000 * 1e18,
+                index:  _i9_91,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 5_000 * 1e18,
+                index:  _i9_81,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 11_000 * 1e18,
+                index:  _i9_72,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 25_000 * 1e18,
+                index:  _i9_62,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 30_000 * 1e18,
+                index:  _i9_52,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+
+       // first borrower adds collateral token and borrows
+        uint256[] memory tokenIdsToAdd = new uint256[](2);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+
+        // borrower deposits two NFTs into the subset pool and borrows
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower,
+                amount:     19.8 * 1e18,
+                indexLimit: _i9_91,
+                newLup:     9.917184843435912074 * 1e18
+            }
+        );
+
+        // second borrower deposits three NFTs into the subset pool and borrows
+        tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 51;
+        tokenIdsToAdd[1] = 53;
+        tokenIdsToAdd[2] = 73;
+        _pledgeCollateral(
+            {
+                from:     _borrower2,
+                borrower: _borrower2,
+                tokenIds: tokenIdsToAdd
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower2,
+                amount:     15 * 1e18,
+                indexLimit: _i9_72,
+                newLup:     9.917184843435912074 * 1e18
+            }
+        );
+
+        /*****************************/
+        /*** Assert pre-kick state ***/
+        /*****************************/
+
+        _assertPool(
+            PoolState({
+                htp:                  9.909519230769230774 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 3.512434434608473285 * 1e18,
+                borrowerDebt:         34.833461538461538478 * 1e18,
+                actualUtilization:    0.000477170706006322 * 1e18,
+                targetUtilization:    1 * 1e18,
+                minDebtAmount:        1.741673076923076924 * 1e18,
+                loans:                2,
+                maxBorrower:          address(_borrower),
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.819038461538461548 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1 * 1e18,
+                borrowerCollateralization: 1.000773560501591181 * 1e18,
+                borrowerPendingDebt:       19.819038461538461548 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              15.014423076923076930 * 1e18,
+                borrowerCollateral:        3 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1 * 1e18,
+                borrowerCollateralization: 1.981531649793150539 * 1e18,
+                borrowerPendingDebt:       15.014423076923076930 * 1e18
+            }
+        );
+        assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
+    }
+
+    function testKickSubsetPool() external {
+        _assertAuction(
+            {
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                hpbIndex:   0
+            }
+        );
+
+        // Skip to make borrower undercollateralized
+        skip(100 days);
+
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower,
+                debt:       20.092400205065766075 * 1e18,
+                collateral: 2 * 1e18,
+                bond:       0.200924002050657661 * 1e18
+            }
+        );
+
+        /******************************/
+        /*** Assert Post-kick state ***/
+        /******************************/
+
+        _assertPool(
+            PoolState({
+                htp:                  5.073838435622668201 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 3.560881043304109325 * 1e18,
+                borrowerDebt:         35.313915511933770677 * 1e18,
+                actualUtilization:    0.000483752267286764 * 1e18,
+                targetUtilization:    0.712176208660821865 * 1e18,
+                minDebtAmount:        3.531391551193377068 * 1e18,
+                loans:                1,
+                maxBorrower:          address(_borrower2),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   block.timestamp
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              20.092400205065766075 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1.013792886272348689 * 1e18,
+                borrowerCollateralization: 0.987157805162128596 * 1e18,
+                borrowerPendingDebt:       20.092400205065766075 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              15.014423076923076930 * 1e18,
+                borrowerCollateral:        3 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerInflator:          1 * 1e18,
+                borrowerCollateralization: 1.981531649793150539 * 1e18,
+                borrowerPendingDebt:       15.221515306868004602 * 1e18
+            }
+        );
+        assertEq(_quote.balanceOf(_lender), 46_999.799075997949342339 * 1e18);
+        _assertAuction(
+            {
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.200924002050657661 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   uint128(block.timestamp),
+                hpbIndex:   3696
+            }
+        );
+
+        // kick should fail if borrower in liquidation
+        _assertKickActiveAuctionRevert(
+            {
+                from:       _lender,
+                borrower:   _borrower
+            }
+        );
+
+        // kick should fail if borrower properly collateralized
+        _assertKickCollateralizedBorrowerRevert(
+            {
+                from:       _lender,
+                borrower:   _borrower2
+            }
+        );
+    }
+}

--- a/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
@@ -179,13 +179,13 @@ contract ERC721PoolLiquidationsTest is ERC721HelperContract {
     function testKickSubsetPool() external {
         _assertAuction(
             {
-                borrower:   _borrower,
-                active:     false,
-                kicker:     address(0),
-                bondSize:   0,
-                bondFactor: 0,
-                kickTime:   0,
-                hpbIndex:   0
+                borrower:       _borrower,
+                active:         false,
+                kicker:         address(0),
+                bondSize:       0,
+                bondFactor:     0,
+                kickTime:       0,
+                kickPriceIndex: 0
             }
         );
 
@@ -248,13 +248,13 @@ contract ERC721PoolLiquidationsTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 46_999.799075997949342339 * 1e18);
         _assertAuction(
             {
-                borrower:   _borrower,
-                active:     true,
-                kicker:     _lender,
-                bondSize:   0.200924002050657661 * 1e18,
-                bondFactor: 0.01 * 1e18,
-                kickTime:   uint128(block.timestamp),
-                hpbIndex:   3696
+                borrower:       _borrower,
+                active:         true,
+                kicker:         _lender,
+                bondSize:       0.200924002050657661 * 1e18,
+                bondFactor:     0.01 * 1e18,
+                kickTime:       uint128(block.timestamp),
+                kickPriceIndex: 3696
             }
         );
 

--- a/src/_test/utils/AuctionsQueueInstance.sol
+++ b/src/_test/utils/AuctionsQueueInstance.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.14;
+
+import './DSTestPlus.sol';
+
+import '../../libraries/Auctions.sol';
+
+contract AuctionsQueueInstance is DSTestPlus {
+    using AuctionsQueue for AuctionsQueue.Data;
+
+    AuctionsQueue.Data private auctions;
+
+    function kick(address borrower_) external returns (uint256) {
+        return auctions.kick(
+            borrower_,
+            1,
+            1,
+            1,
+            1
+        );
+    }
+
+    function remove(address borrower_) external {
+        auctions.remove(borrower_);
+    }
+
+    function getHead() external view returns (address) {
+        return auctions.getHead();
+    }
+
+    function isActive(address borrower_) external view returns (bool) {
+        return auctions.isActive(borrower_);
+    }
+
+    function get(
+        address borrower_
+    )
+        external
+        view
+        returns (
+            address,
+            uint256,
+            uint256,
+            uint128,
+            uint128,
+            address,
+            address
+        )
+    {
+        return auctions.get(borrower_);
+    }
+}
+

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -12,8 +12,6 @@ import '../../base/interfaces/IPoolFactory.sol';
 import '../../base/PoolInfoUtils.sol';
 
 import '../../libraries/Maths.sol';
-import '../../libraries/Heap.sol';
-import '../../libraries/Book.sol';
 
 abstract contract DSTestPlus is Test {
 
@@ -27,7 +25,7 @@ abstract contract DSTestPlus is Test {
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-    event Liquidate(address indexed borrower_, uint256 debt_, uint256 collateral_);
+    event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
     event RemoveQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
@@ -84,6 +82,20 @@ abstract contract DSTestPlus is Test {
         emit Borrow(from, newLup, amount);
         _assertTokenTransferEvent(address(_pool), from, amount);
         _pool.borrow(amount, indexLimit);
+    }
+
+    function _kick(
+        address from,
+        address borrower,
+        uint256 debt,
+        uint256 collateral,
+        uint256 bond
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit Kick(borrower, debt, collateral);
+        _assertTokenTransferEvent(from, address(_pool), bond);
+        _pool.kick(borrower);
     }
 
     function _moveLiquidity(
@@ -187,6 +199,32 @@ abstract contract DSTestPlus is Test {
     /*********************/
     /*** State asserts ***/
     /*********************/
+
+    function _assertAuction(
+        address borrower,
+        bool    active,
+        address kicker,
+        uint256 bondSize,
+        uint256 bondFactor,
+        uint128 kickTime,
+        uint128 hpbIndex
+    ) internal {
+        (
+            address auctionKicker,
+            uint256 auctionBondSize,
+            uint256 auctionBondFactor,
+            uint128 auctionKickTime,
+            uint128 auctionHpbIndex,
+            ,
+        ) = _pool.auctionInfo(borrower);
+
+        assertEq(auctionKicker != address(0), active);
+        assertEq(auctionKicker,     kicker);
+        assertEq(auctionBondSize,   bondSize);
+        assertEq(auctionBondFactor, bondFactor);
+        assertEq(auctionKickTime,   kickTime);
+        assertEq(auctionHpbIndex,   hpbIndex);
+    }
 
     function _assertPool(PoolState memory state_) internal {
         ( 
@@ -396,6 +434,24 @@ abstract contract DSTestPlus is Test {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
         _pool.borrow(amount, indexLimit);
+    }
+
+    function _assertKickActiveAuctionRevert(
+        address from,
+        address borrower
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionActive.selector);
+        _pool.kick(borrower);
+    }
+
+    function _assertKickCollateralizedBorrowerRevert(
+        address from,
+        address borrower
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.BorrowerOk.selector);
+        _pool.kick(borrower);
     }
 
     function _assertRepayNoDebtRevert(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -207,23 +207,23 @@ abstract contract DSTestPlus is Test {
         uint256 bondSize,
         uint256 bondFactor,
         uint128 kickTime,
-        uint128 hpbIndex
+        uint128 kickPriceIndex
     ) internal {
         (
             address auctionKicker,
             uint256 auctionBondSize,
             uint256 auctionBondFactor,
             uint128 auctionKickTime,
-            uint128 auctionHpbIndex,
+            uint128 auctionKickPriceIndex,
             ,
         ) = _pool.auctionInfo(borrower);
 
         assertEq(auctionKicker != address(0), active);
-        assertEq(auctionKicker,     kicker);
-        assertEq(auctionBondSize,   bondSize);
-        assertEq(auctionBondFactor, bondFactor);
-        assertEq(auctionKickTime,   kickTime);
-        assertEq(auctionHpbIndex,   hpbIndex);
+        assertEq(auctionKicker,         kicker);
+        assertEq(auctionBondSize,       bondSize);
+        assertEq(auctionBondFactor,     bondFactor);
+        assertEq(auctionKickTime,       kickTime);
+        assertEq(auctionKickPriceIndex, kickPriceIndex);
     }
 
     function _assertPool(PoolState memory state_) internal {

--- a/src/_test/utils/FenwickTreeInstance.sol
+++ b/src/_test/utils/FenwickTreeInstance.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 
 import './DSTestPlus.sol';
 
+import '../../libraries/Book.sol';
+
 contract FenwickTreeInstance is DSTestPlus {
     using Book for Book.Deposits;
 

--- a/src/_test/utils/HeapInstance.sol
+++ b/src/_test/utils/HeapInstance.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.14;
 
 import './DSTestPlus.sol';
 
+import '../../libraries/Heap.sol';
+
 contract HeapInstance is DSTestPlus {
     using Heap for Heap.Data;
 

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -21,6 +21,16 @@ interface IPoolErrors {
     error AmountLTMinDebt();
 
     /**
+     *  @notice Kicker is attempting to kick or clear an active auction.
+     */
+    error AuctionActive();
+
+    /**
+     *  @notice Borrower has a healthy over-collateralized position.
+     */
+    error BorrowerOk();
+
+    /**
      *  @notice Borrower is attempting to borrow more quote token than they have collateral for.
      */
     error BorrowerUnderCollateralized();

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -9,21 +9,21 @@ interface IPoolState {
 
     /**
      *  @notice Returns details of an auction for a given borrower address.
-     *  @param  borrower   Address of the borrower that is liquidated.
-     *  @return kicker     Address that initiated the auction (kicker).
-     *  @return bondSize   The bond size posted by kicker to initiate the auction.
-     *  @return bondFactor The factor used for calculating bond size.
-     *  @return kickTime   Time the liquidation was initiated.
-     *  @return hpbIndex   Highest Price Bucket index at time of liquidation.
-     *  @return prev       The address of previous borrower in auctions queue.
-     *  @return next       The address of next borrower in auctions queue.
+     *  @param  borrower       Address of the borrower that is liquidated.
+     *  @return kicker         Address that initiated the auction (kicker).
+     *  @return bondSize       The bond size posted by kicker to initiate the auction.
+     *  @return bondFactor     The factor used for calculating bond size.
+     *  @return kickTime       Time the liquidation was initiated.
+     *  @return kickPriceIndex Highest Price Bucket index at time of liquidation.
+     *  @return prev           The address of previous borrower in auctions queue.
+     *  @return next           The address of next borrower in auctions queue.
      */
     function auctionInfo(address borrower) external view returns (
         address kicker,
         uint256 bondSize,
         uint256 bondFactor,
         uint128 kickTime,
-        uint128 hpbIndex,
+        uint128 kickPriceIndex,
         address prev,
         address next
     );

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -8,6 +8,27 @@ pragma solidity 0.8.14;
 interface IPoolState {
 
     /**
+     *  @notice Returns details of an auction for a given borrower address.
+     *  @param  borrower   Address of the borrower that is liquidated.
+     *  @return kicker     Address that initiated the auction (kicker).
+     *  @return bondSize   The bond size posted by kicker to initiate the auction.
+     *  @return bondFactor The factor used for calculating bond size.
+     *  @return kickTime   Time the liquidation was initiated.
+     *  @return hpbIndex   Highest Price Bucket index at time of liquidation.
+     *  @return prev       The address of previous borrower in auctions queue.
+     *  @return next       The address of next borrower in auctions queue.
+     */
+    function auctionInfo(address borrower) external view returns (
+        address kicker,
+        uint256 bondSize,
+        uint256 bondFactor,
+        uint128 kickTime,
+        uint128 hpbIndex,
+        address prev,
+        address next
+    );
+
+    /**
      *  @notice Returns the `borrowerDebt` state variable.
      *  @return borrowerDebt_ Total amount of borrower debt in pool.
      */

--- a/src/erc20/interfaces/pool/IERC20PoolLiquidationActions.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolLiquidationActions.sol
@@ -7,20 +7,6 @@ pragma solidity 0.8.14;
 interface IERC20PoolLiquidationActions {
 
     /**
-     *  @notice Maintains the state of a liquidation.
-     *  @param  kickTime            Time the liquidation was initiated.
-     *  @param  referencePrice      Highest Price Bucket at time of liquidation.
-     *  @param  remainingCollateral Amount of collateral which has not yet been taken.
-     *  @param  remainingDebt       Amount of debt which has not been covered by the liquidation.
-     */
-    struct LiquidationInfo {
-        uint128 kickTime;
-        uint128 referencePrice;
-        uint256 remainingCollateral;
-        uint256 remainingDebt;
-    }
-
-    /**
      *  @notice Called by actors to purchase collateral using quote token they provide themselves.
      *  @param  borrower     Identifies the loan under liquidation.
      *  @param  amount       Amount of quote token which will be used to purchase collateral at the auction price.

--- a/src/erc20/interfaces/pool/IERC20PoolState.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolState.sol
@@ -12,21 +12,4 @@ interface IERC20PoolState {
      */
     function collateralScale() external view returns (uint256);
 
-    /**
-     *  @notice Mapping of borrower under liquidation to {LiquidationInfo} structs.
-     *  @param  borrower            Address of the borrower.
-     *  @return kickTime            Time the liquidation was initiated.
-     *  @return referencePrice      Highest Price Bucket at time of liquidation.
-     *  @return remainingCollateral Amount of collateral which has not yet been taken.
-     *  @return remainingDebt       Amount of debt which has not been covered by the liquidation.
-     */
-    // TODO: Instead of just returning the struct, should also calculate and include auction price.
-    // TODO: Need to implement this for NFT pool.
-    function liquidations(address borrower) external view returns (
-        uint128 kickTime,
-        uint128 referencePrice,
-        uint256 remainingCollateral,
-        uint256 remainingDebt
-    );
-
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -19,10 +19,10 @@ import '../libraries/Actors.sol';
 
 contract ERC721Pool is IERC721Pool, Pool {
     using SafeERC20 for ERC20;
-    using BitMaps   for BitMaps.BitMap;
-    using Book      for mapping(uint256 => Book.Bucket);
     using Actors    for mapping(uint256 => mapping(address => Actors.Lender));
     using Actors    for mapping(address => Actors.Borrower);
+    using BitMaps   for BitMaps.BitMap;
+    using Book      for mapping(uint256 => Book.Bucket);
     using Heap      for Heap.Data;
 
     /***********************/
@@ -41,8 +41,6 @@ contract ERC721Pool is IERC721Pool, Pool {
 
     /// @dev pledged collateral: borrower address -> Set of NFT Token Ids pledged by the borrower
     mapping(address => BitMaps.BitMap) private lockedNFTs;
-
-    mapping(address => NFTLiquidationInfo) private liquidations;
 
     bool public isSubset;
 
@@ -219,30 +217,6 @@ contract ERC721Pool is IERC721Pool, Pool {
     function depositTake(address borrower_, uint256 amount_, uint256 index_) external override {
         // TODO: implement
         emit DepositTake(borrower_, index_, amount_, 0, 0);
-    }
-
-    function kick(address borrower_) external override {
-        PoolState memory poolState = _accruePoolInterest();
-
-        (uint256 borrowerAccruedDebt, uint256 borrowerPledgedCollateral) = borrowers.getBorrowerInfo(
-            borrower_,
-            poolState.inflator
-        );
-        if (borrowerAccruedDebt == 0) revert NoDebt();
-
-        uint256 lup = _lup(poolState.accruedDebt);
-        if (
-            PoolUtils.collateralization(
-                borrowerAccruedDebt,
-                borrowerPledgedCollateral,
-                lup
-            ) >= Maths.WAD
-        ) revert LiquidateBorrowerOk();
-
-        _updatePool(poolState, lup);
-
-        // TODO: Implement similar to ERC20Pool, but this will have a different LiquidationInfo struct
-        //  which includes an array of the borrower's tokenIds being auctioned off.
     }
 
     function take(address borrower_, uint256[] calldata tokenIds_, bytes memory swapCalldata_) external override {

--- a/src/erc721/interfaces/pool/IERC721PoolLiquidationActions.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolLiquidationActions.sol
@@ -9,20 +9,6 @@ import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableS
 interface IERC721PoolLiquidationActions {
 
     /**
-     *  @notice Maintains the state of a liquidation.
-     *  @param  kickTime            Time the liquidation was initiated.
-     *  @param  referencePrice      Highest Price Bucket at time of liquidation.
-     *  @param  remainingTokenIds   Liquidated NFTs which not yet been taken.
-     *  @param  remainingDebt       Amount of debt which has not been covered by the liquidation.
-     */
-    struct NFTLiquidationInfo {
-        uint128               kickTime;
-        uint128               referencePrice;
-        EnumerableSet.UintSet remainingTokenIds;
-        uint256               remainingDebt;
-    }
-
-    /**
      *  @notice Called by actors to purchase collateral using quote token they provide themselves.
      *  @param  borrower     Identifies the loan being liquidated.
      *  @param  tokenIds     NFT token ids caller wishes to purchase from the liquidation.

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.14;
+
+import './Maths.sol';
+
+library AuctionsQueue {
+
+    struct Data {
+        address head;
+        address tail;
+        mapping(address => Liquidation) liquidations;
+    }
+
+    struct Liquidation {
+        address kicker;     // address that initiated liquidation
+        uint256 bondSize;   // bond size posted by kicker to start liquidation
+        uint256 bondFactor; // bond factor used to start liquidation
+        uint128 time;       // timestamp when liquidation was started
+        uint128 hpbIndex;   // HPB index at liquidation start
+        address prev;       // previous liquidated borrower in auctions queue
+        address next;       // next liquidated borrower in auctions queue
+    }
+
+
+    /*********************************/
+    /***  Auctions Queue functions ***/
+    /*********************************/
+
+    /**
+     *  @notice Called to start borrower liquidation and to update the auctions queue
+     *  @param  borrower_       Borrower address to liquidate
+     *  @param  borrowerDebt_   Borrower debt to be recovered
+     *  @param  thresholdPrice_ Current threshold price (used to calculate bond factor)
+     *  @param  momp_           Current MOMP (used to calculate bond factor)
+     *  @param  hpbIndex_       Current HPB index
+     *  @return bondSize_       The bond size posted to liquidate position
+     */
+    function kick(
+        Data storage self_,
+        address borrower_,
+        uint256 borrowerDebt_,
+        uint256 thresholdPrice_,
+        uint256 momp_,
+        uint256 hpbIndex_
+    ) internal returns (uint256 bondSize_) {
+
+        Liquidation storage liquidation = self_.liquidations[borrower_];
+        liquidation.kicker   = msg.sender;
+        liquidation.time     = uint128(block.timestamp);
+        liquidation.hpbIndex = uint128(hpbIndex_);
+
+        uint256 bondFactor;
+        // bondFactor = min(30%, max(1%, (neutralPrice - thresholdPrice) / neutralPrice))
+        if (thresholdPrice_ >= momp_) {
+            bondFactor = 0.01 * 1e18;
+        } else {
+            bondFactor = Maths.min(
+                0.3 * 1e18,
+                Maths.max(
+                    0.01 * 1e18,
+                    1e18 - Maths.wdiv(thresholdPrice_, momp_)
+                )
+            );
+        }
+        bondSize_ = Maths.wmul(bondFactor, borrowerDebt_);
+
+        liquidation.bondSize   = bondSize_;
+        liquidation.bondFactor = bondFactor;
+
+        liquidation.next = address(0);
+        if (self_.head != address(0)) {
+            // other auctions in queue, liquidation doesn't exist or overwriting.
+            self_.liquidations[self_.tail].next = borrower_;
+            liquidation.prev = self_.tail;
+        } else {
+            // first auction in queue
+            self_.head = borrower_;
+            liquidation.prev  = address(0);
+        }
+
+        // update liquidation with the new ordering
+        self_.tail = borrower_;
+    }
+
+    /**
+     *  @notice Removes a borrower from the auctions queue and repairs the queue order.
+     *  @dev    Called by _updateLoanQueue if borrower.debt == 0.
+     *  @param  borrower_ Borrower whose loan is being placed in queue.
+     */
+    function remove(Data storage self_, address borrower_) internal {
+        address next = self_.liquidations[borrower_].next;
+        address prev = self_.liquidations[borrower_].prev;
+
+        if (self_.head == borrower_ && self_.tail == borrower_) {
+            // liquidation is the head and tail
+            self_.head = address(0);
+            self_.tail = address(0);
+
+        } else if(self_.head == borrower_) {
+            // liquidation is the head
+            self_.liquidations[next].prev = address(0);
+            self_.head = next;
+
+        } else if(self_.tail == borrower_) {
+            // liquidation is the tail
+            self_.liquidations[prev].next = address(0);
+            self_.tail = prev;
+
+        } else {
+            // liquidation is in the middle
+            self_.liquidations[prev].next = next;
+            self_.liquidations[next].prev = prev;
+        }
+
+        delete self_.liquidations[borrower_];
+    }
+
+
+    /**************************/
+    /*** View Functions ***/
+    /**************************/
+
+    function getHead(Data storage self_) internal view returns (address) {
+        return self_.head;
+    }
+
+    function isActive(Data storage self_, address borrower_) internal view returns (bool) {
+        return self_.liquidations[borrower_].kicker != address(0);
+    }
+
+    function get(
+        Data storage self_,
+        address borrower_
+    )
+        internal
+        view
+        returns (
+            address,
+            uint256,
+            uint256,
+            uint128,
+            uint128,
+            address,
+            address
+        )
+    {
+        AuctionsQueue.Liquidation memory liquidation = self_.liquidations[borrower_];
+        return (
+            liquidation.kicker,
+            liquidation.bondSize,
+            liquidation.bondFactor,
+            liquidation.time,
+            liquidation.hpbIndex,
+            liquidation.prev,
+            liquidation.next
+        );
+    }
+
+}

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -13,13 +13,13 @@ library AuctionsQueue {
     }
 
     struct Liquidation {
-        address kicker;     // address that initiated liquidation
-        uint256 bondSize;   // bond size posted by kicker to start liquidation
-        uint256 bondFactor; // bond factor used to start liquidation
-        uint128 time;       // timestamp when liquidation was started
-        uint128 hpbIndex;   // HPB index at liquidation start
-        address prev;       // previous liquidated borrower in auctions queue
-        address next;       // next liquidated borrower in auctions queue
+        address kicker;         // address that initiated liquidation
+        uint256 bondSize;       // bond size posted by kicker to start liquidation
+        uint256 bondFactor;     // bond factor used to start liquidation
+        uint128 kickTime;       // timestamp when liquidation was started
+        uint128 kickPriceIndex; // HPB index at liquidation start
+        address prev;           // previous liquidated borrower in auctions queue
+        address next;           // next liquidated borrower in auctions queue
     }
 
 
@@ -46,9 +46,9 @@ library AuctionsQueue {
     ) internal returns (uint256 bondSize_) {
 
         Liquidation storage liquidation = self_.liquidations[borrower_];
-        liquidation.kicker   = msg.sender;
-        liquidation.time     = uint128(block.timestamp);
-        liquidation.hpbIndex = uint128(hpbIndex_);
+        liquidation.kicker         = msg.sender;
+        liquidation.kickTime       = uint128(block.timestamp);
+        liquidation.kickPriceIndex = uint128(hpbIndex_);
 
         uint256 bondFactor;
         // bondFactor = min(30%, max(1%, (neutralPrice - thresholdPrice) / neutralPrice))
@@ -150,8 +150,8 @@ library AuctionsQueue {
             liquidation.kicker,
             liquidation.bondSize,
             liquidation.bondFactor,
-            liquidation.time,
-            liquidation.hpbIndex,
+            liquidation.kickTime,
+            liquidation.kickPriceIndex,
             liquidation.prev,
             liquidation.next
         );

--- a/src/libraries/Book.sol
+++ b/src/libraries/Book.sol
@@ -181,16 +181,22 @@ library Book {
         }
     }
 
+    function momp(
+        Deposits storage self,
+        uint256 curDebt_,
+        uint256 numLoans_
+    ) internal view returns (uint256 momp_) {
+        if (numLoans_ != 0) momp_ = PoolUtils.indexToPrice(findIndexOfSum(self, Maths.wdiv(curDebt_, numLoans_ * 1e18)));
+    }
+
     function mompFactor(
         Deposits storage self,
         uint256 inflator_,
         uint256 curDebt_,
         uint256 numLoans_
     ) internal view returns (uint256 factor_) {
-        if (numLoans_ != 0) factor_ = Maths.wdiv(
-            PoolUtils.indexToPrice(findIndexOfSum(self, Maths.wdiv(curDebt_, numLoans_ * 1e18))),
-            inflator_
-        ); 
+        uint256 curMomp = momp(self, curDebt_, numLoans_);
+        if (curMomp != 0) factor_ = Maths.wdiv(curMomp, inflator_);
     }
 
     /**


### PR DESCRIPTION
based on Ian's https://github.com/ajna-finance/contracts/pull/258 PR

- added Auctions / AuctionsQueue library: kick starts a liquidation (Liquidation struct), remove delete the liquidation from queue
- gas load tests
- updated kick tests

gas costs for kicks
```
│ Function Name     ┆ min         ┆ avg        ┆ median ┆ max        ┆ # calls   │
│ kick                       ┆ 211117   ┆ 242795 ┆ 238420 ┆ 1060341 ┆ 16000   │
```

PR contains a (temporary) workaround for contract deployment size - move all PRB related function in external lib (approach adds about 1200 more gas due to delegate call )
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,233B  (90.46%)
  ERC20Pool                -  20,396B  (82.99%)
```