### PR TITLE
Buckets optimization

### DIFF
--- a/src/_test/utils/QueueInstance.sol
+++ b/src/_test/utils/QueueInstance.sol
@@ -23,7 +23,7 @@ contract QueueInstance is DSTestPlus {
     function remove(address borrower_) external {
         auctions.checkAndRemove(
             borrower_,
-            1e18
+            true
         );
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -103,18 +103,19 @@ abstract contract Pool is Clone, Multicall, IPool {
         if (fromIndex_ == toIndex_) revert MoveToSamePrice();
 
         PoolState memory poolState = _accruePoolInterest();
-
         _revertIfAuctionDebtLocked(fromIndex_, poolState.inflator);
+
         (uint256 lenderLpBalance, uint256 lenderLastDepositTime) = buckets.getLenderInfo(
             fromIndex_,
             msg.sender
         );
         uint256 quoteTokenAmountToMove;
-        (quoteTokenAmountToMove, fromBucketLPs_, ) = buckets.lpsToQuoteToken(
+        (quoteTokenAmountToMove, fromBucketLPs_, ) = Buckets.lpsToQuoteToken(
+            buckets[fromIndex_],
             deposits.valueAt(fromIndex_),
             lenderLpBalance,
             maxQuoteTokenAmountToMove_,
-            fromIndex_
+            PoolUtils.indexToPrice(fromIndex_)
         );
 
         deposits.remove(fromIndex_, quoteTokenAmountToMove);
@@ -911,11 +912,12 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 lpTokens_,
         uint256 index_
     ) external view override returns (uint256 quoteTokenAmount_) {
-        (quoteTokenAmount_, , ) = buckets.lpsToQuoteToken(
+        (quoteTokenAmount_, , ) = Buckets.lpsToQuoteToken(
+            buckets[index_],
             deposit_,
             lpTokens_,
             deposit_,
-            index_
+            PoolUtils.indexToPrice(index_)
         );
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -566,7 +566,12 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 index_
     ) internal returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
-        bucketLPs_ = buckets.addCollateral(deposits.valueAt(index_), collateralAmountToAdd_, index_);
+        bucketLPs_ = Buckets.addCollateral(
+            buckets[index_],
+            deposits.valueAt(index_),
+            collateralAmountToAdd_,
+            PoolUtils.indexToPrice(index_))
+        ;
         _updatePool(poolState, _lup(poolState.accruedDebt));
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -71,10 +71,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     ) external override returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
-        bucketLPs_ = buckets.addQuoteToken(
+        bucketLPs_ = Buckets.addQuoteToken(
+            buckets[index_],
             deposits.valueAt(index_),
             quoteTokenAmountToAdd_,
-            index_
+            PoolUtils.indexToPrice(index_)
         );
         deposits.add(index_, quoteTokenAmountToAdd_);
 
@@ -127,10 +128,11 @@ abstract contract Pool is Clone, Multicall, IPool {
             quoteTokenAmountToMove
         );
 
-        toBucketLPs_ = buckets.quoteTokensToLPs(
+        toBucketLPs_ = Buckets.quoteTokensToLPs(
+            buckets[toIndex_],
             deposits.valueAt(toIndex_),
             quoteTokenAmountToMove,
-            toIndex_
+            PoolUtils.indexToPrice(toIndex_)
         );
 
         deposits.add(toIndex_, quoteTokenAmountToMove);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -110,8 +110,9 @@ abstract contract Pool is Clone, Multicall, IPool {
             msg.sender
         );
         uint256 quoteTokenAmountToMove;
+        Buckets.Bucket storage fromBucket = buckets[fromIndex_];
         (quoteTokenAmountToMove, fromBucketLPs_, ) = Buckets.lpsToQuoteToken(
-            buckets[fromIndex_],
+            fromBucket,
             deposits.valueAt(fromIndex_),
             lenderLpBalance,
             maxQuoteTokenAmountToMove_,
@@ -129,8 +130,9 @@ abstract contract Pool is Clone, Multicall, IPool {
             quoteTokenAmountToMove
         );
 
+        Buckets.Bucket storage toBucket = buckets[toIndex_];
         toBucketLPs_ = Buckets.quoteTokensToLPs(
-            buckets[toIndex_],
+            toBucket,
             deposits.valueAt(toIndex_),
             quoteTokenAmountToMove,
             PoolUtils.indexToPrice(toIndex_)
@@ -141,7 +143,12 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 newLup = _lup(poolState.accruedDebt); // move lup if necessary and check loan book's htp against new lup
         if (fromIndex_ < toIndex_) if(_htp(poolState.inflator) > newLup) revert LUPBelowHTP();
 
-        buckets.moveLPs(fromBucketLPs_, toBucketLPs_, fromIndex_, toIndex_);
+        Buckets.moveLPs(
+            fromBucket,
+            toBucket,
+            fromBucketLPs_,
+            toBucketLPs_
+        );
         _updatePool(poolState, newLup);
 
         emit MoveQuoteToken(msg.sender, fromIndex_, toIndex_, quoteTokenAmountToMove, newLup);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -940,6 +940,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         );
     }
 
+    // TODO: remove this method after solving // FIXME: now getting InsufficientLPs with this amount; was working two days ago
     function lpsToCollateral(
         uint256 deposit_,
         uint256 lpTokens_,
@@ -949,7 +950,7 @@ abstract contract Pool is Clone, Multicall, IPool {
             buckets[index_],
             deposit_,
             lpTokens_,
-            index_
+            PoolUtils.indexToPrice(index_)
         );
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -162,7 +162,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 deposit = deposits.valueAt(index_);
         if (deposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
 
-        (uint256 exchangeRate, ) = buckets.getExchangeRate(deposit, index_);
+        uint256 exchangeRate = Buckets.getExchangeRate(buckets[index_], deposit, PoolUtils.indexToPrice(index_));
         removedAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance, exchangeRate));
 
         // remove min amount of lender entitled LPBs, max amount desired and deposit in bucket

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -591,7 +591,11 @@ abstract contract Pool is Clone, Multicall, IPool {
         (uint256 lenderLpBalance, ) = buckets.getLenderInfo(index_, msg.sender);
         if (lenderLpBalance == 0 || bucketLPs_ > lenderLpBalance) revert InsufficientLPs(); // ensure user can actually remove that much
 
-        buckets.removeCollateral(collateralAmountToRemove_, bucketLPs_, index_);
+        Buckets.removeCollateral(
+            bucket,
+            collateralAmountToRemove_,
+            bucketLPs_
+        );
 
         _updatePool(poolState, _lup(poolState.accruedDebt));
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -160,14 +160,14 @@ abstract contract Pool is Clone, Multicall, IPool {
     ) external returns (uint256 removedAmount_, uint256 redeemedLPs_) {
         auctions.revertIfAuctionClearable(loans);
 
+        PoolState memory poolState = _accruePoolInterest();
+        _revertIfAuctionDebtLocked(index_, poolState.inflator);
+
         (uint256 lenderLPsBalance, uint256 lastDeposit) = buckets.getLenderInfo(
             index_,
             msg.sender
         );
         if (lenderLPsBalance == 0) revert NoClaim(); // revert if no LP to claim
-
-        PoolState memory poolState = _accruePoolInterest();
-        _revertIfAuctionDebtLocked(index_, poolState.inflator);
 
         uint256 deposit = deposits.valueAt(index_);
         if (deposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
@@ -328,14 +328,11 @@ abstract contract Pool is Clone, Multicall, IPool {
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_
     ) external override {
+        PoolState memory poolState     = _accruePoolInterest();
         Loans.Borrower memory borrower = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.t0debt == 0) revert NoDebt();
 
-        PoolState memory poolState     = _accruePoolInterest();
-        uint256 t0repaidDebt = Maths.min(
-            borrower.t0debt,
-            Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState.inflator)
-        );
+        uint256 t0repaidDebt = Maths.min(borrower.t0debt, Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState.inflator));
 
         (
             uint256 quoteTokenAmountToRepay, 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -90,8 +90,6 @@ contract ERC20Pool is IERC20Pool, Pool {
         Buckets.Bucket storage fromBucket = buckets[fromIndex_];
         if (fromBucket.collateral < collateralAmountToMove_) revert InsufficientCollateral();
 
-        PoolState memory poolState = _accruePoolInterest();
-
         fromBucketLPs_= Buckets.collateralToLPs(
             fromBucket,
             deposits.valueAt(fromIndex_),
@@ -110,8 +108,14 @@ contract ERC20Pool is IERC20Pool, Pool {
             collateralAmountToMove_,
             fromBucketLPs_
         );
-        toBucketLPs_ = buckets.addCollateral(deposits.valueAt(toIndex_), collateralAmountToMove_, toIndex_);
+        toBucketLPs_ = Buckets.addCollateral(
+            buckets[toIndex_],
+            deposits.valueAt(toIndex_),
+            collateralAmountToMove_,
+            PoolUtils.indexToPrice(toIndex_)
+        );
 
+        PoolState memory poolState = _accruePoolInterest();
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         emit MoveCollateral(msg.sender, fromIndex_, toIndex_, collateralAmountToMove_);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -175,10 +175,10 @@ contract ERC20Pool is IERC20Pool, Pool {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 
+        PoolState memory poolState = _accruePoolInterest();
         uint256 bucketDeposit = deposits.valueAt(index_);
         if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
-        PoolState memory poolState = _accruePoolInterest();
         Auctions.Liquidation storage liquidation = auctions.liquidations[borrowerAddress_];
         (
             uint256 quoteTokenAmount,
@@ -252,10 +252,10 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 collateral_,
         bytes memory swapCalldata_
     ) external override {
+        PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
-        PoolState memory poolState = _accruePoolInterest();
         (
             uint256 quoteTokenAmount,
             uint256 t0repaidDebt,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -105,7 +105,11 @@ contract ERC20Pool is IERC20Pool, Pool {
         );
         if (fromBucketLPs_ > lpBalance) revert InsufficientLPs();
 
-        buckets.removeCollateral(collateralAmountToMove_, fromBucketLPs_, fromIndex_);
+        Buckets.removeCollateral(
+            fromBucket,
+            collateralAmountToMove_,
+            fromBucketLPs_
+        );
         toBucketLPs_ = buckets.addCollateral(deposits.valueAt(toIndex_), collateralAmountToMove_, toIndex_);
 
         _updatePool(poolState, _lup(poolState.accruedDebt));
@@ -129,7 +133,11 @@ contract ERC20Pool is IERC20Pool, Pool {
         );
         if (collateralAmountRemoved_ == 0) revert NoClaim();
 
-        buckets.removeCollateral(collateralAmountRemoved_, redeemedLenderLPs_, index_);
+        Buckets.removeCollateral(
+            bucket,
+            collateralAmountRemoved_,
+            redeemedLenderLPs_)
+        ;
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         // move collateral from pool to lender

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -120,10 +120,12 @@ contract ERC20Pool is IERC20Pool, Pool {
         PoolState memory poolState = _accruePoolInterest();
 
         (uint256 lenderLPsBalance, ) = buckets.getLenderInfo(index_, msg.sender);
-        (collateralAmountRemoved_, redeemedLenderLPs_) = buckets.lpsToCollateral(
+        Buckets.Bucket storage bucket = buckets[index_];
+        (collateralAmountRemoved_, redeemedLenderLPs_) = Buckets.lpsToCollateral(
+            bucket,
             deposits.valueAt(index_),
             lenderLPsBalance,
-            index_
+            PoolUtils.indexToPrice(index_)
         );
         if (collateralAmountRemoved_ == 0) revert NoClaim();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -177,12 +177,7 @@ contract ERC20Pool is IERC20Pool, Pool {
             if (auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
 
             Buckets.Bucket storage bucket = buckets[index_];
-            uint256 bucketExchangeRate;
-            if (bucket.lps == 0) {
-                bucketExchangeRate = Maths.RAY;
-            } else {
-                bucketExchangeRate = (bucketDeposit * 1e18 + bucketPrice * bucket.collateral) * 1e18 / bucket.lps;
-            }
+            uint256 bucketExchangeRate = Buckets.getExchangeRate(bucket, bucketDeposit, bucketPrice);
 
             // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
             Buckets.addLPs(

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -87,15 +87,17 @@ contract ERC20Pool is IERC20Pool, Pool {
     ) external override returns (uint256 fromBucketLPs_, uint256 toBucketLPs_) {
         if (fromIndex_ == toIndex_) revert MoveToSamePrice();
 
+        Buckets.Bucket storage fromBucket = buckets[fromIndex_];
+        if (fromBucket.collateral < collateralAmountToMove_) revert InsufficientCollateral();
+
         PoolState memory poolState = _accruePoolInterest();
 
-        uint256 fromBucketCollateral;
-        (fromBucketLPs_, fromBucketCollateral) = buckets.collateralToLPs(
+        fromBucketLPs_= Buckets.collateralToLPs(
+            fromBucket,
             deposits.valueAt(fromIndex_),
             collateralAmountToMove_,
-            fromIndex_
+            PoolUtils.indexToPrice(fromIndex_)
         );
-        if (fromBucketCollateral < collateralAmountToMove_) revert InsufficientCollateral();
 
         (uint256 lpBalance, ) = buckets.getLenderInfo(
             fromIndex_,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -175,10 +175,10 @@ contract ERC20Pool is IERC20Pool, Pool {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 
-        PoolState memory poolState = _accruePoolInterest();
         uint256 bucketDeposit = deposits.valueAt(index_);
         if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
+        PoolState memory poolState = _accruePoolInterest();
         Auctions.Liquidation storage liquidation = auctions.liquidations[borrowerAddress_];
         (
             uint256 quoteTokenAmount,
@@ -252,10 +252,10 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 collateral_,
         bytes memory swapCalldata_
     ) external override {
-        PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
+        PoolState memory poolState = _accruePoolInterest();
         (
             uint256 quoteTokenAmount,
             uint256 t0repaidDebt,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -197,7 +197,11 @@ contract ERC20Pool is IERC20Pool, Pool {
             if (auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
 
             Buckets.Bucket storage bucket = buckets[index_];
-            uint256 bucketExchangeRate = Buckets.getExchangeRate(bucket, bucketDeposit, bucketPrice);
+            uint256 bucketExchangeRate = Buckets.getExchangeRate(
+                bucket,
+                bucketDeposit,
+                bucketPrice
+            );
 
             // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
             Buckets.addLPs(

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -90,6 +90,8 @@ contract ERC20Pool is IERC20Pool, Pool {
         Buckets.Bucket storage fromBucket = buckets[fromIndex_];
         if (fromBucket.collateral < collateralAmountToMove_) revert InsufficientCollateral();
 
+        PoolState memory poolState = _accruePoolInterest();
+
         fromBucketLPs_= Buckets.collateralToLPs(
             fromBucket,
             deposits.valueAt(fromIndex_),
@@ -115,7 +117,6 @@ contract ERC20Pool is IERC20Pool, Pool {
             PoolUtils.indexToPrice(toIndex_)
         );
 
-        PoolState memory poolState = _accruePoolInterest();
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         emit MoveCollateral(msg.sender, fromIndex_, toIndex_, collateralAmountToMove_);
@@ -129,6 +130,8 @@ contract ERC20Pool is IERC20Pool, Pool {
             index_,
             msg.sender
         );
+
+        PoolState memory poolState = _accruePoolInterest();
 
         Buckets.Bucket storage bucket = buckets[index_];
         (collateralAmountRemoved_, redeemedLenderLPs_) = Buckets.lpsToCollateral(
@@ -145,7 +148,6 @@ contract ERC20Pool is IERC20Pool, Pool {
             redeemedLenderLPs_)
         ;
 
-        PoolState memory poolState = _accruePoolInterest();
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         // move collateral from pool to lender

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -125,9 +125,11 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 index_
     ) external override returns (uint256 collateralAmountRemoved_, uint256 redeemedLenderLPs_) {
 
-        PoolState memory poolState = _accruePoolInterest();
+        (uint256 lenderLPsBalance, ) = buckets.getLenderInfo(
+            index_,
+            msg.sender
+        );
 
-        (uint256 lenderLPsBalance, ) = buckets.getLenderInfo(index_, msg.sender);
         Buckets.Bucket storage bucket = buckets[index_];
         (collateralAmountRemoved_, redeemedLenderLPs_) = Buckets.lpsToCollateral(
             bucket,
@@ -142,6 +144,8 @@ contract ERC20Pool is IERC20Pool, Pool {
             collateralAmountRemoved_,
             redeemedLenderLPs_)
         ;
+
+        PoolState memory poolState = _accruePoolInterest();
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         // move collateral from pool to lender

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -177,7 +177,7 @@ contract ERC721Pool is IERC721Pool, Pool {
      *  @param debt_       Debt to calculate collateralization for.
      *  @param collateral_ Collateral to calculate collateralization for.
      *  @param price_      Price to calculate collateralization for.
-     *  @return Collateralization value.
+     *  @return True if collateralization calculated is equal or greater than 1.
      */
     function _isCollateralized(
         uint256 debt_,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -179,15 +179,21 @@ contract ERC721Pool is IERC721Pool, Pool {
      *  @param price_      Price to calculate collateralization for.
      *  @return Collateralization value.
      */
-    function _collateralization(
+    function _isCollateralized(
         uint256 debt_,
         uint256 collateral_,
         uint256 price_
-    ) internal pure override returns (uint256) {
-        uint256 encumbered = price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
+    ) internal pure override returns (bool) {
+        if (debt_  == 0) return true;       // if debt is 0 then is collateralized
+        if (price_ == 0) return true;       // if price to calculate collateralized is 0 then is collateralized
+
+        uint256 encumbered = Maths.wdiv(debt_, price_); // calculated to avoid situation where debt dust amount
+        if (encumbered   == 0) return true;  // if encumbered is 0 then is collateralized
+        if (collateral_ == 0) return false; // if encumbered is not 0 and collateral is 0 then is not collateralized
+
         //slither-disable-next-line divide-before-multiply
-        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
-        return encumbered != 0 ? Maths.wdiv(collateral_, encumbered) : Maths.WAD;
+        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD;    // use collateral floor
+        return Maths.wdiv(collateral_, encumbered) >= Maths.WAD; // is collateralized when collateral divided by encumbered >= 1
     }
 
     /**

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -151,16 +151,16 @@ library Auctions {
 
     /**
      *  @notice Removes a collateralized borrower from the auctions queue and repairs the queue order.
-     *  @param  borrower_          Borrower whose loan is being placed in queue.
-     *  @param  collateralization_ Borrower's collateralization.
+     *  @param  borrower_         Borrower whose loan is being placed in queue.
+     *  @param  isCollateralized_ Borrower's collateralization flag.
      */
     function checkAndRemove(
         Data storage self,
         address borrower_,
-        uint256 collateralization_
+        bool    isCollateralized_
     ) internal {
 
-        if (collateralization_ >= Maths.WAD && self.liquidations[borrower_].kickTime != 0) {
+        if (isCollateralized_ && self.liquidations[borrower_].kickTime != 0) {
             _removeAuction(self, borrower_);
         }
     }

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -216,7 +216,6 @@ library Auctions {
         liquidation.bondSize   = bondSize;
         liquidation.bondFactor = bondFactor;
 
-        liquidation.next = address(0);
         if (self.head != address(0)) {
             // other auctions in queue, liquidation doesn't exist or overwriting.
             self.liquidations[self.tail].next = borrower_;
@@ -224,7 +223,6 @@ library Auctions {
         } else {
             // first auction in queue
             self.head = borrower_;
-            liquidation.prev  = address(0);
         }
 
         // update liquidation with the new ordering

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -257,27 +257,25 @@ library Buckets {
      *  @notice Returns the amount of collateral calculated for the given amount of LPs.
      *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
      *  @param  lenderLPsBalance_ The amount of LPs to calculate collateral for.
-     *  @param  index_            Index of the bucket.
+     *  @param  bucketPrice_      Bucket price.
      *  @return collateralAmount_ Amount of collateral calculated for the given LPs amount.
      *  @return lenderLPs_        Amount of lender LPs corresponding for calculated collateral amount.
      */
     function lpsToCollateral(
-        mapping(uint256 => Bucket) storage self,
+        Bucket storage bucket_,
         uint256 deposit_,
         uint256 lenderLPsBalance_,
-        uint256 index_
+        uint256 bucketPrice_
     ) internal view returns (uint256 collateralAmount_, uint256 lenderLPs_) {
         // max collateral to lps
-        Bucket storage bucket = self[index_];
-        lenderLPs_    = lenderLPsBalance_;
-        uint256 price = PoolUtils.indexToPrice(index_);
-        uint256 rate  = getExchangeRate(bucket, deposit_, price);
+        lenderLPs_  = lenderLPsBalance_;
+        uint256 rate = getExchangeRate(bucket_, deposit_, bucketPrice_);
 
-        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), price);
-        if (collateralAmount_ > bucket.collateral) {
+        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), bucketPrice_);
+        if (collateralAmount_ > bucket_.collateral) {
             // user is owed more collateral than is available in the bucket
-            collateralAmount_ = bucket.collateral;
-            lenderLPs_        = Maths.wrdivr(Maths.wmul(collateralAmount_, price), rate);
+            collateralAmount_ = bucket_.collateral;
+            lenderLPs_        = Maths.wrdivr(Maths.wmul(collateralAmount_, bucketPrice_), rate);
         }
     }
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -277,21 +277,20 @@ library Buckets {
      *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
      *  @param  lenderLPsBalance_ The amount of LPs to calculate quote token amount for.
      *  @param  maxQuoteToken_    The max quote token amount to calculate LPs for.
-     *  @param  index_            Index of the bucket.
+     *  @param  bucketPrice_      Bucket price.
      *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given LPs amount.
      *  @return bucketLPs_        Amount of bucket LPs corresponding for calculated collateral amount.
      *  @return lenderLPs_        Lender LPs balance in current bucket.
      */
     function lpsToQuoteToken(
-        mapping(uint256 => Bucket) storage self,
+        Bucket storage bucket_,
         uint256 deposit_,
         uint256 lenderLPsBalance_,
         uint256 maxQuoteToken_,
-        uint256 index_
+        uint256 bucketPrice_
     ) internal view returns (uint256 quoteTokenAmount_, uint256 bucketLPs_, uint256 lenderLPs_) {
-        Bucket storage bucket = self[index_];
         lenderLPs_   = lenderLPsBalance_;
-        uint256 rate = getExchangeRate(bucket, deposit_, PoolUtils.indexToPrice(index_));
+        uint256 rate = getExchangeRate(bucket_, deposit_, bucketPrice_);
         quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
         if (quoteTokenAmount_ > deposit_) {
             quoteTokenAmount_ = deposit_;

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -147,20 +147,17 @@ library Buckets {
      *  @notice Removes collateral from a bucket and subtracts LPs (coresponding to collateral amount removed) from bucket and lender balances.
      *  @param  collateralAmountToRemove_ Collateral amount to be removed from bucket.
      *  @param  lpsAmountToRemove_        The amount of LPs to be removed from bucket.
-     *  @param  index_                    Index of the bucket to remove collateral to.
      */
     function removeCollateral(
-        mapping(uint256 => Bucket) storage self,
+        Bucket storage bucket_,
         uint256 collateralAmountToRemove_,
-        uint256 lpsAmountToRemove_,
-        uint256 index_
+        uint256 lpsAmountToRemove_
     ) internal {
         // update bucket collateral and LPs balance
-        Bucket storage bucket = self[index_];
-        bucket.lps        -= Maths.min(bucket.lps, lpsAmountToRemove_);
-        bucket.collateral -= Maths.min(bucket.collateral, collateralAmountToRemove_);
+        bucket_.lps        -= Maths.min(bucket_.lps, lpsAmountToRemove_);
+        bucket_.collateral -= Maths.min(bucket_.collateral, collateralAmountToRemove_);
         // update lender LPs balance
-        bucket.lenders[msg.sender].lps -= lpsAmountToRemove_;
+        bucket_.lenders[msg.sender].lps -= lpsAmountToRemove_;
     }
 
     /**

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -191,7 +191,7 @@ library Buckets {
         uint256 bucketPrice_
     ) internal view returns (uint256 lps_) {
         uint256 rate = getExchangeRate(bucket_, deposit_, bucketPrice_);
-        lps_        = (collateral_ * bucketPrice_ * 1e18 + rate / 2) / rate;
+        lps_         = (collateral_ * bucketPrice_ * 1e18 + rate / 2) / rate;
     }
 
     /**
@@ -206,6 +206,7 @@ library Buckets {
     ) internal view returns (uint256) {
         return bucket_.lps == 0 ? Maths.RAY :
             (bucketDeposit_ * 1e18 + bucketPrice_ * bucket_.collateral) * 1e18 / bucket_.lps;
+            // 10^36 * 1e18 / 10^27 = 10^54 / 10^27 = 10^27
     }
 
     /**

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -62,31 +62,29 @@ library Buckets {
      *  @notice Add collateral to a bucket and updates LPs for bucket and lender with the amount coresponding to collateral amount added.
      *  @param  deposit_               Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
      *  @param  collateralAmountToAdd_ Additional collateral amount to add to bucket.
-     *  @param  index_                 Index of the bucket to add collateral to.
+     *  @param  bucketPrice_           Bucket price.
      *  @return addedLPs_              Amount of bucket LPs for the collateral amount added.
      */
     function addCollateral(
-        mapping(uint256 => Bucket) storage self,
+        Bucket storage bucket_,
         uint256 deposit_,
         uint256 collateralAmountToAdd_,
-        uint256 index_
+        uint256 bucketPrice_
     ) internal returns (uint256 addedLPs_) {
 
         // calculate amount of LPs to be added for the amount of collateral added to bucket
-        Bucket storage bucket = self[index_];
-        uint256 bucketPrice = PoolUtils.indexToPrice(index_);
         addedLPs_ = collateralToLPs(
-            bucket,
+            bucket_,
             deposit_,
             collateralAmountToAdd_,
-            bucketPrice
+            bucketPrice_
         );
         // update bucket LPs balance and collateral
         // cannot deposit in the same block when bucket becomes insolvent
-        if (bucket.bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
-        bucket.collateral += collateralAmountToAdd_;
+        if (bucket_.bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
+        bucket_.collateral += collateralAmountToAdd_;
         // update bucket and lender LPs balance and deposit timestamp
-        addLPs(bucket, msg.sender, addedLPs_);
+        addLPs(bucket_, msg.sender, addedLPs_);
     }
 
     /**

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.14;
 
 import './Maths.sol';
-import './PoolUtils.sol';
 
 library Buckets {
 
@@ -149,22 +148,6 @@ library Buckets {
         bucket_.collateral -= Maths.min(bucket_.collateral, collateralAmountToRemove_);
         // update lender LPs balance
         bucket_.lenders[msg.sender].lps -= lpsAmountToRemove_;
-    }
-
-    /**
-     *  @notice Remove LPs from a bucket and from lender balance.
-     *  @param  lpsAmountToRemove_ The amount of LPs to be removed from bucket.
-     *  @param  index_             Index of the bucket.
-     */
-    function removeLPs(
-        mapping(uint256 => Bucket) storage self,
-        uint256 lpsAmountToRemove_,
-        uint256 index_
-    ) internal {
-        // update bucket LPs balance
-        self[index_].lps -= lpsAmountToRemove_;
-        // update lender LPs balance
-        self[index_].lenders[msg.sender].lps -= lpsAmountToRemove_;
     }
 
     /**


### PR DESCRIPTION
This PR is for reducing contract size, cleaning out the Buckets library usage and preparing for merging `removeAllCollateral` with `removeCollateral` code
- make sure `Bucket` struct is loaded only once from storage and passed to library where is needed (previously functions like `getExchangeRate` was loading it regardless so that resulted in loading bucket several times in the same function call)
- `_isCollateralized` function added to calculate and compare result instead  old`_collateralization` that was just calculating
- kick: load borrower in storage and save inline, mutate `kickPenalty` to t0, check if borrower kickable before doinf expensive operations like pool debt accrue
- accrue pool interest only after checks are done (where is possible) to avoid paying higher gas on reverts

```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  23,883B  (97.18%)
  ERC20Pool                -  23,877B  (97.15%)
```

vs

```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  24,098B  (98.05%)
  ERC721Pool               -  24,045B  (97.84%)
```
Gas comparison (shows higher for takes and addQuoteToken which I don't have a good explanation for, but lower for the others which is expected)

```
│ addQuoteToken                              ┆ 99628           ┆ 162400 ┆ 141478 ┆ 668973  ┆ 48001   │
│ arbTake                                    ┆ 426199          ┆ 426289 ┆ 426289 ┆ 426379  ┆ 2       │
│ borrow                                     ┆ 166228          ┆ 228036 ┆ 191545 ┆ 799278  ┆ 104002  │
│ kick                                       ┆ 171327          ┆ 249924 ┆ 244623 ┆ 1091439 ┆ 32000   │
│ moveQuoteToken                             ┆ 286722          ┆ 286722 ┆ 286722 ┆ 286722  ┆ 1       │
│ pledgeCollateral                           ┆ 62338           ┆ 64765  ┆ 64559  ┆ 539664  ┆ 96001   │
│ removeQuoteToken                           ┆ 158409          ┆ 176787 ┆ 183942 ┆ 208941  ┆ 4000    │
│ repay                                      ┆ 514080          ┆ 588688 ┆ 600598 ┆ 840177  ┆ 16001   │
│ take                                       ┆ 53199           ┆ 56839  ┆ 56220  ┆ 278006  ┆ 15998   │
```
vs develop

```
│ addQuoteToken                              ┆ 91419           ┆ 154831 ┆ 133004 ┆ 669816  ┆ 48001   │
│ arbTake                                    ┆ 423267          ┆ 423357 ┆ 423357 ┆ 423447  ┆ 2       │
│ borrow                                     ┆ 166192          ┆ 228063 ┆ 191509 ┆ 800057  ┆ 104002  │
│ kick                                       ┆ 173491          ┆ 252090 ┆ 246789 ┆ 1098650 ┆ 32000   │
│ moveQuoteToken                             ┆ 287572          ┆ 287572 ┆ 287572 ┆ 287572  ┆ 1       │
│ pledgeCollateral                           ┆ 62434           ┆ 64861  ┆ 64655  ┆ 540575  ┆ 96001   │
│ removeQuoteToken                           ┆ 159322          ┆ 177700 ┆ 184855 ┆ 209853  ┆ 4000    │
│ repay                                      ┆ 514982          ┆ 589539 ┆ 601398 ┆ 840977  ┆ 16001   │
│ take                                       ┆ 51506           ┆ 55309  ┆ 54689  ┆ 274876  ┆ 15998   │
```