### PR TITLE
Fix bug for apply penalty on remove liquidity

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -146,6 +146,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             }
         );
 
+        skip(1 days); // skip to avoid penalty
         // lender removes some quote token from highest priced bucket
         _removeLiquidity(
             {

--- a/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -84,6 +84,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
 
         uint256 availableCollateral = collateralToPurchaseWith;
 
+        skip(1 days); // skip to avoid penalty
         // bidder uses their LP to purchase all quote token in the bucket
         _removeLiquidity(
             {

--- a/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -331,6 +331,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(address(_pool)), 70_000 * 1e18);
         assertEq(_quote.balanceOf(_lender),        130_000 * 1e18);
 
+        skip(1 days); // skip to avoid penalty
         _removeLiquidity(
             {
                 from:     _lender,
@@ -641,6 +642,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             }
         );
 
+        skip(1 days); // skip to avoid penalty
         // should be able to removeQuoteToken
         _removeLiquidity(
             {

--- a/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -610,6 +610,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         );
 
         // lender removes quote token
+        skip(1 days); // skip to avoid penalty
         _removeAllLiquidity(
             {
                 from:     _lender,

--- a/src/_test/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
@@ -131,6 +131,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_bidder),             0);
 
         // bidder removes quote token from bucket
+        skip(1 days); // skip to avoid penalty
         uint256 qtToRemove = Maths.wmul(priceAtTestIndex, 3 * 1e18);
         _removeAllLiquidity(
             {

--- a/src/_test/PoolUtilsTest.t.sol
+++ b/src/_test/PoolUtilsTest.t.sol
@@ -125,15 +125,15 @@ contract PoolUtilsTest is DSTestPlus {
         uint256 toIndex  = 1000; // price -> 146.575625611106531706 * 1e18
         uint256 amount  = 100000 * 1e18;
 
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount),            amount);
+        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount), amount);
 
         poolState_.collateral = 2 * 1e18;
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount),            amount);
+        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount), amount);
 
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount),    99903.8461538461538 * 1e18);
+        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount), 99903.8461538461538 * 1e18);
 
-        poolState_.collateral = 0;
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount),    amount);
+        poolState_.collateral = 0; // should apply penalty also when no collateral in pool
+        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount), 99903.8461538461538 * 1e18);
     }
 
     /**

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -269,7 +269,7 @@ abstract contract DSTestPlus is Test {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit Repay(borrower, newLup, repaid);
-        _assertTokenTransferEvent(from, address(_pool), amount);
+        _assertTokenTransferEvent(from, address(_pool), repaid);
         _pool.repay(borrower, amount);
     }
 

--- a/src/libraries/PoolUtils.sol
+++ b/src/libraries/PoolUtils.sol
@@ -95,6 +95,15 @@ library PoolUtils {
         }
     }
 
+    /**
+     *  @notice Returns amount plus calculated early withdrawal penalty (if case).
+     *  @param  poolState_         Struct containing pool state details.
+     *  @param  depositTime_       Time when deposit happened.
+     *  @param  fromIndex_         Index of the bucket from where liquidity is removed or moved.
+     *  @param  toIndex_           Index of the bucket where liquidity is moved. 0 in case of withdrawing.
+     *  @param  amount_            Amount to calculate early withdrawal penalty for.
+     *  @return amountWithPenalty_ The amount plus applied early withdrawal penalty. Same amount if not subject of penalty.
+     */
     function applyEarlyWithdrawalPenalty(
         Pool.PoolState memory poolState_,
         uint256 depositTime_,


### PR DESCRIPTION
- Fix apply penalty on remove quote token even if no collateral pledged to pool
- Add test to expose scenario where lender cannot withdraw all their quote tokens if there is still collateral pledged in bucket after repay