### PR TITLE
Move lpsTo* functions in PoolUtils contract

### DIFF
--- a/src/_test/ERC721Pool/ERC721DSTestPlus.sol
+++ b/src/_test/ERC721Pool/ERC721DSTestPlus.sol
@@ -94,7 +94,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
             if (lenderLpBalance == 0) continue;
 
             // Calculating redeemable Quote and Collateral Token in particular bucket
-            (uint256 price, uint256 bucketQuoteToken, uint256 bucketCollateral, , , ) = _poolUtils.bucketInfo(address(_pool), bucketIndex);
+            (uint256 price, , uint256 bucketCollateral, , , ) = _poolUtils.bucketInfo(address(_pool), bucketIndex);
 
             // If bucket has a fractional amount of NFTs, we'll need to defragment collateral across buckets
             if (bucketCollateral % 1e18 != 0) {
@@ -103,7 +103,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
             uint256 noOfBucketNftsRedeemable = Maths.wadToIntRoundingDown(bucketCollateral);
 
             // Calculating redeemable Quote and Collateral Token for Lenders lps
-            uint256 lpsAsCollateral = ERC721Pool(address(_pool)).lpsToCollateral(bucketQuoteToken, lenderLpBalance, bucketIndex);
+            uint256 lpsAsCollateral = _poolUtils.lpsToCollateral(address(_pool), lenderLpBalance, bucketIndex);
 
             // Deposit additional quote token to redeem for all NFTs
             uint256 lpsRedeemed;
@@ -122,7 +122,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
                     Token(_pool.quoteTokenAddress()).approve(address(_pool) , depositRequired);
                     _pool.addQuoteToken(depositRequired, bucketIndex);
                     (lenderLpBalance, ) = _pool.lenderInfo(bucketIndex, lender);
-                    lpsAsCollateral = ERC721Pool(address(_pool)).lpsToCollateral(bucketQuoteToken + depositRequired, lenderLpBalance, bucketIndex);
+                    lpsAsCollateral = _poolUtils.lpsToCollateral(address(_pool), lenderLpBalance, bucketIndex);
                 }
 
                 // First redeem LP for collateral

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.14;
 
 import './interfaces/IPool.sol';
 
+import '../libraries/Buckets.sol';
 import '../libraries/PoolUtils.sol';
 
 contract PoolInfoUtils {
@@ -279,6 +280,51 @@ contract PoolInfoUtils {
         (, uint256 maxThresholdPrice, ) = pool.loansInfo();
         (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
         return Maths.wmul(maxThresholdPrice, inflatorSnapshot);
+    }
+
+    /**
+     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LP Tokens.
+     *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
+     *  @param  index_       The price bucket index for which the value should be calculated.
+     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
+     */
+    function lpsToQuoteTokens(
+        address ajnaPool_,
+        uint256 lpTokens_,
+        uint256 index_
+    ) external view returns (uint256 quoteAmount_) {
+        IPool pool = IPool(ajnaPool_);
+        (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
+        (quoteAmount_, , ) = Buckets.lpsToQuoteToken(
+            bucketCollateral,
+            bucketLPs_,
+            bucketDeposit,
+            lpTokens_,
+            bucketDeposit,
+            PoolUtils.indexToPrice(index_)
+        );
+    }
+
+    /**
+     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LP Tokens.
+     *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
+     *  @param  index_       The price bucket index for which the value should be calculated.
+     *  @return collateralAmount The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
+     */
+    function lpsToCollateral(
+        address ajnaPool_,
+        uint256 lpTokens_,
+        uint256 index_
+    ) external view returns (uint256 collateralAmount) {
+        IPool pool = IPool(ajnaPool_);
+        (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
+        (collateralAmount, ) = Buckets.lpsToCollateral(
+            bucketCollateral,
+            bucketLPs_,
+            bucketDeposit,
+            lpTokens_,
+            PoolUtils.indexToPrice(index_)
+        );
     }
 
 }

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -19,6 +19,7 @@ import './PermitERC20.sol';
 import './PositionNFT.sol';
 
 import '../libraries/Maths.sol';
+import '../libraries/Buckets.sol';
 
 contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC20, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.UintSet;
@@ -110,10 +111,13 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         address owner = ownerOf(params_.tokenId);
 
         IPool pool = IPool(params_.pool);
-        (, , , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
-        uint256 maxQuote      = pool.lpsToQuoteTokens(
+        (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
+        (uint256 maxQuote, , ) = Buckets.lpsToQuoteToken(
+            bucketLPs,
+            bucketCollateral,
             bucketDeposit,
             lps[params_.tokenId][params_.fromIndex],
+            bucketDeposit,
             params_.fromIndex
         );
 

--- a/src/base/interfaces/pool/IPoolDerivedState.sol
+++ b/src/base/interfaces/pool/IPoolDerivedState.sol
@@ -33,31 +33,4 @@ interface IPoolDerivedState {
         uint256 collateral_
     ) external view returns (uint256);
 
-    /**
-     *  @notice Calculate the amount of quote tokens for a given amount of LP Tokens.
-     *  @param  deposit_     The amount of quote tokens available at this bucket index.
-     *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
-     *  @param  index_       The price bucket index for which the value should be calculated.
-     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
-     */
-    function lpsToQuoteTokens(
-        uint256 deposit_,
-        uint256 lpTokens_,
-        uint256 index_
-    ) external view returns (uint256 quoteAmount_);
-
-    /**
-     *  @notice Calculate the amount of collateral tokens for a given amount of LP Tokens.
-     *  @param  deposit_     The amount of quote tokens available at this bucket index.
-     *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
-     *  @param  index_       The price bucket index for which the value should be calculated.
-     *  @return collateralAmount The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
-     */
-
-    function lpsToCollateral(
-        uint256 deposit_,
-        uint256 lpTokens_,
-        uint256 index_
-    ) external view returns (uint256 collateralAmount);
-
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -93,7 +93,8 @@ contract ERC20Pool is IERC20Pool, Pool {
         PoolState memory poolState = _accruePoolInterest();
 
         fromBucketLPs_= Buckets.collateralToLPs(
-            fromBucket,
+            fromBucket.collateral,
+            fromBucket.lps,
             deposits.valueAt(fromIndex_),
             collateralAmountToMove_,
             PoolUtils.indexToPrice(fromIndex_)
@@ -135,7 +136,8 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         Buckets.Bucket storage bucket = buckets[index_];
         (collateralAmountRemoved_, redeemedLenderLPs_) = Buckets.lpsToCollateral(
-            bucket,
+            bucket.collateral,
+            bucket.lps,
             deposits.valueAt(index_),
             lenderLPsBalance,
             PoolUtils.indexToPrice(index_)
@@ -200,7 +202,8 @@ contract ERC20Pool is IERC20Pool, Pool {
 
             Buckets.Bucket storage bucket = buckets[index_];
             uint256 bucketExchangeRate = Buckets.getExchangeRate(
-                bucket,
+                bucket.collateral,
+                bucket.lps,
                 bucketDeposit,
                 bucketPrice
             );


### PR DESCRIPTION
- pass Bucket storage struct storage only to Buckets library functions that change state
- convert all other Buckets library functions in pure functions
- remove lpsToCollateral and lpsToQuoteTokens from Pool contract
- use Buckets library to calculate quoteTokens for LPs in PositionManager
- style on pool's external functions

```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  23,897B  (97.23%)
  ERC721Pool               -  23,878B  (97.16%)
```

vs develop
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,079B  (97.97%)
  ERC20Pool                -  23,954B  (97.47%)
```