### PR TITLE
Liquidation take improvements

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -357,6 +357,7 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
 
     uint256 public constant LARGEST_AMOUNT = type(uint256).max / 10**27;
 
+    uint  internal _anonBorrowerCount = 0;
     Token internal _collateral;
     Token internal _quote;
 
@@ -367,6 +368,24 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
         _pool       = ERC20Pool(new ERC20PoolFactory().deployPool(address(_collateral), address(_quote), 0.05 * 10**18));
         _poolUtils  = new PoolInfoUtils();
         _startTime  = block.timestamp;
+    }
+
+    /**
+     *  @dev Creates debt for an anonymous non-player borrower not otherwise involved in the test.
+     **/
+    function _anonBorrowerDrawsDebt(uint256 collateralAmount, uint256 loanAmount, uint256 limitIndex) internal {
+        _anonBorrowerCount += 1;
+        address borrower = makeAddr(string(abi.encodePacked("anonBorrower", _anonBorrowerCount)));
+        vm.stopPrank();
+        _mintCollateralAndApproveTokens(borrower,  collateralAmount);
+        _pledgeCollateral(
+            {
+                from:     borrower,
+                borrower: borrower,
+                amount:   collateralAmount
+            }
+        );
+        _pool.borrow(loanAmount, limitIndex);
     }
 
     function _mintQuoteAndApproveTokens(address operator_, uint256 mintAmount_) internal {

--- a/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -18,7 +18,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
-    uint internal _anonBorrowerCount = 0;
 
     uint256 highest = 2550;
     uint256 high    = 2551;
@@ -97,24 +96,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 interestRateUpdate:   _startTime
             })
         );
-    }
-
-    /**
-     *  @dev Creates debt for an anonymous non-player borrower not otherwise involved in the test.
-     **/
-    function _anonBorrowerDrawsDebt(uint256 loanAmount) internal {
-        _anonBorrowerCount += 1;
-        address borrower = makeAddr(string(abi.encodePacked("anonBorrower", _anonBorrowerCount)));
-        vm.stopPrank();
-        _mintCollateralAndApproveTokens(borrower,  100 * 1e18);
-        _pledgeCollateral(
-            {
-                from:     borrower,
-                borrower: borrower,
-                amount:   100 * 1e18
-            }
-        );
-        _pool.borrow(loanAmount, 7_777);
     }
 
     function testPoolBorrowAndRepay() external {
@@ -685,7 +666,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     function testMinBorrowAmountCheck() external {
         // 10 borrowers draw debt
         for (uint i=0; i<10; ++i) {
-            _anonBorrowerDrawsDebt(1_200 * 1e18);
+            _anonBorrowerDrawsDebt(100 * 1e18, 1_200 * 1e18, 7777);
         }
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(loansCount, 10);
@@ -847,7 +828,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         // 9 other borrowers draw debt
         for (uint i=0; i<9; ++i) {
-            _anonBorrowerDrawsDebt(1_000 * 1e18);
+            _anonBorrowerDrawsDebt(100 * 1e18, 1_000 * 1e18, 7777);
         }
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(loansCount, 10);

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -970,6 +970,10 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         skip(2 hours);
 
+        // 10 borrowers draw debt to enable the min debt check
+        for (uint i=0; i<10; ++i) {
+            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7777);
+        }        
         // should revert if auction leaves borrower with debt under minimum pool debt
         _assertTakeDebtUnderMinPoolDebtRevert(
             {

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -239,7 +239,7 @@ library Auctions {
      *  @param  maxCollateral_    The max collateral amount to be taken from auction.
      *  @param  poolInflator_     The pool's inflator, used to calculate borrower debt.
      *  @return quoteTokenAmount_ The quote token amount that taker should pay for collateral taken.
-     *  @return repayAmount_      The amount of debt (quote tokens) that is recovered / repayed by take.
+     *  @return t0repayAmount_    The amount of debt (quote tokens) that is recovered / repayed by take t0 terms.
      *  @return collateralTaken_  The amount of collateral taken.
      *  @return bondChange_       The change made on the bond size (beeing reward or penalty).
      *  @return isRewarded_       True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
@@ -252,7 +252,7 @@ library Auctions {
         uint256 poolInflator_
     ) internal returns (
         uint256 quoteTokenAmount_,
-        uint256 repayAmount_,
+        uint256 t0repayAmount_,
         uint256 collateralTaken_,
         uint256 bondChange_,
         bool    isRewarded_
@@ -271,6 +271,7 @@ library Auctions {
         quoteTokenAmount_    = Maths.wmul(auctionPrice, collateralTaken_);
         uint256 borrowerDebt = Maths.wmul(borrower_.t0debt, poolInflator_);
 
+        // calculate the bond payment factor
         int256 bpf = PoolUtils.bpf(
             borrowerDebt,
             borrower_.collateral,
@@ -280,10 +281,10 @@ library Auctions {
             auctionPrice
         );
 
-        repayAmount_      = Maths.wmul(quoteTokenAmount_, uint256(1e18 - Maths.maxInt(0, bpf)));
-
-        if (repayAmount_ >= borrowerDebt) {
-            repayAmount_      = borrowerDebt;
+        // determine how much of the loan will be repaid
+        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, uint256(1e18 - Maths.maxInt(0, bpf))), poolInflator_);
+        if (t0repayAmount_ >= borrower_.t0debt) {
+            t0repayAmount_    = borrower_.t0debt;
             quoteTokenAmount_ = Maths.wmul(borrowerDebt, uint256(1e18 - Maths.maxInt(0, bpf)));
             collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
         }
@@ -291,7 +292,7 @@ library Auctions {
         isRewarded_ = (bpf >= 0);
         if (isRewarded_) {
             // take is below neutralPrice, Kicker is rewarded
-            bondChange_ = quoteTokenAmount_ - repayAmount_;
+            bondChange_ = quoteTokenAmount_ - Maths.wmul(t0repayAmount_, poolInflator_);
             liquidation.bondSize                    += bondChange_;
             self.kickers[liquidation.kicker].locked += bondChange_;
             self.totalBondEscrowed                  += bondChange_;


### PR DESCRIPTION
**Changes**
- Have `take` reuse `repay` logic for paying down a loan.
- Implicitly fixed bug where `take` was not waiving the minimum debt limit when there were under 10 loans.
- Update `Auctions.take` to calculate and return repaid amount in t0 terms.

**Contract size change**
A 0.9% reduction in contract size was observed:
```
============ develop Bytecode Sizes ============
  ERC721Pool               -  24,197B  (98.45%)
  ERC20Pool                -  23,651B  (96.23%)

============ take-t0 Bytecode Sizes ============
  ERC721Pool               -  23,927B  (97.36%)
  ERC20Pool                -  23,381B  (95.13%)
```

**Gas changes**
Tiny increase in `repay` cost, significant decrease in `take` cost:
```
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ develop ERC20Pool contract                 ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ borrow                                     ┆ 662             ┆ 206917 ┆ 196848 ┆ 404496 ┆ 80      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4454            ┆ 95164  ┆ 71799  ┆ 286521 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ take                                       ┆ 2569            ┆ 127538 ┆ 189371 ┆ 233843 ┆ 9       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯

╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ take-t0 ERC20Pool contract                 ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ borrow                                     ┆ 662             ┆ 206004 ┆ 202482 ┆ 404558 ┆ 90      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4498            ┆ 95249  ┆ 71912  ┆ 286634 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ take                                       ┆ 2569            ┆ 108257 ┆ 77115  ┆ 233627 ┆ 9       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```