### PR TITLE
ERC20 Arb take

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -218,46 +218,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         _pool.transferLPTokens(from, to, indexes);
     }
 
-    function _assertTakeAuctionInCooldownRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
-        ERC20Pool(address(_pool)).take(borrower, maxCollateral, new bytes(0));
-    }
-
-    function _assertTakeDebtUnderMinPoolDebtRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        ERC20Pool(address(_pool)).take(borrower, maxCollateral, new bytes(0));
-    }
-
-    function _assertTakeInsufficentCollateralRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        ERC20Pool(address(_pool)).take(borrower, maxCollateral, new bytes(0));
-    }
-
-    function _assertTakeNoAuctionRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
-        ERC20Pool(address(_pool)).take(borrower, maxCollateral, new bytes(0));
-    }
-
     function _assertTransferNoAllowanceRevert(
         address operator,
         address from,

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1903,14 +1903,14 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_91,
                 lpBalance:    2_000.578393654229960874988756440 * 1e27,
                 collateral:   2 * 1e18,
-                deposit:      2_007.563997370011192221 * 1e18,
-                exchangeRate: 1.013406109696938217842432503 * 1e27
+                deposit:      2_007.758423287311827813 * 1e18,
+                exchangeRate: 1.013503294550037375726499132 * 1e27
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              0.336474341151957517 * 1e18,
+                borrowerDebt:              0.530900258452593109 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588739842524087291 * 1e18,
                 borrowerCollateralization: 0

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1728,14 +1728,32 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             }
         );
 
+        _addLiquidity(
+            {
+                from:   _lender1,
+                amount: 1 * 1e18,
+                index:  _i9_52,
+                newLup: 9.721295865031779605 * 1e18
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i9_91,
+                lpBalance:    2_000 * 1e27,
+                collateral:   0,
+                deposit:      2_027.006589100074751447 * 1e18,
+                exchangeRate: 1.013503294550037375723500000 * 1e27
+            }
+        );
+
         _arbTake(
             {
                 from:             taker,
                 borrower:         _borrower,
                 index:            _i9_91,
                 collateralArbed:  2 * 1e18,
-                quoteTokenAmount: 19.248165812762923640 * 1e18,
-                bondChange:       0.192481658127629236 * 1e18,
+                quoteTokenAmount: 19.442591730063559232 * 1e18,
+                bondChange:       0.194425917300635592 * 1e18,
                 isReward:         true
             }
         );
@@ -1752,7 +1770,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 lender:      _lender,
                 index:       _i9_91,
-                lpBalance:   2_000.000000000192481658127629236 * 1e27,
+                lpBalance:   2_000.000000000194425917300635592 * 1e27,
                 depositTime: _startTime + 100 days + 6 hours
             }
         );
@@ -1761,14 +1779,14 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 index:        _i9_91,
                 lpBalance:    2_000 * 1e27,
                 collateral:   2 * 1e18,
-                deposit:      2_007.758423287311827813 * 1e18,
-                exchangeRate: 1.013796396487091825980500000 * 1e27
+                deposit:      2_007.563997370011192221 * 1e18,
+                exchangeRate: 1.013699183528441508184500000 * 1e27
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              0.530900258452593109 * 1e18,
+                borrowerDebt:              0.336474341151957517 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588739842524087291 * 1e18,
                 borrowerCollateralization: 0

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -275,7 +275,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 bondFactor:        0,
                 kickTime:          0,
                 kickMomp:          0,
-                totalBondEscrowed: 0 * 1e18,
+                totalBondEscrowed: 0,
                 auctionPrice:      0
             }
         );
@@ -1768,7 +1768,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              0.264811038950235289 * 1e18,
+                borrowerDebt:              0.530900258452593109 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588739842524087291 * 1e18,
                 borrowerCollateralization: 0
@@ -1877,69 +1877,71 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             }
         );
 
-        // --- GET OVERFLOW HERE IF I UNCOMMENT ARBTAKE--
+        _arbTake(
+            {
+                from:             taker,
+                borrower:         _borrower,
+                index:            _i10016,
+                collateralArbed:  0.254322591527323120 * 1e18,
+                quoteTokenAmount: 19.778761259189860403 * 1e18,
+                bondChange:       0.195342779771472726 * 1e18,
+                isReward:         false
+            }
+        );
 
