### PR TITLE
Remove removeAllQuoteTokens function

### DIFF
--- a/src/_test/ERC20Pool/ERC20DSTestPlus.sol
+++ b/src/_test/ERC20Pool/ERC20DSTestPlus.sol
@@ -198,15 +198,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         ERC20Pool(address(_pool)).removeAllCollateral(index);
     }
 
-    function _assertRemoveAllLiquidityNoClaimRevert(
-        address from,
-        uint256 index
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.NoClaim.selector);
-        ERC20Pool(address(_pool)).removeAllQuoteToken(index);
-    }
-
     function _assertTransferInvalidIndexRevert(
         address operator,
         address from,

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -228,7 +228,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         skip(15 hours);
         _pool.moveQuoteToken(1_000 * 1e18, index_, index_ + 1);
         skip(15 hours);
-        _pool.removeAllQuoteToken(index_);
+        _pool.removeQuoteToken(type(uint256).max, index_);
         vm.stopPrank();
     }
 
@@ -246,7 +246,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             skip(15 hours);
             _pool.removeQuoteToken(5_000 * 1e18, 7388 - i);
             skip(15 hours);
-            _pool.removeAllQuoteToken(1 + i);
+            _pool.removeQuoteToken(type(uint256).max, 1 + i);
             vm.stopPrank();
             vm.revertTo(snapshot);
         }

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -589,6 +589,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 newLup: BucketMath.MAX_PRICE
             }
         );
+        // add collateral in order to give lender LPs in bucket 5_000 with 0 deposit
+        // used to test revert on remove when bucket deposit is 0
         _addCollateral(
             {
                 from:   _lender,

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -555,6 +555,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
      */
     function testPoolRemoveQuoteTokenRequireChecks() external {
         _mintCollateralAndApproveTokens(_borrower, _collateral.balanceOf(_borrower) + 3_500_000 * 1e18);
+        _mintCollateralAndApproveTokens(_lender, 1 * 1e18);
         // lender adds initial quote token
         _addLiquidity(
             {
@@ -588,7 +589,13 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 newLup: BucketMath.MAX_PRICE
             }
         );
-
+        _addCollateral(
+            {
+                from:   _lender,
+                amount: 1 * 1e18,
+                index:  5000
+            }
+        );
         _pledgeCollateral(
             {
                 from:     _borrower,
@@ -612,12 +619,12 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 index: 4550
             }
         );
-        // should revert if insufficient quote token
+        // should revert if no quote token in bucket deposit
         _assertRemoveInsufficientLiquidityRevert(
             {
                 from:  _lender,
-                amount: 20_000 * 1e18,
-                index:  4550
+                amount: 1 * 1e18,
+                index:  5000
             }
         );
         // should revert if removing quote token from higher price buckets would drive lup below htp
@@ -635,15 +642,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 amount: 20_000 * 1e18,
                 index:  4550,
                 newLup: 0.139445853940958153 * 1e18
-            }
-        );
-
-        // should revert if bucket has enough quote token, but lender has insufficient LP
-        _assertRemoveLiquidityInsufficientLPsRevert(
-            {
-                from:   _lender,
-                amount: 15_000 * 1e18,
-                index:  4550
             }
         );
 
@@ -1178,7 +1176,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 amount:   5_003.981613396490344248 * 1e18,
                 index:    2873,
                 newLup:   601.252968524772188572 * 1e18,
-                lpRedeem: 5_000.290483387144984400601020184 * 1e27
+                lpRedeem: 5_000.290483387144984400382330052 * 1e27
             }
         );
         _removeAllLiquidity(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -184,7 +184,7 @@ abstract contract DSTestPlus is Test {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amount, newLup);
         _assertTokenTransferEvent(address(_pool), from, amount);
-        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeAllQuoteToken(index);
+        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, index);
         assertEq(removedAmount, amount);
         assertEq(lpRedeemed,    lpRedeem);
     }
@@ -218,8 +218,9 @@ abstract contract DSTestPlus is Test {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, expectedWithdrawal, newLup);
         _assertTokenTransferEvent(address(_pool), from, expectedWithdrawal);
