### PR TITLE
Add `heal` function

### DIFF
--- a/sdk/ajna_protocol.py
+++ b/sdk/ajna_protocol.py
@@ -6,10 +6,10 @@ from brownie import (
     ERC20PoolFactory,
     ERC20Pool,
     BucketMath,
+    Deposits,
     Maths,
-    Book,
-    Actors,
-    Heap,
+    Loans,
+    PoolInfoUtils,
     PoolUtils,
 )
 from brownie.network.account import Accounts, LocalAccount
@@ -30,10 +30,10 @@ class AjnaProtocol:
         self.deployer = self._accounts[0]
 
         self.bucket_math = BucketMath.deploy({"from": self.deployer})
+        self.deposits = Deposits.deploy({"from": self.deployer})
         self.maths = Maths.deploy({"from": self.deployer})
-        self.book = Book.deploy({"from": self.deployer})
-        self.actors = Actors.deploy({"from": self.deployer})
-        self.heap = Heap.deploy({"from": self.deployer})
+        self.loans = Loans.deploy({"from": self.deployer})
+        self.pool_info_utils = PoolInfoUtils.deploy({"from": self.deployer})
         self.pool_utils = PoolUtils.deploy({"from": self.deployer})
 
         self.ajna_factory = ERC20PoolFactory.deploy({"from": self.deployer})

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -158,6 +158,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
     /*** Revert asserts ***/
     /**********************/
 
+    function _assertAddCollateralBankruptcyBlockRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('BucketBankruptcyBlock()'));
+        ERC20Pool(address(_pool)).addCollateral(amount, index);
+    }
+
     function _assertMoveCollateralInsufficientLPsRevert(
         address from,
         uint256 amount,
@@ -216,6 +226,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         changePrank(from);
         vm.expectRevert(IPoolErrors.NoClaim.selector);
         ERC20Pool(address(_pool)).removeAllQuoteToken(index);
+    }
+
+    function _assertRemoveCollateralAuctionNotClearedRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        ERC20Pool(address(_pool)).removeCollateral(amount, index);
     }
 
     function _assertRemoveCollateralInsufficientLPsRevert(

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -310,6 +310,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     Token internal _quote;
 
     constructor() {
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"));
         _collateral = new Token("Collateral", "C");
         _quote      = new Token("Quote", "Q");
         _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -265,7 +265,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
         ERC20Pool(address(_pool)).removeCollateral(amount, index);
     }
 

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -234,7 +234,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
         ERC20Pool(address(_pool)).removeCollateral(amount, index);
     }
 

--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -10,6 +10,7 @@ import { ERC20Pool }        from '../../erc20/ERC20Pool.sol';
 import { ERC20PoolFactory } from '../../erc20/ERC20PoolFactory.sol';
 
 import '../../base/interfaces/IPool.sol';
+import '../../base/interfaces/IPoolFactory.sol';
 import '../../base/PoolInfoUtils.sol';
 
 import '../../libraries/Maths.sol';
@@ -166,6 +167,36 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('BucketBankruptcyBlock()'));
         ERC20Pool(address(_pool)).addCollateral(amount, index);
+    }
+
+    function _assertDeployWith0xAddressRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        vm.expectRevert(IPoolFactory.DeployWithZeroAddress.selector);
+        ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
+    }
+
+    function _assertDeployWithInvalidRateRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        vm.expectRevert(IPoolFactory.PoolInterestRateInvalid.selector);
+        ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
+    }
+
+    function _assertDeployMultipleTimesRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        vm.expectRevert(IPoolFactory.PoolAlreadyExists.selector);
+        ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
     }
 
     function _assertMoveCollateralInsufficientLPsRevert(

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -947,7 +947,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 amount:   50 * 1e18
             }
         );
-        vm.expectRevert("H:I:VAL_EQ_0");
+        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
         _pool.borrow(0.00000000000000001 * 1e18, 3000);
 
         // borrower 1 borrows 500 quote from the pool after using a non 0 TP
@@ -1041,7 +1041,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         );
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
-        vm.expectRevert("H:I:VAL_EQ_0");
+        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
         _pool.repay(_borrower, 500.480769230769231000 * 1e18 - 1);
 
         // should be able to pay back all pendingDebt

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -165,7 +165,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       highest,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -173,7 +173,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       high,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -181,7 +181,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       med,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -189,7 +189,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       low,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -197,7 +197,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       lowest,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -563,7 +563,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       3333,
                 lpBalance:   1_212.5476695591403933 * 1e27,
-                depositTime: 0
+                depositTime: 2 hours
             }
         );
         _assertBucket(
@@ -682,7 +682,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       toBucket,
                 lpBalance:   1_970_734.1978643312064901215 * 1e27,
-                depositTime: 0
+                depositTime: 2 hours
             }
         );
 
@@ -730,7 +730,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       toBucket,
                 lpBalance:   3_941_468.395728662412980243 * 1e27,
-                depositTime: 0
+                depositTime: 2 hours
             }
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -272,7 +272,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       2550,
                 lpBalance:   12_043.56808879152623138 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -304,7 +304,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       2550,
                 lpBalance:   7_436.90329482876744787715 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -336,7 +336,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       2550,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -381,7 +381,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       1530,
                 lpBalance:   243_808.1263305875209909205 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -413,7 +413,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       1530,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -563,7 +563,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       3333,
                 lpBalance:   1_212.5476695591403933 * 1e27,
-                depositTime: 2 hours
+                depositTime: _startTime + 2 hours
             }
         );
         _assertBucket(
@@ -580,7 +580,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       3334,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
     }
@@ -616,7 +616,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       fromBucket,
                 lpBalance:   1_088_464.114498091939987319 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -664,7 +664,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       fromBucket,
                 lpBalance:   544_232.0572490459699936595 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -682,7 +682,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       toBucket,
                 lpBalance:   1_970_734.1978643312064901215 * 1e27,
-                depositTime: 2 hours
+                depositTime: _startTime + 2 hours
             }
         );
 
@@ -713,7 +713,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       fromBucket,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -730,7 +730,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       toBucket,
                 lpBalance:   3_941_468.395728662412980243 * 1e27,
-                depositTime: 2 hours
+                depositTime: _startTime + 2 hours
             }
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -86,9 +86,9 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(address(_collateral), address(_quote), 0.0543 * 10**18));
 
         assertEq(address(pool),                     poolAddress);
-        assertEq(address(pool.collateral()),        address(_collateral));
+        assertEq(pool.collateralAddress(),          address(_collateral));
         assertEq(pool.collateralScale(),            1);
-        assertEq(address(pool.quoteToken()),        address(_quote));
+        assertEq(pool.quoteTokenAddress(),          address(_quote));
         assertEq(pool.quoteTokenScale(),            1);
         assertEq(pool.inflatorSnapshot(),           10**18);
         assertEq(pool.lastInflatorSnapshotUpdate(), _startTime + 333);

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -80,7 +80,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
     function testDeployERC20Pool() external {
         skip(333);
 
-        address poolAddress = 0x8b233290C5458EdF1a03e2303Abc8aDCB52d5286;
+        address poolAddress = 0x88c0A0F7B9f2D204C16409CF01d85D8BF1231f18;
         vm.expectEmit(true, true, false, true);
         emit PoolCreated(poolAddress);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(address(_collateral), address(_quote), 0.0543 * 10**18));

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -92,7 +92,6 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(pool.quoteTokenScale(),    1);
         assertEq(pool.interestRate(),       0.0543 * 10**18);
         assertEq(pool.interestRateUpdate(), _startTime + 333);
-        assertEq(pool.minFee(),             0.0005 * 10**18);
 
         (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
         assertEq(poolInflatorSnapshot, 10**18);

--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -85,16 +85,18 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         emit PoolCreated(poolAddress);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(address(_collateral), address(_quote), 0.0543 * 10**18));
 
-        assertEq(address(pool),                     poolAddress);
-        assertEq(pool.collateralAddress(),          address(_collateral));
-        assertEq(pool.collateralScale(),            1);
-        assertEq(pool.quoteTokenAddress(),          address(_quote));
-        assertEq(pool.quoteTokenScale(),            1);
-        assertEq(pool.inflatorSnapshot(),           10**18);
-        assertEq(pool.lastInflatorSnapshotUpdate(), _startTime + 333);
-        assertEq(pool.interestRate(),               0.0543 * 10**18);
-        assertEq(pool.interestRateUpdate(),         _startTime + 333);
-        assertEq(pool.minFee(),                     0.0005 * 10**18);
+        assertEq(address(pool),             poolAddress);
+        assertEq(pool.collateralAddress(),  address(_collateral));
+        assertEq(pool.collateralScale(),    1);
+        assertEq(pool.quoteTokenAddress(),  address(_quote));
+        assertEq(pool.quoteTokenScale(),    1);
+        assertEq(pool.interestRate(),       0.0543 * 10**18);
+        assertEq(pool.interestRateUpdate(), _startTime + 333);
+        assertEq(pool.minFee(),             0.0005 * 10**18);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime + 333);
     }
 
 }

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -22,7 +22,7 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
     }
 
     function testLoadERC20PoolFuzzyPartialRepay(uint256 borrowerId_) public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         address borrower = _borrowers[borrowerId_];
@@ -30,11 +30,11 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.repay(borrower, 100 * 1e18);
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasFuzzyFullRepay(uint256 borrowerId_) public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         skip(15 hours);
@@ -43,11 +43,11 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.repay(borrower, pendingDebt);
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT - 1);
+        assertEq(_noOfLoans(), LOANS_COUNT - 1);
     }
 
     function testLoadERC20PoolGasFuzzyBorrowExisting(uint256 borrowerId_) public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         vm.assume(borrowerId_ <= LOANS_COUNT);
         skip(15 hours);
@@ -55,13 +55,13 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         vm.prank(borrower);
         _pool.borrow(1_000 * 1e18, 5_000);
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasBorrowNew() public {
         uint256 snapshot = vm.snapshot();
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         address newBorrower = makeAddr("newBorrower");
 
@@ -75,68 +75,68 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
         _pool.borrow(1_000 * 1e18, 5_000);
         vm.stopPrank();
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT + 1);
+        assertEq(_noOfLoans(), LOANS_COUNT + 1);
 
         vm.revertTo(snapshot);
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExercisePartialRepayForAllBorrowers() public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.noOfLoans(), LOANS_COUNT);
+            assertEq(_noOfLoans(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             vm.prank(borrower);
             _pool.repay(borrower, 100 * 1e18);
 
-            assertEq(_pool.noOfLoans(), LOANS_COUNT);
+            assertEq(_noOfLoans(), LOANS_COUNT);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExerciseRepayAllForAllBorrowers() public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.noOfLoans(), LOANS_COUNT);
+            assertEq(_noOfLoans(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             (, uint256 pendingDebt, , , ) = _poolUtils.borrowerInfo(address(_pool), borrower);
             vm.prank(borrower);
             _pool.repay(borrower, pendingDebt);
 
-            assertEq(_pool.noOfLoans(), LOANS_COUNT - 1);
+            assertEq(_noOfLoans(), LOANS_COUNT - 1);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasExerciseBorrowMoreForAllBorrowers() public {
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
 
         for (uint256 i; i < LOANS_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
             skip(15 hours);
-            assertEq(_pool.noOfLoans(), LOANS_COUNT);
+            assertEq(_noOfLoans(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
             vm.prank(borrower);
             _pool.borrow(1_000 * 1e18, 5_000);
 
-            assertEq(_pool.noOfLoans(), LOANS_COUNT);
+            assertEq(_noOfLoans(), LOANS_COUNT);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_pool.noOfLoans(), LOANS_COUNT);
+        assertEq(_noOfLoans(), LOANS_COUNT);
     }
 
     function testLoadERC20PoolGasFuzzyAddRemoveQuoteToken(uint256 index_) public {
@@ -242,5 +242,9 @@ contract ERC20PoolGasLoadTest is ERC20HelperContract {
 
             _borrowers.push(borrower);
         }
+    }
+
+    function _noOfLoans() internal returns (uint256 loans_) {
+        (, , loans_) = _pool.loansInfo();
     }
 }

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -342,8 +342,12 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 interestRateUpdate:   _startTime
             })
         );
-        assertEq(_pool.debtEma(),   0);
-        assertEq(_pool.lupColEma(), 0);
+        _assertEMAs(
+            {
+                debtEma:   0,
+                lupColEma: 0
+            }
+        );
 
         // borrower 1 borrows 500 quote from the pool
         _pledgeCollateral(
@@ -379,8 +383,12 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 interestRateUpdate:   _startTime
             })
         );
-        assertEq(_pool.debtEma(),   0);
-        assertEq(_pool.lupColEma(), 0);
+        _assertEMAs(
+            {
+                debtEma:   0,
+                lupColEma: 0
+            }
+        );
 
         _pledgeCollateral(
             {
@@ -415,8 +423,12 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 interestRateUpdate:   _startTime
             })
         );
-        assertEq(_pool.debtEma(),   0);
-        assertEq(_pool.lupColEma(), 0);
+        _assertEMAs(
+            {
+                debtEma:   0,
+                lupColEma: 0
+            }
+        );
 
         skip(10 days);
 
@@ -447,8 +459,12 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 interestRateUpdate:   _startTime
             })
         );
-        assertEq(_pool.debtEma(),   95.440014344854493304 * 1e18);
-        assertEq(_pool.lupColEma(), 3_084.610933645840358918 * 1e18);
+        _assertEMAs(
+            {
+                debtEma:   95.440014344854493304 * 1e18,
+                lupColEma: 3_084.610933645840358918 * 1e18
+            }
+        );
     }
 
 }

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -214,7 +214,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 loans:                1,
                 maxBorrower:          _borrower,
                 interestRate:         0.045 * 1e18,
-                interestRateUpdate:   54000
+                interestRateUpdate:   _startTime + 15 hours
             })
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -709,12 +709,12 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 exchangeRate: 1.059436922086476311196000000 * 1e27
             }
         );
-        _clear(
+        _heal(
             {
-                from:                _lender,
-                borrower:            _borrower2,
-                maxDepth:            10,
-                clearedDebt:         3_840.616744192316029288 * 1e18
+                from:       _lender,
+                borrower:   _borrower2,
+                maxDepth:   10,
+                healedDebt: 3_840.616744192316029288 * 1e18
             }
         );
         _assertAuction(
@@ -800,12 +800,12 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         vm.revertTo(snapshot);
 
         // partial clears / debt heal - max buckets to use is 1
-        _clear(
+        _heal(
             {
-                from:                _lender,
-                borrower:            _borrower2,
-                maxDepth:            1,
-                clearedDebt:         86.879330108643410602 * 1e18
+                from:       _lender,
+                borrower:   _borrower2,
+                maxDepth:   1,
+                healedDebt: 86.879330108643410602 * 1e18
             }
         );
         _assertAuction(
@@ -838,12 +838,12 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             }
         );
         // clear remaining debt
-        _clear(
+        _heal(
             {
-                from:                _lender,
-                borrower:            _borrower2,
-                maxDepth:            2,
-                clearedDebt:         3_753.737414083672618686 * 1e18
+                from:       _lender,
+                borrower:   _borrower2,
+                maxDepth:   2,
+                healedDebt: 3_753.737414083672618686 * 1e18
             }
         );
         _assertAuction(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -166,13 +166,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
     function testKick() external {
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -235,13 +235,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.195342779771472726 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -274,13 +274,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -298,13 +298,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.195342779771472726 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -326,13 +326,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
         _assertKicker(
@@ -348,13 +348,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -372,13 +372,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.195342779771472726 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -398,13 +398,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
         _assertKicker(
@@ -420,13 +420,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -444,13 +444,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.195342779771472726 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
 
@@ -488,13 +488,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.195342779771472726 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.195342779771472726 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -520,13 +520,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -587,13 +587,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower2,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    98.533942419792216457 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower2,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   98.533942419792216457 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -632,13 +632,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower2,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    98.655458618105113705 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp - 10 hours,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower2,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   98.655458618105113705 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp - 10 hours,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -674,13 +674,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
         _assertAuction(
             {
-                borrower:    _borrower2,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    104.609752335437078857 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    8640000,
-                kickMomp:    9.721295865031779605 * 1e18
+                borrower:   _borrower2,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   104.609752335437078857 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   8640000,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
@@ -718,8 +718,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        3696,
                 lpBalance:    2_000 * 1e27,
                 collateral:   0,
-                deposit:      2_118.873844172952622392 * 1e18,
-                exchangeRate: 1.059436922086476311196000000 * 1e27
+                deposit:      2_118.911507166546111004 * 1e18,
+                exchangeRate: 1.059455753583273055502000000 * 1e27
             }
         );
         _heal(
@@ -727,24 +727,24 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   10,
-                healedDebt: 3_840.616744192316029288 * 1e18
+                healedDebt: 9_375.568996125070613905 * 1e18
             }
         );
         _assertAuction(
             {
-                borrower:       _borrower2,
-                active:         false,
-                kicker:         address(0),
-                bondSize:       0,
-                bondFactor:     0,
-                kickTime:       0,
-                kickPriceIndex: 0
+                borrower:   _borrower2,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 160.516347691266666957 * 1e18,
+                claimable: 104.609752335437078857 * 1e18,
                 locked:    0
             }
         );
@@ -753,17 +753,16 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              0,
                 borrowerCollateral:        0,
-                borrowerMompFactor:        9.684861431554868575 * 1e18,
-                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerMompFactor:        9.588542815647469183 * 1e18,
+                borrowerInflator:          1.013844966011693846 * 1e18,
                 borrowerCollateralization: 1 * 1e18,
                 borrowerPendingDebt:       0
             }
         );
-        // bucket is bankrupt
         _assertBucket(
             {
-                index:        3696,
-                lpBalance:    0,
+                index:        _i9_91,
+                lpBalance:    0, // bucket is bankrupt
                 collateral:   0,
                 deposit:      0,
                 exchangeRate: 1 * 1e27
@@ -773,17 +772,34 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 lender:      _lender,
                 index:       _i9_91,
-                lpBalance:   0,
+                lpBalance:   0, // bucket is bankrupt
                 depositTime: 0
             }
         );
-        // TODO: shouldn't part of forgive amt be accounted from bucket _i9_81 too?
+        _assertBucket(
+            {
+                index:        _i9_81,
+                lpBalance:    0, // bucket is bankrupt
+                collateral:   0,
+                deposit:      0,
+                exchangeRate: 1 * 1e27
+            }
+        );
         _assertLenderLpBalance(
             {
                 lender:      _lender,
                 index:       _i9_81,
-                lpBalance:   5_000 * 1e27,
+                lpBalance:   0, // bucket is bankrupt
                 depositTime: 0
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i9_72,
+                lpBalance:    11_000 * 1e27,
+                collateral:   0,
+                deposit:      8_897.866273040591852453 * 1e18,
+                exchangeRate: 0.808896933912781077495727272 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -794,12 +810,30 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 depositTime: 0
             }
         );
+        _assertBucket(
+            {
+                index:        _i9_62,
+                lpBalance:    25_000 * 1e27,
+                collateral:   0,
+                deposit:      25_000 * 1e18,
+                exchangeRate: 1 * 1e27
+            }
+        );
         _assertLenderLpBalance(
             {
                 lender:      _lender,
                 index:       _i9_62,
                 lpBalance:   25_000 * 1e27,
                 depositTime: 0
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i9_52,
+                lpBalance:    30_000 * 1e27,
+                collateral:   0,
+                deposit:      30_000 * 1e18,
+                exchangeRate: 1 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -818,36 +852,36 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   1,
-                healedDebt: 86.879330108643410602 * 1e18
+                healedDebt: 154.217189467890354358 * 1e18
             }
         );
         _assertAuction(
             {
-                borrower:       _borrower2,
-                active:         true,
-                kicker:         _lender,
-                bondSize:       160.516347691266666957 * 1e18,
-                bondFactor:     0.01 * 1e18,
-                kickTime:       block.timestamp - 5 hours,
-                kickPriceIndex: 3696
+                borrower:   _borrower2,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   104.609752335437078857 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   100 days,
+                kickMomp:   9.721295865031779605 * 1e18
             }
         );
         _assertKicker(
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    160.516347691266666957 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    104.609752335437078857 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              3_753.737414083672618686 * 1e18,
+                borrowerDebt:              9_221.351806657180259547 * 1e18,
                 borrowerCollateral:        0,
-                borrowerMompFactor:        9.684861431554868575 * 1e18,
-                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerMompFactor:        9.588542815647469183 * 1e18,
+                borrowerInflator:          1.013844966011693846 * 1e18,
                 borrowerCollateralization: 0,
-                borrowerPendingDebt:       3_753.737414083672618686 * 1e18
+                borrowerPendingDebt:       9_221.351806657180259547 * 1e18
             }
         );
         // clear remaining debt
@@ -855,25 +889,25 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 from:       _lender,
                 borrower:   _borrower2,
-                maxDepth:   2,
-                healedDebt: 3_753.737414083672618686 * 1e18
+                maxDepth:   5,
+                healedDebt: 9_221.351806657180259547 * 1e18
             }
         );
         _assertAuction(
             {
-                borrower:       _borrower2,
-                active:         false,
-                kicker:         address(0),
-                bondSize:       0,
-                bondFactor:     0,
-                kickTime:       0,
-                kickPriceIndex: 0
+                borrower:   _borrower2,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 160.516347691266666957 * 1e18,
+                claimable: 104.609752335437078857 * 1e18,
                 locked:    0
             }
         );
@@ -882,8 +916,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              0,
                 borrowerCollateral:        0,
-                borrowerMompFactor:        9.684861431554868575 * 1e18,
-                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerMompFactor:        9.588542815647469183 * 1e18,
+                borrowerInflator:          1.013844966011693846 * 1e18,
                 borrowerCollateralization: 1 * 1e18,
                 borrowerPendingDebt:       0
             }

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -714,10 +714,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:                _lender,
                 borrower:            _borrower2,
                 maxDepth:            10,
-                hpbIndex:            3698,
-                clearedDebt:         3_840.616744192316029288 * 1e18,
-                remainingCollateral: 0,
-                remainingDebt:       0
+                clearedDebt:         3_840.616744192316029288 * 1e18
             }
         );
         _assertAuction(
@@ -808,10 +805,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:                _lender,
                 borrower:            _borrower2,
                 maxDepth:            1,
-                hpbIndex:            3696,
-                clearedDebt:         2_118.873844172952622392 * 1e18,
-                remainingCollateral: 0,
-                remainingDebt:       1_721.742900019363406896 * 1e18
+                clearedDebt:         86.879330108643410602 * 1e18
             }
         );
         _assertAuction(
@@ -835,12 +829,12 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              1_721.742900019363406896 * 1e18,
+                borrowerDebt:              3_753.737414083672618686 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.684861431554868575 * 1e18,
                 borrowerInflator:          1.013824712461823922 * 1e18,
                 borrowerCollateralization: 0,
-                borrowerPendingDebt:       1_721.742900019363406896 * 1e18
+                borrowerPendingDebt:       3_753.737414083672618686 * 1e18
             }
         );
         // clear remaining debt
