### PR TITLE
Get real-world test running

### DIFF
--- a/sdk/ajna_protocol.py
+++ b/sdk/ajna_protocol.py
@@ -6,10 +6,10 @@ from brownie import (
     ERC20PoolFactory,
     ERC20Pool,
     BucketMath,
+    Deposits,
     Maths,
-    Book,
-    Actors,
-    Heap,
+    Loans,
+    PoolInfoUtils,
     PoolUtils,
 )
 from brownie.network.account import Accounts, LocalAccount
@@ -30,10 +30,10 @@ class AjnaProtocol:
         self.deployer = self._accounts[0]
 
         self.bucket_math = BucketMath.deploy({"from": self.deployer})
+        self.deposits = Deposits.deploy({"from": self.deployer})
         self.maths = Maths.deploy({"from": self.deployer})
-        self.book = Book.deploy({"from": self.deployer})
-        self.actors = Actors.deploy({"from": self.deployer})
-        self.heap = Heap.deploy({"from": self.deployer})
+        self.loans = Loans.deploy({"from": self.deployer})
+        self.pool_info_utils = PoolInfoUtils.deploy({"from": self.deployer})
         self.pool_utils = PoolUtils.deploy({"from": self.deployer})
 
         self.ajna_factory = ERC20PoolFactory.deploy({"from": self.deployer})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,9 +61,6 @@ def scaled_pool(deployer):
         scaled_factory.deployedPools("2263c4378b4920f0bef611a3ff22c506afa4745b3319c50b6d704a874990b8b2", MKR_ADDRESS, DAI_ADDRESS)
         )
 
-@pytest.fixture
-def pool_utils(deployer):
-    return PoolInfoUtils.deploy({"from": deployer})
 
 @pytest.fixture
 def lenders(ajna_protocol, scaled_pool):
@@ -101,30 +98,78 @@ def borrowers(ajna_protocol, scaled_pool):
     return borrowers
 
 
-class PoolUtils:
-    def __init__(self, ajna_protocol: AjnaProtocol):
+# Layer of abstraction between pool contracts and brownie tests
+class PoolHelper:
+    def __init__(self, ajna_protocol: AjnaProtocol, pool):
         self.bucket_math = ajna_protocol.bucket_math
+        self.loans = ajna_protocol.loans
+        self.pool = pool
+        self.pool_info_utils = ajna_protocol.pool_info_utils
+        self.pool_utils = ajna_protocol.pool_utils
 
-    @staticmethod
-    def get_origination_fee(pool: ERC20Pool, amount):
-        fee_rate = max(pool.interestRate() / 52, 0.0005 * 10**18)
+    # TODO: Move this functionality into SDK to insulate consumer from implementation logic.
+
+    def borrowerInfo(self, borrower_address):
+        # returns (debt, pendingDebt, collateral, mompFactor, inflatorSnapshot)
+        return self.pool_info_utils.borrowerInfo(self.pool.address, borrower_address)
+
+    def bucketInfo(self, index):
+        # returns (index, price, quoteTokens, collateral, bucketLPs, scale, exchangeRate)
+        return self.pool_info_utils.bucketInfo(self.pool.address, index)
+
+    def collateralToken(self):
+        return Contract(self.pool.collateralAddress())
+
+    def hpb(self):
+        (hpb, hpbIndex, htp, htpIndex, lup, lupIndex) = self.pool_info_utils.poolPricesInfo(self.pool.address)
+        return hpb
+
+    def htp(self):
+        (hpb, hpbIndex, htp, htpIndex, lup, lupIndex) = self.pool_info_utils.poolPricesInfo(self.pool.address)
+        return htp
+
+    def indexToPrice(self, price_index: int):
+        return self.bucket_math.indexToPrice(price_index)
+
+    def lenderInfo(self, index, lender_address):
+        # returns (lpBalance, lastQuoteDeposit)
+        return self.pool.lenderInfo(index, lender_address)
+
+    def loansInfo(self):
+        # returns (poolSize, loansCount, maxBorrower, pendingInflator, pendingInterestFactor)
+        # Not to be confused with pool.loansInfo which returns (maxBorrower, maxThresholdPrice, noOfLoans)
+        return self.pool_info_utils.poolLoansInfo(self.pool.address)
+
+    def lup(self):
+        (hpb, hpbIndex, htp, htpIndex, lup, lupIndex) = self.pool_info_utils.poolPricesInfo(self.pool.address)
+        return lup
+
+    def lupIndex(self):
+        (hpb, hpbIndex, htp, htpIndex, lup, lupIndex) = self.pool_info_utils.poolPricesInfo(self.pool.address)
+        return lupIndex
+
+    def priceToIndex(self, price):
+        return self.bucket_math.priceToIndex(price)
+
+    def quoteToken(self):
+        return Contract(self.pool.quoteTokenAddress())
+
+    def utilizationInfo(self):
+        return self.pool_info_utils.poolUtilizationInfo(self.pool.address)
+
+    def get_origination_fee(self, amount):
+        fee_rate = max(self.pool.interestRate() / 52, 0.0005 * 10**18)
         assert fee_rate >= (0.0005 * 10**18)
         assert fee_rate < (100 * 10**18)
         return fee_rate * amount / 10**18
 
