### PR TITLE
Fix bondChange calculation

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -656,13 +656,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         // skip ahead so take can be called on the loan
         skip(10 hours);
 
-        // perform partial take for 20 collateral
+        // // perform partial take for 20 collateral
         _take(
             {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   20 * 1e18,
-                bondChange:      0.285798096925981399 * 1e18,
+                bondChange:      0.121516198312897248 * 1e18,
                 givenAmount:     12.151619831289724800 * 1e18,
                 collateralTaken: 20 * 1e18,
                 isReward:        true
@@ -673,11 +673,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          98.819740516718197856 * 1e18,
+                bondSize:          98.655458618105113705 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 98.819740516718197856 * 1e18,
+                totalBondEscrowed: 98.655458618105113705 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -685,7 +685,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    98.819740516718197856 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    98.655458618105113705 * 1e18 // locked bond + reward, auction is not yet finished
             }
         );
         _assertBorrower(
@@ -704,7 +704,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   981 * 1e18,
-                bondChange:      14.004106749373088553 * 1e18,
+                bondChange:      5.954293717331965152 * 1e18,
                 givenAmount:     595.429371733196515200 * 1e18,
                 collateralTaken: 980 * 1e18,
                 isReward:        true
@@ -715,11 +715,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          112.823847266091286409 * 1e18,
+                bondSize:          104.609752335437078857 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 112.823847266091286409 * 1e18,
+                totalBondEscrowed: 104.609752335437078857 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -727,7 +727,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0 * 1e18,
-                locked:    112.823847266091286409 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    104.609752335437078857 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
@@ -784,7 +784,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 112.823847266091286409 * 1e18,
+                claimable: 104.609752335437078857 * 1e18,
                 locked:    0
             }
         );
@@ -836,8 +836,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_883.576368194292782499 * 1e18,
-                exchangeRate: 0.807597851654026616590818181 * 1e27
+                deposit:      8_891.790463124946990051 * 1e18,
+                exchangeRate: 0.808344587556813362731909090 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -890,7 +890,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   1,
-                healedDebt: 139.927284621591283280 * 1e18
+                healedDebt: 148.141379552245490832 * 1e18
             }
         );
         _assertAuction(
@@ -898,11 +898,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          112.823847266091286409 * 1e18,
+                bondSize:          104.609752335437078857 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 112.823847266091286409 * 1e18,
+                totalBondEscrowed: 104.609752335437078857 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -910,13 +910,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    112.823847266091286409 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    104.609752335437078857 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_235.641711503479329501 * 1e18,
+                borrowerDebt:              9_227.427616572825121949 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588542815647469183 * 1e18,
                 borrowerCollateralization: 0
@@ -928,7 +928,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   5,
-                healedDebt: 9_235.641711503479329501 * 1e18
+                healedDebt: 9_227.427616572825121949 * 1e18
             }
         );
         _assertAuction(
@@ -947,7 +947,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 112.823847266091286409 * 1e18,
+                claimable: 104.609752335437078857 * 1e18,
                 locked:    0
             }
         );
@@ -964,7 +964,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         // kicker withdraws his auction bonds
         assertEq(_quote.balanceOf(_lender), 46_293.885066015721543543 * 1e18);
         _pool.withdrawBonds();
