### PR TITLE
t0DebtInAuction check

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -269,6 +269,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         _pool.transferLPTokens(from, to, indexes);
     }
 
+    function _assertDepositLockedByAuctionDebtRevert(
+        address operator,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(operator);
+        vm.expectRevert(IPoolErrors.DepositLockedByAuctionDebt.selector);
+        _pool.removeQuoteToken(amount, index);
+    }
+
 }
 
 abstract contract ERC20HelperContract is ERC20DSTestPlus {

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -262,6 +262,12 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:   _borrower2
             }
         );
+
+        _assertDepositLockedByAuctionDebtRevert({
+            operator:  _lender,
+            amount:    100 * 1e18,
+            index:     _i9_91
+        });
     }
 
     function testKickAndSaveByRepay() external {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -1021,12 +1021,17 @@ abstract contract Pool is Clone, Multicall, IPool {
         return _getArgUint256(40);
     }
 
+    /**
+     *  @notice Called by LPB removal functions assess whether or not LPB is locked.
+     *  @param  index_   The bucket index from which LPB is attempting to be removed.
+     *  @param  inflator_ The pool inflator used to properly assess t0DebtInAuction.
+     */
     function _checkAuctionDebtLock(
         uint256 index_,
-        uint256 poolInflator
+        uint256 inflator_
     ) internal view {
         // deposit in buckets within liquidation debt from the top-of-book down are frozen.
-        if(index_ <= deposits.findIndexOfSum(Maths.wmul(t0DebtInAuction, poolInflator))) revert DepositLockedByAuctionDebt();
+        if(index_ <= deposits.findIndexOfSum(Maths.wmul(t0DebtInAuction, inflator_))) revert DepositLockedByAuctionDebt();
     }
 
 }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -42,7 +42,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
     uint256 internal reserveAuctionKicked;    // Time a Claimable Reserve Auction was last kicked.
     uint256 internal reserveAuctionUnclaimed; // Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
-    uint256 internal t0DebtInAuction;
+    uint256 internal t0DebtInAuction;         // Total debt in auction used to restrict LPB holder from withdrawing
 
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 
@@ -377,7 +377,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             ) >= Maths.WAD
         ) revert BorrowerOk();
 
-        (uint256 kickPenalty, uint256 totalBorrowerDebt)= loans.kick(
+        (uint256 kickPenalty, uint256 t0borrowerDebt)= loans.kick(
             borrowerAddress_,
             borrowerDebt,
             poolState.inflator,
@@ -395,7 +395,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         );
 
         // update pool state
-        t0DebtInAuction += totalBorrowerDebt;
+        t0DebtInAuction += t0borrowerDebt;
         _updatePool(poolState, lup);
 
         emit Kick(borrowerAddress_, borrowerDebt, borrower.collateral);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -42,7 +42,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
     uint256 internal reserveAuctionKicked;    // Time a Claimable Reserve Auction was last kicked.
     uint256 internal reserveAuctionUnclaimed; // Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
-    uint256 internal t0DebtInAuction;         // Total debt in auction used to restrict LPB holder from withdrawing
+    uint256 internal t0DebtInAuction;         // Total debt in auction used to restrict LPB holder from withdrawing [WAD]
 
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -113,4 +113,10 @@ interface IPoolErrors {
      *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
      */
     error PoolUnderCollateralized();
+
+
+    /**
+     *  @notice Lender is attempting to remove quote tokens from a bucket that exists above active auction debt from top-of-book downward.
+     */
+    error DepositLockedByAuctionDebt();
 }

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -68,14 +68,15 @@ library Loans {
         uint256 debt_,
         uint256 inflator_,
         uint256 rate_
-    ) internal returns (uint256 kickPenalty_) {
+    ) internal returns (uint256 kickPenalty_, uint256 totalT0BorrowerDebt_) {
         // update loan heap
         _remove(self, borrower_);
 
         // update borrower balance
         Borrower storage borrower = self.borrowers[borrower_];
         kickPenalty_              = Maths.wmul(Maths.wdiv(rate_, 4 * 1e18), debt_); // when loan is kicked, penalty of three months of interest is added
-        borrower.t0debt           = Maths.wdiv(debt_ + kickPenalty_, inflator_);
+        totalT0BorrowerDebt_      = Maths.wdiv(debt_ + kickPenalty_, inflator_);
+        borrower.t0debt           = totalT0BorrowerDebt_;
     }
 
     /**


### PR DESCRIPTION
* Added `_checkAuctionDebtLock()` method which checks `t0DebtInAuction`
 * Prevents lenders from withdrawing LPB if their bucket index is less than `t0DebtInAuction` index calculated from top-of-book down
* Incremented `t0DebtInAuction` in `kick`
* Decremented `t0DebtInAuction` in `take` and `heal`