-    @staticmethod
-    def price_to_index_safe(pool_utils, price):
+    def price_to_index_safe(self, price):
         if price < MIN_PRICE:
-            return pool_utils.priceToIndex(MIN_PRICE)
+            return self.bucket_math.priceToIndex(MIN_PRICE)
         elif price > MAX_PRICE:
-            return pool_utils.priceToIndex(MAX_PRICE)
+            return self.bucket_math.priceToIndex(MAX_PRICE)
         else:
-            return pool_utils.priceToIndex(price)
-
-
-@pytest.fixture
-def scaled_pool_utils(ajna_protocol):
-    return PoolUtils(ajna_protocol)
+            return self.bucket_math.priceToIndex(price)
 
 
 class LoansHeapUtils:
@@ -299,39 +344,41 @@ class TestUtils:
             )
 
     @staticmethod
-    def validate_pool(pool, pool_utils, borrowers):
+    def validate_pool(pool_helper, borrowers):
+        pool = pool_helper.pool
+
         # if pool is collateralized...
-        if pool_utils.lupIndex(pool.address) > PoolUtils.price_to_index_safe(pool_utils, pool_utils.htp(pool.address)):
+        if pool_helper.lupIndex() > pool_helper.price_to_index_safe(pool_helper.htp()):
             # ...ensure debt is less than the size of the pool
             assert pool.borrowerDebt() <= pool.depositSize()
 
         # if there are no borrowers in the pool, ensure there is no debt
-        if pool.noOfLoans() == 0:
+        (_, loansCount, _, inflator, interestFactor) = pool_helper.loansInfo()
+        if loansCount == 0:
             assert pool.borrowerDebt() == 0
 
         # loan count should be decremented as borrowers repay debt
-        loan_count = pool.noOfLoans()
-        if loan_count > 0:
+        if loansCount > 0:
             assert pool.borrowerDebt() > 0
 
         borrowers_with_debt = 0
         for borrower in borrowers:
-            (debt, pending_debt, _, _, _) = pool_utils.borrowerInfo(pool.address, borrower.address)
+            (debt, pending_debt, _, _, _) = pool_helper.borrowerInfo(borrower.address)
             if debt > 0:
                 borrowers_with_debt += 1
-        assert borrowers_with_debt == loan_count
+        assert borrowers_with_debt == loansCount
 
     @staticmethod
-    def dump_book(pool, pool_utils, with_headers=True, csv=False) -> str:
+    def dump_book(pool_helper, with_headers=True, csv=False) -> str:
         """
-        :param pool:             pool contract for which report shall be generated
-        :param pool_utils:       pool utils contract
+        :param pool_helper:      simplifies interaction with pool contracts
         :param min_bucket_index: highest-priced bucket from which to iterate downward in price
         :param max_bucket_index: lowest-priced bucket
         :param with_headers:     print column headings
         :param csv:              export as CSV for importing into a spreadsheet
         :return:                 multi-line string
         """
+        pool = pool_helper.pool
 
         # formatting shortcuts
         w = 15
@@ -346,11 +393,11 @@ class TestUtils:
         def fy(ray):
             return f"{ny(ray):>{w}.3f}"
 
-        lup_index = pool_utils.lupIndex(pool.address)
-        htp_index = PoolUtils.price_to_index_safe(pool_utils, pool_utils.htp(pool.address))
-        ptp_index = PoolUtils.price_to_index_safe(pool_utils, int(pool.borrowerDebt() * 1e18 / pool.pledgedCollateral()))
+        lup_index = pool_helper.lupIndex()
+        htp_index = pool_helper.price_to_index_safe(pool_helper.htp())
+        ptp_index = pool_helper.price_to_index_safe(int(pool.borrowerDebt() * 1e18 / pool.pledgedCollateral()))
 
-        min_bucket_index = max(0, pool_utils.priceToIndex(pool_utils.hpb(pool.address)) - 3)  # HPB
+        min_bucket_index = max(0, pool_helper.priceToIndex(pool_helper.hpb()) - 3)  # HPB
         max_bucket_index = min(7388, max(lup_index, htp_index) + 3) if htp_index < 7388 else min(7388, lup_index + 3)
         assert min_bucket_index < max_bucket_index
 
@@ -362,7 +409,7 @@ class TestUtils:
                 lines.append(j('Index') + j('Price') + j('Pointer') + j('Quote') + j('Collateral')
                              + j('LP Outstanding') + j('Scale'))
         for i in range(min_bucket_index, max_bucket_index):
-            price = pool_utils.indexToPrice(i)
+            price = pool_helper.indexToPrice(i)
             pointer = ""
             if i == lup_index:
                 pointer += "LUP"