-        assertEq(_quote.balanceOf(_lender), 46_406.708913281812829952 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_398.494818351158622400 * 1e18);
         _assertKicker(
             {
                 kicker:    _lender,
@@ -1111,7 +1111,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   800 * 1e18,
-                bondChange:      11.431923877039255962 * 1e18,
+                bondChange:      4.860647932515889920 * 1e18,
                 givenAmount:     486.064793251588992000 * 1e18,
                 collateralTaken: 800 * 1e18,
                 isReward:        true
@@ -1122,11 +1122,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          109.965866296831472419 * 1e18,
+                bondSize:          103.394590352308106377 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 109.965866296831472419 * 1e18,
+                totalBondEscrowed: 103.394590352308106377 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -1231,8 +1231,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_764.918150850655348490 * 1e18,
-                exchangeRate: 0.796810740986423213499090909 * 1e27
+                deposit:      8_771.489426795178714532 * 1e18,
+                exchangeRate: 0.797408129708652610412000000 * 1e27
             }
         );
         _assertBucket(
@@ -1467,7 +1467,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
-                bondChange:      14.289904846299069952 * 1e18,
+                bondChange:      6.075809915644862400 * 1e18,
                 givenAmount:     607.580991564486240000 * 1e18,
                 collateralTaken: 1_000 * 1e18,
                 isReward:        true

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -656,13 +656,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         // skip ahead so take can be called on the loan
         skip(10 hours);
 
-        // // perform partial take for 20 collateral
+        // perform partial take for 20 collateral
         _take(
             {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   20 * 1e18,
-                bondChange:      0.121516198312897248 * 1e18,
+                bondChange:      0.285798096925981399 * 1e18,
                 givenAmount:     12.151619831289724800 * 1e18,
                 collateralTaken: 20 * 1e18,
                 isReward:        true
@@ -673,11 +673,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          98.655458618105113705 * 1e18,
+                bondSize:          98.819740516718197856 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 98.655458618105113705 * 1e18,
+                totalBondEscrowed: 98.819740516718197856 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -685,7 +685,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    98.655458618105113705 * 1e18 // locked bond + reward, auction is not yet finished
+                locked:    98.819740516718197856 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
@@ -704,7 +704,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   981 * 1e18,
-                bondChange:      5.954293717331965152 * 1e18,
+                bondChange:      14.004106749373088553 * 1e18,
                 givenAmount:     595.429371733196515200 * 1e18,
                 collateralTaken: 980 * 1e18,
                 isReward:        true
@@ -715,11 +715,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          104.609752335437078857 * 1e18,
+                bondSize:          112.823847266091286409 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 104.609752335437078857 * 1e18,
+                totalBondEscrowed: 112.823847266091286409 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -727,7 +727,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0 * 1e18,
-                locked:    104.609752335437078857 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    112.823847266091286409 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
@@ -784,7 +784,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 104.609752335437078857 * 1e18,
+                claimable: 112.823847266091286409 * 1e18,
                 locked:    0
             }
         );
@@ -836,8 +836,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_891.790463124946990051 * 1e18,
-                exchangeRate: 0.808344587556813362731909090 * 1e27
+                deposit:      8_883.576368194292782499 * 1e18,
+                exchangeRate: 0.807597851654026616590818181 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -890,7 +890,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   1,
-                healedDebt: 148.141379552245490832 * 1e18
+                healedDebt: 139.927284621591283280 * 1e18
             }
         );
         _assertAuction(
@@ -898,11 +898,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          104.609752335437078857 * 1e18,
+                bondSize:          112.823847266091286409 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 104.609752335437078857 * 1e18,
+                totalBondEscrowed: 112.823847266091286409 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -910,13 +910,13 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    104.609752335437078857 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    112.823847266091286409 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_227.427616572825121949 * 1e18,
+                borrowerDebt:              9_235.641711503479329501 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588542815647469183 * 1e18,
                 borrowerCollateralization: 0
@@ -928,7 +928,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   5,
-                healedDebt: 9_227.427616572825121949 * 1e18
+                healedDebt: 9_235.641711503479329501 * 1e18
             }
         );
         _assertAuction(
@@ -947,7 +947,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 104.609752335437078857 * 1e18,
+                claimable: 112.823847266091286409 * 1e18,
                 locked:    0
             }
         );
@@ -964,7 +964,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         // kicker withdraws his auction bonds
         assertEq(_quote.balanceOf(_lender), 46_293.885066015721543543 * 1e18);
         _pool.withdrawBonds();
-        assertEq(_quote.balanceOf(_lender), 46_398.494818351158622400 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_406.708913281812829952 * 1e18);
         _assertKicker(
             {
                 kicker:    _lender,
@@ -1111,7 +1111,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   800 * 1e18,
-                bondChange:      4.860647932515889920 * 1e18,
+                bondChange:      11.431923877039255962 * 1e18,
                 givenAmount:     486.064793251588992000 * 1e18,
                 collateralTaken: 800 * 1e18,
                 isReward:        true
@@ -1122,11 +1122,11 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          103.394590352308106377 * 1e18,
+                bondSize:          109.965866296831472419 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.721295865031779605 * 1e18,
-                totalBondEscrowed: 103.394590352308106377 * 1e18,
+                totalBondEscrowed: 109.965866296831472419 * 1e18,
                 auctionPrice:      0.607580991564486240 * 1e18
             }
         );