-        // _arbTake(
-        //     {
-        //         from:             taker,
-        //         borrower:         _borrower,
-        //         index:            _i10016,
-        //         collateralArbed:  2 * 1e18,
-        //         quoteTokenAmount: 19.248165812762923640 * 1e18,
-        //         bondChange:       0.192481658127629236 * 1e18,
-        //         isReward:         true
-        //     }
-        // );
-
-        // --- --
-
-
-        // _assertLenderLpBalance(
-        //     {
-        //         lender:      taker,
-        //         index:       _i9_91,
-        //         lpBalance:   0.000000000391777956808264916 * 1e27,
-        //         depositTime: _startTime + 100 days + 6 hours
-        //     }
-        // );
-        // _assertLenderLpBalance(
-        //     {
-        //         lender:      _lender,
-        //         index:       _i9_91,
-        //         lpBalance:   2_000.000000000192481658127629236 * 1e27,
-        //         depositTime: _startTime + 100 days + 6 hours
-        //     }
-        // );
-        // _assertBucket(
-        //     {
-        //         index:        _i9_91,
-        //         lpBalance:    2_000 * 1e27,
-        //         collateral:   2 * 1e18,
-        //         deposit:      2_007.758423287311827813 * 1e18,
-        //         exchangeRate: 1.013796396487091825980500000 * 1e27
-        //     }
-        // );
-        // _assertBorrower(
-        //     {
-        //         borrower:                  _borrower,
-        //         borrowerDebt:              0.264811038950235289 * 1e18,
-        //         borrowerCollateral:        0,
-        //         borrowerMompFactor:        9.588739842524087291 * 1e18,
-        //         borrowerCollateralization: 0
-        //     }
-        // );
-        // _assertAuction(
-        //     {
-        //         borrower:          _borrower,
-        //         active:            true,
-        //         kicker:            _lender,
-        //         bondSize:          0.195342779771472726 * 1e18,
-        //         bondFactor:        0.01 * 1e18,
-        //         kickTime:          block.timestamp - 6 hours,
-        //         kickMomp:          9.721295865031779605 * 1e18,
-        //         totalBondEscrowed: 0.195342779771472726 * 1e18,
-        //         auctionPrice:      9.721295865031779616 * 1e18
-        //     }
-        // );
+        _assertLenderLpBalance(
+            {
+                lender:      taker,
+                index:       _i10016,
+                lpBalance:   0.000002527643880967256869570 * 1e27, // arb taker was rewarded LPBs in arbed bucket
+                depositTime: _startTime + 100 days + 3 hours
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i10016,
+                lpBalance:   1_000 * 1e27,
+                depositTime: _startTime + 100 days + 3 hours
+            }
+        );
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 0,
+                locked:    0 // kicker was penalized
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i10016,
+                lpBalance:    1_000 * 1e27,                         // LP balance is the same in arbed bucket
+                collateral:   0.254322591527323120 * 1e18,          // arbed collateral added to the arbed bucket
+                deposit:      980.221238740810139596 * 1e18,        // quote token amount is diminished in arbed bucket
+                exchangeRate: 3.527643880967256869583690323 * 1e27
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              0,
+                borrowerCollateral:        1.745677408472676880 * 1e18,
+                borrowerMompFactor:        0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+        _assertAuction(
+            {
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0
+            }
+        );
     }
 }

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1653,7 +1653,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
     }
 
-    function testArbTake() external {
+    function testArbTakeLTNeutralPrice() external {
 
         // Skip to make borrower undercollateralized
         skip(100 days);
@@ -1787,5 +1787,155 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 auctionPrice:      9.721295865031779616 * 1e18
             }
         );