@@ -378,7 +425,7 @@ class TestUtils:
                     bucket_lpAccumulator,
                     bucket_scale,
                     _
-                ) = pool_utils.bucketInfo(pool.address, i)
+                ) = pool_helper.bucketInfo(i)
             except VirtualMachineError as ex:
                 lines.append(f"ERROR retrieving bucket {i} at price {price} ({price / 1e18})")
                 continue
@@ -391,32 +438,32 @@ class TestUtils:
         return '\n'.join(lines)
 
     @staticmethod
-    def summarize_pool(pool, pool_utils):
-        (_, poolCollateralization, poolActualUtilization, poolTargetUtilization) = pool_utils.poolUtilizationInfo(pool.address)
+    def summarize_pool(pool_helper):
+        pool = pool_helper.pool
+        (_, poolCollateralization, poolActualUtilization, poolTargetUtilization) = pool_helper.utilizationInfo()
+        (_, loansCount, _, _, _) = pool_helper.loansInfo()
         print(f"actual utlzn:   {poolActualUtilization/1e18:>12.1%}  "
               f"target utlzn:   {poolTargetUtilization/1e18:>12.1%}  "
               f"collateralization: {poolCollateralization/1e18:>9.1%}  "
               f"borrowerDebt:   {pool.borrowerDebt()/1e18:>12.1f}  "
-              f"loan count:     {pool.noOfLoans():>8}")
+              f"loan count:     {loansCount:>8}")
 
-        contract_quote_balance = Contract(pool.quoteToken()).balanceOf(pool)
+        contract_quote_balance = pool_helper.quoteToken().balanceOf(pool)
         reserves = contract_quote_balance + pool.borrowerDebt() - pool.depositSize()
         pledged_collateral = pool.pledgedCollateral()
         if pledged_collateral > 0:
             ptp = pool.borrowerDebt() * 10 ** 18 / pledged_collateral
-            ptp_index = pool_utils.priceToIndex(ptp)
-            ru = pool.bucketDeposit(ptp_index)  # FIXME: saw this revert with under/overflow once
+            ptp_index = pool_helper.priceToIndex(ptp)
         else:
             ptp = 0
-            ru = 0
         print(f"contract q bal: {contract_quote_balance/1e18:>12.1f}  "
               f"deposit:        {pool.depositSize()/1e18:>12.1f}  "
               f"reserves:       {reserves/1e18:>12.1f}  "
               f"pledged:        {pool.pledgedCollateral()/1e18:>12.1f}  "
               f"rate:           {pool.interestRate()/1e18:>8.4%}")
 
-        lup = pool_utils.lup(pool.address)
-        htp = pool_utils.htp(pool.address)
+        lup = pool_helper.lup()
+        htp = pool_helper.htp()
         ptp = int(pool.borrowerDebt() * 1e18 / pool.pledgedCollateral())
         print(f"lup:            {lup/1e18:>12.3f}  "
               f"htp:            {htp/1e18:>12.3f}  "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,7 @@ class PoolHelper:
         return htp
 
     def indexToPrice(self, price_index: int):
-        return self.bucket_math.indexToPrice(price_index)
+        return self.pool_info_utils.indexToPrice(price_index)
 
     def lenderInfo(self, index, lender_address):
         # returns (lpBalance, lastQuoteDeposit)
@@ -149,7 +149,7 @@ class PoolHelper:
         return lupIndex
 
     def priceToIndex(self, price):
-        return self.bucket_math.priceToIndex(price)
+        return self.pool_info_utils.priceToIndex(price)
 
     def quoteToken(self):
         return Contract(self.pool.quoteTokenAddress())
@@ -165,11 +165,11 @@ class PoolHelper:
 
     def price_to_index_safe(self, price):
         if price < MIN_PRICE:
-            return self.bucket_math.priceToIndex(MIN_PRICE)
+            return self.pool_info_utils.priceToIndex(MIN_PRICE)
         elif price > MAX_PRICE:
-            return self.bucket_math.priceToIndex(MAX_PRICE)
+            return self.pool_info_utils.priceToIndex(MAX_PRICE)
         else:
-            return self.bucket_math.priceToIndex(price)
+            return self.pool_info_utils.priceToIndex(price)
 
 
 class LoansHeapUtils:

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -7,7 +7,7 @@ from decimal import *
 from brownie import Contract
 from brownie.exceptions import VirtualMachineError
 from sdk import AjnaProtocol, DAI_ADDRESS, MKR_ADDRESS
-from conftest import LoansHeapUtils, MAX_PRICE, PoolUtils, TestUtils
+from conftest import LoansHeapUtils, MAX_PRICE, PoolHelper, TestUtils
 
 
 MAX_BUCKET = 2532  # 3293.70191, highest bucket for initial deposits, is exceeded after initialization
@@ -42,7 +42,7 @@ def log(message: str):
 
 @pytest.fixture
 def lenders(ajna_protocol, scaled_pool):
-    dai_client = ajna_protocol.get_token(scaled_pool.quoteToken())
+    dai_client = ajna_protocol.get_token(scaled_pool.quoteTokenAddress())
     amount = int(3_000_000_000 * 10**18 / NUM_LENDERS)
     lenders = []
     print("Initializing lenders")
@@ -56,8 +56,8 @@ def lenders(ajna_protocol, scaled_pool):
 
 @pytest.fixture
 def borrowers(ajna_protocol, scaled_pool):
-    collateral_client = ajna_protocol.get_token(scaled_pool.collateral())
-    dai_client = ajna_protocol.get_token(scaled_pool.quoteToken())
+    collateral_client = ajna_protocol.get_token(scaled_pool.collateralAddress())
+    dai_client = ajna_protocol.get_token(scaled_pool.quoteTokenAddress())
     amount = int(150_000 * 10**18 / NUM_BORROWERS)
     borrowers = []
     print("Initializing borrowers")
@@ -73,18 +73,18 @@ def borrowers(ajna_protocol, scaled_pool):
 
 
 @pytest.fixture
-def pool1(scaled_pool, pool_utils, lenders, borrowers, scaled_pool_utils, test_utils, chain):
-    pool = scaled_pool
+def pool_helper(ajna_protocol, scaled_pool, lenders, borrowers, test_utils, chain):
+    pool_helper = PoolHelper(ajna_protocol, scaled_pool)
     # Adds liquidity to an empty pool and draws debt up to a target utilization
-    add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils)
-    draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_utilization=GOAL_UTILIZATION)
+    add_initial_liquidity(lenders, pool_helper)
+    draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilization=GOAL_UTILIZATION)
     global last_triggered
     last_triggered = dict.fromkeys(range(0, max(NUM_LENDERS, NUM_BORROWERS)), 0)
