### PR TITLE
Fix bug calculating Lender Interest Margin when MAU is close to but below 1

### DIFF
--- a/src/_test/BucketMathTest.t.sol
+++ b/src/_test/BucketMathTest.t.sol
@@ -204,21 +204,17 @@ contract BucketMathTest is DSTestPlus {
      *  @notice Tests lender interest margin for varying meaningful actual utilization values
      */
     function testLenderInterestMargin() external {
-        assertEq(BucketMath.lenderInterestMargin(0 * 1e18),     0.85 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.1 * 1e18),   0.855176592309155536 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.2 * 1e18),   0.860752334991616633 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.25 * 1e18),  0.863715955537589525 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.5 * 1e18),   0.880944921102385039 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.75 * 1e18),  0.905505921257884513 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.99 * 1e18),  0.967683479649521744 * 1e18);
-        assertEq(BucketMath.lenderInterestMargin(1 * 1e18),     1 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(1.1 * 1e18),   1 * 1e18);
-
-        // When the pool is in a certain undercollateralized state the tx reverts with a 
-        // PRBMathUD60x18__LogInputTooSmall(20000000000000000) Err
-        // See below
-        assertEq(BucketMath.lenderInterestMargin(0.9998 * 1e18), 0.930376167495808317 * 1e18);
-        //assertEq(1 * 1e18, BucketMath.lenderInterestMargin(0.999899898007666220 * 1e18));
+        assertEq(BucketMath.lenderInterestMargin(0 * 1e18),          0.849999999999999999 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.1 * 1e18),        0.855176592309155536 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.2 * 1e18),        0.860752334991616632 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.25 * 1e18),       0.863715955537589525 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.5 * 1e18),        0.880944921102385039 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.75 * 1e18),       0.905505921257884512 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.99 * 1e18),       0.967683479649521744 * 1e18);
+        assertEq(BucketMath.lenderInterestMargin(0.9998 * 1e18),     0.991227946785361402 * 1e18);
+        assertEq(BucketMath.lenderInterestMargin(0.99999998 * 1e18), 1 * 1e18);
+        assertEq(BucketMath.lenderInterestMargin(1 * 1e18),          1 * 1e18);
+        assertEq(BucketMath.lenderInterestMargin(1.1 * 1e18),        1 * 1e18);
     }
 
     /**

--- a/src/_test/BucketMathTest.t.sol
+++ b/src/_test/BucketMathTest.t.sol
@@ -204,13 +204,21 @@ contract BucketMathTest is DSTestPlus {
      *  @notice Tests lender interest margin for varying meaningful actual utilization values
      */
     function testLenderInterestMargin() external {
-        assertEq(BucketMath.lenderInterestMargin(0.1 * 1e18),   0.855176592309155536 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.5 * 1e18),   0.880944921102385039 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(1 * 1e18),     1 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.75 * 1e18),  0.905505921257884513 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.25 * 1e18),  0.863715955537589525 * 1e18 );
-        assertEq(BucketMath.lenderInterestMargin(0.2 * 1e18),   0.860752334991616633 * 1e18 );
         assertEq(BucketMath.lenderInterestMargin(0 * 1e18),     0.85 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.1 * 1e18),   0.855176592309155536 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.2 * 1e18),   0.860752334991616633 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.25 * 1e18),  0.863715955537589525 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.5 * 1e18),   0.880944921102385039 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.75 * 1e18),  0.905505921257884513 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(0.99 * 1e18),  0.967683479649521744 * 1e18);
