### PR TITLE
Reduce ERC20 pool contract size

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolFactory.t.sol
@@ -87,9 +87,101 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
 
         assertEq(address(pool),             poolAddress);
         assertEq(pool.collateralAddress(),  address(_collateral));
-        assertEq(pool.collateralScale(),    1);
+        assertEq(pool.collateralScale(),    10 ** 0);
         assertEq(pool.quoteTokenAddress(),  address(_quote));
-        assertEq(pool.quoteTokenScale(),    1);
+        assertEq(pool.quoteTokenScale(),    10 ** 0);
+        assertEq(pool.interestRate(),       0.0543 * 10**18);
+        assertEq(pool.interestRateUpdate(), _startTime + 333);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime + 333);
+    }
+
+    function testDeployERC20CompDaiPool() external {
+        skip(333);
+
+        address poolAddress = 0x88c0A0F7B9f2D204C16409CF01d85D8BF1231f18;
+        address compAddress = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+        address daiAddress  = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(poolAddress);
+        ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(compAddress, daiAddress, 0.0543 * 10**18));
+
+        assertEq(address(pool),             poolAddress);
+        assertEq(pool.collateralAddress(),  compAddress);
+        assertEq(pool.collateralScale(),    10 ** 0);
+        assertEq(pool.quoteTokenAddress(),  daiAddress);
+        assertEq(pool.quoteTokenScale(),    10 ** 0);
+        assertEq(pool.interestRate(),       0.0543 * 10**18);
+        assertEq(pool.interestRateUpdate(), _startTime + 333);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime + 333);
+    }
+
+    function testDeployERC20WbtcDaiPool() external {
+        skip(333);
+
+        address poolAddress = 0x88c0A0F7B9f2D204C16409CF01d85D8BF1231f18;
+        address wbtcAddress = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+        address daiAddress  = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(poolAddress);
+        ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(wbtcAddress, daiAddress, 0.0543 * 10**18));
+
+        assertEq(address(pool),             poolAddress);
+        assertEq(pool.collateralAddress(),  wbtcAddress);
+        assertEq(pool.collateralScale(),    10 ** 10);         // WBTC has precision of 8, so 10 ** (18 - 8) = 10 ** 10
+        assertEq(pool.quoteTokenAddress(),  daiAddress);
+        assertEq(pool.quoteTokenScale(),    10 ** 0);          // DAI has precision of 18, so 10 ** (18 - 18) = 10 ** 0
+        assertEq(pool.interestRate(),       0.0543 * 10**18);
+        assertEq(pool.interestRateUpdate(), _startTime + 333);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime + 333);
+    }
+
+    function testDeployERC20WbtcUsdcPool() external {
+        skip(333);
+
+        address poolAddress = 0x88c0A0F7B9f2D204C16409CF01d85D8BF1231f18;
+        address wbtcAddress = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+        address usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(poolAddress);
+        ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(wbtcAddress, usdcAddress, 0.0543 * 10**18));
+
+        assertEq(address(pool),             poolAddress);
+        assertEq(pool.collateralAddress(),  wbtcAddress);
+        assertEq(pool.collateralScale(),    10 ** 10);         // WBTC has precision of 8, so 10 ** (18 - 8) = 10 ** 10
+        assertEq(pool.quoteTokenAddress(),  usdcAddress);
+        assertEq(pool.quoteTokenScale(),    10 ** 12);         // USDC has precision of 6, so 10 ** (18 - 6) = 10 ** 12
+        assertEq(pool.interestRate(),       0.0543 * 10**18);
+        assertEq(pool.interestRateUpdate(), _startTime + 333);
+
+        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflatorSnapshot, 10**18);
+        assertEq(lastInflatorUpdate,   _startTime + 333);
+    }
+
+    function testDeployERC20CompUsdcPool() external {
+        skip(333);
+
+        address poolAddress = 0x88c0A0F7B9f2D204C16409CF01d85D8BF1231f18;
+        address compAddress = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+        address usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(poolAddress);
+        ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(compAddress, usdcAddress, 0.0543 * 10**18));
+
+        assertEq(address(pool),             poolAddress);
+        assertEq(pool.collateralAddress(),  compAddress);
+        assertEq(pool.collateralScale(),    10 ** 0);
+        assertEq(pool.quoteTokenAddress(),  usdcAddress);
+        assertEq(pool.quoteTokenScale(),    10 ** 12);
         assertEq(pool.interestRate(),       0.0543 * 10**18);
         assertEq(pool.interestRateUpdate(), _startTime + 333);
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -329,7 +329,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 maxDepth_
     ) external override {
         uint256 poolDebt          = Maths.wmul(t0poolDebt, inflatorSnapshot);
-        uint256 quoteTokenBalance = IERC20Token(_getArgAddress(20)).balanceOf(address(this));
+        uint256 quoteTokenBalance = _getPoolQuoteTokenBalance();
         uint256 reserves          = poolDebt + quoteTokenBalance - deposits.treeSum() - auctions.totalBondEscrowed - reserveAuctionUnclaimed;
         uint256 healedDebt        = auctions.heal(
             loans,
@@ -398,7 +398,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             deposits.treeSum(),
             auctions.totalBondEscrowed,
             curUnclaimedAuctionReserve,
-            IERC20Token(_getArgAddress(20)).balanceOf(address(this))
+            _getPoolQuoteTokenBalance()
         );
         uint256 kickerAward = Maths.wmul(0.01 * 1e18, claimable);
         curUnclaimedAuctionReserve += claimable - kickerAward;
@@ -694,6 +694,10 @@ abstract contract Pool is Clone, Multicall, IPool {
             inflatorSnapshot           = Maths.WAD;
             lastInflatorSnapshotUpdate = block.timestamp;
         }
+    }
+
+    function _getPoolQuoteTokenBalance() internal returns (uint256) {
+        return IERC20Token(_getArgAddress(20)).balanceOf(address(this));
     }
 
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -693,16 +693,16 @@ abstract contract Pool is Clone, Multicall, IPool {
         }
     }
 
