### PR TITLE
ERC20Pool Deposit take

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -302,7 +302,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[0], 2_000);
+        _pool.arbTake(_borrowers[0], false, 2_000);
         vm.stopPrank();
     }
 
@@ -323,7 +323,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[LOANS_COUNT - 1], 2_000);
+        _pool.arbTake(_borrowers[LOANS_COUNT - 1], false, 2_000);
         vm.stopPrank();
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -286,6 +286,22 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
 contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
 
     function testLoadERC20PoolGasKickAndArbTakeLowestTPLoan() public {
+        _kickAndTakeLowestTPLoan(false);
+    }
+
+    function testLoadERC20PoolGasKickAndDepositTakeLowestTPLoan() public {
+        _kickAndTakeLowestTPLoan(true);
+    }
+
+    function testLoadERC20PoolGasKickAndArbTakeHighestTPLoan() public {
+        _kickAndTakeHighestTPLoan(false);
+    }
+
+    function testLoadERC20PoolGasKickAndDepositTakeHighestTPLoan() public {
+        _kickAndTakeHighestTPLoan(true);
+    }
+
+    function _kickAndTakeLowestTPLoan(bool depositTake_) internal {
         address kicker = makeAddr("kicker");
         _mintQuoteAndApproveTokens(kicker, type(uint256).max); // mint enough to cover bonds
 
@@ -302,11 +318,11 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[0], false, 2_000);
+        _pool.arbTake(_borrowers[0], depositTake_, 2_000);
         vm.stopPrank();
     }
 
-    function testLoadERC20PoolGasKickAndArbTakeHighestTPLoan() public {
+    function _kickAndTakeHighestTPLoan(bool depositTake_) internal {
         address kicker = makeAddr("kicker");
         _mintQuoteAndApproveTokens(kicker, type(uint256).max); // mint enough to cover bonds
 
@@ -323,7 +339,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[LOANS_COUNT - 1], false, 2_000);
+        _pool.arbTake(_borrowers[LOANS_COUNT - 1], depositTake_, 2_000);
         vm.stopPrank();
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -318,7 +318,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[0], depositTake_, 2_000);
+        _pool.bucketTake(_borrowers[0], depositTake_, 2_000);
         vm.stopPrank();
     }
 
@@ -339,7 +339,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         skip(14 hours);
         address taker = makeAddr("taker");
         vm.startPrank(taker);
-        _pool.arbTake(_borrowers[LOANS_COUNT - 1], depositTake_, 2_000);
+        _pool.bucketTake(_borrowers[LOANS_COUNT - 1], depositTake_, 2_000);
         vm.stopPrank();
     }
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -238,6 +238,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            }
         );
 