@@ -848,11 +842,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 from:                _lender,
                 borrower:            _borrower2,
-                maxDepth:            1,
-                hpbIndex:            3698,
-                clearedDebt:         1_721.742900019363406896 * 1e18,
-                remainingCollateral: 0,
-                remainingDebt:       0
+                maxDepth:            2,
+                clearedDebt:         3_753.737414083672618686 * 1e18
             }
         );
         _assertAuction(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -125,7 +125,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 loans:                2,
                 maxBorrower:          address(_borrower),
                 interestRate:         0.05 * 1e18,
-                interestRateUpdate:   0
+                interestRateUpdate:   _startTime
             })
         );
         _assertBorrower(
@@ -156,7 +156,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 claimableReserves :         0,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
-                timeRemaining:              3 days
+                timeRemaining:              0
             }
         );
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
@@ -679,7 +679,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 kicker:     _lender,
                 bondSize:   104.609752335437078857 * 1e18,
                 bondFactor: 0.01 * 1e18,
-                kickTime:   8640000,
+                kickTime:   _startTime + 100 days,
                 kickMomp:   9.721295865031779605 * 1e18
             }
         );
@@ -773,7 +773,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       _i9_91,
                 lpBalance:   0, // bucket is bankrupt
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -790,7 +790,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       _i9_81,
                 lpBalance:   0, // bucket is bankrupt
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -807,7 +807,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       _i9_72,
                 lpBalance:   11_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -824,7 +824,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       _i9_62,
                 lpBalance:   25_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -841,7 +841,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       _i9_52,
                 lpBalance:   30_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         vm.revertTo(snapshot);
@@ -862,7 +862,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 kicker:     _lender,
                 bondSize:   104.609752335437078857 * 1e18,
                 bondFactor: 0.01 * 1e18,
-                kickTime:   100 days,
+                kickTime:   _startTime + 100 days,
                 kickMomp:   9.721295865031779605 * 1e18
             }
         );
@@ -922,7 +922,6 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrowerPendingDebt:       0
             }
         );
-        
     }
 
     function testTakeReverts() external {

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -697,6 +697,193 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 maxCollateral: 10 * 1e18
             }
         );
+
+        // full clear / debt heal
+        uint256 snapshot = vm.snapshot();
+        _assertBucket(
+            {
+                index:        3696,
+                lpBalance:    2_000 * 1e27,
+                collateral:   0,
+                deposit:      2_118.873844172952622392 * 1e18,
+                exchangeRate: 1.059436922086476311196000000 * 1e27
+            }
+        );
+        _clear(
+            {
+                from:                _lender,
+                borrower:            _borrower2,
+                maxDepth:            10,
+                hpbIndex:            3698,
+                clearedDebt:         3_840.616744192316029288 * 1e18,
+                remainingCollateral: 0,
+                remainingDebt:       0
+            }
+        );
+        _assertAuction(
+            {
+                borrower:       _borrower2,
+                active:         false,
+                kicker:         address(0),
+                bondSize:       0,
+                bondFactor:     0,
+                kickTime:       0,
+                kickPriceIndex: 0
+            }
+        );
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 160.516347691266666957 * 1e18,
+                locked:    0
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              0,
+                borrowerCollateral:        0,
+                borrowerMompFactor:        9.684861431554868575 * 1e18,
+                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerCollateralization: 1 * 1e18,
+                borrowerPendingDebt:       0
+            }
+        );
+        // bucket is bankrupt
+        _assertBucket(
+            {
+                index:        3696,
+                lpBalance:    0,
+                collateral:   0,
+                deposit:      0,
+                exchangeRate: 1 * 1e27
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_91,
+                lpBalance:   0,
+                depositTime: 0
+            }
+        );
+        // TODO: shouldn't part of forgive amt be accounted from bucket _i9_81 too?
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_81,
+                lpBalance:   5_000 * 1e27,
+                depositTime: 0
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_72,
+                lpBalance:   11_000 * 1e27,
+                depositTime: 0
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_62,
+                lpBalance:   25_000 * 1e27,
+                depositTime: 0
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_52,
+                lpBalance:   30_000 * 1e27,
+                depositTime: 0
+            }
+        );
+        vm.revertTo(snapshot);
+
+        // partial clears / debt heal - max buckets to use is 1
+        _clear(
+            {
+                from:                _lender,
+                borrower:            _borrower2,
+                maxDepth:            1,
+                hpbIndex:            3696,
+                clearedDebt:         2_118.873844172952622392 * 1e18,
+                remainingCollateral: 0,
+                remainingDebt:       1_721.742900019363406896 * 1e18
+            }
+        );
+        _assertAuction(
+            {
+                borrower:       _borrower2,
+                active:         true,
+                kicker:         _lender,
+                bondSize:       160.516347691266666957 * 1e18,
+                bondFactor:     0.01 * 1e18,
+                kickTime:       block.timestamp - 5 hours,
+                kickPriceIndex: 3696
+            }
+        );
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 0,
+                locked:    160.516347691266666957 * 1e18 // locked bond + reward, auction is not yet finalized
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              1_721.742900019363406896 * 1e18,
+                borrowerCollateral:        0,
+                borrowerMompFactor:        9.684861431554868575 * 1e18,
+                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerCollateralization: 0,
+                borrowerPendingDebt:       1_721.742900019363406896 * 1e18
+            }
+        );
+        // clear remaining debt
+        _clear(
+            {
+                from:                _lender,
+                borrower:            _borrower2,
+                maxDepth:            1,
+                hpbIndex:            3698,
+                clearedDebt:         1_721.742900019363406896 * 1e18,
+                remainingCollateral: 0,
+                remainingDebt:       0
+            }
+        );
+        _assertAuction(
+            {
+                borrower:       _borrower2,
+                active:         false,
+                kicker:         address(0),
+                bondSize:       0,
+                bondFactor:     0,
+                kickTime:       0,
+                kickPriceIndex: 0
+            }
+        );
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 160.516347691266666957 * 1e18,
+                locked:    0
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              0,
+                borrowerCollateral:        0,
+                borrowerMompFactor:        9.684861431554868575 * 1e18,
+                borrowerInflator:          1.013824712461823922 * 1e18,
+                borrowerCollateralization: 1 * 1e18,
+                borrowerPendingDebt:       0
+            }
+        );
         
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1526,6 +1526,36 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 exchangeRate: 0.999999999999999999484545454 * 1e27
             }
         );
+
+        // when moving to a bucket that was marked insolvent, the deposit time should be the greater between from bucket deposit time and insolvency time + 1
+        changePrank(_lender);
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_91,
+                lpBalance:   0,
+                depositTime: _startTime
+            }
+        );
+        _pool.moveQuoteToken(1_000 * 1e18, _i9_52, _i9_91);
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_91,
+                lpBalance:   1_000.000000000000000515454546000 * 1e27,
+                depositTime: _startTime + 100 days + 10 hours + 1 // _i9_91 bucket insolvency time + 1 (since deposit in _i9_52 from bucket was done before _i9_91 target bucket become insolvent)
+            }
+        );
+        _pool.addQuoteToken(1_000 * 1e18, _i9_52);
+        _pool.moveQuoteToken(1_000 * 1e18, _i9_52, _i9_91);
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i9_91,
+                lpBalance:   2_000.000000000000001438852689000 * 1e27,
+                depositTime: _startTime + 100 days + 10 hours + 1 hours // time of deposit in _i9_52 from bucket (since deposit in _i9_52 from bucket was done after _i9_91 target bucket become insolvent)
+            }
+        );
     }
 
     function testAuctionPrice() external {

--- a/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -93,7 +93,7 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -111,7 +111,7 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -129,7 +129,7 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2552,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -77,6 +77,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         init(boundColPrecision, boundQuotePrecision);
 
         // deposit 50_000 quote tokens into each of 3 buckets
+        skip(1 days); // to avoid deposit time 0 equals bucket bankruptcy time
         _addLiquidity(
             {
                 from:   _lender,
@@ -141,7 +142,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   50_000 * 1e27,
-                depositTime: 0
+                depositTime: 1 days
             }
         );
 
@@ -196,7 +197,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   25_000 * _lpPoolPrecision,
-                depositTime: 0
+                depositTime: 1 days
             }
         );
     }
@@ -210,6 +211,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         init(boundColPrecision, boundQuotePrecision);
 
+        skip(1 days); // to avoid deposit time 0 equals bucket bankruptcy time
         _addLiquidity(
             {
                 from:   _lender,
@@ -285,7 +287,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   50_000 * _lpPoolPrecision,
-                depositTime: 0
+                depositTime: 1 days
             }
         );
 
@@ -318,7 +320,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 borrowerMompFactor:        3_025.946482308870940904 * 1e18,
                 borrowerInflator:          1 * 1e18,
                 borrowerCollateralization: 15.115198566768615646 * 1e18,
-                borrowerPendingDebt:       10_009.615384615384620000 * 1e18
+                borrowerPendingDebt:       10_011.123796468639518866 * 1e18
             }
         );
         _assertPoolPrices(
@@ -356,7 +358,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   50_000 * _lpPoolPrecision,
-                depositTime: 0
+                depositTime: 1 days
             }
         );
 
@@ -378,17 +380,17 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_quote.balanceOf(_borrower), 5_000 * _quotePrecision);
 
         // check pool state
-        debt = 5_009.615384615384620000 * 1e18;
+        debt = 5_011.123796468639518866 * 1e18;
         col  = 50 * 1e18;
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              5_009.615384615384620000 * 1e18,
+                borrowerDebt:              5_011.123796468639518866 * 1e18,
                 borrowerCollateral:        50 * 1e18,
-                borrowerMompFactor:        3_025.946482308870940904 * 1e18,
-                borrowerInflator:          1 * 1e18,
-                borrowerCollateralization: 30.201385236096216664 * 1e18,
-                borrowerPendingDebt:       5_009.615384615384620000 * 1e18
+                borrowerMompFactor:        3_025.490552122208009026 * 1e18,
+                borrowerInflator:          1.000150696285051402 * 1e18,
+                borrowerCollateralization: 30.192294235888449159 * 1e18,
+                borrowerPendingDebt:       5_011.123796468639518866 * 1e18
             }
         );
         _assertPoolPrices(
@@ -405,10 +407,10 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             {
                 noOfLoans:         1,
                 maxBorrower:       _borrower,
-                maxThresholdPrice: 100.1923076923076924 * 1e18
+                maxThresholdPrice: 100.207375050217969981 * 1e18
             }
         );
-        assertEq(_pool.depositSize(),       150_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(),       150_001.287299243036100000 * 1e18);
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
 
@@ -417,8 +419,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 index:        2549,
                 lpBalance:    50_000 * _lpPoolPrecision,
                 collateral:   0,
-                deposit:      50_000 * _quotePoolPrecision,
-                exchangeRate: 1 * _lpPoolPrecision
+                deposit:      50_000.429099747678700000 * 1e18,
+                exchangeRate: 1.000008581994953574000000000 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -426,7 +428,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   50_000 * _lpPoolPrecision,
-                depositTime: 0
+                depositTime: 1 days
             }
         );
 
@@ -443,21 +445,21 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         //  FIXME: check balances
         // assertEq(_collateral.balanceOf(address(_pool)),   1.7 * _collateralPrecision);
         // assertEq(_collateral.balanceOf(_borrower), 148.30 * _collateralPrecision);
-        assertEq(_quote.balanceOf(address(_pool)),   145_000 * _quotePrecision);
-        assertEq(_quote.balanceOf(_borrower), 5_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(address(_pool)), 145_000 * _quotePrecision);
+        assertEq(_quote.balanceOf(_borrower),      5_000 * _quotePrecision);
 
         // check pool state
-        debt = 5_009.615384615384620000 * 1e18;
-        col  = 1.655553200925393083 * 1e18;
+        debt = 5_011.123796468639518866 * 1e18;
+        col  = 1.656051693500220099 * 1e18;
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              5_009.615384615384620000 * 1e18,
-                borrowerCollateral:        1.655553200925393083 * 1e18,
-                borrowerMompFactor:        3_025.946482308870940904 * 1e18,
-                borrowerInflator:          1 * 1e18,
+                borrowerDebt:              5_011.123796468639518866 * 1e18,
+                borrowerCollateral:        1.656051693500220099 * 1e18,
+                borrowerMompFactor:        3_025.490552122208009026 * 1e18,
+                borrowerInflator:          1.000150696285051402 * 1e18,
                 borrowerCollateralization: 1 * 1e18,
-                borrowerPendingDebt:       5_009.615384615384620000 * 1e18
+                borrowerPendingDebt:       5_011.123796468639518866 * 1e18
             }
         );
         _assertPoolPrices(
@@ -474,10 +476,10 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             {
                 noOfLoans:         1,
                 maxBorrower:       _borrower,
-                maxThresholdPrice: 3_025.946482308870941594 * 1e18
+                maxThresholdPrice: 3_025.490552122208008612 * 1e18
             }
         );
-        assertEq(_pool.depositSize(),       150_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(),       150_001.287299243036100000 * 1e18);
         assertEq(_pool.borrowerDebt(),      debt);
         assertEq(_pool.pledgedCollateral(), col);
     }

--- a/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -72,7 +72,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       testIndex,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -80,7 +80,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   12_043.56808879152623138 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -114,7 +114,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       testIndex,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -122,7 +122,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   2_043.56808879152623138 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -156,7 +156,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       testIndex,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -164,7 +164,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   2_043.56808879152623138 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -198,7 +198,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       testIndex,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -206,7 +206,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
     }
@@ -330,7 +330,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       2550,
                 lpBalance:   0,
-                depositTime: 3600 + 86400
+                depositTime: _startTime + 3600 + 86400
             }
         );
 
@@ -352,7 +352,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -374,7 +374,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       2550,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 

--- a/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -290,7 +290,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         // bidder purchases all quote from the highest bucket
         uint256 amountToPurchase = 10_100 * 1e18;
         assertGt(_quote.balanceOf(address(_pool)), amountToPurchase);
-        uint256 amountWithInterest = 10_000.629204559150150000 * 1e18;
+        uint256 amountWithInterest = 10_001.321435774090050000 * 1e18;
         // adding extra collateral to account for interest accumulation
         uint256 collateralToPurchaseWith = Maths.wmul(Maths.wdiv(amountToPurchase, p2550), 1.01 * 1e18);
         assertEq(collateralToPurchaseWith, 3.388032491631335842 * 1e18);
@@ -304,24 +304,25 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
             }
         );
 
+        skip(25 hours); // remove liquidity after one day to avoid early withdraw penalty
         _removeAllLiquidity(
             {
                 from:     _bidder,
                 amount:   amountWithInterest,
                 index:    2550,
                 newLup:   PoolUtils.indexToPrice(2552),
-                lpRedeem: 10_000 * 1e27
+                lpRedeem: 10_000.349514602285265304678747886 * 1e27
             }
         );
 
         // bidder withdraws unused collateral
-        uint256 expectedCollateral = 0.066548648694011883 * 1e18;
+        uint256 expectedCollateral = 0.066434834368804842 * 1e18;
         _removeAllCollateral(
             {
                 from:     _bidder,
                 amount:   expectedCollateral,
                 index:    2550,
-                lpRedeem: 200.358188812263475078370320348 * 1e27
+                lpRedeem: 200.008674209978209773691572462 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -329,14 +330,14 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 lender:      _bidder,
                 index:       2550,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: 3600 + 86400
             }
         );
 
         skip(7200);
 
         // lender exchanges their LP for collateral
-        expectedCollateral = 1.992890305762394375 * 1e18;
+        expectedCollateral = 1.992958594357518600 * 1e18;
         _removeAllCollateral(
             {
                 from:     _lender,
@@ -358,7 +359,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
         skip(3600);
 
         // lender1 exchanges their LP for collateral
-        expectedCollateral = 1.328593537174929584 * 1e18;
+        expectedCollateral = 1.328639062905012400 * 1e18;
         _removeAllCollateral(
             {
                 from:     _lender1,

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -81,7 +81,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         // check balances
@@ -129,7 +129,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -146,7 +146,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -195,7 +195,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   40_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -212,7 +212,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -229,7 +229,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -295,7 +295,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   40_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -312,7 +312,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -329,7 +329,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -379,7 +379,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   35_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -396,7 +396,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -413,7 +413,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -463,7 +463,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -480,7 +480,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2550,
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertBucket(
@@ -497,7 +497,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -697,7 +697,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1606,
                 lpBalance:   3_400 * 1e27,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
         _assertBucket(
@@ -714,7 +714,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1663,
                 lpBalance:   3_400 * 1e27,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
 
@@ -746,7 +746,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1663,
                 lpBalance:   3_400 * 1e27,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
         _assertLenderLpBalance(
@@ -754,7 +754,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1663,
                 lpBalance:   3_400 * 1e27,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
 
@@ -802,7 +802,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1606,
                 lpBalance:   0,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
         _assertBucket(
@@ -819,7 +819,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       1663,
                 lpBalance:   3_400 * 1e27,
-                depositTime: 60
+                depositTime: _startTime + 1 minutes
             }
         );
     }
@@ -855,7 +855,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   40_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -884,7 +884,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   35_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -892,7 +892,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2552,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -913,7 +913,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2540,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -921,7 +921,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   30_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -929,7 +929,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2552,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -950,7 +950,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2540,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -958,7 +958,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2549,
                 lpBalance:   30_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -966,7 +966,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2551,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -974,7 +974,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2552,
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -982,7 +982,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 lender:      _lender,
                 index:       2777,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
     }

--- a/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolTransferLPTokens.t.sol
@@ -180,7 +180,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[0],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -196,7 +196,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[1],
                 lpBalance:   20_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -212,7 +212,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[2],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -264,7 +264,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[0],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -280,7 +280,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[1],
                 lpBalance:   20_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -296,7 +296,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[2],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
     }
@@ -342,7 +342,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       depositIndexes[0],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -358,7 +358,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       depositIndexes[1],
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -374,7 +374,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       depositIndexes[2],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -425,7 +425,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       depositIndexes[0],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -433,7 +433,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       depositIndexes[1],
                 lpBalance:   20_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -457,7 +457,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       depositIndexes[2],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
     }
@@ -528,7 +528,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[0],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -536,7 +536,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[0],
                 lpBalance:   5_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
         _assertLenderLpBalance(
@@ -544,7 +544,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[1],
                 lpBalance:   20_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -552,7 +552,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[1],
                 lpBalance:   10_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
         _assertLenderLpBalance(
@@ -560,7 +560,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender1,
                 index:       indexes[2],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 3600
+                depositTime: _startTime + 1 hours
             }
         );
         _assertLenderLpBalance(
@@ -568,7 +568,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[2],
                 lpBalance:   15_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
 
@@ -613,7 +613,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[0],
                 lpBalance:   15_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
         _assertLenderLpBalance(
@@ -629,7 +629,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[1],
                 lpBalance:   30_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
         _assertLenderLpBalance(
@@ -645,7 +645,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
                 lender:      _lender2,
                 index:       indexes[2],
                 lpBalance:   45_000 * 1e27,
-                depositTime: 7200
+                depositTime: _startTime + 2 hours
             }
         );
     }

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -11,6 +11,7 @@ import { ERC721Pool }        from '../../erc721/ERC721Pool.sol';
 import { ERC721PoolFactory } from '../../erc721/ERC721PoolFactory.sol';
 
 import '../../erc721/interfaces/IERC721Pool.sol';
+import '../../base/interfaces/IPoolFactory.sol';
 import '../../base/interfaces/IPool.sol';
 import '../../base/PoolInfoUtils.sol';
 
@@ -100,6 +101,39 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     /**********************/
     /*** Revert asserts ***/
     /**********************/
+
+    function _assertDeployWith0xAddressRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        uint256[] memory tokenIds;
+        vm.expectRevert(IPoolFactory.DeployWithZeroAddress.selector);
+        ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
+    }
+
+    function _assertDeployWithInvalidRateRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        uint256[] memory tokenIds;
+        vm.expectRevert(IPoolFactory.PoolInterestRateInvalid.selector);
+        ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
+    }
+
+    function _assertDeployMultipleTimesRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        uint256[] memory tokenIds;
+        vm.expectRevert(IPoolFactory.PoolAlreadyExists.selector);
+        ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
+    }
 
     function _assertPledgeCollateralNotInSubsetRevert(
         address from,
@@ -192,14 +226,15 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
     function _deployCollectionPool() internal returns (ERC721Pool) {
         _startTime = block.timestamp;
-        address contractAddress = new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
+        uint256[] memory tokenIds;
+        address contractAddress = new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), tokenIds, 0.05 * 10**18);
         vm.makePersistent(contractAddress);
         return ERC721Pool(contractAddress);
     }
 
     function _deploySubsetPool(uint256[] memory subsetTokenIds_) internal returns (ERC721Pool) {
         _startTime = block.timestamp;
-        return ERC721Pool(new ERC721PoolFactory().deploySubsetPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
+        return ERC721Pool(new ERC721PoolFactory().deployPool(address(_collateral), address(_quote), subsetTokenIds_, 0.05 * 10**18));
     }
 
     function _mintAndApproveQuoteTokens(address operator_, uint256 mintAmount_) internal {

--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -93,7 +93,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
             emit Transfer(address(_pool), from, i);
         }
         lpRedeemed_ = ERC721Pool(address(_pool)).removeCollateral(tokenIds, index);
-        assertEq(lpRedeem, lpRedeemed_);
+        assertEq(lpRedeemed_, lpRedeem);
     }
 
 

--- a/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -433,9 +433,12 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
                 interestRateUpdate:   _startTime + 10 days
             })
         );
-
-        assertEq(_pool.debtEma(),      116.548760023014994270 * 1e18);
-        assertEq(_pool.lupColEma(),    257_438_503.676217090117659874 * 1e18);
+        _assertEMAs(
+            {
+                debtEma:   116.548760023014994270 * 1e18,
+                lupColEma: 257_438_503.676217090117659874 * 1e18
+            }
+        );
 
         // check bucket state after fully repay
         _assertBucket(

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -590,7 +590,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 lender:      _borrower,
                 index:       1530,
                 lpBalance:   487_616.252661175041981841 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -619,7 +619,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 lender:      _borrower,
                 index:       1530,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -132,15 +132,17 @@ contract ERC721PoolFactoryTest is DSTestPlus {
 
         assert(_NFTCollectionPoolAddress != _NFTSubsetOnePoolAddress);
 
-        assertEq(_NFTCollectionPool.collateralAddress(),          address(_collateral));
-        assertEq(_NFTCollectionPool.quoteTokenAddress(),          address(_quote));
-        assertEq(_NFTCollectionPool.quoteTokenScale(),            1);
-        assertEq(_NFTCollectionPool.inflatorSnapshot(),           10**18);
-        assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime);
-        assertEq(_NFTCollectionPool.interestRate(),               0.05 * 10**18);
-        assertEq(_NFTCollectionPool.interestRateUpdate(),         _startTime);
-        assertEq(_NFTCollectionPool.minFee(),                     0.0005 * 10**18);
-        assertEq(_NFTCollectionPool.isSubset(),                   false);
+        assertEq(_NFTCollectionPool.collateralAddress(),  address(_collateral));
+        assertEq(_NFTCollectionPool.quoteTokenAddress(),  address(_quote));
+        assertEq(_NFTCollectionPool.quoteTokenScale(),    1);
+        assertEq(_NFTCollectionPool.interestRate(),       0.05 * 10**18);
+        assertEq(_NFTCollectionPool.interestRateUpdate(), _startTime);
+        assertEq(_NFTCollectionPool.minFee(),             0.0005 * 10**18);
+        assertEq(_NFTCollectionPool.isSubset(),           false);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTCollectionPool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime);
     }
 
     /**************************************/