-    function _getPoolQuoteTokenBalance() internal returns (uint256) {
-        return IERC20Token(_getArgAddress(20)).balanceOf(address(this));
-    }
-
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {
         if (!IERC20Token(_getArgAddress(20)).transferFrom(from_, address(this), amount_ / _getArgUint256(40))) revert ERC20TransferFailed();
     }
 
     function _transferQuoteToken(address to_, uint256 amount_) internal {
         if (!IERC20Token(_getArgAddress(20)).transfer(to_, amount_ / _getArgUint256(40))) revert ERC20TransferFailed();
+    }
+
+    function _getPoolQuoteTokenBalance() internal view returns (uint256) {
+        return IERC20Token(_getArgAddress(20)).balanceOf(address(this));
     }
 
     function _htp(uint256 inflator_) internal view returns (uint256) {

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -22,11 +22,12 @@ contract ERC20Pool is IERC20Pool, Pool {
     /****************************/
 
     function initialize(
+        uint256 collateralScale_,
         uint256 rate_
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
-        collateralScale = 10**(18 - IERC20Token(_getArgAddress(0)).decimals());
+        collateralScale = collateralScale_;
 
         inflatorSnapshot           = 10**18;
         lastInflatorSnapshotUpdate = block.timestamp;

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -25,6 +25,7 @@ contract ERC20PoolFactory is IERC20PoolFactory, PoolDeployer {
         address collateral_, address quote_, uint256 interestRate_
     ) external canDeploy(ERC20_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (address pool_) {
         uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
+        uint256 collateralScale = 10**(18 - IERC20Token(collateral_).decimals());
 
         bytes memory data = abi.encodePacked(
             collateral_,
@@ -37,6 +38,6 @@ contract ERC20PoolFactory is IERC20PoolFactory, PoolDeployer {
         deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(interestRate_);
+        pool.initialize(collateralScale, interestRate_);
     }
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -22,9 +22,11 @@ interface IERC20Pool is
 
     /**
      *  @notice Initializes a new pool, setting initial state variables.
-     *  @param  rate Initial interest rate of the pool.
+     *  @param  collateralScale Collateral scale. The precision of the collateral ERC-20 token based on decimals.
+     *  @param  rate            Initial interest rate of the pool.
      */
     function initialize(
+        uint256 collateralScale,
         uint256 rate
     ) external;
 

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -86,11 +86,11 @@ library Auctions {
         if (
             (block.timestamp - kickTime > 72 hours)
             ||
-            (debtToHeal > 0 && remainingCol == 0)
+            (debtToHeal != 0 && remainingCol == 0)
         ) {
             uint256 remainingDebt = debtToHeal;
 
-            while (bucketDepth_ > 0) {
+            while (bucketDepth_ != 0) {
                 // auction has debt to cover with remaining collateral
                 uint256 hpbIndex;
                 if (remainingDebt != 0 && remainingCol != 0) {
@@ -476,7 +476,7 @@ library Auctions {
             (
                 block.timestamp - kickTime > 72 hours
                 ||
-                (loans_.borrowers[head].t0debt > 0 && loans_.borrowers[head].collateral == 0)
+                (loans_.borrowers[head].t0debt != 0 && loans_.borrowers[head].collateral == 0)
             )
         ) revert AuctionNotCleared();
     }


### PR DESCRIPTION
- calculate collateral scale in pool factory
- add more factory test with forked chain
- use `_getPoolQuoteTokenBalance` helper function to retrieve pool qt balance

```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  23,818B  (96.91%)
  ERC721Pool               -  23,754B  (96.65%)
```

vs develop

```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  24,344B  (99.05%)
  ERC721Pool               -  23,864B  (97.10%)
```