+        // add liquidity to accrue interest and update reserves before arb take
         _addLiquidity(
            {
                from:   _lender1,

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -1,0 +1,714 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
+
+import '../../libraries/BucketMath.sol';
+
+contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+    address internal _lender1;
+    address internal _taker;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender1   = makeAddr("lender1");
+        _taker     = makeAddr("taker");
+
+        _mintQuoteAndApproveTokens(_lender,  120_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1, 120_000 * 1e18);
+
+        _mintCollateralAndApproveTokens(_borrower,  4 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_lender1,   4 * 1e18);
+
+        // Lender adds Quote token accross 5 prices
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 2_000 * 1e18,
+                index:  _i9_91,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 5_000 * 1e18,
+                index:  _i9_81,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 11_000 * 1e18,
+                index:  _i9_72,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 25_000 * 1e18,
+                index:  _i9_62,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 30_000 * 1e18,
+                index:  _i9_52,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+
+        // first borrower adds collateral token and borrows
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                amount:   2 * 1e18
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower,
+                amount:     19.25 * 1e18,
+                indexLimit: _i9_91,
+                newLup:     9.917184843435912074 * 1e18
+            }
+        );
+
+        // second borrower adds collateral token and borrows
+        _pledgeCollateral(
+            {
+                from:     _borrower2,
+                borrower: _borrower2,
+                amount:   1_000 * 1e18
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower2,
+                amount:     7_980 * 1e18,
+                indexLimit: _i9_72,
+                newLup:     9.721295865031779605 * 1e18
+            }
+        );
+
+        /*****************************/
+        /*** Assert pre-kick state ***/
+        /*****************************/
+
+        _assertPool(
+            PoolState({
+                htp:                  9.634254807692307697 * 1e18,
+                lup:                  9.721295865031779605 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    1_002 * 1e18,
+                encumberedCollateral: 823.649613971736296163 * 1e18,
+                poolDebt:             8_006.941586538461542154 * 1e18,
+                actualUtilization:    0.109684131322444679 * 1e18,
+                targetUtilization:    1e18,
+                minDebtAmount:        400.347079326923077108 * 1e18,
+                loans:                2,
+                maxBorrower:          address(_borrower),
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.268509615384615394 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerCollateralization: 1.009034539679184679 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              7_987.673076923076926760 * 1e18,
+                borrowerCollateral:        1_000 * 1e18,
+                borrowerMompFactor:        9.818751856078723036 * 1e18,
+                borrowerCollateralization: 1.217037273735858713 * 1e18
+            }
+        );
+        _assertReserveAuction(
+            {
+                reserves:                   7.691586538461542154 * 1e18,
+                claimableReserves :         0,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
+            }
+        );
+        assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
+
+        // should revert if there's no auction started
+        _assertDepositTakeNoAuctionRevert(
+            {
+                from:     _lender,
+                borrower: _borrower,
+                index:    _i9_91
+            }
+        );
+
+        // Skip to make borrower undercollateralized
+        skip(100 days);
+
+        _kick(
+            {
+                from:       _lender,
+                borrower:   _borrower,
+                debt:       19.778456451861613480 * 1e18,
+                collateral: 2 * 1e18,
+                bond:       0.195342779771472726 * 1e18
+            }
+        );
+
+        _assertAuction(
+            AuctionState({
+                borrower:          _borrower,
+                active:            true,
+                kicker:            _lender,
+                bondSize:          0.195342779771472726 * 1e18,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          block.timestamp,
+                kickMomp:          9.721295865031779605 * 1e18,
+                totalBondEscrowed: 0.195342779771472726 * 1e18,
+                auctionPrice:      311.081467681016947360 * 1e18,
+                debtInAuction:     19.778456451861613480 * 1e18
+            })
+        );
+
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 0,
+                locked:    0.195342779771472726 * 1e18
+            }
+        );
+    }
+    
+    function testDepositTakeCollateralRestrict() external {
+
+        skip(6 hours);
+
+        _assertLenderLpBalance(
+           {
+               lender:      _taker,
+               index:       _i9_91,
+               lpBalance:   0,
+               depositTime: 0
+           }
+        );
+        _assertLenderLpBalance(
+           {
+               lender:      _lender,
+               index:       _i9_91,
+               lpBalance:   2_000 * 1e27,
+               depositTime: _startTime
+           }
+        );
+        _assertBucket(
+           {
+               index:        _i9_91,
+               lpBalance:    2_000 * 1e27,
+               collateral:   0,
+               deposit:      2_027.000651340490292000 * 1e18,
+               exchangeRate: 1.013500325670245146000000000 * 1e27
+           }
+        );
+        _assertBorrower(
+           {
+               borrower:                  _borrower,
+               borrowerDebt:              19.779066071215516749 * 1e18,
+               borrowerCollateral:        2 * 1e18,
+               borrowerMompFactor:        9.917184843435912074 * 1e18,
+               borrowerCollateralization: 0.982988360525190378 * 1e18
+           }
+        );
+
+        _addLiquidity(
+           {
+               from:   _lender1,
+               amount: 1 * 1e18,
+               index:  _i9_52,
+               newLup: 9.721295865031779605 * 1e18
+           }
+        );
+        _assertBucket(
+           {
+               index:        _i9_91,
+               lpBalance:    2_000 * 1e27,
+               collateral:   0,
+               deposit:      2_027.006589100074751447 * 1e18,
+               exchangeRate: 1.013503294550037375723500000 * 1e27
+           }
+        );
+        _assertReserveAuction(
+           {
+               reserves:                   23.908406501703106407 * 1e18,
+               claimableReserves :         0,
+               claimableReservesRemaining: 0,
+               auctionPrice:               0,
+               timeRemaining:              0
+           }
+        );
+
+        _assertAuction(
+           AuctionState({
+               borrower:          _borrower,
+               active:            true,
+               kicker:            _lender,
+               bondSize:          0.195342779771472726 * 1e18,
+               bondFactor:        0.01 * 1e18,
+               kickTime:          block.timestamp - 6 hours,
+               kickMomp:          9.721295865031779605 * 1e18,
+               totalBondEscrowed: 0.195342779771472726 * 1e18,
+               auctionPrice:      9.721295865031779616 * 1e18,
+               debtInAuction:     19.779066071215516749 * 1e18
+           })
+        );
+
+        // Amount is restricted by the collateral in the loan
+        _depositTake(
+           {
+               from:             _taker,
+               borrower:         _borrower,
+               index:            _i9_91,
+               collateralArbed:  2 * 1e18,
+               quoteTokenAmount: 19.834369686871824148 * 1e18,
+               bondChange:       0.165053144813076029 * 1e18,
+               isReward:         true
+           }
+        );
+        _assertLenderLpBalance(
+           {
+               lender:      _taker,
+               index:       _i9_91,
+               lpBalance:   0.386558148271438658550864337 * 1e27,
+               depositTime: _startTime + 100 days + 6 hours
+           }
+        );
+        _assertLenderLpBalance(
+           {
+               lender:      _lender,
+               index:       _i9_91,
+               lpBalance:   2_000.162854078226113983588728901 * 1e27,
+               depositTime: _startTime + 100 days + 6 hours
+           }
+        );
+        _assertBucket(
+           {
+               index:        _i9_91,
+               lpBalance:    2_000.549412226497552642139593238 * 1e27,
+               collateral:   2 * 1e18,
+               deposit:      2_007.337272558016003334 * 1e18,
+               exchangeRate: 1.013307459368754730793399042 * 1e27
+           }
+        );
+        // reserves should remain the same after deposit take
+        _assertReserveAuction(
+           {
+               reserves:                   23.908406501703106407 * 1e18,
+               claimableReserves :         0,
+               claimableReservesRemaining: 0,
+               auctionPrice:               0,
+               timeRemaining:              0
+           }
+        );
+        _assertBorrower(
+           {
+               borrower:                  _borrower,
+               borrowerDebt:              0.109749529156768631 * 1e18,
+               borrowerCollateral:        0,
+               borrowerMompFactor:        9.588739842524087291 * 1e18,
+               borrowerCollateralization: 0
+           }
+        );
+        _assertAuction(
+           AuctionState({
+               borrower:          _borrower,
+               active:            true,
+               kicker:            _lender,
+               bondSize:          0.195342779771472726 * 1e18,
+               bondFactor:        0.01 * 1e18,
+               kickTime:          block.timestamp - 6 hours,
+               kickMomp:          9.721295865031779605 * 1e18,
+               totalBondEscrowed: 0.195342779771472726 * 1e18,
+               auctionPrice:      9.721295865031779616 * 1e18,
+               debtInAuction:     0.109749529156768631 * 1e18
+           })
+        );
+
+        // deposit take should fail on an auction without any remaining collateral to auction
+        _assertDepositTakeInsufficentCollateralRevert(
+           {
+               from:     _taker,
+               borrower: _borrower,
+               index:    _i9_91
+           }
+        );
+    }
+
+    function testDepositTakeDebtRestrict() external {
+
+        skip(5 hours);
+
+        _assertAuction(
+           AuctionState({
+               borrower:          _borrower,
+               active:            true,
+               kicker:            _lender,
+               bondSize:          0.195342779771472726 * 1e18,
+               bondFactor:        0.01 * 1e18,
+               kickTime:          block.timestamp - 5 hours,
+               kickMomp:          9.721295865031779605 * 1e18,
+               totalBondEscrowed: 0.195342779771472726 * 1e18,
+               auctionPrice:      19.442591730063559200 * 1e18,
+               debtInAuction:     19.778456451861613480 * 1e18
+           })
+        );
+
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 25_000 * 1e18,
+                index:  _i1505_26,
+                newLup: 1_505.263728469068226832 * 1e18
+            }
+        );
+
+        // Amount is restricted by the debt in the loan
+        _depositTake(
+            {
+                from:             _taker,
+                borrower:         _borrower,
+                index:            _i1505_26,
+                collateralArbed:  0.013139866518142482 * 1e18,
+                quoteTokenAmount: 19.778964466685025779 * 1e18,
+                bondChange:       0.195342779771472726 * 1e18,
+                isReward:         false
+            }
+        );
+
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              0 * 1e18,
+                borrowerCollateral:        1.986860133481857518 * 1e18,
+                borrowerMompFactor:        0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _taker,
+                index:       _i1505_26,
+                lpBalance:   19.523491406585249904 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i1505_26,
+                lpBalance:   25_000.0 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i1505_26,
+                lpBalance:    25_019.523491406585249904 * 1e27,
+                collateral:   0.013139866518142482 * 1e18,
+                deposit:      24_980.221035533314974222 * 1e18,
+                exchangeRate: 0.999219669734585834485785100 * 1e27
+            }
+        );
+
+        _assertReserveAuction(
+            {
+                reserves:                   24.097734789604532721 * 1e18,
+                claimableReserves :         0,
+                claimableReservesRemaining: 0,
+                auctionPrice:               0,
+                timeRemaining:              0
+            }
+        );
+    }
+
+    function testDepositTakeDepositRestrict() external {
+
+        skip(5 hours);
+
+        _assertAuction(
+           AuctionState({
+               borrower:          _borrower,
+               active:            true,
+               kicker:            _lender,
+               bondSize:          0.195342779771472726 * 1e18,
+               bondFactor:        0.01 * 1e18,
+               kickTime:          block.timestamp - 5 hours,
+               kickMomp:          9.721295865031779605 * 1e18,
+               totalBondEscrowed: 0.195342779771472726 * 1e18,
+               auctionPrice:      19.442591730063559200 * 1e18,
+               debtInAuction:     19.778456451861613480 * 1e18
+           })
+        );
+
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 15.0 * 1e18,
+                index:  _i1505_26,
+                newLup: 9.721295865031779605 * 1e18
+            }
+        );
+
+        // Amount is restricted by the deposit in the bucket in the loan
+        _depositTake(
+            {
+                from:             _taker,
+                borrower:         _borrower,
+                index:            _i1505_26,
+                collateralArbed:  0.009965031187761219 * 1e18,
+                quoteTokenAmount: 15.0 * 1e18,
+                bondChange:       0.15 * 1e18,
+                isReward:         false
+            }
+        );
+
+        _assertAuction(
+           AuctionState({
+               borrower:          _borrower,
+               active:            false,
+               kicker:            address(0),
+               bondSize:          0,
+               bondFactor:        0,
+               kickTime:          0,
+               kickMomp:          0,
+               totalBondEscrowed: 0,
+               auctionPrice:      0,
+               debtInAuction:     4.778964466685025779 * 1e18
+           })
+        );
+
+        _assertBucket(
+            {
+                index:        _i1505_26,
+                lpBalance:    29.806253967039008272 * 1e27,
+                collateral:   0.009965031187761219 * 1e18,
+                deposit:      0,
+                exchangeRate: 0.503250090286005818052998433 * 1e27
+            }
+        );
+
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              4.778964466685025779 * 1e18,
+                borrowerCollateral:        1.990034968812238781 * 1e18,
+                borrowerMompFactor:        9.684916710602077770 * 1e18,
+                borrowerCollateralization: 4.048098463264449714 * 1e18
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _taker,
+                index:       _i1505_26,
+                lpBalance:   14.806253967039008272 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i1505_26,
+                lpBalance:   15.0 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+    }
+
+
+    function testDepositTakeGTNeutralPrice() external {
+
+        skip(3 hours);
+
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 1_000 * 1e18,
+                index:  _i10016,
+                newLup: 9.721295865031779605 * 1e18
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _taker,
+                index:       _i10016,
+                lpBalance:   0,
+                depositTime: 0
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i10016,
+                lpBalance:   1_000 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+
+        _assertBucket(
+            {
+                index:        _i10016,
+                lpBalance:    1_000 * 1e27,
+                collateral:   0,
+                deposit:      1_000 * 1e18,
+                exchangeRate: 1.0 * 1e27
+            }
+        );
+        
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.778761259189860403 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowerMompFactor:        9.917184843435912074 * 1e18,
+                borrowerCollateralization: 0.983003509435146965 * 1e18
+            }
+        );
+
+        _depositTake(
+            {
+                from:             _taker,
+                borrower:         _borrower,
+                index:            _i10016,
+                collateralArbed:  0.001974617692901169 * 1e18,
+                quoteTokenAmount: 19.778761259189860403 * 1e18,
+                bondChange:       0.195342779771472726 * 1e18,
+                isReward:         false
+            }
+        );
+
+        _assertLenderLpBalance(
+            {
+                lender:      _taker,
+                index:       _i10016,
+                lpBalance:   19.625194516685711938 * 1e27, // deposit taker was rewarded LPBs in arbed bucket
+                depositTime: _startTime + 100 days + 3 hours
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i10016,
+                lpBalance:   1_000 * 1e27,
+                depositTime: _startTime + 100 days + 3 hours
+            }
+        );
+        _assertKicker(
+            {
+                kicker:    _lender,
+                claimable: 0,
+                locked:    0 // kicker was penalized
+            }
+        );
+        _assertBucket(
+            {
+                index:        _i10016,
+                lpBalance:    1_019.625194516685711938 * 1e27,      // LP balance in arbed bucket increased with LPs awarded for deposit taker
+                collateral:   0.001974617692901169 * 1e18,          // arbed collateral added to the arbed bucket
+                deposit:      980.221238740810139596 * 1e18,        // quote token amount is diminished in arbed bucket
+                exchangeRate: 0.980752540617645013450958726 * 1e27
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              0,
+                borrowerCollateral:        1.998025382307098831 * 1e18,
+                borrowerMompFactor:        0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+        _assertAuction(
+            AuctionState({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0
+            })
+        );
+    }
+
+    function testDepositTakeReverts() external {
+
+        // should revert if auction in grace period
+        _assertDepositTakeAuctionInCooldownRevert(
+            {
+                from:     _lender,
+                borrower: _borrower,
+                index:    _i9_91
+            }
+        );
+
+        skip(2 hours);
+
+        // should revert if bucket deposit is 0
+        _assertDepositTakeAuctionInsufficientLiquidityRevert(
+            {
+                from:     _taker,
+                borrower: _borrower,
+                index:    _i100
+            }
+        );
+
+        // should revert if auction price is greater than the bucket price
+        _assertDepositTakeAuctionPriceGreaterThanBucketPriceRevert(
+            {
+                from:     _taker,
+                borrower: _borrower,
+                index:    _i9_91
+            }
+        );
+
+        skip(4 hours);
+
+        // 10 borrowers draw debt to enable the min debt check
+        for (uint i=0; i<10; ++i) {
+            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7777);
+        }        
+        // should revert if auction leaves borrower with debt under minimum pool debt
+        _assertDepositTakeDebtUnderMinPoolDebtRevert(
+            {
+                from:     _taker,
+                borrower: _borrower,
+                index:    _i9_91
+            }
+        );
+    }
+}

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -238,6 +238,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
            }
         );
 