+        assertEq(BucketMath.lenderInterestMargin(1 * 1e18),     1 * 1e18 );
+        assertEq(BucketMath.lenderInterestMargin(1.1 * 1e18),   1 * 1e18);
+
+        // When the pool is in a certain undercollateralized state the tx reverts with a 
+        // PRBMathUD60x18__LogInputTooSmall(20000000000000000) Err
+        // See below
+        assertEq(BucketMath.lenderInterestMargin(0.9998 * 1e18), 0.930376167495808317 * 1e18);
+        //assertEq(1 * 1e18, BucketMath.lenderInterestMargin(0.999899898007666220 * 1e18));
     }
 
     /**

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -468,4 +468,18 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             }
         );
     }
+
+    function testLenderInterestMargin() external {
+        assertEq(1 * 1e18, BucketMath.lenderInterestMargin(1.1 * 1e18));
+        assertEq(0.967683479649521744 * 1e18, BucketMath.lenderInterestMargin(0.99 * 1e18));
+
+        // When the pool is in a certain undercollateralized state the tx reverts with a 
+        // PRBMathUD60x18__LogInputTooSmall(20000000000000000) Err
+        // See below
+
+        assertEq(0.930376167495808317 * 1e18, BucketMath.lenderInterestMargin(0.9998 * 1e18));
+        //assertEq(1 * 1e18, BucketMath.lenderInterestMargin(0.999899898007666220 * 1e18));
+    }
+
+
 }

--- a/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -468,18 +468,4 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             }
         );
     }
-
-    function testLenderInterestMargin() external {
-        assertEq(1 * 1e18, BucketMath.lenderInterestMargin(1.1 * 1e18));
-        assertEq(0.967683479649521744 * 1e18, BucketMath.lenderInterestMargin(0.99 * 1e18));
-
-        // When the pool is in a certain undercollateralized state the tx reverts with a 
-        // PRBMathUD60x18__LogInputTooSmall(20000000000000000) Err
-        // See below
-
-        assertEq(0.930376167495808317 * 1e18, BucketMath.lenderInterestMargin(0.9998 * 1e18));
-        //assertEq(1 * 1e18, BucketMath.lenderInterestMargin(0.999899898007666220 * 1e18));
-    }
-
-
 }

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -30,8 +30,8 @@ library BucketMath {
     uint256 public constant MIN_PRICE = 99_836_282_890;
     uint256 public constant MAX_PRICE = 1_004_968_987.606512354182109771 * 10**18;
 
-    uint256 public constant CUBIC_ROOT_100      = 4.641588833612778892 * 1e18;
-    uint256 public constant ONE_THIRD           = 0.333333333333333334 * 1e18;
+    uint256 public constant CUBIC_ROOT_1000000 = 100 * 1e18;
+    uint256 public constant ONE_THIRD          = 0.333333333333333334 * 1e18;
 
     /**
         @dev step amounts in basis points. This is a constant across pools at .005, achieved by dividing WAD by 10,000
@@ -146,8 +146,13 @@ library BucketMath {
     ) public pure returns (uint256) {
         // TODO: Consider pre-calculating and storing a conversion table in a library or shared contract.
         // cubic root of the percentage of meaningful unutilized deposit
-        uint256 crpud = PRBMathUD60x18.pow(100 * 1e18 - Maths.wmul(Maths.min(mau_, 1e18), 100 * 1e18), ONE_THIRD);
-        return 1e18 - Maths.wmul(Maths.wdiv(crpud, CUBIC_ROOT_100), 0.15 * 1e18);
+        uint256 base = 1000000 * 1e18 - Maths.wmul(Maths.min(mau_, 1e18), 1000000 * 1e18);
+        if (base < 1e18) {
+            return 1e18;
+        } else {
+            uint256 crpud = PRBMathUD60x18.pow(base, ONE_THIRD);
+            return 1e18 - Maths.wmul(Maths.wdiv(crpud, CUBIC_ROOT_1000000), 0.15 * 1e18);
+        }
     }
 
     function bpf(


### PR DESCRIPTION
**Problem**
When the pool is in a specific undercollateralized state and `_accrueInterest` is called a PRB math error fires:
```Running 1 test for src/_test/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol:ERC20PoolInterestRateTestAndEMAs
[FAIL. Reason: PRBMathUD60x18__LogInputTooSmall(20000000000000000)] testLenderInterestMargin() (gas: 10170)
Traces:
  [10170] ERC20PoolInterestRateTestAndEMAs::testLenderInterestMargin() 
    ├─ [1552] BucketMath::lenderInterestMargin(1100000000000000000) [delegatecall]
    │   └─ ← 1000000000000000000
    ├─ [3958] BucketMath::lenderInterestMargin(990000000000000000) [delegatecall]
    │   └─ ← 967683479649521744
    ├─ [858] BucketMath::lenderInterestMargin(999800000000000000) [delegatecall]
    │   └─ ← "PRBMathUD60x18__LogInputTooSmall(20000000000000000)"
    └─ ← "PRBMathUD60x18__LogInputTooSmall(20000000000000000)"
```

This is because when MAU is close to but under 1, we're trying to raise a base less than 1 to an exponent, which PRBMath doesn't support.  

**Solution**
To resolve this, improve precision to enable calculation of NIM closer to 1, and hardcode a NIM of 1.00 for MAUs between 0.999999 and 1.

**Out of scope**
Note that at some point in the future, we would still like to examine storing an array of precalculated LIM values, since the precision does not matter much.

**Performance**
Contract size and gas consumption largely unchanged.
```
============ develop Bytecode Sizes ============
  ERC20Pool                -  24,098B  (98.05%)
  ERC721Pool               -  24,045B  (97.84%)
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Function Name                              ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ addQuoteToken                              ┆ 6796            ┆ 206877 ┆ 160904 ┆ 492292 ┆ 218     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 640             ┆ 205858 ┆ 202486 ┆ 404410 ┆ 107     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 448             ┆ 170333 ┆ 121432 ┆ 635844 ┆ 15      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4711            ┆ 59153  ┆ 52221  ┆ 184550 ┆ 12      │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```


```
==== lenderInterest-poss-bug Bytecode Sizes ====
  ERC20Pool                -  24,098B  (98.05%)
  ERC721Pool               -  24,045B  (97.84%)
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ addQuoteToken                              ┆ 6796            ┆ 206874 ┆ 160904 ┆ 492072 ┆ 218     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 640             ┆ 205859 ┆ 202486 ┆ 404541 ┆ 107     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ moveQuoteToken                             ┆ 448             ┆ 170323 ┆ 121432 ┆ 635935 ┆ 15      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ repay                                      ┆ 4711            ┆ 59137  ┆ 52221  ┆ 184352 ┆ 12      │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```