@@ -1231,8 +1231,8 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_771.489426795178714532 * 1e18,
-                exchangeRate: 0.797408129708652610412000000 * 1e27
+                deposit:      8_764.918150850655348490 * 1e18,
+                exchangeRate: 0.796810740986423213499090909 * 1e27
             }
         );
         _assertBucket(
@@ -1467,7 +1467,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
-                bondChange:      6.075809915644862400 * 1e18,
+                bondChange:      14.289904846299069952 * 1e18,
                 givenAmount:     607.580991564486240000 * 1e18,
                 collateralTaken: 1_000 * 1e18,
                 isReward:        true

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -281,17 +281,18 @@ library Auctions {
         );
 
         // determine how much of the loan will be repaid
-        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, uint256(1e18 - Maths.maxInt(0, bpf))), poolInflator_);
+        uint256 factor = uint256(1e18 - Maths.maxInt(0, bpf));
+        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, factor), poolInflator_);
         if (t0repayAmount_ >= borrower_.t0debt) {
             t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wmul(borrowerDebt, uint256(1e18 - Maths.maxInt(0, bpf)));
+            quoteTokenAmount_ = Maths.wmul(borrowerDebt, factor);
             collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
         }
 
         isRewarded_ = (bpf >= 0);
         if (isRewarded_) {
             // take is below neutralPrice, Kicker is rewarded
-            bondChange_ = quoteTokenAmount_ - Maths.wmul(t0repayAmount_, poolInflator_);
+            bondChange_ = quoteTokenAmount_ - t0repayAmount_;
             liquidation.bondSize                    += bondChange_;
             self.kickers[liquidation.kicker].locked += bondChange_;
             self.totalBondEscrowed                  += bondChange_;

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -281,18 +281,17 @@ library Auctions {
         );
 
         // determine how much of the loan will be repaid
-        uint256 factor = uint256(1e18 - Maths.maxInt(0, bpf));
-        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, factor), poolInflator_);
+        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, uint256(1e18 - Maths.maxInt(0, bpf))), poolInflator_);
         if (t0repayAmount_ >= borrower_.t0debt) {
             t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wmul(borrowerDebt, factor);
+            quoteTokenAmount_ = Maths.wmul(borrowerDebt, uint256(1e18 - Maths.maxInt(0, bpf)));
             collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
         }
 
         isRewarded_ = (bpf >= 0);
         if (isRewarded_) {
             // take is below neutralPrice, Kicker is rewarded
-            bondChange_ = quoteTokenAmount_ - t0repayAmount_;
+            bondChange_ = quoteTokenAmount_ - Maths.wmul(t0repayAmount_, poolInflator_);
             liquidation.bondSize                    += bondChange_;
             self.kickers[liquidation.kicker].locked += bondChange_;
             self.totalBondEscrowed                  += bondChange_;

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -286,13 +286,13 @@ library Auctions {
         if (t0repayAmount_ >= borrower_.t0debt) {
             t0repayAmount_    = borrower_.t0debt;
             quoteTokenAmount_ = Maths.wdiv(borrowerDebt, factor);
-            collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
+            collateralTaken_  = Maths.min(Maths.wdiv(quoteTokenAmount_, auctionPrice), collateralTaken_);
         }
 
         isRewarded_ = (bpf >= 0);
         if (isRewarded_) {
             // take is below neutralPrice, Kicker is rewarded
-            bondChange_ = quoteTokenAmount_ - Maths.wmul(t0repayAmount_, poolInflator_);
+            bondChange_ = Maths.wmul(quoteTokenAmount_, uint256(bpf));
             liquidation.bondSize                    += bondChange_;
             self.kickers[liquidation.kicker].locked += bondChange_;
             self.totalBondEscrowed                  += bondChange_;

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -281,10 +281,11 @@ library Auctions {
         );
 
         // determine how much of the loan will be repaid
-        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, uint256(1e18 - Maths.maxInt(0, bpf))), poolInflator_);
+        uint256 factor = uint256(1e18 - Maths.maxInt(0, bpf));
+        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, factor), poolInflator_);
         if (t0repayAmount_ >= borrower_.t0debt) {
             t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wmul(borrowerDebt, uint256(1e18 - Maths.maxInt(0, bpf)));
+            quoteTokenAmount_ = Maths.wdiv(borrowerDebt, factor);
             collateralTaken_  = Maths.wdiv(quoteTokenAmount_, auctionPrice);
         }
 


### PR DESCRIPTION
- when take is below neutralPrice and kicker is rewarded and the entire borrower t0 debt is paid, bond change calculation errors out with arithmetic overflow

- in failing test, `bpf > 0`, inflator is `889_702.747247542903837453` and borrower debt is `9_120.196489608478674394` which makes:
  - `factor` = `uint256(1e18 - Maths.maxInt(0, bpf)` with a value of `0.700005367730026597` (factor is always gt than 0 and lt 1)
  - initial `t0repayAmount_ = (quoteTokenAmount_ * factor) / poolInflator_` calculated https://github.com/ajna-finance/contracts/blob/develop/src/libraries/Auctions.sol#L284 gives a value of `1_258_818.218211122131142584` which is greater than the borrower debt `9_120.196489608478674394`, so entire borrower debt will be paid, therefore `t0repayAmount_` is set to borrower t0 debt https://github.com/ajna-finance/contracts/blob/develop/src/libraries/Auctions.sol#L286 as `9120.196489608478674394`. After this step `t0repayAmount_ = borrower_.t0debt`
  - `quoteTokenAmount_` is recalculated as `quoteTokenAmount_ = borrowerDebt * factor = borrower_.t0debt * poolInflator_ * factor` (resulting a value of `5_680_028_265.747273012544394307`) https://github.com/ajna-finance/contracts/blob/develop/src/libraries/Auctions.sol#L294
  - `bondChange` is `bondChange_ = quoteTokenAmount_ - t0repayAmount_ * poolInflator_`  and replacing `quoteTokenAmount_` and  `t0repayAmount_` with values above we get `bondChange_ = borrower_.t0debt * poolInflator_ * factor - borrower_.t0debt * poolInflator_ = borrower_.t0debt * poolInflator_ * (factor - 1)` but since factor is < 1 this errors out https://github.com/ajna-finance/contracts/blob/develop/src/libraries/Auctions.sol#L294

Proposed fix is to not multiplicate `t0repayAmount` with inflator as I don't think amount to repay should accumulate debt? that is `bondChange_ = quoteTokenAmount_ - t0repayAmount_;` https://github.com/ajna-finance/contracts/blob/fix-bondchange-overflow/src/libraries/Auctions.sol#L295