### PR TITLE
Nft take

### DIFF
--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -6,6 +6,7 @@ import './interfaces/IERC20Pool.sol';
 import '../base/Pool.sol';
 
 contract ERC20Pool is IERC20Pool, Pool {
+    using Auctions for Auctions.Data;
     using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
@@ -156,12 +157,37 @@ contract ERC20Pool is IERC20Pool, Pool {
         emit DepositTake(borrower_, index_, amount_, 0, 0);
     }
 
+    /**
+     *  @notice Performs take checks, calculates amounts and bpf reward / penalty.
+     *  @dev Internal support method assisting in the ERC20 and ERC721 pool take calls.
+     *  @param borrowerAddress_   Address of the borower take is being called upon.
+     *  @param collateral_        Max amount of collateral to take, submited by the taker.
+     */
     function take(
-        address borrower_,
-        uint256 maxCollateral_,
+        address borrowerAddress_,
+        uint256 collateral_,
         bytes memory swapCalldata_
     ) external override {
-        uint256 collateralTaken = _take(borrower_, maxCollateral_);
+        PoolState      memory poolState = _accruePoolInterest();
+        Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
+        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
+
+        (
+            uint256 quoteTokenAmount,
+            uint256 t0repaidDebt,
+            uint256 collateralTaken,
+            ,
+            uint256 bondChange,
+            bool isRewarded
+        ) = auctions.take(borrowerAddress_, borrower, collateral_, poolState.inflator);
+
+        borrower.collateral  -= collateralTaken;
+        poolState.collateral -= collateralTaken;
+
+        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
+
+        emit Take(borrowerAddress_, quoteTokenAmount, collateralTaken, bondChange, isRewarded);
+        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount);
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -187,13 +187,13 @@ contract ERC20Pool is IERC20Pool, Pool {
         _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
 
         emit Take(borrowerAddress_, quoteTokenAmount, collateralTaken, bondChange, isRewarded);
-        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount);
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower
         // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
         //msg.sender.call(swapCalldata_);
 
+        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount);
         _transferCollateral(msg.sender, collateralTaken);
     }
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -127,38 +127,41 @@ contract ERC721Pool is IERC721Pool, Pool {
         (
             uint256 quoteTokenAmount,
             uint256 t0repaidDebt,
-            uint256 collateralTaken,
+            uint256 collateralNeeded,
             uint256 auctionPrice,
             uint256 bondChange,
             bool isRewarded
         ) = auctions.take(borrowerAddress_, borrower, Maths.wad(collateral_), poolState.inflator);
 
-        uint256 quoteTokensForCollateralDifference;
-        uint256 roundedCollateralTaken = (collateralTaken / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
-        if (roundedCollateralTaken != collateralTaken) { // collateral taken not a round number
-            roundedCollateralTaken += 1e18; // round up collateral to take
+        uint256 collateralDifference;
+        uint256 collateralTaken = (collateralNeeded / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
+        if (collateralTaken != collateralNeeded) { // collateral taken not a round number
+            collateralTaken += 1e18; // round up collateral to take
              // taker should send additional quote tokens to cover difference between collateral needed to be taken and rounded collateral, at auction price
              // borrower will get quote tokens for the difference between rounded collateral and collateral taken to cover debt
-            quoteTokensForCollateralDifference = Maths.wmul(roundedCollateralTaken - collateralTaken, auctionPrice);
+            collateralDifference = Maths.wmul(collateralTaken - collateralNeeded, auctionPrice);
         }
 
-        borrower.collateral  -= roundedCollateralTaken;
-        poolState.collateral -= roundedCollateralTaken;
+        borrower.collateral  -= collateralTaken;
+        poolState.collateral -= collateralTaken;
 
         _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
 
-        emit Take(borrowerAddress_, quoteTokenAmount, collateralTaken, bondChange, isRewarded);
-        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount + quoteTokensForCollateralDifference);
-        if (quoteTokensForCollateralDifference != 0) {
-            // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
-            _transferQuoteToken(borrowerAddress_, quoteTokensForCollateralDifference);
-        }
+        emit Take(borrowerAddress_, quoteTokenAmount, collateralNeeded, bondChange, isRewarded);
+
+        // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
+        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount + collateralDifference);
+
+        // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
+        if (collateralDifference != 0) _transferQuoteToken(borrowerAddress_, collateralDifference);
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower
         // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
         //msg.sender.call(swapCalldata_);
-        _transferFromPoolToSender(borrowerTokenIds[borrowerAddress_], roundedCollateralTaken / 1e18);
+
+        // transfer rounded collateral from pool to taker
+        _transferFromPoolToSender(borrowerTokenIds[borrowerAddress_], collateralTaken / 1e18);
     }
 
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -6,8 +6,8 @@ import './interfaces/IERC721Pool.sol';
 import '../base/Pool.sol';
 
 contract ERC721Pool is IERC721Pool, Pool {
-    using Buckets for mapping(uint256 => Buckets.Bucket);
-    using Loans   for Loans.Data;
+    using Auctions for Auctions.Data;
+    using Loans    for Loans.Data;
 
     /***********************/
     /*** State Variables ***/
@@ -116,26 +116,49 @@ contract ERC721Pool is IERC721Pool, Pool {
     }
 
     function take(
-        address borrower_,
-        uint256 maxTokens_,
+        address borrowerAddress_,
+        uint256 collateral_,
         bytes memory swapCalldata_
     ) external override {
+        PoolState      memory poolState = _accruePoolInterest();
+        Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
+        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
-        uint256 collateralTaken = _take(borrower_, Maths.wad(maxTokens_));
-        if (collateralTaken != 0) {
-            uint256 nftsTaken = (collateralTaken / 1e18) + 1; // round up collateral taken: (taken / 1e18) rounds down + 1 = rounds up TODO: fix this
+        (
+            uint256 quoteTokenAmount,
+            uint256 t0repaidDebt,
+            uint256 collateralTaken,
+            uint256 auctionPrice,
+            uint256 bondChange,
+            bool isRewarded
+        ) = auctions.take(borrowerAddress_, borrower, Maths.wad(collateral_), poolState.inflator);
 
-            uint256[] storage pledgedNFTs = borrowerTokenIds[borrower_];
-            uint256 noOfNFTsPledged = pledgedNFTs.length;
-
-            if (noOfNFTsPledged < nftsTaken) nftsTaken = noOfNFTsPledged;
-
-            // TODO: implement flashloan functionality
-            // Flash loan full amount to liquidate to borrower
-            // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
-            //msg.sender.call(swapCalldata_);
-            _transferFromPoolToSender(pledgedNFTs, nftsTaken);
+        uint256 quoteTokensForCollateralDifference;
+        uint256 roundedCollateralTaken = (collateralTaken / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
+        if (roundedCollateralTaken != collateralTaken) { // collateral taken not a round number
+            roundedCollateralTaken += 1e18; // round up collateral to take
+             // taker should send additional quote tokens to cover difference between collateral needed to be taken and rounded collateral, at auction price
+             // borrower will get quote tokens for the difference between rounded collateral and collateral taken to cover debt
+            quoteTokensForCollateralDifference = Maths.wmul(roundedCollateralTaken - collateralTaken, auctionPrice);
         }
+
+        borrower.collateral  -= roundedCollateralTaken;
+        poolState.collateral -= roundedCollateralTaken;
+
+        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
+
+        emit Take(borrowerAddress_, quoteTokenAmount, collateralTaken, bondChange, isRewarded);
+        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount + quoteTokensForCollateralDifference);
+        if (quoteTokensForCollateralDifference != 0) {
+            // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
+            _transferQuoteToken(borrowerAddress_, quoteTokensForCollateralDifference);
+        }
+
+        // TODO: implement flashloan functionality
+        // Flash loan full amount to liquidate to borrower
+        // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
+        //msg.sender.call(swapCalldata_);
+        _transferFromPoolToSender(borrowerTokenIds[borrowerAddress_], roundedCollateralTaken / 1e18);
     }
 
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -127,19 +127,19 @@ contract ERC721Pool is IERC721Pool, Pool {
         (
             uint256 quoteTokenAmount,
             uint256 t0repaidDebt,
-            uint256 collateralNeeded,
+            uint256 collateralToCoverDebt,
             uint256 auctionPrice,
             uint256 bondChange,
             bool isRewarded
         ) = auctions.take(borrowerAddress_, borrower, Maths.wad(collateral_), poolState.inflator);
 
         uint256 collateralDifference;
-        uint256 collateralTaken = (collateralNeeded / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
-        if (collateralTaken != collateralNeeded) { // collateral taken not a round number
+        uint256 collateralTaken = (collateralToCoverDebt / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
+        if (collateralTaken != collateralToCoverDebt) { // collateral taken not a round number
             collateralTaken += 1e18; // round up collateral to take
              // taker should send additional quote tokens to cover difference between collateral needed to be taken and rounded collateral, at auction price
              // borrower will get quote tokens for the difference between rounded collateral and collateral taken to cover debt
-            collateralDifference = Maths.wmul(collateralTaken - collateralNeeded, auctionPrice);
+            collateralDifference = Maths.wmul(collateralTaken - collateralToCoverDebt, auctionPrice);
         }
 
         borrower.collateral  -= collateralTaken;
@@ -147,7 +147,7 @@ contract ERC721Pool is IERC721Pool, Pool {
 
         _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
 
-        emit Take(borrowerAddress_, quoteTokenAmount, collateralNeeded, bondChange, isRewarded);
+        emit Take(borrowerAddress_, quoteTokenAmount, collateralToCoverDebt, bondChange, isRewarded);
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -149,16 +149,16 @@ contract ERC721Pool is IERC721Pool, Pool {
 
         emit Take(borrowerAddress_, quoteTokenAmount, collateralNeeded, bondChange, isRewarded);
 
+        // TODO: implement flashloan functionality
+        // Flash loan full amount to liquidate to borrower
+        // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
+        //msg.sender.call(swapCalldata_);
+
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
         _transferQuoteTokenFrom(msg.sender, quoteTokenAmount + collateralDifference);
 
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (collateralDifference != 0) _transferQuoteToken(borrowerAddress_, collateralDifference);
-
-        // TODO: implement flashloan functionality
-        // Flash loan full amount to liquidate to borrower
-        // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
-        //msg.sender.call(swapCalldata_);
 
         // transfer rounded collateral from pool to taker
         _transferFromPoolToSender(borrowerTokenIds[borrowerAddress_], collateralTaken / 1e18);

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -240,6 +240,7 @@ library Auctions {
      *  @return quoteTokenAmount_ The quote token amount that taker should pay for collateral taken.
      *  @return t0repayAmount_    The amount of debt (quote tokens) that is recovered / repayed by take t0 terms.
      *  @return collateralTaken_  The amount of collateral taken.
+     *  @return auctionPrice_     The price of current auction.
      *  @return bondChange_       The change made on the bond size (beeing reward or penalty).
      *  @return isRewarded_       True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
     */
@@ -253,6 +254,7 @@ library Auctions {
         uint256 quoteTokenAmount_,
         uint256 t0repayAmount_,
         uint256 collateralTaken_,
+        uint256 auctionPrice_,
         uint256 bondChange_,
         bool    isRewarded_
     ) {
@@ -260,14 +262,14 @@ library Auctions {
         if (liquidation.kickTime == 0) revert NoAuction();
         if (block.timestamp - liquidation.kickTime <= 1 hours) revert TakeNotPastCooldown();
 
-        uint256 auctionPrice = PoolUtils.auctionPrice(
+        auctionPrice_ = PoolUtils.auctionPrice(
             liquidation.kickMomp,
             liquidation.kickTime
         );
 
         // calculate amounts
         collateralTaken_     = Maths.min(borrower_.collateral, maxCollateral_);
-        quoteTokenAmount_    = Maths.wmul(auctionPrice, collateralTaken_);
+        quoteTokenAmount_    = Maths.wmul(auctionPrice_, collateralTaken_);
         uint256 borrowerDebt = Maths.wmul(borrower_.t0debt, poolInflator_);
 
         // calculate the bond payment factor
@@ -277,7 +279,7 @@ library Auctions {
             borrower_.mompFactor,
             poolInflator_,
             liquidation.bondFactor,
-            auctionPrice
+            auctionPrice_
         );
 
         // determine how much of the loan will be repaid
@@ -285,7 +287,7 @@ library Auctions {
         if (t0repayAmount_ >= borrower_.t0debt) {
             t0repayAmount_    = borrower_.t0debt;
             quoteTokenAmount_ = Maths.wmul(borrowerDebt, uint256(1e18 - Maths.maxInt(0, bpf)));
-            collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
+            collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice_);
         }
 
         isRewarded_ = (bpf >= 0);


### PR DESCRIPTION
- return auction price from `Auctions.take` call (needed to calculate quote tokens for collateral difference taken)
- moved `take` logic from base contract to implementations (ERC20Pool contains same logic)
- ERC721Pool logic
  - rounds up the collateral needed to cover borrower debt and calculates the quote tokens difference to be transferred to borrower as `(roundedCollateral - collateralToCoverDebt) * auctionPrice`
  - quote token amount to purchase `collateralToCoverDebt` plus the quote tokens difference for rounded collateral is then transferred from taker to pool
  - the pool then transfers quote tokens difference for rounded collateral to borrower
  - as a last step, the rounded number of collateral is transferred from pool to taker