### PR TITLE
Apply minimum debt check only if loan count is sufficient

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -114,7 +114,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 amount:   100 * 1e18
             }
         );
-        changePrank(borrower);
         _pool.borrow(loanAmount, 7_777);
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -18,7 +18,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
-    uint _anonBorrowerCount = 0;
+    uint internal _anonBorrowerCount = 0;
 
     uint256 highest = 2550;
     uint256 high    = 2551;

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -202,11 +202,6 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
         return ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
     }
 
-    // TODO: finish implementing
-    function _approveQuoteMultipleUserMultiplePool() internal {
-
-    }
-
     function _mintAndApproveQuoteTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
         vm.prank(operator_);

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -13,13 +13,15 @@ import '../../erc721/ERC721PoolFactory.sol';
 import '../../libraries/BucketMath.sol';
 import '../../libraries/Maths.sol';
 
-contract ERC721PoolBorrowTest is ERC721HelperContract {
-
+abstract contract ERC721PoolBorrowTest is ERC721HelperContract {
     address internal _borrower;
     address internal _borrower2;
     address internal _borrower3;
     address internal _lender;
     address internal _lender2;
+
+    // Called by setUp method to set the _pool which tests will use
+    function createPool() external virtual returns (ERC721Pool);
 
     function setUp() external {
         _borrower  = makeAddr("borrower");
@@ -29,8 +31,20 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
         _lender2   = makeAddr("lender2");
 
         // deploy collection pool
-        ERC721Pool collectionPool = _deployCollectionPool();
+        _pool = this.createPool();
 
+        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
+        _mintAndApproveCollateralTokens(_borrower, 52);
+        _mintAndApproveCollateralTokens(_borrower2, 10);
+        _mintAndApproveCollateralTokens(_borrower3, 13);
+
+        vm.prank(_borrower);
+        _quote.approve(address(_pool), 200_000 * 1e18);
+    }
+}
+
+contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
+    function createPool() external override returns (ERC721Pool) {
         // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](6);
         subsetTokenIds[0] = 1;
@@ -39,20 +53,7 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
         subsetTokenIds[5] = 73;
-        _pool = _deploySubsetPool(subsetTokenIds);
-
-        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
-
-        _mintAndApproveCollateralTokens(_borrower, 52);
-        _mintAndApproveCollateralTokens(_borrower2, 10);
-        _mintAndApproveCollateralTokens(_borrower3, 13);
-
-        // TODO: figure out how to generally approve quote tokens for the borrowers to handle repays
-        // TODO: potentially use _approveQuoteMultipleUserMultiplePool()
-        vm.prank(_borrower);
-        _quote.approve(address(collectionPool), 200_000 * 1e18);
-        vm.prank(_borrower);
-        _quote.approve(address(_pool), 200_000 * 1e18);
+        return _deploySubsetPool(subsetTokenIds);
     }
 
     /***************************/
@@ -548,15 +549,6 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
             }
         );
 
-        // should revert if amount left after repay is less than the average debt
-        _assertRepayMinDebtRevert(
-            {
-                from:     _borrower,
-                borrower: _borrower,
-                amount:   900 * 1e18
-            }
-        );
-
         // should be able to repay loan if properly specified
         _repay(
             {
@@ -568,6 +560,7 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
             }
         );
     }