-    test_utils.validate_pool(pool, pool_utils, borrowers)
-    return pool
+    test_utils.validate_pool(pool_helper, borrowers)
+    return pool_helper
 
 
-def add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils):
+def add_initial_liquidity(lenders, pool_helper):
     # Lenders 0-9 will be "new to the pool" upon actual testing
     # TODO: determine this non-arbitrarily
     deposit_amount = 1_000 * 10 ** 18
@@ -96,11 +96,12 @@ def add_initial_liquidity(lenders, pool, pool_utils, scaled_pool_utils):
             price_position = int(random.expovariate(lambd=6.3) * price_count)
             price_index = price_position + MAX_BUCKET
             log(f" lender {i} depositing {deposit_amount/1e18} into bucket {price_index} "
-                f"({pool_utils.indexToPrice(price_index) / 1e18:.1f})")
-            pool.addQuoteToken(deposit_amount, price_index, {"from": lenders[i]})
+                f"({pool_helper.indexToPrice(price_index) / 1e18:.1f})")
+            pool_helper.pool.addQuoteToken(deposit_amount, price_index, {"from": lenders[i]})
 
 
-def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_utilization):
+def draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilization):
+    pool = pool_helper.pool
     target_debt = (pool.depositSize() - pool.borrowerDebt()) * target_utilization
     sleep_amount = max(1, int(12 * 3600 / NUM_LENDERS))
     for borrower_index in range(0, len(borrowers) - 1):
@@ -109,9 +110,9 @@ def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_uti
         borrow_amount = int(target_debt / NUM_BORROWERS)  # WAD
         assert borrow_amount > 10**18
 
-        pool_price = pool_utils.lup(pool.address)
+        pool_price = pool_helper.lup()
         if pool_price == MAX_PRICE:  # if there is no LUP,
-            pool_price = pool_utils.hpb(pool.address)  # use the highest-priced bucket with deposit
+            pool_price = pool_helper.hpb()  # use the highest-priced bucket with deposit
 
         # determine amount of collateral to deposit
         collateralization_ratio = min((1 / target_utilization) + 0.05, 2.5)  # cap at 250% collateralization
