### PR TITLE
3rd party position NFT minter

### DIFF
--- a/src/_test/PositionManager.t.sol
+++ b/src/_test/PositionManager.t.sol
@@ -124,7 +124,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // construct memorialize params struct
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testAddress, indexes
+            tokenId, indexes
         );
 
         // should revert if access hasn't been granted to transfer LP tokens
@@ -256,7 +256,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // construct memorialize params struct
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testAddress, indexes
+            tokenId, indexes
         );
         // allow position manager to take ownership of the position
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 3_000 * 1e27);
@@ -662,7 +662,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         lender1Indexes[2] = 2552;
 
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId1, testLender1, lender1Indexes
+            tokenId1, lender1Indexes
         );
 
         // allow position manager to take ownership of lender 1's position
@@ -762,7 +762,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         newIndexes[1] = 2553;
 
         memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId2, testLender2, newIndexes
+            tokenId2, newIndexes
         );
 
         vm.expectEmit(true, true, true, true);
@@ -930,7 +930,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 15_000 * 1e27);
         // memorialize positions of testMinter
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testMinter, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
 
@@ -1079,7 +1079,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 15_000 * 1e27);
         // memorialize positions of testMinter
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testMinter, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
 
@@ -1241,7 +1241,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 15_000 * 1e27);
         // memorialize positions of testMinter
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testMinter, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
 
@@ -1400,7 +1400,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = mintIndex;
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId1, testAddress1, indexes
+            tokenId1, indexes
         );
         changePrank(testAddress1);
         _positionManager.memorializePositions(memorializeParams);
@@ -1542,7 +1542,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize positions of testAddress2
         memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId2, testAddress2, indexes
+            tokenId2, indexes
         );
         changePrank(testAddress2);
         _positionManager.memorializePositions(memorializeParams);
@@ -1729,7 +1729,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 15_000 * 1e27);
         // memorialize positions of testMinter
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testMinter, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
 
@@ -1918,7 +1918,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 15_000 * 1e27);
         // memorialize positions of testMinter
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testMinter, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
 
@@ -2112,7 +2112,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256 tokenId = _mintNFT(minter, lender, address(_pool));
         assertEq(_positionManager.ownerOf(tokenId), lender);
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, lender, indexes
+            tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
         _assertLenderLpBalance(
@@ -2395,7 +2395,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
 
         // construct memorialize params struct
         IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-            tokenId, testAddress1, indexes
+            tokenId, indexes
         );
         // allow position manager to take ownership of the position
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 3_000 * 1e27);

--- a/src/base/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/base/interfaces/position/IPositionManagerOwnerActions.sol
@@ -43,12 +43,10 @@ interface IPositionManagerOwnerActions {
     /**
      *  @notice Struct holding parameters for tracking positions.
      *  @param  tokenId The tokenId of the NFT.
-     *  @param  owner   The NFT owner address.
      *  @param  indexes The array of price buckets index with LP tokens to be tracked by a NFT.
      */
     struct MemorializePositionsParams {
         uint256 tokenId;
-        address owner;
         uint256[] indexes;
     }
 

--- a/src/base/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/base/interfaces/position/IPositionManagerOwnerActions.sol
@@ -23,12 +23,10 @@ interface IPositionManagerOwnerActions {
     /**
      *  @notice Struct holding parameters for burning an NFT.
      *  @param  tokenId   The tokenId of the NFT to burn.
-     *  @param  recipient The NFT owner address.
      *  @param  pool      The pool address to burn the token from.
      */
     struct BurnParams {
         uint256 tokenId;
-        address recipient;
         address pool;
     }
 
@@ -89,14 +87,12 @@ interface IPositionManagerOwnerActions {
 
     /**
      *  @notice Struct holding parameters for moving the liquidity of a position.
-     *  @param  owner     The NFT owner address.
      *  @param  tokenId   The tokenId of the NFT.
      *  @param  pool      The pool address to move quote tokens.
      *  @param  fromIndex The price bucket index from which liquidity should be moved.
      *  @param  toIndex   The price bucket index to which liquidity should be moved.
      */
     struct MoveLiquidityParams {
-        address owner;
         uint256 tokenId;
         address pool;
         uint256 fromIndex;
@@ -115,12 +111,10 @@ interface IPositionManagerOwnerActions {
     /**
      *  @notice Struct holding parameters for tracking positions.
      *  @param  tokenId The tokenId of the NFT.
-     *  @param  owner   The NFT owner address.
      *  @param  pool    The pool address to reedem positions.
      *  @param  indexes The array of price buckets index with LP tokens to be tracked by a NFT.
      */
     struct RedeemPositionsParams {
-        address owner;
         uint256 tokenId;
         address pool;
         uint256[] indexes;


### PR DESCRIPTION
`PositionManager` fix for scenario where 3rd party minter mints NFT for lender, then is able to take over and redeem lender's LPs
    
- removed owner variable from `MemorializePositionsParams`, `MoveLiquidityParams`, `RedeemPositionsParams` and `BurnParams` structs. Instead use NFT owner address to make sure everything happens on behalf of NFT owner (when minted NFT is transferred to recipient - `PositionManager.mint` uses `_safeMint` which mints and transfers ownership)
- added check in `mayInteract` modifier to make sure tokenId passed as a parameter is minted
    
tests update:
 - test helper function `_mintNFT` changed to accept minter and lender addresses
- added `test3rdPartyMinter` test to expose allowed interactions of a 3rd party minter with lender's LPs + assert LPs are always redeemed to lender
- added `test3rdPartyMinterAndRedeemer` test to expose scenario where minter can redeem lender's LPs if lender transferred NFT position ownership to minter
- added `testMayInteractReverts` test to cover all reverts scenarios when interacting with a token