+
 
     function testRepayLoanFromDifferentActor() external {
         _addLiquidity(
@@ -650,5 +643,59 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(address(_pool)), 28_500 * 1e18);
         assertEq(_quote.balanceOf(_lender),        168_500 * 1e18);
         assertEq(_quote.balanceOf(_borrower),      3_000 * 1e18);
+    }
+}
+
+contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
+    uint internal _anonBorrowerCount = 0;
+
+    function createPool() external override returns (ERC721Pool) {
+        return _deployCollectionPool();
+    }
+
+    /**
+     *  @dev Creates debt for an anonymous non-player borrower not otherwise involved in the test.
+     **/
+    function _anonBorrowerDrawsDebt(uint256 loanAmount) internal {
+        _anonBorrowerCount += 1;
+        address borrower = makeAddr(string(abi.encodePacked("anonBorrower", _anonBorrowerCount)));
+        vm.stopPrank();
+        _mintAndApproveCollateralTokens(borrower, 1);
+        changePrank(borrower);
+        uint256[] memory tokenIdsToAdd = new uint256[](1);
+        tokenIdsToAdd[0] = _collateral.totalSupply();
+        _pool.pledgeCollateral(borrower, tokenIdsToAdd);
+        _pool.borrow(loanAmount, 7_777);
+    }
+
+    function testMinRepayAmountCheck() external {
+        // add initial quote to the pool
+        changePrank(_lender);
+        assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
+        _pool.addQuoteToken(20_000 * 1e18, 2550);
+
+        // 9 other borrowers draw debt
+        for (uint i=0; i<9; ++i) {
+            _anonBorrowerDrawsDebt(1_200 * 1e18);
+        }
+
+        // borrower 1 borrows 1000 quote from the pool
+        changePrank(_borrower);
+        uint256[] memory tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+        tokenIdsToAdd[2] = 5;
+        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pool.borrow(1_000 * 1e18, 3000);
+        assertEq(_loansCount(), 10);
+
+        // should revert if amount left after repay is less than the average debt
+        _assertRepayMinDebtRevert(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                amount:   900 * 1e18
+            }
+        );
     }
 }

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -664,14 +664,19 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         changePrank(borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = _collateral.totalSupply();
-        _pool.pledgeCollateral(borrower, tokenIdsToAdd);
+        _pledgeCollateral(
+            {
+                from:     borrower,
+                borrower: borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
         _pool.borrow(loanAmount, 7_777);
     }
 
     function testMinRepayAmountCheck() external {
         // add initial quote to the pool
         changePrank(_lender);
-        assertEq(_indexToPrice(2550), 3_010.892022197881557845 * 1e18);
         _pool.addQuoteToken(20_000 * 1e18, 2550);
 
         // 9 other borrowers draw debt
@@ -685,9 +690,16 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
-        _pool.pledgeCollateral(_borrower, tokenIdsToAdd);
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
         _pool.borrow(1_000 * 1e18, 3000);
-        assertEq(_loansCount(), 10);
+        (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
+        assertEq(loansCount, 10);
 
         // should revert if amount left after repay is less than the average debt
         _assertRepayMinDebtRevert(

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -661,7 +661,6 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         address borrower = makeAddr(string(abi.encodePacked("anonBorrower", _anonBorrowerCount)));
         vm.stopPrank();
         _mintAndApproveCollateralTokens(borrower, 1);
-        changePrank(borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = _collateral.totalSupply();
         _pledgeCollateral(
@@ -686,7 +685,6 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(loansCount, 10);
 
-        changePrank(_borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 5;
         _pledgeCollateral(
@@ -718,7 +716,6 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         }
 
         // borrower 1 borrows 1000 quote from the pool
-        changePrank(_borrower);
         uint256[] memory tokenIdsToAdd = new uint256[](3);
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;

--- a/src/_test/utils/Tokens.sol
+++ b/src/_test/utils/Tokens.sol
@@ -26,6 +26,10 @@ contract NFTCollateralToken is ERC721 {
             _safeMint(to_, _nextId++);
         }
     }
+
+    function totalSupply() public view returns (uint256) {
+        return _nextId - 1;
+    }
 }
 
 contract TokenWithNDecimals is ERC20 {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -281,7 +281,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         );
         uint256 loansCount = loans.nodes.length - 1;
         if (
-            loansCount != 0
+            loansCount >= 10
             &&
             (borrowerAccruedDebt + amountToBorrow_ < PoolUtils.minDebtAmount(poolState.accruedDebt, loansCount))
         )  revert AmountLTMinDebt();
@@ -484,7 +484,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             loans.remove(borrower_);
         } else {
             uint256 loansCount = loans.nodes.length - 1;
-            if (loansCount != 0
+            if (loansCount >= 10
                 &&
                 (borrowerAccruedDebt < PoolUtils.minDebtAmount(poolState.accruedDebt, loansCount))
             ) revert AmountLTMinDebt();


### PR DESCRIPTION
This requirement was in place in v8, removed from v10, and then added back to v10.  To conserve borrower gas, I've left the `borrow` check before the heap is updated, and solicited a requirements change to make it only apply to existing loans, not new debt.

In the NFT tests, I moved testing of this feature to a collection pool, such that we can have 10 anonymous borrowers draw debt.