-        uint256 lpRedeemed = _pool.removeQuoteToken(amount, index);
-        assertEq(lpRedeemed, lpRedeem);
+        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
+        assertEq(removedAmount, expectedWithdrawal);
+        assertEq(lpRedeemed,    lpRedeem);
     }
 
     function _repay(
@@ -765,7 +766,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
-        _pool.removeAllQuoteToken(index);
+        _pool.removeQuoteToken(type(uint256).max, index);
     }
 
     function _assertRemoveAllLiquidityLupBelowHtpRevert(
@@ -774,7 +775,16 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.LUPBelowHTP.selector);
-        _pool.removeAllQuoteToken(index);
+        _pool.removeQuoteToken(type(uint256).max, index);
+    }
+
+    function _assertRemoveAllLiquidityNoClaimRevert(
+        address from,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.NoClaim.selector);
+        _pool.removeQuoteToken(type(uint256).max, index);
     }
 
     function _assertMoveLiquidityBankruptcyBlockRevert(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -31,7 +31,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     /***********************/
 
     uint256 public override interestRate;       // [WAD]
-    uint256 public override interestRateUpdate;  // [SEC]
+    uint256 public override interestRateUpdate; // [SEC]
     uint256 public override pledgedCollateral;  // [WAD]
 
     uint256 internal debtEma;   // [WAD]

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -31,7 +31,7 @@ abstract contract Pool is Clone, Multicall, IPool {
     /***********************/
 
     uint256 public override interestRate;       // [WAD]
-    uint256 public override interestRateUpdate; // [SEC]
+    uint256 public override interestRateUpdate;  // [SEC]
     uint256 public override pledgedCollateral;  // [WAD]
 
     uint256 internal debtEma;   // [WAD]
@@ -142,61 +142,52 @@ abstract contract Pool is Clone, Multicall, IPool {
         emit MoveQuoteToken(msg.sender, fromIndex_, toIndex_, quoteTokenAmountToMove, newLup);
     }
 
-    function removeAllQuoteToken(
+    function removeQuoteToken(
+        uint256 maxAmount_,
         uint256 index_
-    ) external returns (uint256 quoteTokenAmountRemoved_, uint256 redeemedLenderLPs_) {
+    ) external returns (uint256 removedAmount_, uint256 redeemedLPs_) {
         auctions.revertIfAuctionClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 
-        (uint256 lenderLPsBalance, ) = buckets.getLenderInfo(
+        (uint256 lenderLPsBalance, uint256 lastDeposit) = buckets.getLenderInfo(
             index_,
             msg.sender
         );
-        if (lenderLPsBalance == 0) revert NoClaim();
+        if (lenderLPsBalance == 0) revert NoClaim(); // revert if no LP to claim
 
         uint256 deposit = deposits.valueAt(index_);
-        (quoteTokenAmountRemoved_, , redeemedLenderLPs_) = buckets.lpsToQuoteToken(
-            deposit,
-            lenderLPsBalance,
-            deposit,
-            index_
-        );
+        if (deposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
 
-        _redeemLPForQuoteToken(
-            index_,
+        (uint256 exchangeRate, ) = buckets.getExchangeRate(deposit, index_);
+        removedAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance, exchangeRate));
+
+        // remove min amount of lender entitled LPBs, max amount desired and deposit in bucket
+        if (removedAmount_ > maxAmount_) removedAmount_ = maxAmount_;
+        if (removedAmount_ > deposit)    removedAmount_ = deposit;
+        redeemedLPs_ = Maths.min(lenderLPsBalance, Maths.wrdivr(removedAmount_, exchangeRate));
+
+        deposits.remove(index_, removedAmount_);  // update FenwickTree
+
+        uint256 newLup = _lup(poolState.accruedDebt);
+        if (_htp(poolState.inflator) > newLup) revert LUPBelowHTP();
+
+        // persist bucket changes
+        buckets.removeLPs(redeemedLPs_, index_);
+
+        removedAmount_ = PoolUtils.applyEarlyWithdrawalPenalty(
             poolState,
-            redeemedLenderLPs_,
-            quoteTokenAmountRemoved_
-        );
-    }
-
-    function removeQuoteToken(
-        uint256 quoteTokenAmountToRemove_,
-        uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
-        auctions.revertIfAuctionClearable(loans);
-
-        PoolState memory poolState = _accruePoolInterest();
-
-        uint256 deposit = deposits.valueAt(index_);
-        if (quoteTokenAmountToRemove_ > deposit) revert InsufficientLiquidity();
-
-        bucketLPs_ = buckets.quoteTokensToLPs(
-            deposit,
-            quoteTokenAmountToRemove_,
-            index_
-        );
-
-        (uint256 lenderLPsBalance, ) = buckets.getLenderInfo(index_, msg.sender);
-        if (lenderLPsBalance == 0 || bucketLPs_ > lenderLPsBalance) revert InsufficientLPs();
-
-        _redeemLPForQuoteToken(
+            lastDeposit,
             index_,
-            poolState,
-            bucketLPs_,
-            quoteTokenAmountToRemove_
+            0,
+            removedAmount_
         );
+
+        _updatePool(poolState, newLup);
+
+        // move quote token amount from pool to lender
+        emit RemoveQuoteToken(msg.sender, index_, removedAmount_, newLup);
+        _transferQuoteToken(msg.sender, removedAmount_);
     }
 
     function transferLPTokens(
@@ -585,36 +576,6 @@ abstract contract Pool is Clone, Multicall, IPool {
         buckets.removeCollateral(collateralAmountToRemove_, bucketLPs_, index_);
 
         _updatePool(poolState, _lup(poolState.accruedDebt));
-    }
-
-    function _redeemLPForQuoteToken(
-        uint256 index_,
-        PoolState memory poolState_,
-        uint256 lpAmount_,
-        uint256 amount
-    ) internal {
-        deposits.remove(index_, amount);  // update FenwickTree
-
-        uint256 newLup = _lup(poolState_.accruedDebt);
-        if (_htp(poolState_.inflator) > newLup) revert LUPBelowHTP();
-
-        // persist bucket changes
-        buckets.removeLPs(lpAmount_, index_);
-
-        (, uint256 lastDeposit) = buckets.getLenderInfo(index_, msg.sender);
-        amount = PoolUtils.applyEarlyWithdrawalPenalty(
-            poolState_,
-            lastDeposit,
-            index_,
-            0,
-            amount
-        );
-
-        _updatePool(poolState_, newLup);
-
-        // move quote token amount from pool to lender
-        emit RemoveQuoteToken(msg.sender, index_, amount, newLup);
-        _transferQuoteToken(msg.sender, amount);
     }
 
 

--- a/src/base/interfaces/pool/IPoolLenderActions.sol
+++ b/src/base/interfaces/pool/IPoolLenderActions.sol
@@ -45,16 +45,6 @@ interface IPoolLenderActions {
     ) external returns (uint256 lpbAmountFrom, uint256 lpbAmountTo);
 
     /**
-     *  @notice Called by lenders to redeem the maximum amount of LP for quote token.
-     *  @param  index           The bucket index from which quote tokens will be removed.
-     *  @return quoteTokenAmount The amount of quote token removed.
-     *  @return lpAmount         The amount of LP used for removing quote tokens.
-     */
-    function removeAllQuoteToken(
-        uint256 index
-    ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
-
-    /**
      *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
      *  @param  amount   The amount of unencumbered collateral (or the number of NFT tokens) to claim.
      *  @param  index    The bucket index from which unencumbered collateral will be removed.
@@ -67,14 +57,15 @@ interface IPoolLenderActions {
 
     /**
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
-     *  @param  amount      The amount of quote token to be removed by a lender.
-     *  @param  index       The bucket index from which quote tokens will be removed.
-     *  @return lpAmount    The amount of LP used for removing quote tokens amount.
+     *  @param  maxAmount        The max amount of quote token to be removed by a lender.
+     *  @param  index            The bucket index from which quote tokens will be removed.
+     *  @return quoteTokenAmount The amount of quote token removed.
+     *  @return lpAmount         The amount of LP used for removing quote tokens amount.
      */
     function removeQuoteToken(
-        uint256 amount,
+        uint256 maxAmount,
         uint256 index
-    ) external returns (uint256 lpAmount);
+    ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
 
     /**
      *  @notice Called by lenders to transfers their LP tokens to a different address.

--- a/tests/test_stable_volatile.py
+++ b/tests/test_stable_volatile.py
@@ -326,7 +326,7 @@ def remove_quote_token(lender, lender_index, price, pool_helper):
               f" from bucket {price_index} ({price / 10**18:.1f}); exchange rate is {exchange_rate/1e27:.8f}")
         if not ensure_pool_is_funded(pool_helper.pool, claimable_quote * 2, "withdraw"):
             return
-        tx = pool_helper.pool.removeAllQuoteToken(price_index, {"from": lender})
+        tx = pool_helper.pool.removeQuoteToken(2**256 - 1, price_index, {"from": lender})
     else:
         log(f" lender   {lender_index:>4} has no claim to bucket {price / 10**18:.1f}")
 
@@ -387,7 +387,7 @@ def test_stable_volatile_one(pool_helper, lenders, borrowers, test_utils, chain)
     start_time = chain.time()
     end_time = start_time + SECONDS_PER_DAY * 7
     actor_id = 0
-    with test_utils.GasWatcher(['addQuoteToken', 'borrow', 'removeAllQuoteToken', 'repay']):
+    with test_utils.GasWatcher(['addQuoteToken', 'borrow', 'removeQuoteToken', 'repay']):
         while chain.time() < end_time:
             # hit the pool an hour at a time, calculating interest and then sending transactions
             actor_id = draw_and_bid(lenders, borrowers, actor_id, pool_helper, chain, test_utils)


### PR DESCRIPTION
- removed `removeAllQuoteToken(index_)` function
-  `removeQuoteToken` now receives a max amount (quote token to withdraw is the min between bucket deposit, lender entitled quote tokens and max amount - reverts if bucket deposit is 0). `removeQuoteToken` returns amount removed and LP redeemed. Handled quoteTokens to LPs conversion inline (TODO: Buckets library needs to be cleaned out and code optimized)
- updated tests

contract size
```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  24,344B  (99.05%)
  ERC721Pool               -  23,864B  (97.10%)
```
vs develop
```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  24,474B  (99.58%)
  ERC721Pool               -  23,994B  (97.63%)
```

gas costs
```
│ removeQuoteToken                           ┆ 159148          ┆ 176526 ┆ 182681 ┆ 208075  ┆ 4000    │
```
vs develop
```
│ removeQuoteToken                           ┆ 183022          ┆ 188854 ┆ 188647 ┆ 208437  ┆ 2000    │
```