@@ -124,14 +125,14 @@ def draw_initial_debt(borrowers, pool, pool_utils, test_utils, chain, target_uti
         else:
             collateral_to_deposit = borrow_amount * 10**18 / pool_price * collateralization_ratio  # WAD
 
-        pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
-        test_utils.validate_pool(pool, pool_utils, borrowers)
+        pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
+        test_utils.validate_pool(pool_helper, borrowers)
         chain.sleep(sleep_amount)
 
 
 def ensure_pool_is_funded(pool, quote_token_amount: int, action: str) -> bool:
     """ Ensures pool has enough funds for an operation which requires an amount of quote token. """
-    pool_quote_balance = Contract(pool.quoteToken()).balanceOf(pool)
+    pool_quote_balance = Contract(pool.quoteTokenAddress()).balanceOf(pool)
     if pool_quote_balance < quote_token_amount:
         log(f" WARN: contract has {pool_quote_balance/1e18:.1f} quote token; "
             f"cannot {action} {quote_token_amount/1e18:.1f}")
@@ -140,16 +141,16 @@ def ensure_pool_is_funded(pool, quote_token_amount: int, action: str) -> bool:
         return True
 
 
-def get_cumulative_bucket_deposit(pool, pool_utils, bucket_depth) -> int:  # WAD
+def get_cumulative_bucket_deposit(pool_helper, bucket_depth) -> int:  # WAD
     # Iterates through number of buckets passed as parameter, adding deposit to determine what loan size will be
     # required to utilize the buckets.
-    index = pool_utils.lupIndex(pool.address)
-    (_, quote, _, _, _, _) = pool_utils.bucketInfo(pool.address, index)
+    index = pool_helper.lupIndex()
+    (_, quote, _, _, _, _) = pool_helper.bucketInfo(index)
     cumulative_deposit = quote
     while bucket_depth > 0 and index > MIN_BUCKET:
         index += 1
         # TODO: This ignores partially-utilized buckets; difficult to calculate in v10
-        (_, quote, _, _, _, _) = pool_utils.bucketInfo(pool.address, index)
+        (_, quote, _, _, _, _) = pool_helper.bucketInfo(index)
         cumulative_deposit += quote
         bucket_depth -= 1
     return cumulative_deposit
@@ -161,12 +162,12 @@ def get_time_between_interactions(actor_index):
 
 
 # for debugging discrepancy between pending borrower debt and pending pool debt
-def aggregate_borrower_debt(borrowers, pool, pool_utils, debug=False):
+def aggregate_borrower_debt(borrowers, pool_helper, debug=False):
     total_debt = 0
     total_pending_debt = 0
     for i in range(0, len(borrowers) - 1):
         borrower = borrowers[i]
-        (debt, pending_debt, _, _, inflatorSnap) = pool_utils.borrowerInfo(pool.address, borrower.address)
+        (debt, pending_debt, _, _, inflatorSnap) = pool_helper.borrowerInfo(borrower.address)
         if debt > 0:
             log(f"   borrower {i:>4}     debt: {debt/1e18:>15.3f}     pending_debt:   {pending_debt/1e18:>15.3f}")
         total_debt += debt
@@ -175,35 +176,37 @@ def aggregate_borrower_debt(borrowers, pool, pool_utils, debug=False):
 
 
 # for debugging debt-with-no-loans issue
-def log_borrower_stats(borrowers, pool, pool_utils, chain, debug=False):
+def log_borrower_stats(borrowers, pool_helper, chain, debug=False):
+    pool = pool_helper.pool
     borrower_debt = pool.borrowerDebt()
-    (_, _, _, inflator, interestFactor) = pool_utils.poolLoansInfo(pool.address)
+    (_, loansCount, _, inflator, interestFactor) = pool_helper.loansInfo()
     assert 1e18 <= interestFactor < 2e18
     pending_borrower_debt = borrower_debt * interestFactor / 10 ** 18
 
-    (agg_borrower_debt, agg_pending_borrower_debt) = aggregate_borrower_debt(borrowers, pool, pool_utils, debug)
+    (agg_borrower_debt, agg_pending_borrower_debt) = aggregate_borrower_debt(borrowers, pool_helper, debug)
     log(f"  pool debt:  {pending_borrower_debt / 1e18:>15.3f}"
         f"  borrower:   {agg_pending_borrower_debt / 1e18:>15.3f}"
         f"  diff:       {(pending_borrower_debt - agg_pending_borrower_debt) / 1e18:>9.6f}"
-        f"  loan count: {pool.noOfLoans():>3}\n")
+        f"  loan count: {loansCount:>3}\n")
     chain.sleep(14)
 
 
-def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=False):
+def pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=False):
+    pool = pool_helper.pool
+
     # prevent invalid actions
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower.address)
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower.address)
     if not ensure_pool_is_funded(pool, borrow_amount, "borrow"):
         # ensure_pool_is_funded logs a message
         return
-    (_, _, _, min_debt) = pool_utils.poolUtilizationInfo(pool.address)
+    (_, _, _, min_debt) = pool_helper.utilizationInfo()
     if borrow_amount < min_debt:
         log(f" WARN: borrower {borrower_index} cannot draw {borrow_amount / 1e18:.1f}, "
             f"which is below minimum debt of {min_debt/1e18:.1f}")
         return
 
     # pledge collateral
-    collateral_token = Contract(pool.collateral())
-    collateral_balance = collateral_token.balanceOf(borrower)
+    collateral_balance = pool_helper.collateralToken().balanceOf(borrower)
     if collateral_balance < collateral_to_deposit:
         log(f" WARN: borrower {borrower_index} only has {collateral_balance/1e18:.1f} collateral "
               f"and cannot deposit {collateral_to_deposit/1e18:.1f} to draw debt")