+        // add liquidity to accrue interest and update reserves before deposit take
         _addLiquidity(
            {
                from:   _lender1,

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -596,7 +596,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('AuctionPriceGteQArbPrice()'));
+        vm.expectRevert(abi.encodeWithSignature('AuctionPriceGtBucketPrice()'));
         _pool.arbTake(borrower, false, index);
     }
 
@@ -656,7 +656,7 @@ abstract contract DSTestPlus is Test {
         uint256 index
     ) internal {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('AuctionPriceGteQArbPrice()'));
+        vm.expectRevert(abi.encodeWithSignature('AuctionPriceGtBucketPrice()'));
         _pool.arbTake(borrower, true, index);
     }
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -27,7 +27,7 @@ abstract contract DSTestPlus is Test {
 
     // Pool events
     event AddQuoteToken(address indexed lender_, uint256 indexed price_, uint256 amount_, uint256 lup_);
-    event ArbTake(address indexed borrower, uint256 index, uint256 amount, uint256 collateral, uint256 bondChange, bool isReward);
+    event BucketTake(address indexed borrower, uint256 index, uint256 amount, uint256 collateral, uint256 bondChange, bool isReward);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event Heal(address indexed borrower, uint256 healedDebt);
     event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
@@ -130,8 +130,8 @@ abstract contract DSTestPlus is Test {
     ) internal virtual {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit ArbTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
-        _pool.arbTake(borrower, false, index);
+        emit BucketTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _borrow(
@@ -161,8 +161,8 @@ abstract contract DSTestPlus is Test {
     ) internal virtual {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit ArbTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
-        _pool.arbTake(borrower, true, index);
+        emit BucketTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _heal(
@@ -577,7 +577,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
-        _pool.arbTake(borrower, false, index);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _assertArbTakeAuctionInsufficientLiquidityRevert(
@@ -587,7 +587,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientLiquidity.selector);
-        _pool.arbTake(borrower,false, index);
+        _pool.bucketTake(borrower,false, index);
     }
 
     function _assertArbTakeAuctionPriceGreaterThanBucketPriceRevert(
@@ -597,7 +597,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionPriceGtBucketPrice()'));
-        _pool.arbTake(borrower, false, index);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _assertArbTakeDebtUnderMinPoolDebtRevert(
@@ -607,7 +607,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        _pool.arbTake(borrower, false, index);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _assertArbTakeInsufficentCollateralRevert(
@@ -617,7 +617,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        _pool.arbTake(borrower, false, index);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _assertArbTakeNoAuctionRevert(
@@ -627,7 +627,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
-        _pool.arbTake(borrower, false, index);
+        _pool.bucketTake(borrower, false, index);
     }
 
     function _assertDepositTakeAuctionInCooldownRevert(
@@ -637,7 +637,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertDepositTakeAuctionInsufficientLiquidityRevert(
@@ -647,7 +647,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientLiquidity.selector);
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertDepositTakeAuctionPriceGreaterThanBucketPriceRevert(
@@ -657,7 +657,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionPriceGtBucketPrice()'));
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertDepositTakeDebtUnderMinPoolDebtRevert(
@@ -667,7 +667,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertDepositTakeInsufficentCollateralRevert(
@@ -677,7 +677,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertDepositTakeNoAuctionRevert(
@@ -687,7 +687,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
-        _pool.arbTake(borrower, true, index);
+        _pool.bucketTake(borrower, true, index);
     }
 
     function _assertBorrowAuctionActiveRevert(

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -131,7 +131,7 @@ abstract contract DSTestPlus is Test {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit ArbTake(borrower, index, quoteTokenAmount, collateralArbed, bondChange, isReward);
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _borrow(
@@ -562,7 +562,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('TakeNotPastCooldown()'));
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _assertArbTakeAuctionInsufficientLiquidityRevert(
@@ -572,7 +572,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientLiquidity.selector);
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower,false, index);
     }
 
     function _assertArbTakeAuctionPriceGreaterThanBucketPriceRevert(
@@ -582,7 +582,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AuctionPriceGteQArbPrice.selector);
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _assertArbTakeDebtUnderMinPoolDebtRevert(
@@ -592,7 +592,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _assertArbTakeInsufficentCollateralRevert(
@@ -602,7 +602,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _assertArbTakeNoAuctionRevert(
@@ -612,7 +612,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
-        _pool.arbTake(borrower, index);
+        _pool.arbTake(borrower, false, index);
     }
 
     function _assertBorrowAuctionActiveRevert(

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -21,11 +21,6 @@ interface IPoolErrors {
     error AmountLTMinDebt();
 
     /**
-     *  @notice The auction price is greater or the same as the arbed bucket price.
-     */
-    error AuctionPriceGteQArbPrice();
-
-    /**
      *  @notice Borrower has a healthy over-collateralized position.
      */
     error BorrowerOk();

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -22,12 +22,12 @@ interface IPoolEvents {
 
     /**
      *  @notice Emitted when an actor uses quote token to arb higher-priced deposit off the book.
-     *  @param  borrower   Identifies the loan being liquidated.
-     *  @param  index      The index of the Highest Price Bucket used for this take.
-     *  @param  amount     Amount of quote token used to purchase collateral.
-     *  @param  collateral Amount of collateral purchased with quote token.
-     *  @param  bondChange Impact of this take to the liquidation bond.
-     *  @param  isReward   True if kicker was rewarded with `bondChange` amount, false if kicker was penalized.
+     *  @param  borrower    Identifies the loan being liquidated.
+     *  @param  index       The index of the Highest Price Bucket used for this take.
+     *  @param  amount      Amount of quote token used to purchase collateral.
+     *  @param  collateral  Amount of collateral purchased with quote token.
+     *  @param  bondChange  Impact of this take to the liquidation bond.
+     *  @param  isReward    True if kicker was rewarded with `bondChange` amount, false if kicker was penalized.
      *  @dev    amount / collateral implies the auction price.
      */
     event ArbTake(

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -30,7 +30,7 @@ interface IPoolEvents {
      *  @param  isReward    True if kicker was rewarded with `bondChange` amount, false if kicker was penalized.
      *  @dev    amount / collateral implies the auction price.
      */
-    event ArbTake(
+    event BucketTake(
         address indexed borrower,
         uint256 index,
         uint256 amount,

--- a/src/base/interfaces/pool/IPoolLiquidationActions.sol
+++ b/src/base/interfaces/pool/IPoolLiquidationActions.sol
@@ -8,23 +8,13 @@ pragma solidity 0.8.14;
 interface IPoolLiquidationActions {
     /**
      *  @notice Called by actors to use quote token to arb higher-priced deposit off the book.
-     *  @param  borrower Identifies the loan to liquidate.
-     *  @param  index    Index of a bucket, likely the HPB, in which collateral will be deposited.
+     *  @param  borrower    Identifies the loan to liquidate.
+     *  @param  depositTake If true then the arb will happen at an auction price equal with bucket price.
+     *  @param  index       Index of a bucket, likely the HPB, in which collateral will be deposited.
      */
     function arbTake(
         address borrower,
-        uint256 index
-    ) external;
-
-    /**
-     *  @notice Called by actors to purchase collateral using quote token already on the book.
-     *  @param  borrower Identifies the loan under liquidation.
-     *  @param  amount   Amount of bucket deposit to use to exchange for collateral.
-     *  @param  index    Index of the bucket which has amount_ quote token available.
-     */
-    function depositTake(
-        address borrower,
-        uint256 amount,
+        bool    depositTake,
         uint256 index
     ) external;
 

--- a/src/base/interfaces/pool/IPoolLiquidationActions.sol
+++ b/src/base/interfaces/pool/IPoolLiquidationActions.sol
@@ -9,10 +9,10 @@ interface IPoolLiquidationActions {
     /**
      *  @notice Called by actors to use quote token to arb higher-priced deposit off the book.
      *  @param  borrower    Identifies the loan to liquidate.
-     *  @param  depositTake If true then the arb will happen at an auction price equal with bucket price.
+     *  @param  depositTake If true then the take will happen at an auction price equal with bucket price. Auction price is used otherwise.
      *  @param  index       Index of a bucket, likely the HPB, in which collateral will be deposited.
      */
-    function arbTake(
+    function bucketTake(
         address borrower,
         bool    depositTake,
         uint256 index

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -184,63 +184,65 @@ contract ERC20Pool is IERC20Pool, Pool {
         uint256 bucketDeposit = deposits.valueAt(index_);
         if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
-        Auctions.Liquidation storage liquidation = auctions.liquidations[borrowerAddress_];
-        (
-            uint256 quoteTokenAmount,
-            uint256 t0repaidDebt,
-            uint256 collateralArbed,
-            uint256 auctionPrice,
-            uint256 bondChange,
-            bool isRewarded
-        ) = auctions.arbTake(liquidation, borrower, bucketDeposit, poolState.inflator);
+        uint256 bucketPrice = PoolUtils.indexToPrice(index_);
+        Auctions.TakeParams memory params = auctions.arbTake(
+            borrowerAddress_,
+            borrower,
+            bucketDeposit,
+            depositTake_ ? bucketPrice : 0, // if deposit take then calculate all take amounts at price bucket
+            poolState.inflator
+        );
+        
+        // cannot arb with a price lower than or equal with the auction price
+        if (params.auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
 
-        // bucket operations
-        {
-            // cannot arb with a price lower than or equal with the auction price
-            uint256 bucketPrice = PoolUtils.indexToPrice(index_);
-            if (auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
+        Buckets.Bucket storage bucket = buckets[index_];
+        uint256 bucketExchangeRate = Buckets.getExchangeRate(
+            bucket.collateral,
+            bucket.lps,
+            bucketDeposit,
+            bucketPrice
+        );
 
-            Buckets.Bucket storage bucket = buckets[index_];
-            uint256 bucketExchangeRate = Buckets.getExchangeRate(
-                bucket.collateral,
-                bucket.lps,
-                bucketDeposit,
-                bucketPrice
-            );
+        // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
+        Buckets.addLPs(
+            bucket,
+            msg.sender,
+            Maths.wrdivr(
+                Maths.wmul(params.collateralAmount, bucketPrice - params.auctionPrice),
+                bucketExchangeRate
+            )
+        );
 
-            // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
+        uint256 depositAmountToRemove = params.quoteTokenAmount;
+        // the bondholder/kicker is awarded bond change worth of LPB in the bucket
+        if (params.isRewarded) {
             Buckets.addLPs(
                 bucket,
-                msg.sender,
-                Maths.wrdivr(
-                    Maths.wmul(collateralArbed, bucketPrice - auctionPrice),
-                    bucketExchangeRate
-                )
+                params.kicker,
+                Maths.wrdivr(params.bondChange, bucketExchangeRate)
             );
-
-            uint256 depositAmountToRemove = quoteTokenAmount;
-            // the bondholder/kicker is awarded bond change worth of LPB in the bucket
-            if (isRewarded) {
-                Buckets.addLPs(
-                    bucket,
-                    liquidation.kicker,
-                    Maths.wrdivr(bondChange, bucketExchangeRate)
-                );
-                depositAmountToRemove -= bondChange;
-            }
-
-            // collateral is added to the bucket’s claimable collateral
-            bucket.collateral += collateralArbed;
-            // collateral is removed from the loan
-            borrower.collateral -= collateralArbed;
-
-            // quote tokens are removed from the bucket’s deposit
-            deposits.remove(index_, depositAmountToRemove);
+            depositAmountToRemove -= params.bondChange;
         }
 
-        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
+        // collateral is removed from the loan
+        borrower.collateral -= params.collateralAmount;
+        // collateral is added to the bucket’s claimable collateral
+        bucket.collateral += params.collateralAmount;
 
-        emit ArbTake(borrowerAddress_, index_, quoteTokenAmount, collateralArbed, bondChange, isRewarded);
+        // quote tokens are removed from the bucket’s deposit
+        deposits.remove(index_, depositAmountToRemove);
+
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
+
+        emit ArbTake(
+            borrowerAddress_,
+            index_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
     }
 
     /**
@@ -258,29 +260,33 @@ contract ERC20Pool is IERC20Pool, Pool {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
-        (
-            uint256 quoteTokenAmount,
-            uint256 t0repaidDebt,
-            uint256 collateralTaken,
-            ,
-            uint256 bondChange,
-            bool isRewarded
-        ) = auctions.take(borrowerAddress_, borrower, collateral_, poolState.inflator);
+        Auctions.TakeParams memory params = auctions.take(
+            borrowerAddress_,
+            borrower,
+            collateral_,
+            poolState.inflator
+        );
 
-        borrower.collateral  -= collateralTaken;
-        poolState.collateral -= collateralTaken;
+        borrower.collateral  -= params.collateralAmount;
+        poolState.collateral -= params.collateralAmount;
 
-        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
-        emit Take(borrowerAddress_, quoteTokenAmount, collateralTaken, bondChange, isRewarded);
+        emit Take(
+            borrowerAddress_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower
         // Execute arbitrary code at msg.sender address, allowing atomic conversion of asset
         //msg.sender.call(swapCalldata_);
 
-        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount);
-        _transferCollateral(msg.sender, collateralTaken);
+        _transferQuoteTokenFrom(msg.sender, params.quoteTokenAmount);
+        _transferCollateral(msg.sender, params.collateralAmount);
     }
 
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -189,12 +189,10 @@ contract ERC20Pool is IERC20Pool, Pool {
             borrowerAddress_,
             borrower,
             bucketDeposit,
-            depositTake_ ? bucketPrice : 0, // if deposit take then calculate all take amounts at price bucket
+            bucketPrice,
+            depositTake_,
             poolState.inflator
         );
-        
-        // cannot arb with a price lower than or equal with the auction price
-        if (params.auctionPrice >= bucketPrice) revert AuctionPriceGteQArbPrice();
 
         Buckets.Bucket storage bucket = buckets[index_];
         uint256 bucketExchangeRate = Buckets.getExchangeRate(
@@ -203,7 +201,6 @@ contract ERC20Pool is IERC20Pool, Pool {
             bucketDeposit,
             bucketPrice
         );
-
         // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
         Buckets.addLPs(
             bucket,
@@ -225,13 +222,10 @@ contract ERC20Pool is IERC20Pool, Pool {
             depositAmountToRemove -= params.bondChange;
         }
 
-        // collateral is removed from the loan
-        borrower.collateral -= params.collateralAmount;
-        // collateral is added to the bucket’s claimable collateral
-        bucket.collateral += params.collateralAmount;
+        borrower.collateral -= params.collateralAmount; // collateral is removed from the loan
+        bucket.collateral += params.collateralAmount;   // collateral is added to the bucket’s claimable collateral
 
-        // quote tokens are removed from the bucket’s deposit
-        deposits.remove(index_, depositAmountToRemove);
+        deposits.remove(index_, depositAmountToRemove); // quote tokens are removed from the bucket’s deposit
 
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -172,7 +172,7 @@ contract ERC20Pool is IERC20Pool, Pool {
     /*** Pool External Functions ***/
     /*******************************/
 
-    function arbTake(
+    function bucketTake(
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
@@ -185,7 +185,7 @@ contract ERC20Pool is IERC20Pool, Pool {
         if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
         uint256 bucketPrice = PoolUtils.indexToPrice(index_);
-        Auctions.TakeParams memory params = auctions.arbTake(
+        Auctions.TakeParams memory params = auctions.bucketTake(
             borrowerAddress_,
             borrower,
             bucketDeposit,
@@ -229,7 +229,7 @@ contract ERC20Pool is IERC20Pool, Pool {
 
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
-        emit ArbTake(
+        emit BucketTake(
             borrowerAddress_,
             index_,
             params.quoteTokenAmount,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -107,15 +107,11 @@ contract ERC721Pool is IERC721Pool, Pool {
 
     function arbTake(
         address borrowerAddress_,
+        bool    depositTake_,
         uint256 index_
     ) external override {
         // TODO: implement
         emit ArbTake(borrowerAddress_, index_, 0, 0, 0, true);
-    }
-
-    function depositTake(address borrower_, uint256 amount_, uint256 index_) external override {
-        // TODO: implement
-        emit DepositTake(borrower_, index_, amount_, 0, 0);
     }
 
     function take(

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -123,30 +123,34 @@ contract ERC721Pool is IERC721Pool, Pool {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
-        (
-            uint256 quoteTokenAmount,
-            uint256 t0repaidDebt,
-            uint256 takeCollateral,
-            uint256 auctionPrice,
-            uint256 bondChange,
-            bool isRewarded
-        ) = auctions.take(borrowerAddress_, borrower, Maths.wad(collateral_), poolState.inflator);
+        Auctions.TakeParams memory params = auctions.take(
+            borrowerAddress_,
+            borrower,
+            Maths.wad(collateral_),
+            poolState.inflator
+        );
 
         uint256 excessQuoteToken;
-        uint256 collateralTaken = (takeCollateral / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
-        if (collateralTaken !=  takeCollateral) { // collateral taken not a round number
+        uint256 collateralTaken = (params.collateralAmount / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
+        if (collateralTaken !=  params.collateralAmount) { // collateral taken not a round number
             collateralTaken += 1e18; // round up collateral to take
             // taker should send additional quote tokens to cover difference between collateral needed to be taken and rounded collateral, at auction price
             // borrower will get quote tokens for the difference between rounded collateral and collateral taken to cover debt
-            excessQuoteToken = Maths.wmul(collateralTaken - takeCollateral, auctionPrice);
+            excessQuoteToken = Maths.wmul(collateralTaken - params.collateralAmount, params.auctionPrice);
         }
 
         borrower.collateral  -= collateralTaken;
         poolState.collateral -= collateralTaken;
 
-        _payLoan(t0repaidDebt, poolState, borrowerAddress_, borrower);
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
-        emit Take(borrowerAddress_, quoteTokenAmount, takeCollateral, bondChange, isRewarded);
+        emit Take(
+            borrowerAddress_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
 
         // TODO: implement flashloan functionality
         // Flash loan full amount to liquidate to borrower
@@ -154,7 +158,7 @@ contract ERC721Pool is IERC721Pool, Pool {
         //msg.sender.call(swapCalldata_);
 
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
-        _transferQuoteTokenFrom(msg.sender, quoteTokenAmount + excessQuoteToken);
+        _transferQuoteTokenFrom(msg.sender, params.quoteTokenAmount + excessQuoteToken);
 
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, excessQuoteToken);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -105,13 +105,13 @@ contract ERC721Pool is IERC721Pool, Pool {
     /*** Pool External Functions ***/
     /*******************************/
 
-    function arbTake(
+    function bucketTake(
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
     ) external override {
         // TODO: implement
-        emit ArbTake(borrowerAddress_, index_, 0, 0, 0, true);
+        emit BucketTake(borrowerAddress_, index_, 0, 0, 0, true);
     }
 
     function take(

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -244,17 +244,17 @@ library Auctions {
     }
 
     /**
-     *  @notice Performs arb take collateral on an auction and updates bond size and kicker balance in case kicker is penalized.
+     *  @notice Performs bucket take collateral on an auction and updates bond size and kicker balance in case kicker is penalized.
      *  @notice Logic of kicker being rewarded happens outside this function as bond change will be given as LPs in the arbed bucket.
      *  @param  borrowerAddress_  Borrower address in auction.
      *  @param  borrower_         Borrower struct containing updated info of auctioned borrower.
      *  @param  bucketDeposit_    Arbed bucket deposit.
      *  @param  bucketPrice_      Bucket price.
-     *  @param  depositTake_      If true then the arb is a deposit take.
+     *  @param  depositTake_      If true then the take happens at bucket price. Auction price is used otherwise.
      *  @param  poolInflator_     The pool's inflator, used to calculate borrower debt.
      *  @return params_           Struct containing take action details.
     */
-    function arbTake(
+    function bucketTake(
         Data storage self,
         address borrowerAddress_,
         Loans.Borrower memory borrower_,

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -54,7 +54,7 @@ library Auctions {
      */
     error AuctionNotCleared();
     /**
-     *  @notice The auction price is greater or the same as the arbed bucket price.
+     *  @notice The auction price is greater than the arbed bucket price.
      */
     error AuctionPriceGtBucketPrice();
     /**

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -31,6 +31,16 @@ library Auctions {
         uint256 locked;    // kicker's balance of tokens locked in auction bonds
     }
 
+    struct TakeParams {
+        uint256 quoteTokenAmount; // The quote token amount that taker should pay for collateral taken.
+        uint256 t0repayAmount;    // The amount of debt (quote tokens) that is recovered / repayed by take t0 terms.
+        uint256 collateralAmount;  // The amount of collateral taken.
+        uint256 auctionPrice;     // The price of auction.
+        uint256 bondChange;       // The change made on the bond size (beeing reward or penalty).
+        address kicker;           // Address of auction kicker.
+        bool    isRewarded;       // True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
+    }
+
     /**
      *  @notice The action cannot be executed on an active auction.
      */
@@ -232,60 +242,62 @@ library Auctions {
     /**
      *  @notice Performs arb take collateral on an auction and updates bond size and kicker balance in case kicker is penalized.
      *  @notice Logic of kicker being rewarded happens outside this function as bond change will be given as LPs in the arbed bucket.
-     *  @param  liquidation_      The auction to be arbed.
+     *  @param  borrowerAddress_  Borrower address in auction.
      *  @param  borrower_         Borrower struct containing updated info of auctioned borrower.
+     *  @param  bucketDeposit_    Arbed bucket deposit.
+     *  @param  price_            Price to use when arbing (auction price for arb take, bucket price for deposit take).
      *  @param  poolInflator_     The pool's inflator, used to calculate borrower debt.
-     *  @return quoteTokenAmount_ The quote token amount that taker should pay for collateral taken.
-     *  @return t0repayAmount_    The amount of debt (quote tokens) that is recovered / repayed by take t0 terms.
-     *  @return collateralArbed_  The amount of collateral arbed.
-     *  @return auctionPrice_     The price of current auction.
-     *  @return bondChange_       The change made on the bond size (beeing reward or penalty).
-     *  @return isRewarded_       True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
+     *  @return params_           Struct containing take action details.
     */
     function arbTake(
         Data storage self,
-        Liquidation storage liquidation_,
+        address borrowerAddress_,
         Loans.Borrower memory borrower_,
         uint256 bucketDeposit_,
+        uint256 price_,
         uint256 poolInflator_
-    ) internal returns (
-        uint256 quoteTokenAmount_,
-        uint256 t0repayAmount_,
-        uint256 collateralArbed_,
-        uint256 auctionPrice_,
-        uint256 bondChange_,
-        bool    isRewarded_
-    ) {
-        uint256 borrowerDebt;
-        int256  bpf;
-        uint256 factor;
-        (auctionPrice_, borrowerDebt, bpf, factor, isRewarded_) = _validateTake(liquidation_, borrower_, poolInflator_);
+    ) internal returns (TakeParams memory params_) {
+        Liquidation storage liquidation = self.liquidations[borrowerAddress_];
+        _validateTake(liquidation);
+
+        params_.auctionPrice = PoolUtils.auctionPrice(
+            liquidation.kickMomp,
+            liquidation.kickTime
+        );
+        if (price_ == 0) price_ = params_.auctionPrice; // not a deposit take action, use auction price
+        params_.kicker = liquidation.kicker;
+        (
+            uint256 borrowerDebt,
+            int256  bpf,
+            uint256 factor
+        ) = _takeParameters(liquidation, borrower_, price_, poolInflator_);
+        params_.isRewarded = (bpf >= 0);
 
         // determine how much of the loan will be repaid
         if (borrowerDebt >= bucketDeposit_) {
-            t0repayAmount_    = Maths.wdiv(bucketDeposit_, poolInflator_);
-            quoteTokenAmount_ = Maths.wdiv(bucketDeposit_, factor);
+            params_.t0repayAmount    = Maths.wdiv(bucketDeposit_, poolInflator_);
+            params_.quoteTokenAmount = Maths.wdiv(bucketDeposit_, factor);
         } else {
-            t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wdiv(Maths.wmul(t0repayAmount_, poolInflator_), factor);
+            params_.t0repayAmount    = borrower_.t0debt;
+            params_.quoteTokenAmount = Maths.wdiv(Maths.wmul(params_.t0repayAmount, poolInflator_), factor);
         }
 
-        collateralArbed_ = Maths.wdiv(quoteTokenAmount_, auctionPrice_);
+        params_.collateralAmount = Maths.wdiv(params_.quoteTokenAmount, price_);
 
-        if (collateralArbed_ > borrower_.collateral) {
-            collateralArbed_  = borrower_.collateral;
-            quoteTokenAmount_ = Maths.wmul(collateralArbed_, auctionPrice_);
-            t0repayAmount_    = Maths.wdiv(Maths.wmul(factor, quoteTokenAmount_), poolInflator_);
+        if (params_.collateralAmount > borrower_.collateral) {
+            params_.collateralAmount = borrower_.collateral;
+            params_.quoteTokenAmount = Maths.wmul(params_.collateralAmount, price_);
+            params_.t0repayAmount    = Maths.wdiv(Maths.wmul(factor, params_.quoteTokenAmount), poolInflator_);
         }
 
-        if (!isRewarded_) {
+        if (!params_.isRewarded) {
             // take is above neutralPrice, Kicker is penalized
-            bondChange_ = Maths.min(liquidation_.bondSize, Maths.wmul(quoteTokenAmount_, uint256(-bpf)));
-            liquidation_.bondSize                    -= bondChange_;
-            self.kickers[liquidation_.kicker].locked -= bondChange_;
-            self.totalBondEscrowed                   -= bondChange_;
+            params_.bondChange = Maths.min(liquidation.bondSize, Maths.wmul(params_.quoteTokenAmount, uint256(-bpf)));
+            liquidation.bondSize                -= params_.bondChange;
+            self.kickers[params_.kicker].locked -= params_.bondChange;
+            self.totalBondEscrowed              -= params_.bondChange;
         } else {
-            bondChange_ = Maths.wmul(quoteTokenAmount_, uint256(bpf)); // will be rewarded as LPBs
+            params_.bondChange = Maths.wmul(params_.quoteTokenAmount, uint256(bpf)); // will be rewarded as LPBs
         }
     }
 
@@ -295,12 +307,7 @@ library Auctions {
      *  @param  borrower_         Borrower struct containing updated info of auctioned borrower.
      *  @param  maxCollateral_    The max collateral amount to be taken from auction.
      *  @param  poolInflator_     The pool's inflator, used to calculate borrower debt.
-     *  @return quoteTokenAmount_ The quote token amount that taker should pay for collateral taken.
-     *  @return t0repayAmount_    The amount of debt (quote tokens) that is recovered / repayed by take t0 terms.
-     *  @return collateralTaken_  The amount of collateral taken.
-     *  @return auctionPrice_     The price of current auction.
-     *  @return bondChange_       The change made on the bond size (beeing reward or penalty).
-     *  @return isRewarded_       True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
+     *  @return params_           Struct containing take action details.
     */
     function take(
         Data storage self,
@@ -308,43 +315,46 @@ library Auctions {
         Loans.Borrower memory borrower_,
         uint256 maxCollateral_,
         uint256 poolInflator_
-    ) internal returns (
-        uint256 quoteTokenAmount_,
-        uint256 t0repayAmount_,
-        uint256 collateralTaken_,
-        uint256 auctionPrice_,
-        uint256 bondChange_,
-        bool    isRewarded_
-    ) {
+    ) internal returns (TakeParams memory params_) {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
-        uint256 borrowerDebt;
-        int256  bpf;
-        uint256 factor;
-        (auctionPrice_, borrowerDebt, bpf, factor, isRewarded_) = _validateTake(liquidation, borrower_, poolInflator_);
+        _validateTake(liquidation);
+
+        params_.auctionPrice = PoolUtils.auctionPrice(
+            liquidation.kickMomp,
+            liquidation.kickTime
+        );
+        params_.kicker = liquidation.kicker;
+        (
+            uint256 borrowerDebt,
+            int256 bpf,
+            uint256 factor
+        ) = _takeParameters(liquidation, borrower_, params_.auctionPrice, poolInflator_);
+        params_.isRewarded = (bpf >= 0);
 
         // determine how much of the loan will be repaid
-        collateralTaken_     = Maths.min(borrower_.collateral, maxCollateral_);
-        quoteTokenAmount_    = Maths.wmul(auctionPrice_, collateralTaken_);
-        t0repayAmount_ = Maths.wdiv(Maths.wmul(quoteTokenAmount_, factor), poolInflator_);
-        if (t0repayAmount_ >= borrower_.t0debt) {
-            t0repayAmount_    = borrower_.t0debt;
-            quoteTokenAmount_ = Maths.wdiv(borrowerDebt, factor);
-            collateralTaken_  = Maths.min(Maths.wdiv(quoteTokenAmount_, auctionPrice_), collateralTaken_);
+        params_.collateralAmount = Maths.min(borrower_.collateral, maxCollateral_);
+        params_.quoteTokenAmount = Maths.wmul(params_.auctionPrice, params_.collateralAmount);
+        params_.t0repayAmount    = Maths.wdiv(Maths.wmul(params_.quoteTokenAmount, factor), poolInflator_);
+
+        if (params_.t0repayAmount >= borrower_.t0debt) {
+            params_.t0repayAmount    = borrower_.t0debt;
+            params_.quoteTokenAmount = Maths.wdiv(borrowerDebt, factor);
+            params_.collateralAmount  = Maths.min(Maths.wdiv(params_.quoteTokenAmount, params_.auctionPrice), params_.collateralAmount);
         }
 
-        if (isRewarded_) {
+        if (params_.isRewarded) {
             // take is below neutralPrice, Kicker is rewarded
-            bondChange_ = Maths.wmul(quoteTokenAmount_, uint256(bpf));
-            liquidation.bondSize                    += bondChange_;
-            self.kickers[liquidation.kicker].locked += bondChange_;
-            self.totalBondEscrowed                  += bondChange_;
+            params_.bondChange = Maths.wmul(params_.quoteTokenAmount, uint256(bpf));
+            liquidation.bondSize                += params_.bondChange;
+            self.kickers[params_.kicker].locked += params_.bondChange;
+            self.totalBondEscrowed              += params_.bondChange;
 
         } else {
             // take is above neutralPrice, Kicker is penalized
-            bondChange_ = Maths.min(liquidation.bondSize, Maths.wmul(quoteTokenAmount_, uint256(-bpf)));
-            liquidation.bondSize                    -= bondChange_;
-            self.kickers[liquidation.kicker].locked -= bondChange_;
-            self.totalBondEscrowed                  -= bondChange_;
+            params_.bondChange = Maths.min(liquidation.bondSize, Maths.wmul(params_.quoteTokenAmount, uint256(-bpf)));
+            liquidation.bondSize                -= params_.bondChange;
+            self.kickers[params_.kicker].locked -= params_.bondChange;
+            self.totalBondEscrowed              -= params_.bondChange;
         }
     }
 
@@ -398,35 +408,36 @@ library Auctions {
     }
 
     /**
-     *  @notice Utility function to validate take and calculate take's parameters.
+     *  @notice Utility function to validate take action.
+     *  @param  liquidation_  Liquidation struct holding auction details.
+     */
+    function _validateTake(
+        Liquidation storage liquidation_
+    ) internal view {
+        if (liquidation_.kickTime == 0) revert NoAuction();
+        if (block.timestamp - liquidation_.kickTime <= 1 hours) revert TakeNotPastCooldown();
+    }
+
+    /**
+     *  @notice Utility function to calculate take's parameters.
      *  @param  liquidation_  Liquidation struct holding auction details.
      *  @param  borrower_     Borrower struct holding details of the borrower being liquidated.
+     *  @param  price_        The price to be used by take.
      *  @param  poolInflator_ The pool's inflator, used to calculate borrower debt.
-     *  @return auctionPrice_ The price of current auction.
      *  @return borrowerDebt_ The debt of auctioned borrower.
      *  @return bpf_          The bond penalty factor.
      *  @return factor_       The take factor, calculated based on bond penalty factor.
-     *  @return isRewarded_   True if the kicker should be rewarded. False for penalized.
      */
-    function _validateTake(
+    function _takeParameters(
         Liquidation storage liquidation_,
         Loans.Borrower memory borrower_,
+        uint256 price_,
         uint256 poolInflator_
     ) internal view returns (
-        uint256 auctionPrice_,
         uint256 borrowerDebt_,
         int256  bpf_,
-        uint256 factor_,
-        bool    isRewarded_
+        uint256 factor_
     ) {
-        if (liquidation_.kickTime == 0) revert NoAuction();
-        if (block.timestamp - liquidation_.kickTime <= 1 hours) revert TakeNotPastCooldown();
-
-        auctionPrice_ = PoolUtils.auctionPrice(
-            liquidation_.kickMomp,
-            liquidation_.kickTime
-        );
-
         // calculate the bond payment factor
         borrowerDebt_ = Maths.wmul(borrower_.t0debt, poolInflator_);
         bpf_ = PoolUtils.bpf(
@@ -435,10 +446,9 @@ library Auctions {
             borrower_.mompFactor,
             poolInflator_,
             liquidation_.bondFactor,
-            auctionPrice_
+            price_
         );
         factor_ = uint256(1e18 - Maths.maxInt(0, bpf_));
-        isRewarded_ = (bpf_ >= 0);
     }
 
     /**********************/

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -56,7 +56,7 @@ library Auctions {
     /**
      *  @notice The auction price is greater or the same as the arbed bucket price.
      */
-    error AuctionPriceGteQArbPrice();
+    error AuctionPriceGtBucketPrice();
     /**
      *  @notice Actor is attempting to take or clear an inactive auction.
      */
@@ -270,8 +270,8 @@ library Auctions {
             liquidation.kickMomp,
             liquidation.kickTime
         );
-        // cannot arb with a price lower than or equal with the auction price
-        if (params_.auctionPrice >= bucketPrice_) revert AuctionPriceGteQArbPrice();
+        // cannot arb with a price lower than the auction price
+        if (params_.auctionPrice > bucketPrice_) revert AuctionPriceGtBucketPrice();
 
         // if deposit take then price to use when calculating take is bucket price
         uint256 price = depositTake_ ? bucketPrice_ : params_.auctionPrice;


### PR DESCRIPTION
- removed `Pool.depositTake` function, added bool to `Pool.arbTake` to indicate if it's an deposit or arb take
- moved `AuctionPriceGteQArbPrice` in `Auctions` library and compared auction price with bucket price / revert within library call
- introduced `TakeParams` struct to avoid stack too deep
- used same logic for `depositTake` as for `arbTake` just that all calculations are done at bucket price vs auction price

Unit tests
- added same as for arb
- added gas tests
- 
```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  24,011B  (97.70%)
  ERC721Pool               -  23,828B  (96.95%)
```
vs `develop`
```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  23,797B  (96.83%)
  ERC721Pool               -  23,778B  (96.75%)
```

gas
```
│ addQuoteToken                              ┆ 101846          ┆ 161507 ┆ 143570 ┆ 666181  ┆ 52003   │
│ arbTake                                    ┆ 359908          ┆ 388108 ┆ 388093 ┆ 416338  ┆ 4       │
│ borrow                                     ┆ 165115          ┆ 219190 ┆ 188443 ┆ 796007  ┆ 120002  │
│ kick                                       ┆ 163067          ┆ 237137 ┆ 232953 ┆ 1082383 ┆ 48000   │
│ moveQuoteToken                             ┆ 273273          ┆ 273273 ┆ 273273 ┆ 273273  ┆ 1       │
│ pledgeCollateral                           ┆ 61816           ┆ 62165  ┆ 62136  ┆ 536984  ┆ 112001  │
│ removeQuoteToken                           ┆ 155488          ┆ 174141 ┆ 174040 ┆ 204889  ┆ 4000    │
│ repay                                      ┆ 511378          ┆ 585702 ┆ 597327 ┆ 836906  ┆ 16001   │
│ take                                       ┆ 52954           ┆ 53912  ┆ 53641  ┆ 270764  ┆ 15998   │
```
vs `develop`

```
│ addQuoteToken                              ┆ 101839          ┆ 164213 ┆ 143689 ┆ 666174  ┆ 48001   │
│ arbTake                                    ┆ 415746          ┆ 415836 ┆ 415836 ┆ 415926  ┆ 2       │
│ borrow                                     ┆ 165086          ┆ 224094 ┆ 188414 ┆ 795978  ┆ 104002  │
│ kick                                       ┆ 163060          ┆ 237214 ┆ 232946 ┆ 1082376 ┆ 32000   │
│ moveQuoteToken                             ┆ 274814          ┆ 274814 ┆ 274814 ┆ 274814  ┆ 1       │
│ pledgeCollateral                           ┆ 61765           ┆ 62089  ┆ 62061  ┆ 536933  ┆ 96001   │
│ removeQuoteToken                           ┆ 155481          ┆ 174135 ┆ 174033 ┆ 207055  ┆ 4000    │
│ repay                                      ┆ 511349          ┆ 585673 ┆ 597298 ┆ 836877  ┆ 16001   │
│ take                                       ┆ 52648           ┆ 53635  ┆ 53364  ┆ 270486  ┆ 15998   │
```