### PR TITLE
Fix accrue pool interest:

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1653,6 +1653,130 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
         );
     }
 
+    function testInterestsAccumulationWithAllLoansAuctioned() external {
+        // Borrower2 borrows
+        _borrow(
+            {
+                from:       _borrower2,
+                amount:     1_730 * 1e18,
+                indexLimit: _i9_72,
+                newLup:     9.721295865031779605 * 1e18
+            }
+        );
+
+        // Skip to make borrower undercollateralized
+        skip(100 days);
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.534277977147272573 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerCollateralization: 0.995306391810796636 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              9_853.394241979221645666 * 1e18,
+                borrowerCollateral:        1_000 * 1e18,
+                borrowerMompFactor:        9.818751856078723036 * 1e18,
+                borrowerCollateralization: 0.986593617011217057 * 1e18
+            }
+        );
+        _assertLoans(
+            {
+                noOfLoans:         2,
+                maxBorrower:       _borrower2,
+                maxThresholdPrice: 9.719336538461538466 * 1e18
+            }
+        );
+
+        // kick first loan
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower2,
+                debt:       9_853.394241979221645666 * 1e18,
+                collateral: 1_000 * 1e18,
+                bond:       98.533942419792216457 * 1e18
+            }
+        );
+        _assertLoans(
+            {
+                noOfLoans:         1,
+                maxBorrower:       _borrower,
+                maxThresholdPrice: 9.767138988573636287 * 1e18
+            }
+        );
+
+        // kick 2nd loan
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower,
+                debt:       19.534277977147272573 * 1e18,
+                collateral: 2 * 1e18,
+                bond:       0.195342779771472726 * 1e18
+            }
+        );
+        _assertLoans(
+            {
+                noOfLoans:         0,
+                maxBorrower:       address(0),
+                maxThresholdPrice: 0
+            }
+        );
+
+        _assertPool(
+            PoolState({
+                htp:                  0,
+                lup:                  9.721295865031779605 * 1e18,
+                poolSize:             73_118.781595119199960000 * 1e18,
+                pledgedCollateral:    1_002 * 1e18,
+                encumberedCollateral: 1_028.267844818693957410 * 1e18,
+                poolDebt:             9_996.095947981109188810 * 1e18,
+                actualUtilization:    0,
+                targetUtilization:    1.026215413990712532 * 1e18,
+                minDebtAmount:        0,
+                loans:                0,
+                maxBorrower:          address(0),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   _startTime + 100 days
+            })
+        );
+
+        // force pool interest accumulation 
+        skip(14 hours);
+
+        _addLiquidity(
+            {
+                from:   _lender1,
+                amount: 1 * 1e18,
+                index:  _i9_91,
+                newLup: 9.721295865031779605 * 1e18
+            }
+        );
+
+        _assertPool(
+            PoolState({
+                htp:                  0,
+                lup:                  9.721295865031779605 * 1e18,
+                poolSize:             73_119.781595119199960000 * 1e18,
+                pledgedCollateral:    1_002 * 1e18,
+                encumberedCollateral: 1_028.341798247607959833 * 1e18,
+                poolDebt:             9_996.814871143815802222 * 1e18,
+                actualUtilization:    0,
+                targetUtilization:    1.026254142489845669 * 1e18,
+                minDebtAmount:        0,
+                loans:                0,
+                maxBorrower:          address(0),
+                interestRate:         0.0405 * 1e18,
+                interestRateUpdate:   _startTime + 100 days + 14 hours
+            })
+        );
+    }
+
     // TODO: move to DSTestPlus?
     function _logBorrowerInfo(address borrower_) internal {
         (

--- a/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidations.t.sol
@@ -1762,7 +1762,7 @@ contract ERC20PoolLiquidationsTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_119.781595119199960000 * 1e18,
+                poolSize:             73_120.392679807500549985 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
                 encumberedCollateral: 1_028.341798247607959833 * 1e18,
                 poolDebt:             9_996.814871143815802222 * 1e18,

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -641,15 +641,12 @@ abstract contract Pool is Clone, Multicall, IPool {
                 poolState_.inflator = Maths.wmul(poolState_.inflator, factor);
 
                 // Scale the fenwick tree to update amount of debt owed to lenders
-                uint256 newHtp = _htp(poolState_.inflator);
-                if (newHtp != 0) {
-                    deposits.accrueInterest(
-                        poolState_.accruedDebt,
-                        poolState_.collateral,
-                        newHtp,
-                        factor
-                    );
-                }
+                deposits.accrueInterest(
+                    poolState_.accruedDebt,
+                    poolState_.collateral,
+                    _htp(poolState_.inflator),
+                    factor
+                );
 
                 // After debt owed to lenders has accrued, calculate current debt owed by borrowers
                 poolState_.accruedDebt = Maths.wmul(t0Debt, poolState_.inflator);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -642,12 +642,14 @@ abstract contract Pool is Clone, Multicall, IPool {
 
                 // Scale the fenwick tree to update amount of debt owed to lenders
                 uint256 newHtp = _htp(poolState_.inflator);
-                deposits.accrueInterest(
-                    poolState_.accruedDebt,
-                    poolState_.collateral,
-                    newHtp,
-                    factor
-                );
+                if (newHtp != 0) {
+                    deposits.accrueInterest(
+                        poolState_.accruedDebt,
+                        poolState_.collateral,
+                        newHtp,
+                        factor
+                    );
+                }
 
                 // After debt owed to lenders has accrued, calculate current debt owed by borrowers
                 poolState_.accruedDebt = Maths.wmul(t0Debt, poolState_.inflator);

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -29,7 +29,7 @@ library Deposits {
         uint256 htp_,
         uint256 pendingInterestFactor_
     ) internal {
-        uint256 htpIndex        = PoolUtils.priceToIndex(htp_);
+        uint256 htpIndex = (htp_ != 0) ? PoolUtils.priceToIndex(htp_) : 4_156; // if HTP is 0 then accrue interest at max index (min price)
         uint256 depositAboveHtp = prefixSum(self, htpIndex);
 
         if (depositAboveHtp != 0) {


### PR DESCRIPTION
- when a loan is auctioned it it removed from loans heap, hence when all loans are kicked there's no loan in heap and HTP is 0
- in `accruePoolInterest` function accrue deposit interest only if HTP is not 0, otherwise tx is reverted with `BM:PTI:OOB` reason
- another solution would be to check condition `(htp != 0)` instead `(t0Debt != 0)` but not sure about implications
- added unit test to expose this scenario