+    }
+
+
+    function testArbTakeGTNeutralPrice() external {
+
+        // Skip to make borrower undercollateralized
+        skip(100 days);
+
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower,
+                debt:       19.534277977147272573 * 1e18,
+                collateral: 2 * 1e18,
+                bond:       0.195342779771472726 * 1e18
+            }
+        );
+
+        _assertAuction(
+            {
+                borrower:          _borrower,
+                active:            true,
+                kicker:            _lender,
+                bondSize:          0.195342779771472726 * 1e18,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          block.timestamp,
+                kickMomp:          9.721295865031779605 * 1e18,
+                totalBondEscrowed: 0.195342779771472726 * 1e18,
+                auctionPrice:      311.081467681016947360 * 1e18
+            }
+        );
+
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 0,
+                locked:    0.195342779771472726 * 1e18
+            }
+        );
+        skip(3 hours);
+
+        address taker = makeAddr("taker");
+
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 1_000 * 1e18,
+                index:  _i10016,
+                newLup: 9.721295865031779605 * 1e18
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      taker,
+                index:       _i10016,
+                lpBalance:   0,
+                depositTime: 0
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i10016,
+                lpBalance:   1_000 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+
+        _assertBucket(
+            {
+                index:        _i10016,
+                lpBalance:    1_000 * 1e27,
+                collateral:   0,
+                deposit:      1_000 * 1e18,
+                exchangeRate: 1.0 * 1e27
+            }
+        );
+        
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.778761259189860403 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerCollateralization: 0.983003509435146965 * 1e18
+            }
+        );
+ 
+        _arbTake(
+            {
+                from:             taker,
+                borrower:         _borrower,
+                index:            _i10016,
+                collateralArbed:  2 * 1e18,
+                quoteTokenAmount: 19.248165812762923640 * 1e18,
+                bondChange:       0.192481658127629236 * 1e18,
+                isReward:         true
+            }
+        );
+
+
+        // _assertLenderLpBalance(
+        //     {
+        //         lender:      taker,
+        //         index:       _i9_91,
+        //         lpBalance:   0.000000000391777956808264916 * 1e27,
+        //         depositTime: _startTime + 100 days + 6 hours
+        //     }
+        // );
+        // _assertLenderLpBalance(
+        //     {
+        //         lender:      _lender,
+        //         index:       _i9_91,
+        //         lpBalance:   2_000.000000000192481658127629236 * 1e27,
+        //         depositTime: _startTime + 100 days + 6 hours
+        //     }
+        // );
+        // _assertBucket(
+        //     {
+        //         index:        _i9_91,
+        //         lpBalance:    2_000 * 1e27,
+        //         collateral:   2 * 1e18,
+        //         deposit:      2_007.758423287311827813 * 1e18,
+        //         exchangeRate: 1.013796396487091825980500000 * 1e27
+        //     }
+        // );
+        // _assertBorrower(
+        //     {
+        //         borrower:                  _borrower,
+        //         borrowerDebt:              0.264811038950235289 * 1e18,
+        //         borrowerCollateral:        0,
+        //         borrowerMompFactor:        9.588739842524087291 * 1e18,
+        //         borrowerCollateralization: 0
+        //     }
+        // );
+        // _assertAuction(
+        //     {
+        //         borrower:          _borrower,
+        //         active:            true,
+        //         kicker:            _lender,
+        //         bondSize:          0.195342779771472726 * 1e18,
+        //         bondFactor:        0.01 * 1e18,
+        //         kickTime:          block.timestamp - 6 hours,
+        //         kickMomp:          9.721295865031779605 * 1e18,
+        //         totalBondEscrowed: 0.195342779771472726 * 1e18,
+        //         auctionPrice:      9.721295865031779616 * 1e18
+        //     }
+        // );
     }
 }

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -2132,6 +2132,15 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
 
         address taker = makeAddr("taker");
 
+        // should revert if bucket deposit is 0
+        _assertArbTakeAuctionInsufficientLiquidityRevert(
+            {
+                from:     taker,
+                borrower: _borrower,
+                index:    _i100
+            }
+        );
+
         // should revert if auction price is greater than the bucket price
         _assertArbTakeAuctionPriceGreaterThanBucketPriceRevert(
             {

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -652,6 +652,15 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrowerCollateralization: 0.974413448899967463 * 1e18
             }
         );
+        _assertReserveAuction(
+            {
+                reserves:                   148.064352861909228810 * 1e18,
+                claimableReserves :         98.083873122003682866 * 1e18,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
+            }
+        );
 
         // skip ahead so take can be called on the loan
         skip(10 hours);
@@ -697,6 +706,16 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrowerCollateralization: 0.956028882245805301 * 1e18
             }
         );
+        // reserves should increase after take action
+        _assertReserveAuction(
+            {
+                reserves:                   148.141379552245490832 * 1e18,
+                claimableReserves :         98.218482774160286961 * 1e18,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
+            }
+        );
 
         // take remaining collateral
         _take(
@@ -737,6 +756,16 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrowerCollateral:        0,
                 borrowerMompFactor:        9.588542815647469183 * 1e18,
                 borrowerCollateralization: 0
+            }
+        );
+        // reserves should increase after take action
+        _assertReserveAuction(
+            {
+                reserves:                   148.141379552245490832 * 1e18,
+                claimableReserves :         101.165858164239609711 * 1e18,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
             }
         );
 
@@ -1869,6 +1898,15 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 exchangeRate: 1.013503294550037375723500000 * 1e27
             }
         );
+        _assertReserveAuction(
+            {
+                reserves:                   23.908406501703106407 * 1e18,
+                claimableReserves :         0,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
+            }
+        );
 
         _arbTake(
             {
@@ -1905,6 +1943,16 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 collateral:   2 * 1e18,
                 deposit:      2_007.758423287311827813 * 1e18,
                 exchangeRate: 1.013503294550037375726499132 * 1e27
+            }
+        );
+        // reserves should remain the same after arb take
+        _assertReserveAuction(
+            {
+                reserves:                   23.908406501703106407 * 1e18,
+                claimableReserves :         0,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
             }
         );
         _assertBorrower(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1762,7 +1762,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 lender:      taker,
                 index:       _i9_91,
-                lpBalance:   0.000000000391777956808264916 * 1e27,
+                lpBalance:   0.386558148271438658550864337 * 1e27,
                 depositTime: _startTime + 100 days + 6 hours
             }
         );