@@ -196,15 +198,17 @@ contract ERC721PoolFactoryTest is DSTestPlus {
 
         assertTrue(_NFTSubsetOnePoolAddress != _NFTSubsetTwoPoolAddress);
 
-        assertEq(_NFTSubsetOnePool.collateralAddress(),          address(_collateral));
-        assertEq(_NFTSubsetOnePool.quoteTokenAddress(),          address(_quote));
-        assertEq(_NFTSubsetOnePool.quoteTokenScale(),            1);
-        assertEq(_NFTSubsetOnePool.inflatorSnapshot(),           10**18);
-        assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), _startTime);
-        assertEq(_NFTSubsetOnePool.interestRate(),               0.05 * 10**18);
-        assertEq(_NFTSubsetOnePool.interestRateUpdate(),         _startTime);
-        assertEq(_NFTSubsetOnePool.minFee(),                     0.0005 * 10**18);
-        assertEq(_NFTSubsetOnePool.isSubset(),                   true);
+        assertEq(_NFTSubsetOnePool.collateralAddress(),  address(_collateral));
+        assertEq(_NFTSubsetOnePool.quoteTokenAddress(),  address(_quote));
+        assertEq(_NFTSubsetOnePool.quoteTokenScale(),    1);
+        assertEq(_NFTSubsetOnePool.interestRate(),       0.05 * 10**18);
+        assertEq(_NFTSubsetOnePool.interestRateUpdate(), _startTime);
+        assertEq(_NFTSubsetOnePool.minFee(),             0.0005 * 10**18);
+        assertEq(_NFTSubsetOnePool.isSubset(),           true);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTSubsetOnePool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime);
 
         assertTrue(_NFTSubsetOnePool.tokenIdsAllowed(1));
         assertTrue(_NFTSubsetOnePool.tokenIdsAllowed(5));

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.14;
 
-import { DSTestPlus }                from '../utils/DSTestPlus.sol';
+import { ERC721HelperContract } from './ERC721DSTestPlus.sol';
 import { NFTCollateralToken, Token } from '../utils/Tokens.sol';
 
 import '../../erc721/ERC721Pool.sol';
@@ -9,7 +9,7 @@ import '../../erc721/ERC721PoolFactory.sol';
 
 import '../../base/PoolDeployer.sol';
 
-contract ERC721PoolFactoryTest is DSTestPlus {
+contract ERC721PoolFactoryTest is ERC721HelperContract {
     address            internal _NFTCollectionPoolAddress;
     address            internal _NFTSubsetOnePoolAddress;
     address            internal _NFTSubsetTwoPoolAddress;
@@ -17,8 +17,6 @@ contract ERC721PoolFactoryTest is DSTestPlus {
     ERC721Pool         internal _NFTSubsetOnePool;
     ERC721Pool         internal _NFTSubsetTwoPool;
     ERC721PoolFactory  internal _factory;
-    NFTCollateralToken internal _collateral;
-    Token              internal _quote;
     uint256[]          internal _tokenIdsSubsetOne;
     uint256[]          internal _tokenIdsSubsetTwo;
 
@@ -31,7 +29,8 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         _factory = new ERC721PoolFactory();
 
         // deploy NFT collection pool
-        _NFTCollectionPoolAddress = _factory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
+        uint256[] memory tokenIds;
+        _NFTCollectionPoolAddress = _factory.deployPool(address(_collateral), address(_quote), tokenIds, 0.05 * 10**18);
         _NFTCollectionPool        = ERC721Pool(_NFTCollectionPoolAddress);
 
         // deploy NFT subset one pool
@@ -41,7 +40,7 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         _tokenIdsSubsetOne[2] = 50;
         _tokenIdsSubsetOne[3] = 61;
 
-        _NFTSubsetOnePoolAddress = _factory.deploySubsetPool(address(_collateral), address(_quote), _tokenIdsSubsetOne, 0.05 * 10**18);
+        _NFTSubsetOnePoolAddress = _factory.deployPool(address(_collateral), address(_quote), _tokenIdsSubsetOne, 0.05 * 10**18);
         _NFTSubsetOnePool        = ERC721Pool(_NFTSubsetOnePoolAddress);
 
         // deploy NFT subset two pool
@@ -54,7 +53,7 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         _tokenIdsSubsetTwo[5] = 61;
         _tokenIdsSubsetTwo[6] = 180;
 
-        _NFTSubsetTwoPoolAddress = _factory.deploySubsetPool(address(_collateral), address(_quote), _tokenIdsSubsetTwo, 0.05 * 10**18);
+        _NFTSubsetTwoPoolAddress = _factory.deployPool(address(_collateral), address(_quote), _tokenIdsSubsetTwo, 0.05 * 10**18);
         _NFTSubsetTwoPool        = ERC721Pool(_NFTSubsetTwoPoolAddress);
     }
 
@@ -156,11 +155,11 @@ contract ERC721PoolFactoryTest is DSTestPlus {
 
         // should revert if trying to deploy with zero address as collateral
         vm.expectRevert(IPoolFactory.DeployWithZeroAddress.selector);
-        _factory.deploySubsetPool(address(0), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
+        _factory.deployPool(address(0), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
 
         // should revert if trying to deploy with zero address as quote token
         vm.expectRevert(IPoolFactory.DeployWithZeroAddress.selector);
-        _factory.deploySubsetPool(address(_collateral), address(0), tokenIdsTestSubset, 0.05 * 10**18);
+        _factory.deployPool(address(_collateral), address(0), tokenIdsTestSubset, 0.05 * 10**18);
     }
 
     function testDeployERC721SubsetPoolWithInvalidRate() external {
@@ -170,10 +169,10 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         tokenIdsTestSubset[2] = 3;
 
         vm.expectRevert(IPoolFactory.PoolInterestRateInvalid.selector);
-        _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.11 * 10**18);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.11 * 10**18);
 
         vm.expectRevert(IPoolFactory.PoolInterestRateInvalid.selector);
-        _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.009 * 10**18);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.009 * 10**18);
     }
 
     function testDeployERC721SubsetPoolMultipleTimes() external {
@@ -182,10 +181,10 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         tokenIdsTestSubset[1] = 2;
         tokenIdsTestSubset[2] = 3;
 
-        _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
 
         vm.expectRevert(IPoolFactory.PoolAlreadyExists.selector);
-        _factory.deploySubsetPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
     }
 
     function testDeployERC721SubsetPool() external {

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -137,7 +137,6 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTCollectionPool.quoteTokenScale(),    1);
         assertEq(_NFTCollectionPool.interestRate(),       0.05 * 10**18);
         assertEq(_NFTCollectionPool.interestRateUpdate(), _startTime);
-        assertEq(_NFTCollectionPool.minFee(),             0.0005 * 10**18);
         assertEq(_NFTCollectionPool.isSubset(),           false);
 
         (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTCollectionPool.inflatorInfo();
@@ -203,7 +202,6 @@ contract ERC721PoolFactoryTest is DSTestPlus {
         assertEq(_NFTSubsetOnePool.quoteTokenScale(),    1);
         assertEq(_NFTSubsetOnePool.interestRate(),       0.05 * 10**18);
         assertEq(_NFTSubsetOnePool.interestRateUpdate(), _startTime);
-        assertEq(_NFTSubsetOnePool.minFee(),             0.0005 * 10**18);
         assertEq(_NFTSubsetOnePool.isSubset(),           true);
 
         (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTSubsetOnePool.inflatorInfo();

--- a/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolFactory.t.sol
@@ -127,13 +127,13 @@ contract ERC721PoolFactoryTest is DSTestPlus {
     }
 
     function testDeployERC721CollectionPool() external {
-        assertEq(address(_collateral), address(_NFTCollectionPool.collateral()));
-        assertEq(address(_quote),      address(_NFTCollectionPool.quoteToken()));
+        assertEq(address(_collateral), _NFTCollectionPool.collateralAddress());
+        assertEq(address(_quote),      _NFTCollectionPool.quoteTokenAddress());
 
         assert(_NFTCollectionPoolAddress != _NFTSubsetOnePoolAddress);
 
-        assertEq(address(_NFTCollectionPool.collateral()),        address(_collateral));
-        assertEq(address(_NFTCollectionPool.quoteToken()),        address(_quote));
+        assertEq(_NFTCollectionPool.collateralAddress(),          address(_collateral));
+        assertEq(_NFTCollectionPool.quoteTokenAddress(),          address(_quote));
         assertEq(_NFTCollectionPool.quoteTokenScale(),            1);
         assertEq(_NFTCollectionPool.inflatorSnapshot(),           10**18);
         assertEq(_NFTCollectionPool.lastInflatorSnapshotUpdate(), _startTime);
@@ -188,16 +188,16 @@ contract ERC721PoolFactoryTest is DSTestPlus {
     }
 
     function testDeployERC721SubsetPool() external {
-        assertEq(address(_collateral), address(_NFTSubsetOnePool.collateral()));
-        assertEq(address(_quote),      address(_NFTSubsetOnePool.quoteToken()));
+        assertEq(address(_collateral), _NFTCollectionPool.collateralAddress());
+        assertEq(address(_quote),      _NFTCollectionPool.quoteTokenAddress());
 
-        assertEq(address(_NFTSubsetOnePool.collateral()), address(_NFTSubsetTwoPool.collateral()));
-        assertEq(address(_NFTSubsetOnePool.quoteToken()), address(_NFTSubsetTwoPool.quoteToken()));
+        assertEq(_NFTSubsetOnePool.collateralAddress(), _NFTSubsetTwoPool.collateralAddress());
+        assertEq(_NFTSubsetOnePool.quoteTokenAddress(), _NFTSubsetTwoPool.quoteTokenAddress());
 
         assertTrue(_NFTSubsetOnePoolAddress != _NFTSubsetTwoPoolAddress);
 
-        assertEq(address(_NFTSubsetOnePool.collateral()),        address(_collateral));
-        assertEq(address(_NFTSubsetOnePool.quoteToken()),        address(_quote));
+        assertEq(_NFTSubsetOnePool.collateralAddress(),          address(_collateral));
+        assertEq(_NFTSubsetOnePool.quoteTokenAddress(),          address(_quote));
         assertEq(_NFTSubsetOnePool.quoteTokenScale(),            1);
         assertEq(_NFTSubsetOnePool.inflatorSnapshot(),           10**18);
         assertEq(_NFTSubsetOnePool.lastInflatorSnapshotUpdate(), _startTime);

--- a/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidations.t.sol
@@ -178,13 +178,13 @@ contract ERC721PoolLiquidationsTest is ERC721HelperContract {
     function testKickSubsetPool() external {
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      false,
-                kicker:      address(0),
-                bondSize:    0,
-                bondFactor:  0,
-                kickTime:    0,
-                kickMomp:    0
+                borrower:   _borrower,
+                active:     false,
+                kicker:     address(0),
+                bondSize:   0,
+                bondFactor: 0,
+                kickTime:   0,
+                kickMomp:   0
             }
         );
 
@@ -247,13 +247,13 @@ contract ERC721PoolLiquidationsTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 46_999.772712801701582812 * 1e18);
         _assertAuction(
             {
-                borrower:    _borrower,
-                active:      true,
-                kicker:      _lender,
-                bondSize:    0.227287198298417188 * 1e18,
-                bondFactor:  0.01 * 1e18,
-                kickTime:    block.timestamp,
-                kickMomp:    9.917184843435912074 * 1e18
+                borrower:   _borrower,
+                active:     true,
+                kicker:     _lender,
+                bondSize:   0.227287198298417188 * 1e18,
+                bondFactor: 0.01 * 1e18,
+                kickTime:   block.timestamp,
+                kickMomp:   9.917184843435912074 * 1e18
             }
         );
         _assertKicker(

--- a/src/_test/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
@@ -126,7 +126,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   lpBalanceChange,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -164,7 +164,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 lender:      _bidder,
                 index:       testIndex,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -308,7 +308,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         tokenIdsToAdd[3] = 74;
         uint256 amountToPurchase = 10_100 * 1e18;
         assertGt(_quote.balanceOf(address(_pool)), amountToPurchase);
-        uint256 amountWithInterest = 24_001.477919844844176000 * 1e18;
+        uint256 amountWithInterest = 24_002.808232738534440000 * 1e18;
 
         _addCollateral(
             {
@@ -317,13 +317,14 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 index:    2350
             }
         );
+        skip(25 hours); // remove liquidity after one day to avoid early withdraw penalty
         _removeAllLiquidity(
             {
                 from:     _bidder,
                 amount:   amountWithInterest,
                 index:    2350,
                 newLup:   PoolUtils.indexToPrice(2352),
-                lpRedeem: 24_000.000000000000000000000023999 * 1e27
+                lpRedeem: 24_000.766698354457765204510601361 * 1e27
             }
         );
 
@@ -333,10 +334,10 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         _assertBucket(
             {
                 index:        2350,
-                lpBalance:    32_654.330240478871500328243823671 * 1e27,
+                lpBalance:    32_653.563542124413735123733246309 * 1e27,
                 collateral:   Maths.wad(4),
                 deposit:      0,
-                exchangeRate: 1.000061579993535174 * 1e27
+                exchangeRate: 1.000085061215324285728665849 * 1e27
             }
         );
 
@@ -348,7 +349,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 from:     _bidder,
                 tokenIds: tokenIdsToRemove,
                 index:    2350,
-                lpRedeem: 8_163.582560119717875082060961917 * 1e27
+                lpRedeem: 8_163.390885531103433780933317567 * 1e27
             }
         );
 
@@ -356,8 +357,8 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
             {
                 lender:      _bidder,
                 index:       2350,
-                lpBalance:   490.747680359153625246182861754 * 1e27,
-                depositTime: 0
+                lpBalance:   490.172656593310301342799928742 * 1e27,
+                depositTime: _startTime + 25 hours
             }
         );
 
@@ -398,7 +399,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 from:     _lender,
                 tokenIds: tokenIdsToRemove,
                 index:    2350,
-                lpRedeem: 8_163.582560119717875082060961917 * 1e27
+                lpRedeem: 8_163.390885531103433780933317567 * 1e27
             }
         );
 
@@ -406,8 +407,8 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
             {
                 lender:      _bidder,
                 index:       2350,
-                lpBalance:   490.747680359153625246182861754 * 1e27,
-                depositTime: 0
+                lpBalance:   490.172656593310301342799928742 * 1e27,
+                depositTime: _startTime + 25 hours
             }
         );
 
@@ -417,10 +418,10 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         _assertBucket(
             {
                 index:        2350,
-                lpBalance:    16_327.165120239435750164121899837 * 1e27,
+                lpBalance:    16_326.781771062206867561866611175 * 1e27,
                 collateral:   Maths.wad(2),
                 deposit:      0,
-                exchangeRate: 1.000061579993535174000000001 * 1e27
+                exchangeRate: 1.000085061215324285728665850 * 1e27
             }
         );
 