@@ -215,10 +218,10 @@ def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_
     pool.pledgeCollateral(borrower, collateral_to_deposit, {"from": borrower})
 
     # draw debt
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower.address)
-    new_total_debt = pending_debt + borrow_amount + PoolUtils.get_origination_fee(pool, borrow_amount)
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower.address)
+    new_total_debt = pending_debt + borrow_amount + pool_helper.get_origination_fee(borrow_amount)
     threshold_price = new_total_debt * 10**18 / collateral_deposited
-    log(f" borrower {borrower_index:>4} drawing {borrow_amount / 1e18:>8.1f} from bucket {pool_utils.lup(pool.address) / 1e18:>6.3f} "
+    log(f" borrower {borrower_index:>4} drawing {borrow_amount / 1e18:>8.1f} from bucket {pool_helper.lup() / 1e18:>6.3f} "
         f"with {collateral_deposited / 1e18:>6.1f} collateral deposited, "
         f"with {new_total_debt/1e18:>9.1f} total debt "
         f"at a TP of {threshold_price/1e18:8.1f}")
@@ -226,11 +229,11 @@ def pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_
     return tx
 
 
-def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_utils, duration=3600):
+def draw_and_bid(lenders, borrowers, start_from, pool_helper, chain, test_utils, duration=3600):
     user_index = start_from
     end_time = chain.time() + duration
     # Update the interest rate
-    interest_rate = pool.interestRate() / 10**18
+    interest_rate = pool_helper.pool.interestRate() / 10**18
     chain.sleep(14)
 
     while chain.time() < end_time:
@@ -238,40 +241,39 @@ def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_u
 
             # Draw debt, repay debt, or do nothing depending on interest rate
             if user_index < NUM_BORROWERS:
-                (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool.address)
+                (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
                 utilization = poolActualUtilization / 10**18
                 if interest_rate < 0.10 and utilization < MAX_UTILIZATION:
                     target_collateralization = max(1.1, 1/GOAL_UTILIZATION)
-                    draw_debt(borrowers[user_index], user_index, pool, pool_utils, test_utils, collateralization=target_collateralization)
+                    draw_debt(borrowers[user_index], user_index, pool_helper, test_utils, collateralization=target_collateralization)
                 elif utilization > MIN_UTILIZATION:  # start repaying debt if interest grows too high
-                    repay(borrowers[user_index], user_index, pool, pool_utils, test_utils)
-                # log_borrower_stats(borrowers, pool, pool_utils, chain, debug=True)
+                    repay(borrowers[user_index], user_index, pool_helper, test_utils)
+                # log_borrower_stats(borrowers, pool_helper, chain, debug=True)
                 chain.sleep(14)
 
             # Add or remove liquidity
             if user_index < NUM_LENDERS:
-                (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool.address)
+                (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
                 utilization = poolActualUtilization / 10**18
                 if utilization < MAX_UTILIZATION and len(buckets_deposited[user_index]) > 0:
                     price = buckets_deposited[user_index].pop()
                     # try:
-                    remove_quote_token(lenders[user_index], user_index, price, pool_utils, pool)
+                    remove_quote_token(lenders[user_index], user_index, price, pool_helper)
                     # except VirtualMachineError as ex:
-                    #     log(f" ERROR removing liquidity at {price / 10**18:.1f}, "
-                    #           f"collateralized at {pool.poolCollateralization() / 10**18:.1%}: {ex}")
-                    #     log(test_utils.dump_book(pool1, pool_utils))
+                    #     log(f" ERROR removing liquidity at {price / 10**18:.1f}: {ex}")
+                    #     log(test_utils.dump_book(pool_helper))
                     #     buckets_deposited[user_index].add(price)  # try again later when pool is better collateralized
                 else:
-                    price = add_quote_token(lenders[user_index], user_index, pool, pool_utils)
+                    price = add_quote_token(lenders[user_index], user_index, pool_helper)
                     if price:
                         buckets_deposited[user_index].add(price)
                 chain.sleep(14)
 
             try:
-                test_utils.validate_pool(pool, pool_utils, borrowers)
+                test_utils.validate_pool(pool_helper, borrowers)
             except AssertionError as ex:
                 log("Pool state became invalid:")
-                log(TestUtils.dump_book(pool, pool_utils))
+                log(TestUtils.dump_book(pool_helper))
                 raise ex
 
             last_triggered[user_index] = chain.time()
@@ -281,33 +283,32 @@ def draw_and_bid(lenders, borrowers, start_from, pool, pool_utils, chain, test_u
     return user_index
 
 
-def draw_debt(borrower, borrower_index, pool, pool_utils, test_utils, collateralization=1.1):
+def draw_debt(borrower, borrower_index, pool_helper, test_utils, collateralization=1.1):
     # Draw debt based on added liquidity
-    borrow_amount = get_cumulative_bucket_deposit(pool, pool_utils, (borrower_index % 4) + 1)
-    pool_quote_on_deposit = pool.depositSize() - pool.borrowerDebt()
+    borrow_amount = get_cumulative_bucket_deposit(pool_helper, (borrower_index % 4) + 1)
+    pool_quote_on_deposit = pool_helper.pool.depositSize() - pool_helper.pool.borrowerDebt()
     borrow_amount = min(pool_quote_on_deposit / 2, borrow_amount)
-    collateral_to_deposit = borrow_amount / pool_utils.lup(pool.address) * collateralization * 10**18
+    collateral_to_deposit = borrow_amount / pool_helper.lup() * collateralization * 10**18
 
     # if borrower doesn't have enough collateral, adjust debt based on what they can afford
-    collateral_token = Contract(pool.collateral())
-    collateral_balance = collateral_token.balanceOf(borrower)
+    collateral_balance = pool_helper.collateralToken().balanceOf(borrower)
     if collateral_balance <= 10**18:
         log(f" WARN: borrower {borrower_index} has insufficient collateral to draw debt")
         return
     elif collateral_balance < collateral_to_deposit:
         collateral_to_deposit = collateral_balance
-        borrow_amount = collateral_to_deposit * pool_utils.lup(pool.address) / collateralization / 10**18
+        borrow_amount = collateral_to_deposit * pool_helper.lup() / collateralization / 10**18
         log(f" WARN: borrower {borrower_index} only has {collateral_balance/1e18:.1f} collateral; "
               f" drawing {borrow_amount/1e18:.1f} of debt against it")
 
-    tx = pledge_and_borrow(pool, pool_utils, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils)
+    tx = pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils)
 
 
-def add_quote_token(lender, lender_index, pool, pool_utils):
-    dai = Contract(pool.quoteToken())
+def add_quote_token(lender, lender_index, pool_helper):
+    dai = pool_helper.quoteToken()
     index_offset = ((lender_index % 6) - 2) * 2
-    deposit_index = pool_utils.lupIndex(pool.address) - index_offset
-    deposit_price = pool_utils.indexToPrice(deposit_index)
+    deposit_index = pool_helper.lupIndex() - index_offset
+    deposit_price = pool_helper.indexToPrice(deposit_index)
     quantity = int(MIN_PARTICIPATION * ((lender_index % 4) + 1) ** 2) * 10**18
 
     if dai.balanceOf(lender) < quantity:
@@ -315,31 +316,30 @@ def add_quote_token(lender, lender_index, pool, pool_utils):
         return None
 
     log(f" lender   {lender_index:>4} adding {quantity / 10**18:.1f} liquidity at {deposit_price / 10**18:.1f}")
-    # try:
-    tx = pool.addQuoteToken(quantity, deposit_index, {"from": lender})
+    tx = pool_helper.pool.addQuoteToken(quantity, deposit_index, {"from": lender})
     return deposit_price
 
 
-def remove_quote_token(lender, lender_index, price, pool_utils, pool):
-    price_index = pool_utils.priceToIndex(price)
-    (lp_balance, _) = pool.lenders(price_index, lender)
+def remove_quote_token(lender, lender_index, price, pool_helper):
+    price_index = pool_helper.priceToIndex(price)
+    (lp_balance, _) = pool_helper.lenderInfo(price_index, lender)
     if lp_balance > 0:
-        (_, _, _, _, _, exchange_rate) = pool_utils.bucketInfo(pool.address, price_index)
+        (_, _, _, _, _, exchange_rate) = pool_helper.bucketInfo(price_index)
         claimable_quote = lp_balance * exchange_rate / 10**36
         log(f" lender   {lender_index:>4} removing {claimable_quote / 10**18:.1f} quote"
               f" from bucket {price_index} ({price / 10**18:.1f}); exchange rate is {exchange_rate/1e27:.8f}")
-        if not ensure_pool_is_funded(pool, claimable_quote * 2, "withdraw"):
+        if not ensure_pool_is_funded(pool_helper.pool, claimable_quote * 2, "withdraw"):
             return
-        tx = pool.removeAllQuoteToken(price_index, {"from": lender})
+        tx = pool_helper.pool.removeAllQuoteToken(price_index, {"from": lender})
     else:
         log(f" lender   {lender_index:>4} has no claim to bucket {price / 10**18:.1f}")
 
 
-def repay(borrower, borrower_index, pool, pool_utils, test_utils):
-    dai = Contract(pool.quoteToken())
-    (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower)
+def repay(borrower, borrower_index, pool_helper, test_utils):
+    dai = pool_helper.quoteToken()
+    (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower)
     quote_balance = dai.balanceOf(borrower)
-    (_, _, _, min_debt) = pool_utils.poolUtilizationInfo(pool.address)
+    (_, _, _, min_debt) = pool_helper.utilizationInfo()
 
     if quote_balance < 100 * 10**18:
         log(f" borrower {borrower_index:>4} only has {quote_balance/1e18:.1f} quote token and will not repay debt")
@@ -357,35 +357,35 @@ def repay(borrower, borrower_index, pool, pool_utils, test_utils):
         # do the repayment
         repay_amount = int(repay_amount * 1.01)
         log(f" borrower {borrower_index:>4} repaying {repay_amount/1e18:.1f} of {pending_debt/1e18:.1f} debt")
-        tx = pool.repay(borrower, repay_amount, {"from": borrower})
+        tx = pool_helper.pool.repay(borrower, repay_amount, {"from": borrower})
 
         # withdraw appropriate amount of collateral to maintain a target-utilization-friendly collateralization
-        (_, pending_debt, collateral_deposited, _, _) = pool_utils.borrowerInfo(pool.address, borrower)
-        collateral_encumbered = int((pending_debt * 10**18) / pool_utils.lup(pool.address))
+        (_, pending_debt, collateral_deposited, _, _) = pool_helper.borrowerInfo(borrower)
+        collateral_encumbered = int((pending_debt * 10**18) / pool_helper.lup())
         collateral_to_withdraw = int(collateral_deposited - (collateral_encumbered * 1.667))
         log(f" borrower {borrower_index:>4}, with {collateral_deposited/1e18:.1f} deposited "
               f"and {collateral_encumbered/1e18:.1f} encumbered, "
               f"is withdrawing {collateral_deposited/1e18:.1f} collateral")
         assert collateral_to_withdraw > 0
-        tx = pool.pullCollateral(collateral_to_withdraw, {"from": borrower})
+        tx = pool_helper.pool.pullCollateral(collateral_to_withdraw, {"from": borrower})
     elif pending_debt == 0:
         log(f" borrower {borrower_index:>4} has no debt to repay")
     else:
         log(f" borrower {borrower_index:>4} will not repay dusty {pending_debt/1e18:.1f} debt")
 
 
-def test_stable_volatile_one(pool1, pool_utils, lenders, borrowers, scaled_pool_utils, test_utils, chain):
+def test_stable_volatile_one(pool_helper, lenders, borrowers, test_utils, chain):
     # Validate test set-up
-    print("Before test:\n" + test_utils.dump_book(pool1, pool_utils))
-    test_utils.summarize_pool(pool1, pool_utils)
-    assert pool1.collateral() == MKR_ADDRESS
-    assert pool1.quoteToken() == DAI_ADDRESS
+    print("Before test:\n" + test_utils.dump_book(pool_helper))
+    test_utils.summarize_pool(pool_helper)
+    assert pool_helper.pool.collateralAddress() == MKR_ADDRESS
+    assert pool_helper.pool.quoteTokenAddress() == DAI_ADDRESS
     assert len(lenders) == NUM_LENDERS
     assert len(borrowers) == NUM_BORROWERS
     # assert pool1.poolSize() > 2_700_000 * 10**18
-    (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool1.address)
+    (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
     assert poolActualUtilization > 0
-    test_utils.validate_pool(pool1, pool_utils, borrowers)
+    test_utils.validate_pool(pool_helper, borrowers)
 
     # Simulate pool activity over a configured time duration
     start_time = chain.time()
@@ -394,14 +394,14 @@ def test_stable_volatile_one(pool1, pool_utils, lenders, borrowers, scaled_pool_
     with test_utils.GasWatcher(['addQuoteToken', 'borrow', 'removeAllQuoteToken', 'repay']):
         while chain.time() < end_time:
             # hit the pool an hour at a time, calculating interest and then sending transactions
-            actor_id = draw_and_bid(lenders, borrowers, actor_id, pool1, pool_utils, chain, test_utils)
-            test_utils.summarize_pool(pool1, pool_utils)
+            actor_id = draw_and_bid(lenders, borrowers, actor_id, pool_helper, chain, test_utils)
+            test_utils.summarize_pool(pool_helper)
             print(f"days remaining: {(end_time - chain.time()) / 3600 / 24:.3f}\n")
 
     # Validate test ended with the pool in a meaningful state
-    test_utils.validate_pool(pool1, pool_utils, borrowers)
-    print("After test:\n" + test_utils.dump_book(pool1, pool_utils))
-    (_, _, poolActualUtilization, _) = pool_utils.poolUtilizationInfo(pool1.address)
+    test_utils.validate_pool(pool_helper, borrowers)
+    print("After test:\n" + test_utils.dump_book(pool_helper))
+    (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
     utilization = poolActualUtilization / 10**18
     print(f"elapsed time: {(chain.time()-start_time) / 3600 / 24} days   actual utilization: {utilization}")
     assert MIN_UTILIZATION * 0.9 < utilization < MAX_UTILIZATION * 1.1


### PR DESCRIPTION
**Changes**
Over the past month, code refactoring has made it difficult to maintain the real-world test.  The last refactor added `BucketMath` and `PoolUtils` artifacts which had been awkwardly sprinkled around the RWT code as a growing list of function arguments.  To mitigate this, I now have a (poorly-named) `PoolHelper` class which provides some insulation between the test and the contract or library with the implementation logic.

**Out of scope**
- Intelligently incorporating `PoolHelper` logic into `./sdk/`
- Getting the other Brownie test running