@@ -1770,17 +1770,17 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 lender:      _lender,
                 index:       _i9_91,
-                lpBalance:   2_000.000000000194425917300635592 * 1e27,
+                lpBalance:   2_000.191835505958522216437892103 * 1e27,
                 depositTime: _startTime + 100 days + 6 hours
             }
         );
         _assertBucket(
             {
                 index:        _i9_91,
-                lpBalance:    2_000 * 1e27,
+                lpBalance:    2_000.578393654229960874988756440 * 1e27,
                 collateral:   2 * 1e18,
                 deposit:      2_007.563997370011192221 * 1e18,
-                exchangeRate: 1.013699183528441508184500000 * 1e27
+                exchangeRate: 1.013406109696938217842432503 * 1e27
             }
         );
         _assertBorrower(
@@ -1920,7 +1920,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             {
                 lender:      taker,
                 index:       _i10016,
-                lpBalance:   0.000002527643880967256869570 * 1e27, // arb taker was rewarded LPBs in arbed bucket
+                lpBalance:   2_527.64388096725686957 * 1e27, // arb taker was rewarded LPBs in arbed bucket
                 depositTime: _startTime + 100 days + 3 hours
             }
         );
@@ -1942,10 +1942,10 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i10016,
-                lpBalance:    1_000 * 1e27,                         // LP balance is the same in arbed bucket
+                lpBalance:    3_527.64388096725686957 * 1e27,       // LP balance in arbed bucket increased with LPs awarded for arb taker
                 collateral:   0.254322591527323120 * 1e18,          // arbed collateral added to the arbed bucket
                 deposit:      980.221238740810139596 * 1e18,        // quote token amount is diminished in arbed bucket
-                exchangeRate: 3.527643880967256869583690323 * 1e27
+                exchangeRate: 1.000000000000000000003880868 * 1e27
             }
         );
         _assertBorrower(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1876,18 +1876,22 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
                 borrowerCollateralization: 0.983003509435146965 * 1e18
             }
         );
- 
-        _arbTake(
-            {
-                from:             taker,
-                borrower:         _borrower,
-                index:            _i10016,
-                collateralArbed:  2 * 1e18,
-                quoteTokenAmount: 19.248165812762923640 * 1e18,
-                bondChange:       0.192481658127629236 * 1e18,
-                isReward:         true
-            }
-        );
+
+        // --- GET OVERFLOW HERE IF I UNCOMMENT ARBTAKE--
+
+        // _arbTake(
+        //     {
+        //         from:             taker,
+        //         borrower:         _borrower,
+        //         index:            _i10016,
+        //         collateralArbed:  2 * 1e18,
+        //         quoteTokenAmount: 19.248165812762923640 * 1e18,
+        //         bondChange:       0.192481658127629236 * 1e18,
+        //         isReward:         true
+        //     }
+        // );
+
+        // --- --
 
 
         // _assertLenderLpBalance(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -524,6 +524,56 @@ abstract contract DSTestPlus is Test {
         _pool.addQuoteToken(amount, index);
     }
 
+    function _assertArbTakeAuctionInCooldownRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
+        _pool.arbTake(borrower, index);
+    }
+
+    function _assertArbTakeAuctionPriceGreaterThanBucketPriceRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionPriceGteQArbPrice.selector);
+        _pool.arbTake(borrower, index);
+    }
+
+    function _assertArbTakeDebtUnderMinPoolDebtRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
+        _pool.arbTake(borrower, index);
+    }
+
+    function _assertArbTakeInsufficentCollateralRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
+        _pool.arbTake(borrower, index);
+    }
+
+    function _assertArbTakeNoAuctionRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
+        _pool.arbTake(borrower, index);
+    }
+
     function _assertBorrowAuctionActiveRevert(
         address from,
         uint256 amount,
@@ -748,6 +798,46 @@ abstract contract DSTestPlus is Test {
         changePrank(from);
         vm.expectRevert(IPoolErrors.MoveToSamePrice.selector);
         _pool.moveQuoteToken(amount, fromIndex, toIndex);
+    }
+
+    function _assertTakeAuctionInCooldownRevert(
+        address from,
+        address borrower,
+        uint256 maxCollateral
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
+        _pool.take(borrower, maxCollateral, new bytes(0));
+    }
+
+    function _assertTakeDebtUnderMinPoolDebtRevert(
+        address from,
+        address borrower,
+        uint256 maxCollateral
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
+        _pool.take(borrower, maxCollateral, new bytes(0));
+    }
+
+    function _assertTakeInsufficentCollateralRevert(
+        address from,
+        address borrower,
+        uint256 maxCollateral
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
+        _pool.take(borrower, maxCollateral, new bytes(0));
+    }
+
+    function _assertTakeNoAuctionRevert(
+        address from,
+        address borrower,
+        uint256 maxCollateral
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
+        _pool.take(borrower, maxCollateral, new bytes(0));
     }
 
     function _assertTakeReservesNoAuctionRevert(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -24,6 +24,7 @@ abstract contract DSTestPlus is Test {
 
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
+    event ArbTake(address indexed borrower, uint256 index, uint256 amount, uint256 collateral, uint256 bondChange, bool isReward);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event Heal(address indexed borrower, uint256 healedDebt);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
@@ -88,6 +89,21 @@ abstract contract DSTestPlus is Test {
         emit AddQuoteToken(from, index, amount, newLup);
         _assertTokenTransferEvent(from, address(_pool), amount);
         _pool.addQuoteToken(amount, index);
+    }
+
+    function _arbTake(
+        address from,
+        address borrower,
+        uint256 index,
+        uint256 collateralArbed,
+        uint256 quoteTokenAmount,
+        uint256 bondChange,
+        bool isReward
+    ) internal virtual {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit ArbTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
+        _pool.arbTake(borrower, index);
     }
 
     function _borrow(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -534,6 +534,16 @@ abstract contract DSTestPlus is Test {
         _pool.arbTake(borrower, index);
     }
 
+    function _assertArbTakeAuctionInsufficientLiquidityRevert(
+        address from,
+        address borrower,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InsufficientLiquidity.selector);
+        _pool.arbTake(borrower, index);
+    }
+
     function _assertArbTakeAuctionPriceGreaterThanBucketPriceRevert(
         address from,
         address borrower,

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -21,6 +21,11 @@ interface IPoolErrors {
     error AmountLTMinDebt();
 
     /**
+     *  @notice The bucket price used to arb take is lower than the auction price.
+     */
+    error BadArbTakePrice();
+
+    /**
      *  @notice Borrower has a healthy over-collateralized position.
      */
     error BorrowerOk();

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -21,9 +21,9 @@ interface IPoolErrors {
     error AmountLTMinDebt();
 
     /**
-     *  @notice The bucket price used to arb take is lower than the auction price.
+     *  @notice The auction price is greater or the same as the arbed bucket price.
      */
-    error BadArbTakePrice();
+    error AuctionPriceGteQArbPrice();
 
     /**
      *  @notice Borrower has a healthy over-collateralized position.

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -27,6 +27,7 @@ interface IPoolEvents {
      *  @param  amount     Amount of quote token used to purchase collateral.
      *  @param  collateral Amount of collateral purchased with quote token.
      *  @param  bondChange Impact of this take to the liquidation bond.
+     *  @param  isReward   True if kicker was rewarded with `bondChange` amount, false if kicker was penalized.
      *  @dev    amount / collateral implies the auction price.
      */
     event ArbTake(
@@ -34,7 +35,8 @@ interface IPoolEvents {
         uint256 index,
         uint256 amount,
         uint256 collateral,
-        int256 bondChange
+        uint256 bondChange,
+        bool    isReward
     );
 
     /**

--- a/src/base/interfaces/pool/IPoolLiquidationActions.sol
+++ b/src/base/interfaces/pool/IPoolLiquidationActions.sol
@@ -9,12 +9,10 @@ interface IPoolLiquidationActions {
     /**
      *  @notice Called by actors to use quote token to arb higher-priced deposit off the book.
      *  @param  borrower Identifies the loan to liquidate.
-     *  @param  amount   Amount of bucket deposit to use to exchange for collateral.
      *  @param  index    Index of a bucket, likely the HPB, in which collateral will be deposited.
      */
     function arbTake(
         address borrower,
-        uint256 amount,
         uint256 index
     ) external;
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -159,6 +159,7 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 bucketDeposit = deposits.valueAt(index_);
         (
             uint256 quoteTokenAmount,
+            uint256 t0repaidDebt,
             uint256 collateralArbed,
             uint256 auctionPrice,
             uint256 bondChange,
@@ -181,7 +182,7 @@ contract ERC20Pool is IERC20Pool, Pool {
         // the bondholder/kicker is awarded bond change worth of LPB in the bucket
         if (isRewarded) buckets.addLPs(liquidation.kicker, bondChange, index_);
 
-        _payLoan(quoteTokenAmount, poolState, borrowerAddress_, borrower); // TODO should quoteTokenAmount be expressed in t0 debt or it is already?
+        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
 
         emit ArbTake(borrowerAddress_, index_, quoteTokenAmount, collateralArbed, bondChange, isRewarded);
     }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -168,7 +168,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         // cannot arb with a price lower than or equal with the auction price
         uint256 bucketPrice = PoolUtils.indexToPrice(index_);
-        if (auctionPrice >= bucketPrice) revert BadArbTakePrice();
+        if (auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
 
         // collateral is moved from the loan to the bucket’s claimable collateral
         borrower.collateral         -= collateralArbed;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -166,6 +166,7 @@ contract ERC20Pool is IERC20Pool, Pool {
             bool isRewarded
         ) = auctions.arbTake(liquidation, borrower, bucketDeposit, poolState.inflator);
 
+        uint256 depositAmountToRemove = quoteTokenAmount;
         // bucket operations
         {
             // cannot arb with a price lower than or equal with the auction price
@@ -194,15 +195,17 @@ contract ERC20Pool is IERC20Pool, Pool {
                 Buckets.addLPs(
                     bucket,
                     liquidation.kicker,
-                    Maths.wrdivr(bondChange, bucketExchangeRate));
+                    Maths.wrdivr(bondChange, bucketExchangeRate)
+                );
+                depositAmountToRemove -= bondChange;
             }
 
             // collateral is moved to the bucket’s claimable collateral
             bucket.collateral += collateralArbed;
         }
 
-        // quote token are removed from the bucket’s deposit
-        deposits.remove(index_, quoteTokenAmount);
+        // quote tokens are removed from the bucket’s deposit
+        deposits.remove(index_, depositAmountToRemove);
 
         // collateral is ewmoved from the loan
         borrower.collateral -= collateralArbed;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -151,12 +151,14 @@ contract ERC20Pool is IERC20Pool, Pool {
         address borrowerAddress_,
         uint256 index_
     ) external override {
-        PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 
-        Auctions.Liquidation storage liquidation = auctions.liquidations[borrowerAddress_];
+        PoolState memory poolState = _accruePoolInterest();
         uint256 bucketDeposit = deposits.valueAt(index_);
+        if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
+
+        Auctions.Liquidation storage liquidation = auctions.liquidations[borrowerAddress_];
         (
             uint256 quoteTokenAmount,
             uint256 t0repaidDebt,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -176,7 +176,7 @@ contract ERC20Pool is IERC20Pool, Pool {
         // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
         buckets.addLPs(msg.sender, Maths.wmul(collateralArbed, bucketPrice - auctionPrice), index_);
         // the bondholder/kicker is awarded bond change worth of LPB in the bucket
-        if (isRewarded) buckets.addLPs(liquidation.kicker, Maths.wmul(collateralArbed, bucketPrice - auctionPrice), index_);
+        if (isRewarded) buckets.addLPs(liquidation.kicker, bondChange, index_);
 
         _payLoan(quoteTokenAmount, poolState, borrowerAddress_, borrower); // TODO should quoteTokenAmount be expressed in t0 debt or it is already?
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -170,9 +170,12 @@ contract ERC20Pool is IERC20Pool, Pool {
         if (auctionPrice >= bucketPrice) revert BadArbTakePrice();
 
         // collateral is moved from the loan to the bucket’s claimable collateral
-        borrower.collateral  -= collateralArbed;
+        borrower.collateral         -= collateralArbed;
+        buckets[index_].collateral += collateralArbed;
+
         // quote token are removed from the bucket’s deposit
         deposits.remove(index_, quoteTokenAmount);
+
         // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
         buckets.addLPs(msg.sender, Maths.wmul(collateralArbed, bucketPrice - auctionPrice), index_);
         // the bondholder/kicker is awarded bond change worth of LPB in the bucket

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -105,9 +105,12 @@ contract ERC721Pool is IERC721Pool, Pool {
     /*** Pool External Functions ***/
     /*******************************/
 
-    function arbTake(address borrower_, uint256 amount_, uint256 index_) external override {
+    function arbTake(
+        address borrowerAddress_,
+        uint256 index_
+    ) external override {
         // TODO: implement
-        emit ArbTake(borrower_, index_, amount_, 0, 0);
+        emit ArbTake(borrowerAddress_, index_, 0, 0, 0, true);
     }
 
     function depositTake(address borrower_, uint256 amount_, uint256 index_) external override {

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -266,10 +266,10 @@ library Auctions {
         // determine how much of the loan will be repaid
         if (borrowerDebt >= bucketDeposit_) {
             t0repayAmount_    = Maths.wdiv(bucketDeposit_, poolInflator_);
-            quoteTokenAmount_ = bucketDeposit_;
+            quoteTokenAmount_ = Maths.wdiv(bucketDeposit_, factor);
         } else {
             t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wmul(t0repayAmount_, poolInflator_);
+            quoteTokenAmount_ = Maths.wdiv(Maths.wmul(t0repayAmount_, poolInflator_), factor);
         }
 
         collateralArbed_ = Maths.wdiv(quoteTokenAmount_, auctionPrice_);
@@ -277,7 +277,7 @@ library Auctions {
         if (collateralArbed_ > borrower_.collateral) {
             collateralArbed_  = borrower_.collateral;
             quoteTokenAmount_ = Maths.wmul(collateralArbed_, auctionPrice_);
-            t0repayAmount_    = Maths.wdiv(quoteTokenAmount_, poolInflator_);
+            t0repayAmount_    = Maths.wdiv(Maths.wmul(factor, quoteTokenAmount_), poolInflator_);
         }
 
         if (!isRewarded_) {

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -265,19 +265,19 @@ library Auctions {
 
         // determine how much of the loan will be repaid
         if (borrowerDebt >= bucketDeposit_) {
-            collateralArbed_ = Maths.wdiv(bucketDeposit_, Maths.wmul(auctionPrice_, factor));
+            t0repayAmount_    = Maths.wdiv(bucketDeposit_, poolInflator_);
+            quoteTokenAmount_ = bucketDeposit_;
         } else {
-            collateralArbed_ = Maths.wdiv(borrowerDebt, Maths.wmul(auctionPrice_, factor));
+            t0repayAmount_    = borrower_.t0debt;
+            quoteTokenAmount_ = Maths.wmul(t0repayAmount_, poolInflator_);
         }
 
-        if (collateralArbed_ > borrower_.collateral) collateralArbed_ = borrower_.collateral;
-        quoteTokenAmount_ = Maths.wmul(Maths.wmul(factor, collateralArbed_), auctionPrice_);
+        collateralArbed_ = Maths.wdiv(quoteTokenAmount_, auctionPrice_);
 
-        t0repayAmount_ = Maths.wdiv(quoteTokenAmount_, poolInflator_);
-        if (t0repayAmount_ >= borrower_.t0debt) {
-            t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wdiv(borrowerDebt, factor);
-            collateralArbed_  = Maths.wdiv(quoteTokenAmount_, auctionPrice_);
+        if (collateralArbed_ > borrower_.collateral) {
+            collateralArbed_  = borrower_.collateral;
+            quoteTokenAmount_ = Maths.wmul(collateralArbed_, auctionPrice_);
+            t0repayAmount_    = Maths.wdiv(quoteTokenAmount_, poolInflator_);
         }
 
         if (!isRewarded_) {
@@ -287,7 +287,7 @@ library Auctions {
             self.kickers[liquidation_.kicker].locked -= bondChange_;
             self.totalBondEscrowed                   -= bondChange_;
         } else {
-            bondChange_ = Maths.wmul(quoteTokenAmount_, uint256(bpf));
+            bondChange_ = Maths.wmul(quoteTokenAmount_, uint256(bpf)); // wil be rewarded as LPBs
         }
     }
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -53,13 +53,9 @@ library Buckets {
         Bucket storage bucket = self[index_];
         // cannot deposit in the same block when bucket becomes insolvent
         if (bucket.bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
-        bucket.lps += addedLPs_;
 
-        // update lender LPs balance and deposit timestamp
-        Lender storage lender = bucket.lenders[msg.sender];
-        if (bucket.bankruptcyTime >= lender.depositTime) lender.lps = addedLPs_;
-        else lender.lps += addedLPs_;
-        lender.depositTime = block.timestamp;
+        // update bucket and lender LPs balance and deposit timestamp
+        addLPs(bucket, msg.sender, addedLPs_);
     }
 
     /**
@@ -87,14 +83,9 @@ library Buckets {
         Bucket storage bucket = self[index_];
         // cannot deposit in the same block when bucket becomes insolvent
         if (bucket.bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
-        bucket.lps += addedLPs_;
         bucket.collateral += collateralAmountToAdd_;
-
-        // update lender LPs balance
-        Lender storage lender = bucket.lenders[msg.sender];
-        if (bucket.bankruptcyTime >= lender.depositTime) lender.lps = addedLPs_;
-        else lender.lps += addedLPs_;
-        lender.depositTime = block.timestamp;
+        // update bucket and lender LPs balance and deposit timestamp
+        addLPs(bucket, msg.sender, addedLPs_);
     }
 
     /**
@@ -108,6 +99,8 @@ library Buckets {
         address lender_,
         uint256 lpsAmount_
     ) internal {
+        bucket_.lps += lpsAmount_;
+
         Lender storage lender = bucket_.lenders[lender_];
         if (bucket_.bankruptcyTime >= lender.depositTime) lender.lps = lpsAmount_;
         else lender.lps += lpsAmount_;

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -97,14 +97,19 @@ library Buckets {
         lender.depositTime = block.timestamp;
     }
 
+    /**
+     *  @notice Add amount of LPs for a given lender in a given bucket.
+     *  @param  bucket_    Bucket to record lender LPs.
+     *  @param  lender_    Lender address to add LPs for in the given bucket.
+     *  @param  lpsAmount_ Amount of LPs to be recorded for the given lender.
+     */
     function addLPs(
-        mapping(uint256 => Bucket) storage self,
+        Bucket storage bucket_,
         address lender_,
-        uint256 lpsAmount_,
-        uint256 index_
+        uint256 lpsAmount_
     ) internal {
-        Lender storage lender = self[index_].lenders[lender_];
-        if (self[index_].bankruptcyTime >= lender.depositTime) lender.lps = lpsAmount_;
+        Lender storage lender = bucket_.lenders[lender_];
+        if (bucket_.bankruptcyTime >= lender.depositTime) lender.lps = lpsAmount_;
         else lender.lps += lpsAmount_;
         lender.depositTime = block.timestamp;
     }

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -97,6 +97,18 @@ library Buckets {
         lender.depositTime = block.timestamp;
     }
 
+    function addLPs(
+        mapping(uint256 => Bucket) storage self,
+        address lender_,
+        uint256 lpsAmount_,
+        uint256 index_
+    ) internal {
+        Lender storage lender = self[index_].lenders[lender_];
+        if (self[index_].bankruptcyTime >= lender.depositTime) lender.lps = lpsAmount_;
+        else lender.lps += lpsAmount_;
+        lender.depositTime = block.timestamp;
+    }
+
     /**
      *  @notice Moves LPs between buckets and updates lender balance accordingly.
      *  @param  fromLPsAmount_ The amount of LPs to move from origin bucket.


### PR DESCRIPTION
- changed pool's `arbTake` signature and removed `amount` parameter (arb is bounded by amount of borrower debt / collateral and bucket deposit) 
- added `AuctionPriceGteQArbPrice` error to revert when price of arbed bucket is lower than auction price
- included `isReward` flag in `ArbTake` event
- added `Auctions._validateTake` that is called by both `*take` methods (and will probably be called by `depositTake` too): check if auction is valid to be taken and calculates values for take action
- added `Buckets.addLPs` to add LP amount in bucket and lender's accumulators

Tests:
- moved all `*take` assertion from `ERC20DSTestPlus` to `DSTestPlus`
- `testArbTakeLTNeutralPrice` and `testArbTakeGTNeutralPrice` + revert tests `testArbTakeReverts`. Other tests pending. TODO: in a different PR we should split auction related tests in different contracts as `ERC20PoolLiquidationsTest` counts now 2160 LOCs and it becomes hard to follow / maintain
- added gas load test for `arbTake` with different way of deposits setup

gas results (`arbTake` test skips hours to account interest rate accumulation while regular `take` doesn't hence the difference in gas)
```
│ addQuoteToken                              ┆ 91205           ┆ 153360 ┆ 132790 ┆ 638279  ┆ 47999   │
│ arbTake                                    ┆ 400167          ┆ 400191 ┆ 400191 ┆ 400215  ┆ 2       │
│ borrow                                     ┆ 167250          ┆ 226820 ┆ 192581 ┆ 768700  ┆ 104002  │
│ kick                                       ┆ 173453          ┆ 252313 ┆ 246817 ┆ 1078412 ┆ 32000   │
│ moveQuoteToken                             ┆ 269533          ┆ 269533 ┆ 269533 ┆ 269533  ┆ 1       │
│ pledgeCollateral                           ┆ 62635           ┆ 65226  ┆ 64870  ┆ 508922  ┆ 96001   │
│ removeAllQuoteToken                        ┆ 149391          ┆ 151566 ┆ 151274 ┆ 165987  ┆ 2000    │
│ removeQuoteToken                           ┆ 184168          ┆ 189999 ┆ 189793 ┆ 207041  ┆ 2000    │
│ repay                                      ┆ 483292          ┆ 558028 ┆ 569947 ┆ 809526  ┆ 16001   │
│ take                                       ┆ 51484           ┆ 55208  ┆ 54672  ┆ 274626  ┆ 15998   │
```
compared with `develop`
```
│ addQuoteToken                              ┆ 91148           ┆ 156506 ┆ 133879 ┆ 638222  ┆ 43999   │
│ borrow                                     ┆ 167250          ┆ 231927 ┆ 191892 ┆ 768700  ┆ 88002   │
│ kick                                       ┆ 173475          ┆ 249007 ┆ 244636 ┆ 1078434 ┆ 16000   │
│ moveQuoteToken                             ┆ 288482          ┆ 288482 ┆ 288482 ┆ 288482  ┆ 1       │
│ pledgeCollateral                           ┆ 62657           ┆ 64767  ┆ 64836  ┆ 508944  ┆ 80001   │
│ removeAllQuoteToken                        ┆ 149413          ┆ 151586 ┆ 151292 ┆ 168363  ┆ 2000    │
│ removeQuoteToken                           ┆ 184190          ┆ 190022 ┆ 189815 ┆ 209403  ┆ 2000    │
│ repay                                      ┆ 483292          ┆ 558028 ┆ 569947 ┆ 809526  ┆ 16001   │
│ take                                       ┆ 51387           ┆ 55130  ┆ 54594  ┆ 274548  ┆ 15998   │
```