--- a/src/_test/Heap.t.sol
+++ b/src/_test/Heap.t.sol
@@ -234,12 +234,12 @@ contract HeapTest is DSTestPlus {
 
     function testHeapUpsertRequireChecks() public {
         address b1 = makeAddr("b1");
-        vm.expectRevert("H:I:VAL_EQ_0");
+        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
         _loans.upsertTp(b1, 0);
 
         _loans.upsertTp(b1, 100 * 1e18);
 
-        vm.expectRevert("H:I:VAL_EQ_0");
+        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
         _loans.upsertTp(b1, 0);
     }
 
@@ -277,7 +277,7 @@ contract HeapTest is DSTestPlus {
         assertEq(_loans.getMaxBorrower(), b6);
         assertEq(_loans.getTotalTps(),    7);
 
-        vm.expectRevert("H:R:NO_BORROWER");
+        vm.expectRevert(abi.encodeWithSignature('NoLoan()'));
         _loans.removeTp(address(100));
     }
 

--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -201,7 +201,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -217,7 +217,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -233,7 +233,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -282,7 +282,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -298,7 +298,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -314,7 +314,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -358,7 +358,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[0],
                 lpBalance:   1_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -366,7 +366,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -374,7 +374,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[1],
                 lpBalance:   2_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -382,7 +382,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -390,7 +390,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress,
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -398,7 +398,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -436,7 +436,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[0],
                 lpBalance:   4_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -452,7 +452,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[1],
                 lpBalance:   5_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -468,7 +468,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[2],
                 lpBalance:   6_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -552,7 +552,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testLender1,
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -560,7 +560,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testLender2,
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -576,7 +576,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testLender1,
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -600,7 +600,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testLender1,
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -632,7 +632,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testLender2,
                 index:       indexes[3],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -691,7 +691,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[0],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -707,7 +707,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -723,7 +723,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -784,7 +784,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[0],
                 lpBalance:   6_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -800,7 +800,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[1],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -816,7 +816,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[2],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -832,7 +832,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       indexes[3],
                 lpBalance:   3_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -898,7 +898,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testMinter,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -954,7 +954,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -996,7 +996,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1047,7 +1047,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testMinter,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1104,7 +1104,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -1166,7 +1166,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1337,7 +1337,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress1,
                 index:       mintIndex,
                 lpBalance:   2_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1345,7 +1345,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress2,
                 index:       mintIndex,
                 lpBalance:   5_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1418,7 +1418,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress2,
                 index:       mintIndex,
                 lpBalance:   5_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1426,7 +1426,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       mintIndex,
                 lpBalance:   2_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1489,7 +1489,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testAddress2,
                 index:       mintIndex,
                 lpBalance:   5_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1497,7 +1497,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       mintIndex,
                 lpBalance:   0,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1521,7 +1521,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       moveIndex,
                 lpBalance:   2_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -1568,7 +1568,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       mintIndex,
                 lpBalance:   5_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1592,7 +1592,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       moveIndex,
                 lpBalance:   2_500 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -1639,7 +1639,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       mintIndex,
                 lpBalance:   0 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1663,7 +1663,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       moveIndex,
                 lpBalance:   8_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -1705,7 +1705,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testMinter,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1746,7 +1746,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
 
@@ -1776,7 +1776,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testMinter,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1862,7 +1862,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testMinter,
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1870,7 +1870,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       testIndexPrice,
                 lpBalance:   25_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1894,7 +1894,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       2551,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1935,7 +1935,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       testIndexPrice,
                 lpBalance:   25_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1943,7 +1943,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      address(_positionManager),
                 index:       testIndexPrice,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -1959,7 +1959,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       2551,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -2020,7 +2020,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       testIndexPrice,
                 lpBalance:   40_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(
@@ -2044,7 +2044,7 @@ contract PositionManagerTest is PositionManagerHelperContract {
                 lender:      testReceiver,
                 index:       2551,
                 lpBalance:   15_000 * 1e27,
-                depositTime: 0
+                depositTime: _startTime
             }
         );
         _assertLenderLpBalance(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -442,6 +442,16 @@ abstract contract DSTestPlus is Test {
     /*** Revert asserts ***/
     /**********************/
 
+    function _assertAddLiquidityBankruptcyBlockRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('BucketBankruptcyBlock()'));
+        _pool.addQuoteToken(amount, index);
+    }
+
     function _assertBorrowAuctionActiveRevert(
         address from,
         uint256 amount,
@@ -520,6 +530,16 @@ abstract contract DSTestPlus is Test {
         _pool.repay(borrower, amount);
     }
 
+    function _assertRemoveLiquidityAuctionNotClearedRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        _pool.removeQuoteToken(amount, index);
+    }
+
     function _assertRemoveLiquidityInsufficientLPsRevert(
         address from,
         uint256 amount,
@@ -550,6 +570,15 @@ abstract contract DSTestPlus is Test {
         _pool.removeQuoteToken(amount, index);
     }
 
+    function _assertRemoveAllLiquidityAuctionNotClearedRevert(
+        address from,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        _pool.removeAllQuoteToken(index);
+    }
+
     function _assertRemoveAllLiquidityLupBelowHtpRevert(
         address from,
         uint256 index
@@ -557,6 +586,17 @@ abstract contract DSTestPlus is Test {
         changePrank(from);
         vm.expectRevert(IPoolErrors.LUPBelowHTP.selector);
         _pool.removeAllQuoteToken(index);
+    }
+
+    function _assertMoveLiquidityBankruptcyBlockRevert(
+        address from,
+        uint256 amount,
+        uint256 fromIndex,
+        uint256 toIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('BucketBankruptcyBlock()'));
+        _pool.moveQuoteToken(amount, fromIndex, toIndex);
     }
 
     function _assertMoveLiquidityLupBelowHtpRevert(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -25,7 +25,7 @@ abstract contract DSTestPlus is Test {
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-    event Clear(address indexed borrower, uint256 clearedDebt);
+    event Heal(address indexed borrower, uint256 clearedDebt);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
@@ -86,16 +86,16 @@ abstract contract DSTestPlus is Test {
         _pool.borrow(amount, indexLimit);
     }
 
-    function _clear(
+    function _heal(
         address from,
         address borrower,
         uint256 maxDepth,
-        uint256 clearedDebt
+        uint256 healedDebt
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit Clear(borrower, clearedDebt);
-        _pool.clear(borrower, maxDepth);
+        emit Heal(borrower, healedDebt);
+        _pool.heal(borrower, maxDepth);
     }
 
     function _kick(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -25,6 +25,7 @@ abstract contract DSTestPlus is Test {
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
+    event Clear(address indexed borrower, uint256 hpbIndex, uint256 amount, uint256 collateralReturned, uint256 amountRemaining);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
@@ -83,6 +84,21 @@ abstract contract DSTestPlus is Test {
         emit Borrow(from, newLup, amount);
         _assertTokenTransferEvent(address(_pool), from, amount);
         _pool.borrow(amount, indexLimit);
+    }
+
+    function _clear(
+        address from,
+        address borrower,
+        uint256 maxDepth,
+        uint256 hpbIndex,
+        uint256 clearedDebt,
+        uint256 remainingCollateral,
+        uint256 remainingDebt
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit Clear(borrower, hpbIndex, clearedDebt, remainingCollateral, remainingDebt);
+        _pool.clear(borrower, maxDepth);
     }
 
     function _kick(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -280,7 +280,7 @@ abstract contract DSTestPlus is Test {
         assertEq(loansCount,  state_.loans);
         assertEq(maxBorrower, state_.maxBorrower);
 
-        uint256 poolInflatorSnapshot = _pool.inflatorSnapshot();
+        (uint256 poolInflatorSnapshot, ) = _pool.inflatorInfo();
         assertGe(poolInflatorSnapshot, 1e18);
         assertGe(pendingInflator,      poolInflatorSnapshot);
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -230,7 +230,7 @@ abstract contract DSTestPlus is Test {
             uint256 auctionKickPriceIndex,
             ,
         ) = _pool.auctionInfo(borrower);
-        (, uint256 lockedBonds) = _pool.kickers(kicker);
+        (, uint256 lockedBonds) = _pool.kickerInfo(kicker);
 
         assertEq(auctionKickTime != 0,  active);
         assertEq(auctionKicker,         kicker);
@@ -294,7 +294,7 @@ abstract contract DSTestPlus is Test {
         uint256 lpBalance,
         uint256 depositTime
     ) internal {
-        (uint256 curLpBalance, uint256 time) = _pool.lenders(index, lender);
+        (uint256 curLpBalance, uint256 time) = _pool.lenderInfo(index, lender);
         assertEq(curLpBalance, lpBalance);
         assertEq(time,       depositTime);
     }
@@ -359,7 +359,7 @@ abstract contract DSTestPlus is Test {
         uint256 claimable,
         uint256 locked
     ) internal {
-        (uint256 curClaimable, uint256 curLocked) = _pool.kickers(kicker);
+        (uint256 curClaimable, uint256 curLocked) = _pool.kickerInfo(kicker);
 
         assertEq(curClaimable, claimable);
         assertEq(curLocked,    locked);
@@ -370,9 +370,10 @@ abstract contract DSTestPlus is Test {
         address maxBorrower,
         uint256 maxThresholdPrice
     ) internal {
-        assertEq(_pool.noOfLoans(),         noOfLoans);
-        assertEq(_pool.maxBorrower(),       maxBorrower);
-        assertEq(_pool.maxThresholdPrice(), maxThresholdPrice);
+        (address curMaxBorrower, uint256 curTpPrice, uint256 curNoOfLoans) = _pool.loansInfo();
+        assertEq(curNoOfLoans,   noOfLoans);
+        assertEq(curMaxBorrower, maxBorrower);
+        assertEq(curTpPrice,     maxThresholdPrice);
     }
 
     function _assertPoolPrices(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -25,7 +25,7 @@ abstract contract DSTestPlus is Test {
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-    event Heal(address indexed borrower, uint256 clearedDebt);
+    event Heal(address indexed borrower, uint256 healedDebt);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -458,7 +458,7 @@ abstract contract DSTestPlus is Test {
         uint256 indexLimit
     ) internal {
         changePrank(from);
-        vm.expectRevert(IPoolErrors.AuctionActive.selector);
+        vm.expectRevert(abi.encodeWithSignature('AuctionActive()'));
         _pool.borrow(amount, indexLimit);
     }
 
@@ -492,12 +492,30 @@ abstract contract DSTestPlus is Test {
         _pool.borrow(amount, indexLimit);
     }
 
+    function _assertHealOnNotClearableAuctionRevert(
+        address from,
+        address borrower
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotClearable()'));
+        _pool.heal(borrower, 1);
+    }
+
+    function _assertHealOnNotKickedAuctionRevert(
+        address from,
+        address borrower
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
+        _pool.heal(borrower, 1);
+    }
+
     function _assertKickAuctionActiveRevert(
         address from,
         address borrower
     ) internal {
         changePrank(from);
-        vm.expectRevert(IPoolErrors.AuctionActive.selector);
+        vm.expectRevert(abi.encodeWithSignature('AuctionActive()'));
         _pool.kick(borrower);
     }
 
@@ -536,7 +554,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
         _pool.removeQuoteToken(amount, index);
     }
 
@@ -575,7 +593,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
         _pool.removeAllQuoteToken(index);
     }
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -554,7 +554,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
         _pool.removeQuoteToken(amount, index);
     }
 
@@ -593,7 +593,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('HeadNotCleared()'));
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
         _pool.removeAllQuoteToken(index);
     }
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -25,7 +25,7 @@ abstract contract DSTestPlus is Test {
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
-    event Clear(address indexed borrower, uint256 hpbIndex, uint256 amount, uint256 collateralReturned, uint256 amountRemaining);
+    event Clear(address indexed borrower, uint256 clearedDebt);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
@@ -90,14 +90,11 @@ abstract contract DSTestPlus is Test {
         address from,
         address borrower,
         uint256 maxDepth,
-        uint256 hpbIndex,
-        uint256 clearedDebt,
-        uint256 remainingCollateral,
-        uint256 remainingDebt
+        uint256 clearedDebt
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit Clear(borrower, hpbIndex, clearedDebt, remainingCollateral, remainingDebt);
+        emit Clear(borrower, clearedDebt);
         _pool.clear(borrower, maxDepth);
     }
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -354,6 +354,16 @@ abstract contract DSTestPlus is Test {
         assertEq(pendingDebt, borrowerPendingDebt);
     }
 
+    function _assertEMAs(
+        uint256 debtEma,
+        uint256 lupColEma
+    ) internal {
+        (uint256 curDebtEma, uint256 curLupColEma) = _pool.emasInfo();
+
+        assertEq(curDebtEma,   debtEma);
+        assertEq(curLupColEma, lupColEma);
+    }
+
     function _assertKicker(
         address kicker,
         uint256 claimable,

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -651,36 +651,6 @@ abstract contract DSTestPlus is Test {
         _pool.startClaimableReserveAuction();
     }
 
-    function _assertDeployWith0xAddressRevert(
-        address poolFactory,
-        address collateral,
-        address quote,
-        uint256 interestRate
-    ) internal {
-        vm.expectRevert(IPoolFactory.DeployWithZeroAddress.selector);
-        IPoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
-    }
-
-    function _assertDeployWithInvalidRateRevert(
-        address poolFactory,
-        address collateral,
-        address quote,
-        uint256 interestRate
-    ) internal {
-        vm.expectRevert(IPoolFactory.PoolInterestRateInvalid.selector);
-        IPoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
-    }
-
-    function _assertDeployMultipleTimesRevert(
-        address poolFactory,
-        address collateral,
-        address quote,
-        uint256 interestRate
-    ) internal {
-        vm.expectRevert(IPoolFactory.PoolAlreadyExists.selector);
-        IPoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
-    }
-
     function _lup() internal view returns (uint256 lup_) {
         ( , , , , lup_, ) = _poolUtils.poolPricesInfo(address(_pool));
     }

--- a/src/_test/utils/QueueInstance.sol
+++ b/src/_test/utils/QueueInstance.sol
@@ -32,7 +32,7 @@ contract QueueInstance is DSTestPlus {
     }
 
     function isActive(address borrower_) external view returns (bool kicked_) {
-        (kicked_, ) = auctions.getStatus(borrower_);
+        kicked_ = auctions.liquidations[borrower_].kickTime != 0;
     }
 
     function get(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -764,10 +764,6 @@ abstract contract Pool is Clone, Multicall, IPool {
         IERC20Token(_getArgAddress(20)).transfer(to_, amount_ / _getArgUint256(40));
     }
 
-    function _hpbIndex() internal view returns (uint256) {
-        return deposits.findIndexOfSum(1);
-    }
-
     function _htp(uint256 inflator_) internal view returns (uint256) {
         return Maths.wmul(loans.getMax().thresholdPrice, inflator_);
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -353,6 +353,25 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** Liquidation Functions ***/
     /*****************************/
 
+    function clear(
+        address borrower_,
+        uint256 maxDepth_
+    ) external override {
+        (
+            uint256 clearedDebt,
+            uint256 remainingDebt,
+            uint256 remainingCol,
+            uint256 remainingReserves,
+            uint256 totalForgived,
+            uint256 hpbIndex
+
+        ) = auctions.clear(loans, buckets, deposits, borrower_, 0, maxDepth_);
+        if (clearedDebt != 0) {
+            borrowerDebt -= totalForgived;
+            emit Clear(borrower_, hpbIndex, clearedDebt, remainingCol, remainingDebt);
+        }
+    }
+
     function kick(address borrowerAddress_) external override {
 
         (bool auctionKicked, ) = auctions.getStatus(borrowerAddress_);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -676,12 +676,15 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*****************************/
 
     function _accruePoolInterest() internal returns (PoolState memory poolState_) {
+        uint256 t0Debt = t0poolDebt;
+
         poolState_.collateral  = pledgedCollateral;
         poolState_.inflator    = inflatorSnapshot;
-        // TODO: when new interest has accrued, this gets overwriten, wasting a storage read and multiplication
-        poolState_.accruedDebt = Maths.wmul(t0poolDebt, poolState_.inflator);
 
-        if (t0poolDebt != 0) {
+        if (t0Debt != 0) {
+            // TODO: when new interest has accrued, this gets overwriten, wasting a multiplication
+            poolState_.accruedDebt = Maths.wmul(t0Debt, poolState_.inflator);
+
             uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;
             poolState_.isNewInterestAccrued = elapsed != 0;
             if (poolState_.isNewInterestAccrued) {
@@ -702,7 +705,7 @@ abstract contract Pool is Clone, Multicall, IPool {
                 }
 
                 // Calculate pool debt using the new inflator
-                poolState_.accruedDebt = Maths.wmul(t0poolDebt, poolState_.inflator);
+                poolState_.accruedDebt = Maths.wmul(t0Debt, poolState_.inflator);
             }
         }
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -151,7 +151,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     function removeAllQuoteToken(
         uint256 index_
     ) external returns (uint256 quoteTokenAmountRemoved_, uint256 redeemedLenderLPs_) {
-        if (auctions.isHeadClearable()) revert AuctionNotCleared();
+        auctions.revertIfHeadClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -181,8 +181,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 quoteTokenAmountToRemove_,
         uint256 index_
     ) external override returns (uint256 bucketLPs_) {
-
-        if (auctions.isHeadClearable()) revert AuctionNotCleared();
+        auctions.revertIfHeadClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -255,10 +254,8 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 amountToBorrow_,
         uint256 limitIndex_
     ) external override {
-
         // if borrower auctioned then it cannot draw more debt
-        (bool auctionKicked, ) = auctions.getStatus(msg.sender);
-        if (auctionKicked) revert AuctionActive();
+        auctions.revertIfActive(msg.sender);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -362,8 +359,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 reserves = poolDebt + quoteTokenBalance - deposits.treeSum() - auctions.liquidationBondEscrowed - reserveAuctionUnclaimed;
         (
             uint256 healedDebt,
-            uint256 totalForgived,
-            uint256 rewardedCollateral
+            uint256 totalForgived
 
         ) = auctions.heal(loans, buckets, deposits, borrower_, reserves, maxDepth_);
         if (healedDebt != 0) {
@@ -373,9 +369,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function kick(address borrowerAddress_) external override {
-
-        (bool auctionKicked, ) = auctions.getStatus(borrowerAddress_);
-        if (auctionKicked) revert AuctionActive();
+        auctions.revertIfActive(borrowerAddress_);
 
         PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.accrueBorrowerInterest(
@@ -524,8 +518,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateralAmountToRemove_,
         uint256 index_
     ) internal returns (uint256 bucketLPs_) {
-
-        if (auctions.isHeadClearable()) revert AuctionNotCleared();
+        auctions.revertIfHeadClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -51,7 +51,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     uint256 public override reserveAuctionKicked;    // Time a Claimable Reserve Auction was last kicked.
     uint256 public override reserveAuctionUnclaimed; // Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
 
-    mapping(uint256 => Buckets.Bucket)              public override buckets;     // deposit index -> bucket
+    mapping(uint256 => Buckets.Bucket)                                  public override buckets;     // deposit index -> bucket
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 
     Auctions.Data internal auctions;
@@ -357,7 +357,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** Liquidation Functions ***/
     /*****************************/
 
-    function clear(
+    function heal(
         address borrower_,
         uint256 maxDepth_
     ) external override {
@@ -365,14 +365,14 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 quoteTokenBalance = ERC20(_getArgAddress(0x14)).balanceOf(address(this));
         uint256 reserves = poolDebt + quoteTokenBalance - deposits.treeSum() - auctions.liquidationBondEscrowed - reserveAuctionUnclaimed;
         (
-            uint256 clearedDebt,
+            uint256 healedDebt,
             uint256 totalForgived,
             uint256 rewardedCollateral
 
-        ) = auctions.clear(loans, buckets, deposits, borrower_, reserves, maxDepth_);
-        if (clearedDebt != 0) {
+        ) = auctions.heal(loans, buckets, deposits, borrower_, reserves, maxDepth_);
+        if (healedDebt != 0) {
             borrowerDebt -= Maths.min(poolDebt, totalForgived);
-            emit Clear(borrower_, clearedDebt);
+            emit Heal(borrower_, healedDebt);
         }
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -443,7 +443,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
         emit ReserveAuction(reserveAuctionUnclaimed, price);
 
-        IERC20Token ajnaToken = IERC20Token(_getArgAddress(40));
+        IERC20Token ajnaToken = IERC20Token(0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079);
         ajnaToken.transferFrom(msg.sender, address(this), ajnaRequired);
         ajnaToken.burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);
@@ -757,11 +757,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(20)).transferFrom(from_, address(this), amount_ / _getArgUint256(60));
+        IERC20Token(_getArgAddress(20)).transferFrom(from_, address(this), amount_ / _getArgUint256(40));
     }
 
     function _transferQuoteToken(address to_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(20)).transfer(to_, amount_ / _getArgUint256(60));
+        IERC20Token(_getArgAddress(20)).transfer(to_, amount_ / _getArgUint256(40));
     }
 
     function _hpbIndex() internal view returns (uint256) {
@@ -987,6 +987,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function quoteTokenScale() external pure override returns (uint256) {
-        return _getArgUint256(60);
+        return _getArgUint256(40);
     }
 }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -394,11 +394,11 @@ abstract contract Pool is Clone, Multicall, IPool {
             ) >= Maths.WAD) revert BorrowerOk();
 
         poolState.accruedDebt += loans.kick(
-                borrowerAddress_,
-                borrower.debt,
-                borrower.inflatorSnapshot,
-                poolState.rate
-            );
+            borrowerAddress_,
+            borrower.debt,
+            borrower.inflatorSnapshot,
+            poolState.rate
+        );
         
         // kick auction
         uint256 kickAuctionAmount = auctions.kick(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -30,16 +30,16 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** State Variables ***/
     /***********************/
 
-    uint256 public override minFee;                     // [WAD]
-    uint256 public override interestRate;               // [WAD]
-    uint256 public override interestRateUpdate;         // [SEC]
-    uint256 public override borrowerDebt;               // [WAD]
+    uint256 public override interestRate;       // [WAD]
+    uint256 public override interestRateUpdate; // [SEC]
 
-    uint256 public override quoteTokenScale;
+    uint256 public override borrowerDebt;      // [WAD]
+    uint256 public override minFee;            // [WAD]
     uint256 public override pledgedCollateral; // [WAD]
+    uint256 public override quoteTokenScale;
 
-    uint256 internal debtEma;      // [WAD]
-    uint256 internal lupColEma;    // [WAD]
+    uint256 internal debtEma;   // [WAD]
+    uint256 internal lupColEma; // [WAD]
 
     uint256 internal inflatorSnapshot;           // [WAD]
     uint256 internal lastInflatorSnapshotUpdate; // [SEC]

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -36,7 +36,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     uint256 public override borrowerDebt;      // [WAD]
     uint256 public override minFee;            // [WAD]
     uint256 public override pledgedCollateral; // [WAD]
-    uint256 public override quoteTokenScale;
 
     uint256 internal debtEma;   // [WAD]
     uint256 internal lupColEma; // [WAD]
@@ -54,7 +53,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     Deposits.Data                      internal deposits;
     Loans.Data                         internal loans;
 
-    address internal ajnaTokenAddress;    //  Address of the Ajna token, needed for Claimable Reserve Auctions.
     uint256 internal poolInitializations;
 
     struct PoolState {
@@ -357,7 +355,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 maxDepth_
     ) external override {
         uint256 poolDebt = borrowerDebt;
-        uint256 quoteTokenBalance = IERC20Token(_getArgAddress(0x14)).balanceOf(address(this));
+        uint256 quoteTokenBalance = IERC20Token(_getArgAddress(20)).balanceOf(address(this));
         uint256 reserves = poolDebt + quoteTokenBalance - deposits.treeSum() - auctions.liquidationBondEscrowed - reserveAuctionUnclaimed;
         (
             uint256 healedDebt,
@@ -424,7 +422,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             deposits.treeSum(),
             auctions.liquidationBondEscrowed,
             curUnclaimedAuctionReserve,
-            IERC20Token(_getArgAddress(0x14)).balanceOf(address(this))
+            IERC20Token(_getArgAddress(20)).balanceOf(address(this))
         );
         uint256 kickerAward = Maths.wmul(0.01 * 1e18, claimable);
         curUnclaimedAuctionReserve += claimable - kickerAward;
@@ -447,7 +445,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
         emit ReserveAuction(reserveAuctionUnclaimed, price);
 
-        IERC20Token ajnaToken = IERC20Token(ajnaTokenAddress);
+        IERC20Token ajnaToken = IERC20Token(_getArgAddress(40));
         ajnaToken.transferFrom(msg.sender, address(this), ajnaRequired);
         ajnaToken.burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);
@@ -762,11 +760,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(0x14)).transferFrom(from_, address(this), amount_ / quoteTokenScale);
+        IERC20Token(_getArgAddress(20)).transferFrom(from_, address(this), amount_ / _getArgUint256(60));
     }
 
     function _transferQuoteToken(address to_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(0x14)).transfer(to_, amount_ / quoteTokenScale);
+        IERC20Token(_getArgAddress(20)).transfer(to_, amount_ / _getArgUint256(60));
     }
 
     function _hpbIndex() internal view returns (uint256) {
@@ -988,7 +986,10 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function quoteTokenAddress() external pure override returns (address) {
-        return _getArgAddress(0x14);
+        return _getArgAddress(20);
     }
 
+    function quoteTokenScale() external pure override returns (uint256) {
+        return _getArgUint256(60);
+    }
 }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.14;
 import '@clones/Clone.sol';
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/utils/Multicall.sol';
 
 import './interfaces/IPool.sol';
@@ -18,8 +17,6 @@ import '../libraries/Maths.sol';
 import '../libraries/PoolUtils.sol';
 
 abstract contract Pool is Clone, Multicall, IPool {
-    using SafeERC20 for ERC20;
-
     using Auctions for Auctions.Data;
     using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
@@ -451,7 +448,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         reserveAuctionUnclaimed -= amount_;
 
         emit ReserveAuction(reserveAuctionUnclaimed, price);
-        ERC20(ajnaTokenAddress).safeTransferFrom(msg.sender, address(this), ajnaRequired);
+        ERC20(ajnaTokenAddress).transferFrom(msg.sender, address(this), ajnaRequired);
         ERC20Burnable(ajnaTokenAddress).burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);
     }
@@ -765,11 +762,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     }
 
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {
-        quoteToken().safeTransferFrom(from_, address(this), amount_ / quoteTokenScale);
+        quoteToken().transferFrom(from_, address(this), amount_ / quoteTokenScale);
     }
 
     function _transferQuoteToken(address to_, uint256 amount_) internal {
-        quoteToken().safeTransfer(to_, amount_ / quoteTokenScale);
+        quoteToken().transfer(to_, amount_ / quoteTokenScale);
     }
 
     function _hpbIndex() internal view returns (uint256) {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -271,7 +271,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             loansCount >= 10
             &&
             (borrower.debt + amountToBorrow_ < PoolUtils.minDebtAmount(poolState.accruedDebt, loansCount))
-        )  revert AmountLTMinDebt();
+        ) revert AmountLTMinDebt();
 
         uint256 debt  = Maths.wmul(amountToBorrow_, PoolUtils.feeRate(interestRate, minFee) + Maths.WAD);
         borrower.debt += debt;
@@ -296,7 +296,8 @@ abstract contract Pool is Clone, Multicall, IPool {
                 poolState.accruedDebt,
                 poolState.collateral,
                 newLup
-            ) < Maths.WAD) revert PoolUnderCollateralized();
+            ) < Maths.WAD
+        ) revert PoolUnderCollateralized();
 
         loans.update(
             deposits,
@@ -330,7 +331,8 @@ abstract contract Pool is Clone, Multicall, IPool {
 
         if (borrower.debt != 0) {
             uint256 loansCount = loans.noOfLoans();
-            if (loansCount >= 10
+            if (
+                loansCount >= 10
                 &&
                 (borrower.debt < PoolUtils.minDebtAmount(poolState.accruedDebt, loansCount))
             ) revert AmountLTMinDebt();
@@ -385,7 +387,8 @@ abstract contract Pool is Clone, Multicall, IPool {
                 borrower.debt,
                 borrower.collateral,
                 lup
-            ) >= Maths.WAD) revert BorrowerOk();
+            ) >= Maths.WAD
+        ) revert BorrowerOk();
 
         poolState.accruedDebt += loans.kick(
             borrowerAddress_,
@@ -716,7 +719,8 @@ abstract contract Pool is Clone, Multicall, IPool {
                     poolState_.accruedDebt,
                     poolState_.collateral,
                     lup_
-                ) != Maths.WAD) {
+                ) != Maths.WAD
+            ) {
 
                 int256 actualUtilization = int256(
                     deposits.utilization(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -34,7 +34,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     uint256 public override interestRateUpdate; // [SEC]
 
     uint256 public override borrowerDebt;      // [WAD]
-    uint256 public override minFee;            // [WAD]
     uint256 public override pledgedCollateral; // [WAD]
 
     uint256 internal debtEma;   // [WAD]
@@ -122,7 +121,6 @@ abstract contract Pool is Clone, Multicall, IPool {
         // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
         quoteTokenAmountToMove = PoolUtils.applyEarlyWithdrawalPenalty(
             poolState,
-            minFee,
             lenderLastDepositTime,
             fromIndex_,
             toIndex_,
@@ -271,7 +269,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             (borrower.debt + amountToBorrow_ < PoolUtils.minDebtAmount(poolState.accruedDebt, loansCount))
         ) revert AmountLTMinDebt();
 
-        uint256 debt  = Maths.wmul(amountToBorrow_, PoolUtils.feeRate(interestRate, minFee) + Maths.WAD);
+        uint256 debt  = Maths.wmul(amountToBorrow_, PoolUtils.feeRate(interestRate) + Maths.WAD);
         borrower.debt += debt;
 
         uint256 newLup = PoolUtils.indexToPrice(lupId);
@@ -556,7 +554,6 @@ abstract contract Pool is Clone, Multicall, IPool {
         (, uint256 lastDeposit) = buckets.getLenderInfo(index_, msg.sender);
         amount = PoolUtils.applyEarlyWithdrawalPenalty(
             poolState_,
-            minFee,
             lastDeposit,
             index_,
             0,

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -30,8 +30,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** State Variables ***/
     /***********************/
 
-    uint256 public override inflatorSnapshot;           // [WAD]
-    uint256 public override lastInflatorSnapshotUpdate; // [SEC]
     uint256 public override minFee;                     // [WAD]
     uint256 public override interestRate;               // [WAD]
     uint256 public override interestRateUpdate;         // [SEC]
@@ -42,6 +40,9 @@ abstract contract Pool is Clone, Multicall, IPool {
 
     uint256 public override debtEma;      // [WAD]
     uint256 public override lupColEma;    // [WAD]
+
+    uint256 internal inflatorSnapshot;           // [WAD]
+    uint256 internal lastInflatorSnapshotUpdate; // [SEC]
 
     uint256 internal reserveAuctionKicked;    // Time a Claimable Reserve Auction was last kicked.
     uint256 internal reserveAuctionUnclaimed; // Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
@@ -873,6 +874,21 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateral_
     ) external view override returns (uint256) {
         return deposits.utilization(debt_, collateral_);
+    }
+
+    function inflatorInfo()
+        external
+        view
+        override
+        returns (
+            uint256,
+            uint256
+        )
+    {
+        return (
+            inflatorSnapshot,
+            lastInflatorSnapshotUpdate
+        );
     }
 
     function kickerInfo(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -38,8 +38,8 @@ abstract contract Pool is Clone, Multicall, IPool {
     uint256 public override quoteTokenScale;
     uint256 public override pledgedCollateral; // [WAD]
 
-    uint256 public override debtEma;      // [WAD]
-    uint256 public override lupColEma;    // [WAD]
+    uint256 internal debtEma;      // [WAD]
+    uint256 internal lupColEma;    // [WAD]
 
     uint256 internal inflatorSnapshot;           // [WAD]
     uint256 internal lastInflatorSnapshotUpdate; // [SEC]
@@ -874,6 +874,21 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateral_
     ) external view override returns (uint256) {
         return deposits.utilization(debt_, collateral_);
+    }
+
+    function emasInfo()
+        external
+        view
+        override
+        returns (
+            uint256,
+            uint256
+        )
+    {
+        return (
+            debtEma,
+            lupColEma
+        );
     }
 
     function inflatorInfo()

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -367,7 +367,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
         ) = auctions.clear(loans, buckets, deposits, borrower_, 0, maxDepth_);
         if (clearedDebt != 0) {
-            borrowerDebt -= totalForgived;
+            borrowerDebt -= Maths.min(borrowerDebt, totalForgived);
             emit Clear(borrower_, hpbIndex, clearedDebt, remainingCol, remainingDebt);
         }
     }

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -19,7 +19,7 @@ abstract contract PoolDeployer {
     /**
      *  @notice Address of the Ajna token, needed for Claimable Reserve Auctions.
      */
-    address internal ajnaTokenAddress = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
+    address immutable ajnaTokenAddress = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
 
     /*****************/
     /*** Modifiers ***/

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -16,11 +16,6 @@ abstract contract PoolDeployer {
     /// @dev SubsetHash => CollateralAddress => QuoteAddress => Pool Address
     mapping(bytes32 => mapping(address => mapping(address => address))) public deployedPools;
 
-    /**
-     *  @notice Address of the Ajna token, needed for Claimable Reserve Auctions.
-     */
-    address immutable ajnaTokenAddress = 0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079;
-
     /*****************/
     /*** Modifiers ***/
     /*****************/

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -2,8 +2,6 @@
 
 pragma solidity 0.8.14;
 
-import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
-
 import './interfaces/IPool.sol';
 
 import '../libraries/PoolUtils.sol';
@@ -154,7 +152,7 @@ contract PoolInfoUtils {
         uint256 poolDebt = pool.borrowerDebt();
         uint256 poolSize = pool.depositSize();
 
-        uint256 quoteTokenBalance = ERC20(pool.quoteTokenAddress()).balanceOf(ajnaPool_);
+        uint256 quoteTokenBalance = IERC20Token(pool.quoteTokenAddress()).balanceOf(ajnaPool_);
 
         uint256 bondEscrowed     = pool.liquidationBondEscrowed();
         uint256 unclaimedReserve = pool.reserveAuctionUnclaimed();

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -21,9 +21,11 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        uint256 poolInflatorSnapshot       = pool.inflatorSnapshot();
-        uint256 lastInflatorSnapshotUpdate = pool.lastInflatorSnapshotUpdate();
-        uint256 interestRate               = pool.interestRate();
+        (
+            uint256 poolInflatorSnapshot,
+            uint256 lastInflatorSnapshotUpdate
+        ) = pool.inflatorInfo();
+        uint256 interestRate = pool.interestRate();
 
         uint256 pendingInflator = PoolUtils.pendingInflator(poolInflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
         (debt_, collateral_, mompFactor_, inflatorSnapshot_) = pool.borrowerInfo(borrower_);
@@ -88,9 +90,11 @@ contract PoolInfoUtils {
         poolSize_    = pool.depositSize();
         (maxBorrower_, , loansCount_)  = pool.loansInfo();
 
-        uint256 inflatorSnapshot           = pool.inflatorSnapshot();
-        uint256 lastInflatorSnapshotUpdate = pool.lastInflatorSnapshotUpdate();
-        uint256 interestRate               = pool.interestRate();
+        (
+            uint256 inflatorSnapshot,
+            uint256 lastInflatorSnapshotUpdate
+        ) = pool.inflatorInfo();
+        uint256 interestRate = pool.interestRate();
 
         pendingInflator_       = PoolUtils.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
         pendingInterestFactor_ = PoolUtils.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
@@ -121,7 +125,8 @@ contract PoolInfoUtils {
         hpbIndex_ = pool.depositIndex(1);
         hpb_      = PoolUtils.indexToPrice(hpbIndex_);
         (, uint256 maxThresholdPrice, ) = pool.loansInfo();
-        htp_      = Maths.wmul(maxThresholdPrice, pool.inflatorSnapshot());
+        (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
+        htp_      = Maths.wmul(maxThresholdPrice, inflatorSnapshot);
         if (htp_ != 0) htpIndex_ = PoolUtils.priceToIndex(htp_);
         lupIndex_ = pool.depositIndex(pool.borrowerDebt());
         lup_      = PoolUtils.indexToPrice(lupIndex_);
@@ -270,7 +275,8 @@ contract PoolInfoUtils {
     ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
         (, uint256 maxThresholdPrice, ) = pool.loansInfo();
-        return Maths.wmul(maxThresholdPrice, pool.inflatorSnapshot());
+        (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
+        return Maths.wmul(maxThresholdPrice, inflatorSnapshot);
     }
 
 }

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -200,7 +200,8 @@ contract PoolInfoUtils {
         uint256 currentLup      = PoolUtils.indexToPrice(pool.depositIndex(poolDebt));
         poolCollateralization_ = PoolUtils.collateralization(poolDebt, poolCollateral, currentLup);
         poolActualUtilization_ = pool.depositUtilization(poolDebt, poolCollateral);
-        poolTargetUtilization_ = PoolUtils.poolTargetUtilization(pool.debtEma(), pool.lupColEma());
+        (uint256 debtEma, uint256 lupColEma) = pool.emasInfo();
+        poolTargetUtilization_ = PoolUtils.poolTargetUtilization(debtEma, lupColEma);
     }
 
     /**

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -60,7 +60,7 @@ contract PoolInfoUtils {
         quoteTokens_                  = pool.bucketDeposit(index_); // quote token in bucket, deposit + interest (WAD)
         scale_                        = pool.bucketScale(index_);     // lender interest multiplier (WAD)
 
-        (bucketLPs_, collateral_) = pool.buckets(index_);
+        (bucketLPs_, collateral_, ) = pool.buckets(index_);
         if (bucketLPs_ == 0) {
             exchangeRate_ = Maths.RAY;
         } else {

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -80,7 +80,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
             if (!positionPrice.contains(params_.indexes[i])) require(positionPrice.add(params_.indexes[i]), "PM:ME:ADD_FAIL");
 
             // update PositionManager accounting
-            (uint256 lpBalance, ) = pool.lenders(params_.indexes[i], params_.owner);
+            (uint256 lpBalance, ) = pool.lenderInfo(params_.indexes[i], params_.owner);
             lps[params_.tokenId][params_.indexes[i]] += lpBalance;
 
             // increment call counter in gas efficient way by skipping safemath checks
@@ -107,7 +107,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
     function moveLiquidity(MoveLiquidityParams calldata params_) external override mayInteract(params_.pool, params_.tokenId) {
 
         IPool pool = IPool(params_.pool);
-        uint256 bucketDeposit = pool.bucketDeposit(params_.fromIndex);
+        (, , , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
         uint256 maxQuote      = pool.lpsToQuoteTokens(
             bucketDeposit,
             lps[params_.tokenId][params_.fromIndex],

--- a/src/base/PositionNFT.sol
+++ b/src/base/PositionNFT.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.14;
 import { Base64 } from '@base64-sol/base64.sol';
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
-import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol';  // TODO: determine if tokens should be burnable
 import '@openzeppelin/contracts/utils/Strings.sol';
 
 import './interfaces/IPositionManager.sol';

--- a/src/base/interfaces/IPool.sol
+++ b/src/base/interfaces/IPool.sol
@@ -27,14 +27,6 @@ interface IPool is
     IPoolErrors
 {
 
-    /**
-     *  @notice Initializes a new pool, setting initial state variables.
-     *  @param  rate Initial interest rate of the pool.
-     */
-    function initialize(
-        uint256 rate
-    ) external;
-
 }
 
 interface IERC20Token {

--- a/src/base/interfaces/IPool.sol
+++ b/src/base/interfaces/IPool.sol
@@ -38,3 +38,23 @@ interface IPool is
     ) external;
 
 }
+
+interface IERC20Token {
+    function balanceOf(address account) external view returns (uint256);
+    function burn(uint256 amount) external;
+    function decimals() external view returns (uint8);
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+}
+
+interface IERC721Token {
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
+}

--- a/src/base/interfaces/IPool.sol
+++ b/src/base/interfaces/IPool.sol
@@ -29,12 +29,10 @@ interface IPool is
 
     /**
      *  @notice Initializes a new pool, setting initial state variables.
-     *  @param  rate             Initial interest rate of the pool.
-     *  @param  ajnaTokenAddress Address of the Ajna token.
+     *  @param  rate Initial interest rate of the pool.
      */
     function initialize(
-        uint256 rate,
-        address ajnaTokenAddress
+        uint256 rate
     ) external;
 
 }

--- a/src/base/interfaces/IPoolFactory.sol
+++ b/src/base/interfaces/IPoolFactory.sol
@@ -36,22 +36,4 @@ interface IPoolFactory {
      *  @param  pool_ The address of the new pool.
      */
     event PoolCreated(address pool_);
-
-    /**************************/
-    /*** External Functions ***/
-    /**************************/
-
-    /**
-     *  @notice Deploys a cloned pool for the given collateral and quote token.
-     *  @dev    Pool must not already exist, and must use WETH instead of ETH.
-     *  @param  collateral   Address of ERC20 collateral token.
-     *  @param  quote        Address of ERC20 quote token.
-     *  @param  interestRate Initial interest rate of the pool.
-     *  @return pool         Address of the newly created pool.
-     */
-    function deployPool(
-        address collateral,
-        address quote,
-        uint256 interestRate
-    ) external returns (address pool);
 }

--- a/src/base/interfaces/pool/IPoolDerivedState.sol
+++ b/src/base/interfaces/pool/IPoolDerivedState.sol
@@ -8,24 +8,6 @@ pragma solidity 0.8.14;
 interface IPoolDerivedState {
 
     /**
-     *  @notice Returns the amount of quote tokens deposited at a given bucket.
-     *  @param  index_  The price bucket index for which the value should be calculated.
-     *  @return Amount of quote tokens in bucket.
-     */
-    function bucketDeposit(
-        uint256 index_
-    ) external view returns (uint256);
-
-    /**
-     *  @notice Returns the multiplier of a given bucket.
-     *  @param  index_  The price bucket index for which the value should be calculated.
-     *  @return Bucket multiplier.
-     */
-    function bucketScale(
-        uint256 index_
-    ) external view returns (uint256);
-
-    /**
      *  @notice Returns the bucket index for a given debt amount.
      *  @param  debt_  The debt amount to calculate bucket index for.
      *  @return Bucket index.

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -108,10 +108,4 @@ interface IPoolErrors {
      *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
      */
     error PoolUnderCollateralized();
-
-    /**
-     *  @notice Pool cannot be initialized with 0x address for Ajna token.
-     */
-    error Token0xAddress();
-
 }

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -26,6 +26,11 @@ interface IPoolErrors {
     error AuctionActive();
 
     /**
+     *  @notice Head auction should be cleared prior of taking auctions.
+     */
+    error AuctionNotCleared();
+
+    /**
      *  @notice Borrower has a healthy over-collateralized position.
      */
     error BorrowerOk();

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -21,16 +21,6 @@ interface IPoolErrors {
     error AmountLTMinDebt();
 
     /**
-     *  @notice Kicker is attempting to kick or clear an active auction.
-     */
-    error AuctionActive();
-
-    /**
-     *  @notice Head auction should be cleared prior of taking auctions.
-     */
-    error AuctionNotCleared();
-
-    /**
      *  @notice Borrower has a healthy over-collateralized position.
      */
     error BorrowerOk();

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -105,6 +105,11 @@ interface IPoolErrors {
     error NoReserves();
 
     /**
+     *  @notice Underlying ERC20 transfer failed.
+     */
+    error ERC20TransferFailed();
+
+    /**
      *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
      */
     error PoolUnderCollateralized();

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -50,17 +50,6 @@ interface IPoolEvents {
     );
 
     /**
-     *  @notice Emitted when an actor settles debt in a completed liquidation
-     *  @param  borrower           Identifies the loan under liquidation.
-     *  @param  clearedDebt        Amount of debt cleared from the HPB in this transaction.
-     *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
-     */
-    event Clear(
-        address indexed borrower,
-        uint256 clearedDebt
-    );
-
-    /**
      *  @notice Emitted when an actor uses quote token outside of the book to purchase collateral under liquidation.
      *  @param  borrower   Identifies the loan being liquidated.
      *  @param  index      Index of the price bucket from which quote token was exchanged for collateral.
@@ -75,6 +64,17 @@ interface IPoolEvents {
         uint256 amount,
         uint256 collateral,
         int256 bondChange
+    );
+
+    /**
+     *  @notice Emitted when an actor settles debt in a completed liquidation
+     *  @param  borrower   Identifies the loan under liquidation.
+     *  @param  healedDebt Amount of pool debt healed in this transaction.
+     *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
+     */
+    event Heal(
+        address indexed borrower,
+        uint256 healedDebt
     );
 
     /**

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -52,18 +52,13 @@ interface IPoolEvents {
     /**
      *  @notice Emitted when an actor settles debt in a completed liquidation
      *  @param  borrower           Identifies the loan under liquidation.
-     *  @param  hpbIndex           The index of the Highest Price Bucket where debt was cleared.
-     *  @param  amount             Amount of debt cleared from the HPB in this transaction.
-     *  @param  collateralReturned Amount of collateral returned to the borrower in this transaction.
-     *  @param  amountRemaining    Amount of debt which still needs to be cleared.
+     *  @param  clearedDebt        Amount of debt cleared from the HPB in this transaction.
      *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
      */
     event Clear(
         address indexed borrower,
-        uint256 hpbIndex,
-        uint256 amount,
-        uint256 collateralReturned,
-        uint256 amountRemaining);
+        uint256 clearedDebt
+    );
 
     /**
      *  @notice Emitted when an actor uses quote token outside of the book to purchase collateral under liquidation.

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -50,6 +50,22 @@ interface IPoolEvents {
     );
 
     /**
+     *  @notice Emitted when an actor settles debt in a completed liquidation
+     *  @param  borrower           Identifies the loan under liquidation.
+     *  @param  hpbIndex           The index of the Highest Price Bucket where debt was cleared.
+     *  @param  amount             Amount of debt cleared from the HPB in this transaction.
+     *  @param  collateralReturned Amount of collateral returned to the borrower in this transaction.
+     *  @param  amountRemaining    Amount of debt which still needs to be cleared.
+     *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
+     */
+    event Clear(
+        address indexed borrower,
+        uint256 hpbIndex,
+        uint256 amount,
+        uint256 collateralReturned,
+        uint256 amountRemaining);
+
+    /**
      *  @notice Emitted when an actor uses quote token outside of the book to purchase collateral under liquidation.
      *  @param  borrower   Identifies the loan being liquidated.
      *  @param  index      Index of the price bucket from which quote token was exchanged for collateral.

--- a/src/base/interfaces/pool/IPoolImmutables.sol
+++ b/src/base/interfaces/pool/IPoolImmutables.sol
@@ -12,12 +12,6 @@ interface IPoolImmutables {
     function collateralAddress() external pure returns (address);
 
     /**
-     *  @notice Returns the `minFee` state variable.
-     *  @return minimum fee that can be applied for early withdraw penalty
-     */
-    function minFee() external view returns (uint256);
-
-    /**
      *  @notice Returns the address of the pools quote token
      */
     function quoteTokenAddress() external pure returns (address);

--- a/src/base/interfaces/pool/IPoolLiquidationActions.sol
+++ b/src/base/interfaces/pool/IPoolLiquidationActions.sol
@@ -19,17 +19,6 @@ interface IPoolLiquidationActions {
     ) external;
 
     /**
-     *  @notice Called by actors to settle an amount of debt in a completed liquidation.
-     *  @param  borrower Identifies the loan under liquidation.
-     *  @param  maxDepth Measured from HPB, maximum number of buckets deep to settle debt.
-     *  @dev maxDepth is used to prevent unbounded iteration clearing large liquidations.
-     */
-    function clear(
-        address borrower,
-        uint256 maxDepth
-    ) external;
-
-    /**
      *  @notice Called by actors to purchase collateral using quote token already on the book.
      *  @param  borrower Identifies the loan under liquidation.
      *  @param  amount   Amount of bucket deposit to use to exchange for collateral.
@@ -39,6 +28,17 @@ interface IPoolLiquidationActions {
         address borrower,
         uint256 amount,
         uint256 index
+    ) external;
+
+    /**
+     *  @notice Called by actors to settle an amount of debt in a completed liquidation.
+     *  @param  borrower Identifies the loan under liquidation.
+     *  @param  maxDepth Measured from HPB, maximum number of buckets deep to settle debt.
+     *  @dev maxDepth is used to prevent unbounded iteration clearing large liquidations.
+     */
+    function heal(
+        address borrower,
+        uint256 maxDepth
     ) external;
 
     /**

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -41,7 +41,7 @@ interface IPoolState {
      *  @return mompFactor Momp / borrowerInflatorSnapshot factor used.
      *  @return inflator   Snapshot of inflator value used to track interest on loans.
      */
-    function borrowers(address borrower)
+    function borrowerInfo(address borrower)
         external
         view
         returns (
@@ -57,15 +57,19 @@ interface IPoolState {
      *  @param  index               Bucket index.
      *  @return lpAccumulator       Amount of LPs accumulated in current bucket.
      *  @return availableCollateral Amount of collateral available in current bucket.
-     *  @return bankruptcyTime      Timestamp when bucket become insolvent, 0 if healthy
+     *  @return bankruptcyTime      Timestamp when bucket become insolvent, 0 if healthy.
+     *  @return bucketDeposit       Amount of quote tokens in bucket.
+     *  @return bucketScale         Bucket multiplier.
      */
-    function buckets(uint256 index)
+    function bucketInfo(uint256 index)
         external
         view
         returns (
             uint256 lpAccumulator,
             uint256 availableCollateral,
-            uint256 bankruptcyTime
+            uint256 bankruptcyTime,
+            uint256 bucketDeposit,
+            uint256 bucketScale
         );
 
     /**
@@ -92,7 +96,7 @@ interface IPoolState {
      */
     function interestRateUpdate() external view returns (uint256);
 
-    function kickers(address kicker)
+    function kickerInfo(address kicker)
         external
         view
         returns (
@@ -108,13 +112,12 @@ interface IPoolState {
 
     /**
      *  @notice Mapping of buckets indexes and owner addresses to {Lender} structs.
-     *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
      *  @param  index            Bucket index.
      *  @param  lp               Address of the liquidity provider.
      *  @return lpBalance        Amount of LPs owner has in current bucket.
      *  @return lastQuoteDeposit Time the user last deposited quote token.
      */
-    function lenders(
+    function lenderInfo(
         uint256 index,
         address lp
     )
@@ -126,51 +129,45 @@ interface IPoolState {
     );
 
     /**
-     *  @notice Returns the amount of liquidation bond across all liquidators.
-     *  @return Total amount of quote token being escrowed.
-     */
-    function liquidationBondEscrowed() external view returns (uint256);
-
-    /**
      *  @notice Returns the `lupColEma` state variable.
      *  @return Exponential LUP * pledged collateral moving average.
      */
     function lupColEma() external view returns (uint256);
 
     /**
-     *  @notice Returns the borrower address with highest threshold price in pool.
-     *  @return Borrower address with highest threshold price.
+     *  @notice Returns information about pool loans.
+     *  @return maxBorrower       Borrower address with highest threshold price.
+     *  @return maxThresholdPrice Highest threshold price in pool.
+     *  @return noOfLoans         Total number of loans.
      */
-    function maxBorrower() external view returns (address);
+    function loansInfo()
+        external
+        view
+        returns (
+            address maxBorrower,
+            uint256 maxThresholdPrice,
+            uint256 noOfLoans
+    );
 
     /**
-     *  @notice Returns the highest threshold price in pool.
-     *  @return Highest threshold price in pool.
+     *  @notice Returns information about pool reserves.
+     *  @return liquidationBondEscrowed Amount of liquidation bond across all liquidators.
+     *  @return reserveAuctionUnclaimed Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
+     *  @return reserveAuctionKicked    Time a Claimable Reserve Auction was last kicked.
      */
-    function maxThresholdPrice() external view returns (uint256);
-
-    /**
-     *  @notice Returns the total number of loans within pool.
-     *  @return Total number of loans.
-     */
-    function noOfLoans() external view returns (uint256);
+    function reservesInfo()
+        external
+        view
+        returns (
+            uint256 liquidationBondEscrowed,
+            uint256 reserveAuctionUnclaimed,
+            uint256 reserveAuctionKicked
+    );
 
     /**
      *  @notice Returns the `pledgedCollateral` state variable.
      *  @return The total pledged collateral in the system, in WAD units.
      */
     function pledgedCollateral() external view returns (uint256);
-
-    /**
-     *  @notice Returns the amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
-     *  @return Unclaimed Auction Reserve.
-     */
-    function reserveAuctionUnclaimed() external view returns (uint256);
-
-    /**
-     *  @notice Returns the Time a Claimable Reserve Auction was last kicked.
-     *  @return Time a Claimable Reserve Auction was last kicked.
-     */
-    function reserveAuctionKicked() external view returns (uint256);
 
 }

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -57,7 +57,7 @@ interface IPoolState {
      *  @param  index               Bucket index.
      *  @return lpAccumulator       Amount of LPs accumulated in current bucket.
      *  @return availableCollateral Amount of collateral available in current bucket.
-     *  @return locked              True if bucket locked for LPs withdrawalss.
+     *  @return bankruptcyTs        Timestamp when bucket become insolvent, 0 if healthy
      */
     function buckets(uint256 index)
         external
@@ -65,7 +65,7 @@ interface IPoolState {
         returns (
             uint256 lpAccumulator,
             uint256 availableCollateral,
-            bool    locked
+            uint256 bankruptcyTs
         );
 
     /**

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -57,13 +57,15 @@ interface IPoolState {
      *  @param  index               Bucket index.
      *  @return lpAccumulator       Amount of LPs accumulated in current bucket.
      *  @return availableCollateral Amount of collateral available in current bucket.
+     *  @return locked              True if bucket locked for LPs withdrawalss.
      */
     function buckets(uint256 index)
         external
         view
         returns (
             uint256 lpAccumulator,
-            uint256 availableCollateral
+            uint256 availableCollateral,
+            bool    locked
         );
 
     /**

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -73,10 +73,17 @@ interface IPoolState {
         );
 
     /**
-     *  @notice Returns the `debtEma` state variable.
-     *  @return Exponential debt moving average.
+     *  @notice Returns information about the pool EMA (Exponential Moving Average) variables.
+     *  @return debtEma   Exponential debt moving average.
+     *  @return lupColEma Exponential LUP * pledged collateral moving average.
      */
-    function debtEma() external view returns (uint256);
+    function emasInfo()
+        external
+        view
+        returns (
+            uint256 debtEma,
+            uint256 lupColEma
+    );
 
     /**
      *  @notice Returns information about pool inflator.
@@ -134,12 +141,6 @@ interface IPoolState {
             uint256 lpBalance,
             uint256 lastQuoteDeposit
     );
-
-    /**
-     *  @notice Returns the `lupColEma` state variable.
-     *  @return Exponential LUP * pledged collateral moving average.
-     */
-    function lupColEma() external view returns (uint256);
 
     /**
      *  @notice Returns information about pool loans.

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -79,10 +79,17 @@ interface IPoolState {
     function debtEma() external view returns (uint256);
 
     /**
-     *  @notice Returns the `inflatorSnapshot` state variable.
-     *  @return A snapshot of the last inflator value, in RAY units.
+     *  @notice Returns information about pool inflator.
+     *  @return inflatorSnapshot A snapshot of the last inflator value.
+     *  @return lastUpdate       The timestamp of the last `inflatorSnapshot` update.
      */
-    function inflatorSnapshot() external view returns (uint256);
+    function inflatorInfo()
+        external
+        view
+        returns (
+            uint256 inflatorSnapshot,
+            uint256 lastUpdate
+    );
 
     /**
      *  @notice Returns the `interestRate` state variable.
@@ -96,6 +103,12 @@ interface IPoolState {
      */
     function interestRateUpdate() external view returns (uint256);
 
+    /**
+     *  @notice Returns details about kicker balances.
+     *  @param  kicker    The address of the kicker to retrieved info for.
+     *  @return claimable Amount of quote token kicker can claim / withdraw from pool at any time.
+     *  @return locked    Amount of quote token kicker locked in auctions (as bonds).
+     */
     function kickerInfo(address kicker)
         external
         view
@@ -103,12 +116,6 @@ interface IPoolState {
             uint256 claimable,
             uint256 locked
         );
-
-    /**
-     *  @notice Returns the `lastInflatorSnapshotUpdate` state variable.
-     *  @return The timestamp of the last `inflatorSnapshot` update.
-     */
-    function lastInflatorSnapshotUpdate() external view returns (uint256);
 
     /**
      *  @notice Mapping of buckets indexes and owner addresses to {Lender} structs.

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -57,7 +57,7 @@ interface IPoolState {
      *  @param  index               Bucket index.
      *  @return lpAccumulator       Amount of LPs accumulated in current bucket.
      *  @return availableCollateral Amount of collateral available in current bucket.
-     *  @return bankruptcyTs        Timestamp when bucket become insolvent, 0 if healthy
+     *  @return bankruptcyTime      Timestamp when bucket become insolvent, 0 if healthy
      */
     function buckets(uint256 index)
         external
@@ -65,7 +65,7 @@ interface IPoolState {
         returns (
             uint256 lpAccumulator,
             uint256 availableCollateral,
-            uint256 bankruptcyTs
+            uint256 bankruptcyTime
         );
 
     /**

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -176,10 +176,10 @@ contract ERC20Pool is IERC20Pool, Pool {
     /************************/
 
     function _transferCollateralFrom(address from_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(0)).transferFrom(from_, address(this), amount_ / collateralScale);
+        if (!IERC20Token(_getArgAddress(0)).transferFrom(from_, address(this), amount_ / collateralScale)) revert ERC20TransferFailed();
     }
 
     function _transferCollateral(address to_, uint256 amount_) internal {
-        IERC20Token(_getArgAddress(0)).transfer(to_, amount_ / collateralScale);
+        if (!IERC20Token(_getArgAddress(0)).transfer(to_, amount_ / collateralScale)) revert ERC20TransferFailed();
     }
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -161,12 +161,6 @@ contract ERC20Pool is IERC20Pool, Pool {
         emit ArbTake(borrower_, index_, amount_, 0, 0);
     }
 
-    function clear(address borrower_, uint256 maxDepth_) external override {
-        // TODO: implement
-        uint256 debtCleared = maxDepth_ * 10_000;
-        emit Clear(borrower_, _hpbIndex(), debtCleared, 0, 0);
-    }
-
     function depositTake(address borrower_, uint256 amount_, uint256 index_) external override {
         // TODO: implement
         emit DepositTake(borrower_, index_, amount_, 0, 0);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -3,7 +3,6 @@
 pragma solidity 0.8.14;
 
 import './interfaces/IERC20Pool.sol';
-
 import '../base/Pool.sol';
 
 contract ERC20Pool is IERC20Pool, Pool {

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -3,17 +3,15 @@
 pragma solidity 0.8.14;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 
 import './interfaces/IERC20Pool.sol';
 
 import '../base/Pool.sol';
 
 contract ERC20Pool is IERC20Pool, Pool {
-    using SafeERC20 for ERC20;
-    using Buckets   for mapping(uint256 => Buckets.Bucket);
-    using Deposits  for Deposits.Data;
-    using Loans     for Loans.Data;
+    using Buckets  for mapping(uint256 => Buckets.Bucket);
+    using Deposits for Deposits.Data;
+    using Loans    for Loans.Data;
 
     /***********************/
     /*** State Variables ***/
@@ -186,11 +184,11 @@ contract ERC20Pool is IERC20Pool, Pool {
     /************************/
 
     function _transferCollateralFrom(address from_, uint256 amount_) internal {
-        collateral().safeTransferFrom(from_, address(this), amount_ / collateralScale);
+        collateral().transferFrom(from_, address(this), amount_ / collateralScale);
     }
 
     function _transferCollateral(address to_, uint256 amount_) internal {
-        collateral().safeTransfer(to_, amount_ / collateralScale);
+        collateral().transfer(to_, amount_ / collateralScale);
     }
 
     /**

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -31,7 +31,6 @@ contract ERC20Pool is IERC20Pool, Pool {
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;
         interestRateUpdate         = block.timestamp;
-        minFee                     = 0.0005 * 10**18;
 
         loans.init();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -60,7 +60,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // move collateral from sender to pool
         emit PledgeCollateral(borrower_, collateralAmountToPledge_);
-        collateral().safeTransferFrom(msg.sender, address(this), collateralAmountToPledge_ / collateralScale);
+        _transferCollateralFrom(msg.sender, collateralAmountToPledge_);
     }
 
     function pullCollateral(
@@ -70,7 +70,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // move collateral from pool to sender
         emit PullCollateral(msg.sender, collateralAmountToPull_);
-        collateral().safeTransfer(msg.sender, collateralAmountToPull_ / collateralScale);
+        _transferCollateral(msg.sender, collateralAmountToPull_);
     }
 
     /*********************************/
@@ -85,7 +85,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // move required collateral from sender to pool
         emit AddCollateral(msg.sender, index_, collateralAmountToAdd_);
-        collateral().safeTransferFrom(msg.sender, address(this), collateralAmountToAdd_ / collateralScale);
+        _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
     }
 
     function moveCollateral(
@@ -138,7 +138,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // move collateral from pool to lender
         emit RemoveCollateral(msg.sender, index_, collateralAmountRemoved_);
-        collateral().safeTransfer(msg.sender, collateralAmountRemoved_ / collateralScale);
+        _transferCollateral(msg.sender, collateralAmountRemoved_);
     }
 
     function removeCollateral(
@@ -149,7 +149,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // move collateral from pool to lender
         emit RemoveCollateral(msg.sender, index_, collateralAmountToRemove_);
-        collateral().safeTransfer(msg.sender, collateralAmountToRemove_ / collateralScale);
+        _transferCollateral(msg.sender, collateralAmountToRemove_);
     }
 
     /*******************************/
@@ -178,12 +178,20 @@ contract ERC20Pool is IERC20Pool, Pool {
         // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
         //msg.sender.call(swapCalldata_);
 
-        collateral().safeTransfer(msg.sender, collateralTaken);
+        _transferCollateral(msg.sender, collateralTaken);
     }
 
     /************************/
     /*** Helper Functions ***/
     /************************/
+
+    function _transferCollateralFrom(address from_, uint256 amount_) internal {
+        collateral().safeTransferFrom(from_, address(this), amount_ / collateralScale);
+    }
+
+    function _transferCollateral(address to_, uint256 amount_) internal {
+        collateral().safeTransfer(to_, amount_ / collateralScale);
+    }
 
     /**
      *  @dev Pure function used to facilitate accessing token via clone state.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -2,8 +2,6 @@
 
 pragma solidity 0.8.14;
 
-import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
-
 import './interfaces/IERC20Pool.sol';
 
 import '../base/Pool.sol';
@@ -30,8 +28,8 @@ contract ERC20Pool is IERC20Pool, Pool {
         if (poolInitializations != 0)         revert AlreadyInitialized();
         if (ajnaTokenAddress_ == address(0))  revert Token0xAddress();
 
-        collateralScale = 10**(18 - collateral().decimals());
-        quoteTokenScale = 10**(18 - quoteToken().decimals());
+        collateralScale = 10**(18 - IERC20Token(_getArgAddress(0)).decimals());
+        quoteTokenScale = 10**(18 - IERC20Token(_getArgAddress(0x14)).decimals());
 
         ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
@@ -184,17 +182,10 @@ contract ERC20Pool is IERC20Pool, Pool {
     /************************/
 
     function _transferCollateralFrom(address from_, uint256 amount_) internal {
-        collateral().transferFrom(from_, address(this), amount_ / collateralScale);
+        IERC20Token(_getArgAddress(0)).transferFrom(from_, address(this), amount_ / collateralScale);
     }
 
     function _transferCollateral(address to_, uint256 amount_) internal {
-        collateral().transfer(to_, amount_ / collateralScale);
-    }
-
-    /**
-     *  @dev Pure function used to facilitate accessing token via clone state.
-     */
-    function collateral() public pure returns (ERC20) {
-        return ERC20(_getArgAddress(0));
+        IERC20Token(_getArgAddress(0)).transfer(to_, amount_ / collateralScale);
     }
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -21,16 +21,12 @@ contract ERC20Pool is IERC20Pool, Pool {
     /****************************/
 
     function initialize(
-        uint256 rate_,
-        address ajnaTokenAddress_
+        uint256 rate_
     ) external override {
-        if (poolInitializations != 0)         revert AlreadyInitialized();
-        if (ajnaTokenAddress_ == address(0))  revert Token0xAddress();
+        if (poolInitializations != 0) revert AlreadyInitialized();
 
         collateralScale = 10**(18 - IERC20Token(_getArgAddress(0)).decimals());
-        quoteTokenScale = 10**(18 - IERC20Token(_getArgAddress(0x14)).decimals());
 
-        ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -24,13 +24,20 @@ contract ERC20PoolFactory is IPoolFactory, PoolDeployer {
     function deployPool(
         address collateral_, address quote_, uint256 interestRate_
     ) external canDeploy(ERC20_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (address pool_) {
-        bytes memory data = abi.encodePacked(collateral_, quote_);
+        uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
+
+        bytes memory data = abi.encodePacked(
+            collateral_,
+            quote_,
+            ajnaTokenAddress,
+            quoteTokenScale
+        );
 
         ERC20Pool pool = ERC20Pool(address(implementation).clone(data));
         pool_ = address(pool);
         deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(interestRate_, ajnaTokenAddress);
+        pool.initialize(interestRate_);
     }
 }

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -29,7 +29,6 @@ contract ERC20PoolFactory is IPoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(
             collateral_,
             quote_,
-            ajnaTokenAddress,
             quoteTokenScale
         );
 

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.14;
 
 import { ClonesWithImmutableArgs } from '@clones/ClonesWithImmutableArgs.sol';
 
-import '../base/interfaces/IPoolFactory.sol';
+import './interfaces/IERC20PoolFactory.sol';
 import '../base/PoolDeployer.sol';
 
 import './ERC20Pool.sol';
 
-contract ERC20PoolFactory is IPoolFactory, PoolDeployer {
+contract ERC20PoolFactory is IERC20PoolFactory, PoolDeployer {
 
     using ClonesWithImmutableArgs for address;
 

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -22,4 +22,12 @@ interface IERC20Pool is
     IERC20PoolEvents
 {
 
+    /**
+     *  @notice Initializes a new pool, setting initial state variables.
+     *  @param  rate Initial interest rate of the pool.
+     */
+    function initialize(
+        uint256 rate
+    ) external;
+
 }

--- a/src/erc20/interfaces/IERC20PoolFactory.sol
+++ b/src/erc20/interfaces/IERC20PoolFactory.sol
@@ -5,10 +5,10 @@ pragma solidity 0.8.14;
 import '../../base/interfaces/IPoolFactory.sol';
 
 /**
- *  @title ERC721 Pool Factory
- *  @dev   Used to deploy non fungible pools.
+ *  @title ERC20 Pool Factory
+ *  @dev   Used to deploy ERC20 pools.
  */
-interface IERC721PoolFactory is IPoolFactory {
+interface IERC20PoolFactory is IPoolFactory {
 
     /**************************/
     /*** External Functions ***/
@@ -17,16 +17,14 @@ interface IERC721PoolFactory is IPoolFactory {
     /**
      *  @notice Deploys a cloned pool for the given collateral and quote token.
      *  @dev    Pool must not already exist, and must use WETH instead of ETH.
-     *  @param  collateral   Address of NFT collateral token.
-     *  @param  quote        Address of NFT quote token.
-     *  @param  tokenIds     Ids of subset NFT tokens.
+     *  @param  collateral   Address of ERC20 collateral token.
+     *  @param  quote        Address of ERC20 quote token.
      *  @param  interestRate Initial interest rate of the pool.
      *  @return pool         Address of the newly created pool.
      */
     function deployPool(
         address collateral,
         address quote,
-        uint256[] memory tokenIds,
         uint256 interestRate
     ) external returns (address pool);
 }

--- a/src/erc20/interfaces/pool/IERC20PoolEvents.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolEvents.sol
@@ -19,22 +19,6 @@ interface IERC20PoolEvents {
     );
 
     /**
-     *  @notice Emitted when an actor settles debt in a completed liquidation
-     *  @param  borrower           Identifies the loan under liquidation.
-     *  @param  hpbIndex           The index of the Highest Price Bucket where debt was cleared.
-     *  @param  amount             Amount of debt cleared from the HPB in this transaction.
-     *  @param  collateralReturned Amount of collateral returned to the borrower in this transaction.
-     *  @param  amountRemaining    Amount of debt which still needs to be cleared.
-     *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
-     */
-    event Clear(
-        address indexed borrower,
-        uint256 hpbIndex,
-        uint256 amount,
-        uint256 collateralReturned,
-        uint256 amountRemaining);
-
-    /**
      *  @notice Emitted when lender moves collateral from a bucket price to another.
      *  @param  lender Recipient that moved collateral.
      *  @param  from   Price bucket from which collateral was moved.

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -25,7 +25,6 @@ contract ERC721Pool is IERC721Pool, Pool {
     /// @dev Defaults to length 0 if the whole collection is to be used
     mapping(uint256 => bool) public tokenIdsAllowed;
 
-
     bool public isSubset;
 
     /****************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.14;
 
 import { Clone } from '@clones/Clone.sol';
 
-import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
-
 import './interfaces/IERC721Pool.sol';
 
 import '../base/Pool.sol';
@@ -41,7 +39,7 @@ contract ERC721Pool is IERC721Pool, Pool {
         if (poolInitializations != 0)         revert AlreadyInitialized();
         if (ajnaTokenAddress_ == address(0))  revert Token0xAddress();
 
-        quoteTokenScale = 10**(18 - quoteToken().decimals());
+        quoteTokenScale = 10**(18 - IERC20Token(_getArgAddress(0x14)).decimals());
 
         ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
@@ -245,19 +243,12 @@ contract ERC721Pool is IERC721Pool, Pool {
 
     function _transferNFT(address from_, address to_, uint256 tokenId_) internal {
         //slither-disable-next-line calls-loop
-        collateral().safeTransferFrom(from_, to_, tokenId_);
+        IERC721Token(_getArgAddress(0)).safeTransferFrom(from_, to_, tokenId_);
     }
 
     /************************/
     /*** Helper Functions ***/
     /************************/
-
-    /** @dev Collateral tokens are always non-fungible
-     *  @dev Pure function used to facilitate accessing token via clone state
-     */
-    function collateral() public pure returns (ERC721) {
-        return ERC721(_getArgAddress(0));
-    }
 
     /** @notice Implementing this method allows contracts to receive ERC721 tokens
      *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.14;
 
 import { Clone } from '@clones/Clone.sol';
 
-import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
-import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 
 import './interfaces/IERC721Pool.sol';
@@ -12,9 +10,8 @@ import './interfaces/IERC721Pool.sol';
 import '../base/Pool.sol';
 
 contract ERC721Pool is IERC721Pool, Pool {
-    using SafeERC20 for ERC20;
-    using Buckets   for mapping(uint256 => Buckets.Bucket);
-    using Loans     for Loans.Data;
+    using Buckets for mapping(uint256 => Buckets.Bucket);
+    using Loans   for Loans.Data;
 
     /***********************/
     /*** State Variables ***/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -38,7 +38,6 @@ contract ERC721Pool is IERC721Pool, Pool {
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;
         interestRateUpdate         = block.timestamp;
-        minFee                     = 0.0005 * 10**18;
 
         loans.init();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -30,15 +30,10 @@ contract ERC721Pool is IERC721Pool, Pool {
     /****************************/
 
     function initialize(
-        uint256 rate_,
-        address ajnaTokenAddress_
+        uint256 rate_
     ) external override {
-        if (poolInitializations != 0)         revert AlreadyInitialized();
-        if (ajnaTokenAddress_ == address(0))  revert Token0xAddress();
+        if (poolInitializations != 0) revert AlreadyInitialized();
 
-        quoteTokenScale = 10**(18 - IERC20Token(_getArgAddress(0x14)).decimals());
-
-        ajnaTokenAddress           = ajnaTokenAddress_;
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;
         interestRate               = rate_;
@@ -53,8 +48,7 @@ contract ERC721Pool is IERC721Pool, Pool {
 
     function initializeSubset(
         uint256[] memory tokenIds_,
-        uint256 rate_,
-        address ajnaTokenAddress_
+        uint256 rate_
     ) external override {
         isSubset = true;
 
@@ -66,7 +60,7 @@ contract ERC721Pool is IERC721Pool, Pool {
             }
         }
 
-        this.initialize(rate_, ajnaTokenAddress_);
+        this.initialize(rate_);
     }
 
     /***********************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -30,6 +30,7 @@ contract ERC721Pool is IERC721Pool, Pool {
     /****************************/
 
     function initialize(
+        uint256[] memory tokenIds_,
         uint256 rate_
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
@@ -39,27 +40,20 @@ contract ERC721Pool is IERC721Pool, Pool {
         interestRate               = rate_;
         interestRateUpdate         = block.timestamp;
 
-        loans.init();
-
-        // increment initializations count to ensure these values can't be updated
-        poolInitializations += 1;
-    }
-
-    function initializeSubset(
-        uint256[] memory tokenIds_,
-        uint256 rate_
-    ) external override {
-        isSubset = true;
-
+        uint256 noOfTokens = tokenIds_.length;
+        isSubset = noOfTokens > 0;
         // add subset of tokenIds allowed in the pool
-        for (uint256 id = 0; id < tokenIds_.length;) {
+        for (uint256 id = 0; id < noOfTokens;) {
             tokenIdsAllowed[tokenIds_[id]] = true;
             unchecked {
                 ++id;
             }
         }
 
-        this.initialize(rate_);
+        loans.init();
+
+        // increment initializations count to ensure these values can't be updated
+        poolInitializations += 1;
     }
 
     /***********************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
+
 pragma solidity 0.8.14;
 
-import { Clone } from '@clones/Clone.sol';
-
 import './interfaces/IERC721Pool.sol';
-
 import '../base/Pool.sol';
 
 contract ERC721Pool is IERC721Pool, Pool {

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -177,14 +177,6 @@ contract ERC721Pool is IERC721Pool, Pool {
         emit ArbTake(borrower_, index_, amount_, 0, 0);
     }
 
-    function clear(address borrower_, uint256 maxDepth_) external override {
-        // TODO: implement
-        uint256[] memory tokenIdsReturned = new uint256[](1);
-        tokenIdsReturned[0] = 0;
-        uint256 debtCleared = maxDepth_ * 10_000;
-        emit ClearNFT(borrower_, _hpbIndex(), debtCleared, tokenIdsReturned, 0);
-    }
-
     function depositTake(address borrower_, uint256 amount_, uint256 index_) external override {
         // TODO: implement
         emit DepositTake(borrower_, index_, amount_, 0, 0);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -198,7 +198,8 @@ contract ERC721Pool is IERC721Pool, Pool {
         uint256 price_
     ) internal pure override returns (uint256) {
         uint256 encumbered = price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
-        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD;
+        //slither-disable-next-line divide-before-multiply
+        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
         return encumbered != 0 ? Maths.wdiv(collateral_, encumbered) : Maths.WAD;
     }
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -41,12 +41,14 @@ contract ERC721Pool is IERC721Pool, Pool {
         interestRateUpdate         = block.timestamp;
 
         uint256 noOfTokens = tokenIds_.length;
-        isSubset = noOfTokens > 0;
-        // add subset of tokenIds allowed in the pool
-        for (uint256 id = 0; id < noOfTokens;) {
-            tokenIdsAllowed[tokenIds_[id]] = true;
-            unchecked {
-                ++id;
+        if (noOfTokens > 0) {
+            isSubset = true;
+            // add subset of tokenIds allowed in the pool
+            for (uint256 id = 0; id < noOfTokens;) {
+                tokenIdsAllowed[tokenIds_[id]] = true;
+                unchecked {
+                    ++id;
+                }
             }
         }
 

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -30,7 +30,6 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(
             collateral_,
             quote_,
-            ajnaTokenAddress,
             quoteTokenScale
         );
 
@@ -50,7 +49,6 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(
             collateral_,
             quote_,
-            ajnaTokenAddress,
             quoteTokenScale
         );
 

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -25,27 +25,41 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
     function deployPool(
         address collateral_, address quote_, uint256 interestRate_
     ) external canDeploy(ERC721_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (address pool_) {
-        bytes memory data = abi.encodePacked(collateral_, quote_);
+        uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
+
+        bytes memory data = abi.encodePacked(
+            collateral_,
+            quote_,
+            ajnaTokenAddress,
+            quoteTokenScale
+        );
 
         ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
         pool_ = address(pool);
         deployedPools[ERC721_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(interestRate_, ajnaTokenAddress);
+        pool.initialize(interestRate_);
     }
 
     function deploySubsetPool(
         address collateral_, address quote_, uint256[] memory tokenIds_, uint256 interestRate_
     ) external canDeploy(getNFTSubsetHash(tokenIds_), collateral_, quote_, interestRate_) returns (address pool_) {
-        bytes memory data = abi.encodePacked(collateral_, quote_, tokenIds_);
+        uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
+
+        bytes memory data = abi.encodePacked(
+            collateral_,
+            quote_,
+            ajnaTokenAddress,
+            quoteTokenScale
+        );
 
         ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
         pool_ = address(pool);
         deployedPools[getNFTSubsetHash(tokenIds_)][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initializeSubset(tokenIds_, interestRate_, ajnaTokenAddress);
+        pool.initializeSubset(tokenIds_, interestRate_);
     }
 
     /*********************************/

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -23,25 +23,6 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
     }
 
     function deployPool(
-        address collateral_, address quote_, uint256 interestRate_
-    ) external canDeploy(ERC721_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (address pool_) {
-        uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
-
-        bytes memory data = abi.encodePacked(
-            collateral_,
-            quote_,
-            quoteTokenScale
-        );
-
-        ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
-        pool_ = address(pool);
-        deployedPools[ERC721_NON_SUBSET_HASH][collateral_][quote_] = pool_;
-        emit PoolCreated(pool_);
-
-        pool.initialize(interestRate_);
-    }
-
-    function deploySubsetPool(
         address collateral_, address quote_, uint256[] memory tokenIds_, uint256 interestRate_
     ) external canDeploy(getNFTSubsetHash(tokenIds_), collateral_, quote_, interestRate_) returns (address pool_) {
         uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
@@ -57,7 +38,7 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         deployedPools[getNFTSubsetHash(tokenIds_)][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initializeSubset(tokenIds_, interestRate_);
+        pool.initialize(tokenIds_, interestRate_);
     }
 
     /*********************************/

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -24,14 +24,12 @@ interface IERC721Pool is
     IERC721PoolErrors
 {
 
-
     /**
-     *  @notice Called by deployNFTSubsetPool()
-     *  @dev    Used to initialize pools that only support a subset of tokenIds
-     *  @param  tokenIds         Enumerates tokenIds to be allowed in the pool.
-     *  @param  rate             Initial interest rate of the pool.
+     *  @notice Initializes a new pool, setting initial state variables.
+     *  @param  tokenIds  Enumerates tokenIds to be allowed in the pool.
+     *  @param  rate      Initial interest rate of the pool.
      */
-    function initializeSubset(
+    function initialize(
         uint256[] memory tokenIds,
         uint256 rate
     ) external;

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -30,12 +30,10 @@ interface IERC721Pool is
      *  @dev    Used to initialize pools that only support a subset of tokenIds
      *  @param  tokenIds         Enumerates tokenIds to be allowed in the pool.
      *  @param  rate             Initial interest rate of the pool.
-     *  @param  ajnaTokenAddress Address of the Ajna token.
      */
     function initializeSubset(
         uint256[] memory tokenIds,
-        uint256 rate,
-        address ajnaTokenAddress
+        uint256 rate
     ) external;
 
 }

--- a/src/erc721/interfaces/pool/IERC721PoolEvents.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolEvents.sol
@@ -19,22 +19,6 @@ interface IERC721PoolEvents {
     );
 
     /**
-     *  @notice Emitted when an actor settles debt in a completed liquidation
-     *  @param  borrower           Identifies the loan being liquidated.
-     *  @param  hpbIndex           The index of the Highest Price Bucket where debt was cleared.
-     *  @param  amount             Amount of debt cleared from the HPB in this transaction.
-     *  @param  tokenIdsReturned   Array of NFTs returned to the borrower in this transaction.
-     *  @param  amountRemaining    Amount of debt which still needs to be cleared.
-     *  @dev    When amountRemaining_ == 0, the auction has been completed cleared and removed from the queue.
-     */
-    event ClearNFT(
-        address   indexed borrower,
-        uint256   hpbIndex,
-        uint256   amount,
-        uint256[] tokenIdsReturned,
-        uint256   amountRemaining);
-
-    /**
      *  @notice Emitted when borrower locks collateral in the pool.
      *  @param  borrower `msg.sender`.
      *  @param  tokenIds Array of tokenIds to be added to the pool.

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -104,7 +104,7 @@ library Auctions {
                     remainingCol  -= clearableCol;
 
                     Deposits.remove(deposits_, hpbIndex, clearableDebt);
-                    buckets_[hpbIndex].collateral -= clearableCol;
+                    buckets_[hpbIndex].collateral += clearableCol;
                 }
 
                 // there's still debt to cover but no collateral left to auction, use reserve or forgive amount form next HPB

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -63,8 +63,9 @@ library Auctions {
     {
 
         if (self.liquidations[borrower_].kickTime > 72 hours) {
+            uint256 debtToClear = loans_.borrowers[borrower_].debt;
 
-            remainingDebt_     = loans_.borrowers[borrower_].debt;
+            remainingDebt_     = debtToClear;
             remainingCol_      = loans_.borrowers[borrower_].collateral;
             remainingReserves_ = reserves_;
 
@@ -89,8 +90,9 @@ library Auctions {
                         remainingReserves_ -= fromReserve;
                         remainingDebt_     -= fromReserve;
                     } else {
-                        hpbIndex_          = Deposits.findIndexOfSum(deposits_, 1);
-                        uint256 forgiveAmt = Maths.min(remainingDebt_, Deposits.valueAt(deposits_, hpbIndex_));
+                        hpbIndex_         = Deposits.findIndexOfSum(deposits_, 1);
+                        uint256 hpbDeposit = Deposits.valueAt(deposits_, hpbIndex_);
+                        uint256 forgiveAmt = Maths.min(remainingDebt_, hpbDeposit);
 
                         totalForgived_ += forgiveAmt;
                         remainingDebt_ -= forgiveAmt;
@@ -114,7 +116,7 @@ library Auctions {
                 --bucketDepth_;
             }
 
-            clearedDebt_ = loans_.borrowers[borrower_].debt - remainingDebt_;
+            clearedDebt_ = debtToClear - remainingDebt_;
 
             // save remaining debt and collateral after auction clear action
             loans_.borrowers[borrower_].debt       = remainingDebt_;

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -50,11 +50,11 @@ library Auctions {
      *  @param  borrower_      Borrower whose debt is healed.
      *  @param  reserves_      Pool reserves.
      *  @param  bucketDepth_   Max number of buckets heal action should iterate through.
-     *  @return clearedDebt_   The amount of debt that was healed.
+     *  @return healedDebt_    The amount of debt that was healed.
      *  @return totalForgived_ The amount of total forgived debt in the pool.
      *  @return reward_        The amount of collateral rewarded to the actor that healed debt.
      */
-    function clear(
+    function heal(
         Data storage self,
         Loans.Data storage loans_,
         mapping(uint256 => Buckets.Bucket) storage buckets_,
@@ -63,16 +63,16 @@ library Auctions {
         uint256 reserves_,
         uint256 bucketDepth_
     ) internal returns (
-        uint256 clearedDebt_,
+        uint256 healedDebt_,
         uint256 totalForgived_,
         uint256 reward_
     )
     {
 
         if (self.liquidations[borrower_].kickTime > 72 hours) {
-            uint256 debtToClear = loans_.borrowers[borrower_].debt;
+            uint256 debtToHeal = loans_.borrowers[borrower_].debt;
 
-            uint256 remainingDebt = debtToClear;
+            uint256 remainingDebt = debtToHeal;
             uint256 remainingCol  = loans_.borrowers[borrower_].collateral;
 
             while (bucketDepth_ > 0) {
@@ -127,7 +127,7 @@ library Auctions {
                 --bucketDepth_;
             }
 
-            clearedDebt_ = debtToClear - remainingDebt;
+            healedDebt_ = debtToHeal - remainingDebt;
 
             // save remaining debt and collateral after auction clear action
             loans_.borrowers[borrower_].debt       = remainingDebt;

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -100,7 +100,7 @@ library Auctions {
                         if (buckets_[hpbIndex_].collateral == 0 && Deposits.valueAt(deposits_, hpbIndex_) == 0) {
                             // existing LPB and LP tokens for the bucket shall become unclaimable.
                             buckets_[hpbIndex_].lps = 0;
-                            buckets_[hpbIndex_].bankruptcyTs = block.timestamp;
+                            buckets_[hpbIndex_].bankruptcyTime = block.timestamp;
                         }
                     }
                 }

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -68,7 +68,6 @@ library Auctions {
         uint256 reward_
     )
     {
-
         if (self.liquidations[borrower_].kickTime > 72 hours) {
             uint256 debtToHeal = loans_.borrowers[borrower_].debt;
 

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -20,7 +20,7 @@ library Auctions {
         address kicker;      // address that initiated liquidation
         uint256 bondSize;    // liquidation bond size
         uint256 bondFactor;  // bond factor used to start liquidation
-        uint128 kickTime;    // timestamp when liquidation was started
+        uint256 kickTime;    // timestamp when liquidation was started
         uint256 kickMomp;    // Momp when liquidation was started
         address prev;        // previous liquidated borrower in auctions queue
         address next;        // next liquidated borrower in auctions queue
@@ -233,11 +233,11 @@ library Auctions {
 
         // record liquidation info
         Liquidation storage liquidation = self.liquidations[borrower_];
-        liquidation.kicker   = msg.sender;
-        liquidation.kickTime = uint128(block.timestamp);
-        liquidation.kickMomp = momp_;
-        liquidation.bondSize       = bondSize;
-        liquidation.bondFactor     = bondFactor;
+        liquidation.kicker     = msg.sender;
+        liquidation.kickTime   = block.timestamp;
+        liquidation.kickMomp   = momp_;
+        liquidation.bondSize   = bondSize;
+        liquidation.bondFactor = bondFactor;
 
         liquidation.next = address(0);
         if (self.head != address(0)) {

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -87,8 +87,7 @@ library Auctions {
             (block.timestamp - kickTime > 72 hours)
             ||
             (debtToHeal > 0 && remainingCol == 0)
-            )
-        {
+        ) {
             uint256 remainingDebt = debtToHeal;
 
             while (bucketDepth_ > 0) {

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -99,7 +99,8 @@ library Auctions {
 
                         if (buckets_[hpbIndex_].collateral == 0 && Deposits.valueAt(deposits_, hpbIndex_) == 0) {
                             // existing LPB and LP tokens for the bucket shall become unclaimable.
-                            buckets_[hpbIndex_].locked = true;
+                            buckets_[hpbIndex_].lps = 0;
+                            buckets_[hpbIndex_].bankruptcyTs = block.timestamp;
                         }
                     }
                 }

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -120,14 +120,16 @@ library Buckets {
         Bucket storage fromBucket = self[fromIndex_];
         fromBucket.lps -= fromLPsAmount_;
         toBucket.lps   += toLPsAmount_;
-        // update lender LPs balance
-        fromBucket.lenders[msg.sender].lps -= fromLPsAmount_;
+        // update lender LPs balance in from bucket
+        Lender storage fromLender = fromBucket.lenders[msg.sender];
+        fromLender.lps -= fromLPsAmount_;
 
-        // update lender LPs balance
+        // update lender LPs balance and deposit time in target bucket
         Lender storage lender = toBucket.lenders[msg.sender];
         if (toBucket.bankruptcyTime >= lender.depositTime) lender.lps = toLPsAmount_;
         else lender.lps += toLPsAmount_;
-        lender.depositTime = block.timestamp;
+        // set deposit time to the greater of the lender's from bucket and the target bucket's last bankruptcy timestamp + 1 so deposit won't get invalidated
+        lender.depositTime = Maths.max(fromLender.depositTime, toBucket.bankruptcyTime + 1);
     }
 
     /**

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -14,6 +14,7 @@ library Buckets {
     struct Bucket {
         uint256 lps;                        // [RAY] Bucket LP accumulator
         uint256 collateral;                 // [WAD] Available collateral tokens deposited in the bucket
+        bool    locked;                     // True if bucket locked for LPs withdrawals
         mapping(address => Lender) lenders; // lender address to Lender struct mapping
     }
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -221,9 +221,8 @@ library Buckets {
     ) internal view returns (uint256, uint256) {
         uint256 bucketCollateral = self[index_].collateral;
         uint256 bucketLPs        = self[index_].lps;
-        if (bucketLPs == 0) {
-            return  (Maths.RAY, bucketCollateral);
-        }
+        if (bucketLPs == 0) return (Maths.RAY, bucketCollateral);
+
         uint256 bucketSize = quoteToken_ * 10**18 + PoolUtils.indexToPrice(index_) * bucketCollateral;  // 10^36 + // 10^36
         return (bucketSize * 10**18 / bucketLPs, bucketCollateral); // 10^27
     }

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -284,7 +284,7 @@ library Deposits {
             } else {
                 scaled = self.scaling[index];
                 if (scaled != 0) sc = Maths.wmul(sc, scaled);
-                self.values[index] -= Maths.wdiv(x_, sc);
+                self.values[index] -= Maths.min(self.values[index], Maths.wdiv(x_, sc));
             }
 
             j = j >> 1;

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -28,6 +28,8 @@ library Loans {
         uint256 inflatorSnapshot; // [WAD] Current borrower inflator snapshot.
     }
 
+    error NoLoan();
+    error ZeroThresholdPrice();
 
     /***********************/
     /***  Initialization ***/
@@ -39,7 +41,6 @@ library Loans {
      *  @param self Holds tree loan data.
      */
     function init(Data storage self) internal {
-        require(self.loans.length == 0, "H:ALREADY_INIT");
         self.loans.push(Loan(address(0), 0));
     }
 
@@ -178,7 +179,7 @@ library Loans {
      */
     function _remove(Data storage self, address borrower_) internal {
         uint256 i_ = self.indices[borrower_];
-        require(i_ != 0, "H:R:NO_BORROWER");
+        if (i_ == 0) revert NoLoan();
 
         delete self.indices[borrower_];
         uint256 tailIndex = self.loans.length - 1;
@@ -202,7 +203,7 @@ library Loans {
         address borrower_,
         uint256 thresholdPrice_
     ) internal {
-        require(thresholdPrice_ != 0, "H:I:VAL_EQ_0");
+        if (thresholdPrice_ == 0) revert ZeroThresholdPrice();
         uint256 i = self.indices[borrower_];
 
         // Loan exists, update in place.

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -28,7 +28,13 @@ library Loans {
         uint256 inflatorSnapshot; // [WAD] Current borrower inflator snapshot.
     }
 
+    /**
+     *  @notice The loan to be removed does not exist in loans heap.
+     */
     error NoLoan();
+    /**
+     *  @notice The threshold price of the loan to be inserted in loans heap is zero.
+     */
     error ZeroThresholdPrice();
 
     /***********************/
@@ -176,7 +182,7 @@ library Loans {
 
     /**
      *  @notice Removes loan for given borrower address.
-     *  @param self     Holds tree loan data.
+     *  @param self      Holds tree loan data.
      *  @param borrower_ Borrower address whose loan is being updated or inserted.
      */
     function _remove(Data storage self, address borrower_) internal {

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -7,7 +7,7 @@ from decimal import *
 from brownie import Contract
 from brownie.exceptions import VirtualMachineError
 from sdk import AjnaProtocol, DAI_ADDRESS, MKR_ADDRESS
-from conftest import LoansHeapUtils, MAX_PRICE, PoolUtils, TestUtils
+from conftest import LoansHeapUtils, MAX_PRICE, PoolHelper, TestUtils
 
 
 MAX_BUCKET = 2532  # 3293.70191, highest bucket for initial deposits, is exceeded after initialization
@@ -42,7 +42,7 @@ def log(message: str):
 
 @pytest.fixture
 def lenders(ajna_protocol, scaled_pool):
-    dai_client = ajna_protocol.get_token(scaled_pool.quoteToken())
+    dai_client = ajna_protocol.get_token(scaled_pool.quoteTokenAddress())
     amount = int(3_000_000_000 * 10**18 / NUM_LENDERS)
     lenders = []
     print("Initializing lenders")
@@ -56,8 +56,8 @@ def lenders(ajna_protocol, scaled_pool):
 
 @pytest.fixture
 def borrowers(ajna_protocol, scaled_pool):
-    collateral_client = ajna_protocol.get_token(scaled_pool.collateral())
-    dai_client = ajna_protocol.get_token(scaled_pool.quoteToken())
+    collateral_client = ajna_protocol.get_token(scaled_pool.collateralAddress())
+    dai_client = ajna_protocol.get_token(scaled_pool.quoteTokenAddress())
     amount = int(150_000 * 10**18 / NUM_BORROWERS)
     borrowers = []
     print("Initializing borrowers")
@@ -73,18 +73,18 @@ def borrowers(ajna_protocol, scaled_pool):
 
 
 @pytest.fixture
-def pool1(scaled_pool, pool_utils, lenders, borrowers, scaled_pool_utils, test_utils, chain):
-    pool = scaled_pool
+def pool_helper(ajna_protocol, scaled_pool, lenders, borrowers, test_utils, chain):
+    pool_helper = PoolHelper(ajna_protocol, scaled_pool)
     # Adds liquidity to an empty pool and draws debt up to a target utilization
-    add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils)
-    draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_utilization=GOAL_UTILIZATION)
+    add_initial_liquidity(lenders, pool_helper)
+    draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilization=GOAL_UTILIZATION)
     global last_triggered
     last_triggered = dict.fromkeys(range(0, max(NUM_LENDERS, NUM_BORROWERS)), 0)
-    test_utils.validate_pool(pool, pool_utils, borrowers)
-    return pool
+    test_utils.validate_pool(pool_helper, borrowers)
+    return pool_helper
 
 
-def add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils):
+def add_initial_liquidity(lenders, pool_helper):
     # Lenders 0-9 will be "new to the pool" upon actual testing
     # TODO: determine this non-arbitrarily
     deposit_amount = 1_000 * 10 ** 18
@@ -96,11 +96,12 @@ def add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils):
             price_position = int(random.expovariate(lambd=6.3) * price_count)
             price_index = price_position + MAX_BUCKET
             log(f" lender {i} depositing {deposit_amount/1e18} into bucket {price_index} "
-                f"({pool_utils.indexToPrice(price_index) / 1e18:.1f})")
-            pool.addQuoteToken(deposit_amount, price_index, {"from": lenders[i]})
+                f"({pool_helper.indexToPrice(price_index) / 1e18:.1f})")
+            pool_helper.pool.addQuoteToken(deposit_amount, price_index, {"from": lenders[i]})
 
 
-def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_utilization):
+def draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilization):
+    pool = pool_helper.pool
     target_debt = (pool.depositSize() - pool.borrowerDebt()) * target_utilization
     sleep_amount = max(1, int(12 * 3600 / NUM_LENDERS))
     for borrower_index in range(0, len(borrowers) - 1):
@@ -109,9 +110,9 @@ def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_uti
         borrow_amount = int(target_debt / NUM_BORROWERS)  # WAD
         assert borrow_amount > 10**18
 
-        pool_price = pool_utils.lup(pool.address)
+        pool_price = pool_helper.lup()
         if pool_price == MAX_PRICE:  # if there is no LUP,
-            pool_price = pool_utils.hpb(pool.address)  # use the highest-priced bucket with deposit
+            pool_price = pool_helper.hpb()  # use the highest-priced bucket with deposit
 
         # determine amount of collateral to deposit
         collateralization_ratio = min((1 / target_utilization) + 0.05, 2.5)  # cap at 250% collateralization
@@ -124,14 +125,14 @@ def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_uti
         else:
             collateral_to_deposit = borrow_amount * 10**18 / pool_price * collateralization_ratio  # WAD
 
-        pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
-        test_utils.validate_pool(pool, pool_utils, borrowers)
+        pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
+        test_utils.validate_pool(pool_helper, borrowers)
         chain.sleep(sleep_amount)
 
 
 def ensure_pool_is_funded(pool, quote_token_amount: int, action: str) -> bool:
     """ Ensures pool has enough funds for an operation which requires an amount of quote token. """
-    pool_quote_balance = Contract(pool.quoteToken()).balanceOf(pool)
+    pool_quote_balance = Contract(pool.quoteTokenAddress()).balanceOf(pool)
     if pool_quote_balance < quote_token_amount:
         log(f" WARN: contract has {pool_quote_balance/1e18:.1f} quote token; "
             f"cannot {action} {quote_token_amount/1e18:.1f}")
@@ -140,16 +141,16 @@ def ensure_pool_is_funded(pool, quote_token_amount: int, action: str) -> bool:
         return True
 
 
-def get_cumulative_bucket_deposit(pool, pool_utils, bucket_depth) -> int:  # WAD
+def get_cumulative_bucket_deposit(pool_helper, bucket_depth) -> int:  # WAD
     # Iterates through number of buckets passed as parameter, adding deposit to determine what loan size will be
     # required to utilize the buckets.
-    index = pool_utils.lupIndex(pool.address)
-    (_, quote, _, _, _, _) = pool_utils.bucketInfo(pool.address, index)
+    index = pool_helper.lupIndex()
+    (_, quote, _, _, _, _) = pool_helper.bucketInfo(index)
     cumulative_deposit = quote
     while bucket_depth > 0 and index > MIN_BUCKET:
         index += 1
         # TODO: This ignores partially-utilized buckets; difficult to calculate in v10
-        (_, quote, _, _, _, _) = pool_utils.bucketInfo(pool.address, index)
+        (_, quote, _, _, _, _) = pool_helper.bucketInfo(index)
         cumulative_deposit += quote
         bucket_depth -= 1
     return cumulative_deposit
@@ -161,12 +162,12 @@ def get_time_between_interactions(actor_index):
 
 
 # for debugging discrepancy between pending borrower debt and pending pool debt
-def aggregate_borrower_debt(borrowers, pool, pool_utils, debug=False):
+def aggregate_borrower_debt(borrowers, pool_helper, debug=False):
     total_debt = 0
     total_pending_debt = 0
     for i in range(0, len(borrowers) - 1):
         borrower = borrowers[i]
-        (debt, pending_debt, _, _, inflatorSnap) = pool_utils.borrowerInfo(pool.address, borrower.address)
+        (debt, pending_debt, _, _, inflatorSnap) = pool_helper.borrowerInfo(borrower.address)
         if debt > 0:
             log(f"   borrower {i:>4}     debt: {debt/1e18:>15.3f}     pending_debt:   {pending_debt/1e18:>15.3f}")
         total_debt += debt
@@ -175,35 +176,37 @@ def aggregate_borrower_debt(borrowers, pool, pool_utils, debug=False):
 
 
 # for debugging debt-with-no-loans issue
-def log_borrower_stats(borrowers, pool, pool_utils, chain, debug=False):
+def log_borrower_stats(borrowers, pool_helper, chain, debug=False):
+    pool = pool_helper.pool
     borrower_debt = pool.borrowerDebt()
-    (_, _, _, inflator, interestFactor) = pool_utils.poolLoansInfo(pool.address)
+    (_, loansCount, _, inflator, interestFactor) = pool_helper.loansInfo()
     assert 1e18 <= interestFactor < 2e18
     pending_borrower_debt = borrower_debt * interestFactor / 10 ** 18
 
-    (agg_borrower_debt, agg_pending_borrower_debt) = aggregate_borrower_debt(borrowers, pool, pool_utils, debug)
+    (agg_borrower_debt, agg_pending_borrower_debt) = aggregate_borrower_debt(borrowers, pool_helper, debug)
     log(f"  pool debt:  {pending_borrower_debt / 1e18:>15.3f}"
         f"  borrower:   {agg_pending_borrower_debt / 1e18:>15.3f}"
         f"  diff:       {(pending_borrower_debt - agg_pending_borrower_debt) / 1e18:>9.6f}"
-        f"  loan count: {pool.noOfLoans():>3}\n")
+        f"  loan count: {loansCount:>3}\n")
     chain.sleep(14)
 
 
-def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=False):
+def pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=False):
+    pool = pool_helper.pool
+
     # prevent invalid actions
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower.address)
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower.address)
     if not ensure_pool_is_funded(pool, borrow_amount, "borrow"):
         # ensure_pool_is_funded logs a message
         return
-    (_, _, _, min_debt) = pool_utils.poolUtilizationInfo(pool.address)
+    (_, _, _, min_debt) = pool_helper.utilizationInfo()
     if borrow_amount < min_debt:
         log(f" WARN: borrower {borrower_index} cannot draw {borrow_amount / 1e18:.1f}, "
             f"which is below minimum debt of {min_debt/1e18:.1f}")
         return
 
     # pledge collateral
-    collateral_token = Contract(pool.collateral())
-    collateral_balance = collateral_token.balanceOf(borrower)
+    collateral_balance = pool_helper.collateralToken().balanceOf(borrower)
     if collateral_balance < collateral_to_deposit:
         log(f" WARN: borrower {borrower_index} only has {collateral_balance/1e18:.1f} collateral "
               f"and cannot deposit {collateral_to_deposit/1e18:.1f} to draw debt")
@@ -215,10 +218,10 @@ def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_
     pool.pledgeCollateral(borrower, collateral_to_deposit, {"from": borrower})
 
     # draw debt
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower.address)
-    new_total_debt = pending_debt + borrow_amount + PoolUtils.get_origination_fee(pool, borrow_amount)
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower.address)
+    new_total_debt = pending_debt + borrow_amount + pool_helper.get_origination_fee(borrow_amount)
     threshold_price = new_total_debt * 10**18 / collateral_deposited
-    log(f" borrower {borrower_index:>4} drawing {borrow_amount / 1e18:>8.1f} from bucket {pool_utils.lup(pool.address) / 1e18:>6.3f} "
+    log(f" borrower {borrower_index:>4} drawing {borrow_amount / 1e18:>8.1f} from bucket {pool_helper.lup() / 1e18:>6.3f} "
         f"with {collateral_deposited / 1e18:>6.1f} collateral deposited, "
         f"with {new_total_debt/1e18:>9.1f} total debt "
         f"at a TP of {threshold_price/1e18:8.1f}")
@@ -226,11 +229,11 @@ def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_
     return tx
 
 
-def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_utils, duration=3600):
+def draw_and_bid(lenders, borrowers, start_from, pool_helper, chain, test_utils, duration=3600):
     user_index = start_from
     end_time = chain.time() + duration
     # Update the interest rate
-    interest_rate = pool.interestRate() / 10**18
+    interest_rate = pool_helper.pool.interestRate() / 10**18
     chain.sleep(14)
 
     while chain.time() < end_time:
@@ -238,40 +241,39 @@ def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_u
 
             # Draw debt, repay debt, or do nothing depending on interest rate
             if user_index < NUM_BORROWERS:
-                (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool.address)
+                (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
                 utilization = poolActualUtilization / 10**18
                 if interest_rate < 0.10 and utilization < MAX_UTILIZATION:
                     target_collateralization = max(1.1, 1/GOAL_UTILIZATION)
-                    draw_debt(borrowers[user_index], user_index, pool, pool_utils, test_utils, collateralization=target_collateralization)
+                    draw_debt(borrowers[user_index], user_index, pool_helper, test_utils, collateralization=target_collateralization)
                 elif utilization > MIN_UTILIZATION:  # start repaying debt if interest grows too high
-                    repay(borrowers[user_index], user_index, pool, pool_utils, test_utils)
-                # log_borrower_stats(borrowers, pool, pool_utils, chain, debug=True)
+                    repay(borrowers[user_index], user_index, pool_helper, test_utils)
+                # log_borrower_stats(borrowers, pool_helper, chain, debug=True)
                 chain.sleep(14)
 
             # Add or remove liquidity
             if user_index < NUM_LENDERS:
-                (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool.address)
+                (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
                 utilization = poolActualUtilization / 10**18
                 if utilization < MAX_UTILIZATION and len(buckets_deposited[user_index]) > 0:
                     price = buckets_deposited[user_index].pop()
                     # try:
-                    remove_quote_token(lenders[user_index], user_index, price, pool_utils, pool)
+                    remove_quote_token(lenders[user_index], user_index, price, pool_helper)
                     # except VirtualMachineError as ex:
-                    #     log(f" ERROR removing liquidity at {price / 10**18:.1f}, "
-                    #           f"collateralized at {pool.poolCollateralization() / 10**18:.1%}: {ex}")
-                    #     log(test_utils.dump_book(pool1, pool_utils))
+                    #     log(f" ERROR removing liquidity at {price / 10**18:.1f}: {ex}")
+                    #     log(test_utils.dump_book(pool_helper))
                     #     buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
                 else:
-                    price = add_quote_token(lenders[user_index], user_index, pool, pool_utils)
+                    price = add_quote_token(lenders[user_index], user_index, pool_helper)
                     if price:
                         buckets_deposited[user_index].add(price)
                 chain.sleep(14)
 
             try:
-                test_utils.validate_pool(pool, pool_utils, borrowers)
+                test_utils.validate_pool(pool_helper, borrowers)
             except AssertionError as ex:
                 log("Pool state became invalid:")
-                log(TestUtils.dump_book(pool, pool_utils))
+                log(TestUtils.dump_book(pool_helper))
                 raise ex
 
             last_triggered[user_index] = chain.time()
@@ -281,33 +283,32 @@ def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_u
     return user_index
 
 
-def draw_debt(borrower, borrower_index, pool, pool_utils, test_utils, collateralization=1.1):
+def draw_debt(borrower, borrower_index, pool_helper, test_utils, collateralization=1.1):
     # Draw debt based on added liquidity
-    borrow_amount = get_cumulative_bucket_deposit(pool, pool_utils, (borrower_index % 4) + 1)
-    pool_quote_on_deposit = pool.depositSize() - pool.borrowerDebt()
+    borrow_amount = get_cumulative_bucket_deposit(pool_helper, (borrower_index % 4) + 1)
+    pool_quote_on_deposit = pool_helper.pool.depositSize() - pool_helper.pool.borrowerDebt()
     borrow_amount = min(pool_quote_on_deposit / 2, borrow_amount)
-    collateral_to_deposit = borrow_amount / pool_utils.lup(pool.address) * collateralization * 10**18
+    collateral_to_deposit = borrow_amount / pool_helper.lup() * collateralization * 10**18
 
     # if borrower doesn't have enough collateral, adjust debt based on what they can afford
-    collateral_token = Contract(pool.collateral())
-    collateral_balance = collateral_token.balanceOf(borrower)
+    collateral_balance = pool_helper.collateralToken().balanceOf(borrower)
     if collateral_balance <= 10**18:
         log(f" WARN: borrower {borrower_index} has insufficient collateral to draw debt")
         return
     elif collateral_balance < collateral_to_deposit:
         collateral_to_deposit = collateral_balance
-        borrow_amount = collateral_to_deposit * pool_utils.lup(pool.address) / collateralization / 10**18
+        borrow_amount = collateral_to_deposit * pool_helper.lup() / collateralization / 10**18
         log(f" WARN: borrower {borrower_index} only has {collateral_balance/1e18:.1f} collateral; "
               f" drawing {borrow_amount/1e18:.1f} of debt against it")
 
-    tx = pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils)
+    tx = pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils)
 
 
-def add_quote_token(lender, lender_index, pool, pool_utils):
-    dai = Contract(pool.quoteToken())
+def add_quote_token(lender, lender_index, pool_helper):
+    dai = pool_helper.quoteToken()
     index_offset = ((lender_index % 6) - 2) * 2
-    deposit_index = pool_utils.lupIndex(pool.address) - index_offset
-    deposit_price = pool_utils.indexToPrice(deposit_index)
+    deposit_index = pool_helper.lupIndex() - index_offset
+    deposit_price = pool_helper.indexToPrice(deposit_index)
     quantity = int(MIN_PARTICIPATION * ((lender_index % 4) + 1) ** 2) * 10**18
 
     if dai.balanceOf(lender) < quantity:
@@ -315,31 +316,30 @@ def add_quote_token(lender, lender_index, pool, pool_utils):
         return None
 
     log(f" lender   {lender_index:>4} adding {quantity / 10**18:.1f} liquidity at {deposit_price / 10**18:.1f}")
-    # try:
-    tx = pool.addQuoteToken(quantity, deposit_index, {"from": lender})
+    tx = pool_helper.pool.addQuoteToken(quantity, deposit_index, {"from": lender})
     return deposit_price
 
 
-def remove_quote_token(lender, lender_index, price, pool_utils, pool):
-    price_index = pool_utils.priceToIndex(price)
-    (lp_balance, _) = pool.lenders(price_index, lender)
+def remove_quote_token(lender, lender_index, price, pool_helper):
+    price_index = pool_helper.priceToIndex(price)
+    (lp_balance, _) = pool_helper.lenderInfo(price_index, lender)
     if lp_balance > 0:
-        (_, _, _, _, _, exchange_rate) = pool_utils.bucketInfo(pool.address, price_index)
+        (_, _, _, _, _, exchange_rate) = pool_helper.bucketInfo(price_index)
         claimable_quote = lp_balance * exchange_rate / 10**36
         log(f" lender   {lender_index:>4} removing {claimable_quote / 10**18:.1f} quote"
               f" from bucket {price_index} ({price / 10**18:.1f}); exchange rate is {exchange_rate/1e27:.8f}")
-        if not ensure_pool_is_funded(pool, claimable_quote * 2, "withdraw"):
+        if not ensure_pool_is_funded(pool_helper.pool, claimable_quote * 2, "withdraw"):
             return
-        tx = pool.removeAllQuoteToken(price_index, {"from": lender})
+        tx = pool_helper.pool.removeAllQuoteToken(price_index, {"from": lender})
     else:
         log(f" lender   {lender_index:>4} has no claim to bucket {price / 10**18:.1f}")
 
 
-def repay(borrower, borrower_index, pool, pool_utils, test_utils):
-    dai = Contract(pool.quoteToken())
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower)
+def repay(borrower, borrower_index, pool_helper, test_utils):
+    dai = pool_helper.quoteToken()
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower)
     quote_balance = dai.balanceOf(borrower)
-    (_, _, _, min_debt) = pool_utils.poolUtilizationInfo(pool.address)
+    (_, _, _, min_debt) = pool_helper.utilizationInfo()
 
     if quote_balance < 100 * 10**18:
         log(f" borrower {borrower_index:>4} only has {quote_balance/1e18:.1f} quote token and will not repay debt")
@@ -357,35 +357,35 @@ def repay(borrower, borrower_index, pool, pool_utils, test_utils):
         # do the repayment
         repay_amount = int(repay_amount * 1.01)
         log(f" borrower {borrower_index:>4} repaying {repay_amount/1e18:.1f} of {pending_debt/1e18:.1f} debt")
-        tx = pool.repay(borrower, repay_amount, {"from": borrower})
+        tx = pool_helper.pool.repay(borrower, repay_amount, {"from": borrower})
 
         # withdraw appropriate amount of collateral to maintain a target-utilization-friendly collateralization
-        (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower)
-        collateral_encumbered = int((pending_debt * 10**18) / pool_utils.lup(pool.address))
+        (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower)
+        collateral_encumbered = int((pending_debt * 10**18) / pool_helper.lup())
         collateral_to_withdraw = int(collateral_deposited - (collateral_encumbered * 1.667))
         log(f" borrower {borrower_index:>4}, with {collateral_deposited/1e18:.1f} deposited "
               f"and {collateral_encumbered/1e18:.1f} encumbered, "
               f"is withdrawing {collateral_deposited/1e18:.1f} collateral")
         assert collateral_to_withdraw > 0
-        tx = pool.pullCollateral(collateral_to_withdraw, {"from": borrower})
+        tx = pool_helper.pool.pullCollateral(collateral_to_withdraw, {"from": borrower})
     elif pending_debt == 0:
         log(f" borrower {borrower_index:>4} has no debt to repay")
     else:
         log(f" borrower {borrower_index:>4} will not repay dusty {pending_debt/1e18:.1f} debt")
 
 
-def test_stable_volatile_one(pool1, pool_utils, lenders, borrowers, scaled_pool_utils, test_utils, chain):
+def test_stable_volatile_one(pool_helper, lenders, borrowers, test_utils, chain):
     # Validate test set-up
-    print("Before test:\n" + test_utils.dump_book(pool1, pool_utils))
-    test_utils.summarize_pool(pool1, pool_utils)
-    assert pool1.collateral() == MKR_ADDRESS
-    assert pool1.quoteToken() == DAI_ADDRESS
+    print("Before test:\n" + test_utils.dump_book(pool_helper))
+    test_utils.summarize_pool(pool_helper)
+    assert pool_helper.pool.collateralAddress() == MKR_ADDRESS
+    assert pool_helper.pool.quoteTokenAddress() == DAI_ADDRESS
     assert len(lenders) == NUM_LENDERS
     assert len(borrowers) == NUM_BORROWERS
     # assert pool1.poolSize() > 2_700_000 * 10**18
-    (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool1.address)
+    (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
     assert poolActualUtilization > 0
-    test_utils.validate_pool(pool1, pool_utils, borrowers)
+    test_utils.validate_pool(pool_helper, borrowers)
 
     # Simulate pool activity over a configured time duration
     start_time = chain.time()
@@ -394,14 +394,14 @@ def test_stable_volatile_one(pool1, pool_utils, lenders, borrowers, scaled_pool_
     with test_utils.GasWatcher(['addQuoteToken', 'borrow', 'removeAllQuoteToken', 'repay']):
         while chain.time() < end_time:
             # hit the pool an hour at a time, calculating interest and then sending transactions
-            actor_id = draw_and_bid(lenders, borrowers, actor_id, pool1, pool_utils, chain, test_utils)
-            test_utils.summarize_pool(pool1, pool_utils)
+            actor_id = draw_and_bid(lenders, borrowers, actor_id, pool_helper, chain, test_utils)
+            test_utils.summarize_pool(pool_helper)
             print(f"days remaining: {(end_time - chain.time()) / 3600 / 24:.3f}\n")
 
     # Validate test ended with the pool in a meaningful state
-    test_utils.validate_pool(pool1, pool_utils, borrowers)
-    print("After test:\n" + test_utils.dump_book(pool1, pool_utils))
-    (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool1.address)
+    test_utils.validate_pool(pool_helper, borrowers)
+    print("After test:\n" + test_utils.dump_book(pool_helper))
+    (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
     utilization = poolActualUtilization / 10**18
     print(f"elapsed time: {(chain.time()-start_time) / 3600 / 24} days   actual utilization: {utilization}")
     assert MIN_UTILIZATION * 0.9 < utilization < MAX_UTILIZATION * 1.1


### PR DESCRIPTION
Heal aka clear functionality:
- introduced notion of insolvent bucket: if debt is attempting to be healed but there's still debt and no collateral left to be auctioned / no collateral in bucket then `bankruptcyTime` is set on bucket
- stamp all deposits with the `depositTime` (when lender adds quote tokens or collateral in bucket or move liquidity). If deposit time happened before `bankruptcyTime` then balance is resetted / deposits are zeroed
- prevent deposits into a bucket to happen in same block when bucket becomes insolvent (that is to avoid resetting deposits that happens after bucket becomes insolvent)
- changed `Buckets.getLenderInfolender` function to account bucket insolvency - returns 0 LPs in bucket in case deposit time is lower than bucket bakruptcy time
- prevent remove quote tokens, remove collateral if head clearable (`auctions.revertIfHeadClearable` function): auction is clearable if kicked and 72 hours passed since kick time or auction still has debt but no remaining collateral
- added `Auctions.heal `with logic for healing pool debt

TODO: complete logic for NFT pool heal (and take)

Unit tests for ERC20 clear:
- start ERC20 tests in forked environment (to avoid bucket bankruptcy time to be the same as deposit time). updated all tests accordingly
- test heal on auction kicked 72 hours ago
- test heal on auction kicked more than 72 hours ago and partially taken
- reverts:
  - when heal called on an auction that wasn't kicked
  - when heal called on kicked auction but 72 hours not passed yet (and there's still debt to heal and collateral to be auctioned)
  - when remove liquidity or remove collateral called and auction head is clearable
  - when adding quote tokens or collateral or when moving quote tokens in same block with bucket becoming insolvent


Contract size changes:
- imported libraries:
  - remove all OZ's libraries but `Multicall`
  - use interfaces rather than `ERC20` and `ERC20Burnable` implementations; `IERC20Token` and `IERC721Token` interfaces added to `IPool`;
  - removed `SafeERC20` library, now explicitly checking the result of transfer action
- made `minFee` constant in `PoolUtils` library
- ajna token address used inline instead saving in storage
- quote token scale recorded as immutable arg in cloned pool (better gas too as it doesn't require loading it from storage but reading the calldata)
- grouped functionalities in *info functions to reduced external pool functions: `borrowerInfo`, `bucketInfo` (and removed `bucketDeposit` and `bucketScale`), `emasInfo`, `inflatorInfo`, `loansInfo`, `reservesInfo` (includded `liquidationBondEscrowed`)
- migrated `Deposits` and `Loans` libraries from requires to custom errors
- `ERC721Pool`: made only one `initialize` function for both collection and subset pools. If the `tokenIds` passed to `initialize` is empty then it's considered to be a collection pool, otherwise is a subset pool supporting only tokens passed in initialize method; initialize methods in `IERC20Pool` and `IERC721Pool` interfaces

Slither warnings:
- small change in `Pool.startClaimableReserveAuction` and `Pool.takeReserves` functions to prevent strict equalities https://github.com/crytic/slither/wiki/Detector-Documentation#dangerous-strict-equalities (`ERC20Pool` does not show any warning now)

- RW tests updates



```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  24,205B  (98.49%)
  ERC20Pool          -  23,659B  (96.26%)
```

gas results

```
│ addQuoteToken                              ┆ 91126           ┆ 156484 ┆ 133857 ┆ 638206  ┆ 43999   │
│ borrow                                     ┆ 167188          ┆ 231938 ┆ 191903 ┆ 768717  ┆ 88002   │
│ kick                                       ┆ 173475          ┆ 249007 ┆ 244636 ┆ 1078440 ┆ 16000   │
│ moveQuoteToken                             ┆ 277479          ┆ 277479 ┆ 277479 ┆ 277479  ┆ 1       │
│ pledgeCollateral                           ┆ 62657           ┆ 64767  ┆ 64836  ┆ 508950  ┆ 80001   │
│ removeAllQuoteToken                        ┆ 149419          ┆ 151590 ┆ 151296 ┆ 166452  ┆ 2000    │
│ removeQuoteToken                           ┆ 184196          ┆ 190027 ┆ 189821 ┆ 207436  ┆ 2000    │
│ repay                                      ┆ 483162          ┆ 557902 ┆ 569824 ┆ 809403  ┆ 16001   │
│ take                                       ┆ 50284           ┆ 53764  ┆ 53247  ┆ 99329   ┆ 15998   │
```

vs `develop`

```
│ addQuoteToken                              ┆ 72331           ┆ 140144 ┆ 113244 ┆ 687960  ┆ 43999   │
│ borrow                                     ┆ 167405          ┆ 237579 ┆ 192121 ┆ 828568  ┆ 88002   │
│ kick                                       ┆ 174219          ┆ 249222 ┆ 244850 ┆ 1094004 ┆ 16000   │
│ moveQuoteToken                             ┆ 260183          ┆ 260183 ┆ 260183 ┆ 260183  ┆ 1       │
│ pledgeCollateral                           ┆ 63373           ┆ 65442  ┆ 65552  ┆ 564738  ┆ 80001   │
│ removeAllQuoteToken                        ┆ 159208          ┆ 163856 ┆ 163836 ┆ 168548  ┆ 2000    │
│ removeQuoteToken                           ┆ 180704          ┆ 185716 ┆ 185682 ┆ 203828  ┆ 2000    │
│ repay                                      ┆ 539120          ┆ 614679 ┆ 627542 ┆ 867123  ┆ 16001   │
│ take                                       ┆ 51848           ┆ 55200  ┆ 54600  ┆ 101829  ┆ 15998   │
```