### PR TITLE
accruePoolInterest cleanup

### DIFF
--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -184,7 +184,7 @@ abstract contract DSTestPlus is Test {
         emit RemoveCollateral(from, index, amount);
         _assertTokenTransferEvent(address(_pool), from, amount);
         lpRedeemed_ = _pool.removeCollateral(amount, index);
-        assertEq(lpRedeem, lpRedeemed_);
+        assertEq(lpRedeemed_, lpRedeem);
     }
 
     function _removeLiquidity(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -467,7 +467,8 @@ class TestUtils:
 
         lup = pool_helper.lup()
         htp = pool_helper.htp()
-        ptp = int(poolDebt * 1e18 / pool.pledgedCollateral())
+        poolCollateral = pool.pledgedCollateral()
+        ptp = int(poolDebt * 1e18 / poolCollateral) if poolCollateral else 0
         print(f"lup:            {lup/1e18:>12.3f}  "
               f"htp:            {htp/1e18:>12.3f}  "
               f"ptp:            {ptp/1e18:>12.3f}")


### PR DESCRIPTION
**Overview**
~~Since introducing my t0 debt accounting changes, `_accruePoolInterest` has had a `TODO` I added noting (new) inefficiencies in the function, and that the previous implementation was calculating Net Interest Margin using a stale pool debt amount.  Specifically, the NIM was calculated using debt which accumulated at the last accrual rather than the current debt.~~

~~This change seeks to solve both problems.  This resulted in nontrivial changes in reserves for tests where significant time passed without lender interest accrual.  Because prior implementations had been using old debt values, the stale NIM was generally sending too much debt to reserves.~~

~~Surprisingly, the initial working implementation -- despite removing a storage read, assignment, and `wmul` -- consumed more gas.  Issue was that conditionals required an explicit `return` statement to avoid copy/pasting assignment of `accruedDebt` and `inflator` in the case where no time had elapsed since the last call.  Eventually I was able to find an implementation which was both maintainable and (generally) less expensive.~~

Upon review, we need to pass the old debt value when scaling the Fenwick tree, otherwise we double-account for interest owed by borrowers.  The existing implementation was appropriate, so this PR just merely makes some minor tweaks.

**Contract size**
No change in contract size.
```
============ develop Bytecode Sizes ============
  ERC721Pool               -  23,899B  (97.24%)
  ERC20Pool                -  23,522B  (95.71%)
```
```
===== accruePoolInterest2 Bytecode Sizes ==========
  ERC721Pool               -  23,899B  (97.24%)
  ERC20Pool                -  23,522B  (95.71%)

```

**Gas cost**
Microscopic improvements in gas cost.
```
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ develop ERC20Pool contract                 ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                              ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addCollateral                              ┆ 17220           ┆ 187887 ┆ 210827 ┆ 412195 ┆ 11      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addQuoteToken                              ┆ 6818            ┆ 202630 ┆ 160633 ┆ 446049 ┆ 194     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 662             ┆ 205752 ┆ 202482 ┆ 404558 ┆ 88      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ kick                                       ┆ 676             ┆ 579379 ┆ 676723 ┆ 751199 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveCollateral                             ┆ 449             ┆ 56921  ┆ 47003  ┆ 153422 ┆ 6       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 448             ┆ 169922 ┆ 119033 ┆ 638825 ┆ 15      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pledgeCollateral                           ┆ 26271           ┆ 92257  ┆ 71938  ┆ 323498 ┆ 78      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pullCollateral                             ┆ 24128           ┆ 141834 ┆ 79410  ┆ 345128 ┆ 6       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllCollateral                        ┆ 29981           ┆ 70010  ┆ 50798  ┆ 145700 ┆ 8       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllQuoteToken                        ┆ 1293            ┆ 91611  ┆ 53796  ┆ 192823 ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeCollateral                           ┆ 1293            ┆ 43402  ┆ 44959  ┆ 80292  ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeQuoteToken                           ┆ 1313            ┆ 74569  ┆ 61800  ┆ 335510 ┆ 10      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4520            ┆ 95291  ┆ 71934  ┆ 286656 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ take                                       ┆ 2562            ┆ 108299 ┆ 77120  ┆ 233634 ┆ 9       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```
```
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ accruePoolInterest2 ERC20Pool contract     ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ addCollateral                              ┆ 17220           ┆ 187886 ┆ 210827 ┆ 412182 ┆ 11      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addQuoteToken                              ┆ 6818            ┆ 202630 ┆ 160633 ┆ 446036 ┆ 194     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 662             ┆ 205752 ┆ 202482 ┆ 404545 ┆ 88      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ kick                                       ┆ 676             ┆ 579368 ┆ 676710 ┆ 751186 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveCollateral                             ┆ 449             ┆ 56921  ┆ 47003  ┆ 153422 ┆ 6       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 448             ┆ 169920 ┆ 119033 ┆ 638812 ┆ 15      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pledgeCollateral                           ┆ 26271           ┆ 92257  ┆ 71938  ┆ 323485 ┆ 78      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ pullCollateral                             ┆ 24128           ┆ 141830 ┆ 79410  ┆ 345115 ┆ 6       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllCollateral                        ┆ 29981           ┆ 70007  ┆ 50798  ┆ 145687 ┆ 8       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeAllQuoteToken                        ┆ 1293            ┆ 91606  ┆ 53796  ┆ 192812 ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeCollateral                           ┆ 1293            ┆ 43402  ┆ 44959  ┆ 80292  ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ removeQuoteToken                           ┆ 1313            ┆ 74568  ┆ 61800  ┆ 335497 ┆ 10      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4520            ┆ 95287  ┆ 71934  ┆ 286643 ┆ 12      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ take                                       ┆ 2562            ┆ 108294 ┆ 77120  ┆ 233621 ┆ 9       │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```

