### PR TITLE
Shift the interest rate update function left to promote rate increase in overutilized pools

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -867,7 +867,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
     }
-    
+
     function testLenderForcedExit() external {
 
         skip(25 hours);

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -867,7 +867,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
     }
-
+    
     function testLenderForcedExit() external {
 
         skip(25 hours);
@@ -1201,16 +1201,16 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             8_105.883902814389196535 * 1e18,
+                poolSize:             8_105.800538156165693723 * 1e18,
                 pledgedCollateral:    1.746878914360183483 * 1e18,
-                encumberedCollateral: 82_096_034_878.592379941350198240 * 1e18,
-                poolDebt:             8_196.162962286455648823 * 1e18,
+                encumberedCollateral: 82_095_199_864.949941479526972802 * 1e18,
+                poolDebt:             8_196.079597628232153239 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.174755075706248551 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.049005000000000000 * 1e18,
+                interestRate:         0.04009500000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
@@ -1218,7 +1218,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              8_196.162962286455648823 * 1e18,
+                borrowerDebt:              8_196.079597628232153239 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        0,
                 borrowerCollateralization: 0
@@ -1236,7 +1236,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   5,
-                healedDebt: 8_196.162962286455648823 * 1e18
+                healedDebt: 8_196.079597628232153239 * 1e18
             }
         );
 
@@ -1253,7 +1253,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.04900500000000000 * 1e18,
+                interestRate:         0.04009500000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
@@ -1263,15 +1263,15 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_52,
                 lpBalance:    7_989.987933044093783839063327613 * 1e27,
                 collateral:   0,          
-                deposit:      9.176155018749415259 * 1e18,
-                exchangeRate: 1_148_456.680491306501499054 * 1e18
+                deposit:      9.176155018749414998 * 1e18,
+                exchangeRate: 1_148_456.680491306468833172 * 1e18
             }
         );
 
         _removeLiquidity(
             {
                 from:     _lender,
-                amount:   9.176155018749415259 * 1e18,
+                amount:   9.176155018749414998 * 1e18,
                 penalty:  0,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
@@ -1315,7 +1315,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.04900500000000000 * 1e18,
+                interestRate:         0.04009500000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1201,16 +1201,16 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             8_105.800538156165693723 * 1e18,
+                poolSize:             8_105.883902814389196535 * 1e18,
                 pledgedCollateral:    1.746878914360183483 * 1e18,
-                encumberedCollateral: 82_095_199_864.949941479526972802 * 1e18,
-                poolDebt:             8_196.079597628232153239 * 1e18,
+                encumberedCollateral: 82_096_034_878.592379941350198240 * 1e18,
+                poolDebt:             8_196.162962286455648823 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.174755075706248551 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.04009500000000000 * 1e18,
+                interestRate:         0.049005000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
@@ -1218,7 +1218,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              8_196.079597628232153239 * 1e18,
+                borrowerDebt:              8_196.162962286455648823 * 1e18,
                 borrowerCollateral:        0,
                 borrowerMompFactor:        0,
                 borrowerCollateralization: 0
@@ -1236,7 +1236,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:       _lender,
                 borrower:   _borrower2,
                 maxDepth:   5,
-                healedDebt: 8_196.079597628232153239 * 1e18
+                healedDebt: 8_196.162962286455648823 * 1e18
             }
         );
 
@@ -1253,7 +1253,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.04009500000000000 * 1e18,
+                interestRate:         0.04900500000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
@@ -1263,15 +1263,15 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_52,
                 lpBalance:    7_989.987933044093783839063327613 * 1e27,
                 collateral:   0,          
-                deposit:      9.176155018749414998 * 1e18,
-                exchangeRate: 1_148_456.680491306468833172 * 1e18
+                deposit:      9.176155018749415259 * 1e18,
+                exchangeRate: 1_148_456.680491306501499054 * 1e18
             }
         );
 
         _removeLiquidity(
             {
                 from:     _lender,
-                amount:   9.176155018749414998 * 1e18,
+                amount:   9.176155018749415259 * 1e18,
                 penalty:  0,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
@@ -1315,7 +1315,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.04009500000000000 * 1e18,
+                interestRate:         0.04900500000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -730,15 +730,6 @@ abstract contract Pool is Clone, Multicall, IPool {
                     newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
                 }
 
-                // int256 decreaseFactor = 4 * (tu - mau);
-                // int256 increaseFactor = ((tu + mau - 10**18) ** 2) / 10**18;
-                // uint256 newInterestRate = poolState_.rate;
-                // if (decreaseFactor < increaseFactor - 10**18) {
-                //     newInterestRate = Maths.wmul(poolState_.rate, INCREASE_COEFFICIENT);
-                // } else if (decreaseFactor > 10**18 - increaseFactor) {
-                //     newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
-                // }
-
                 if (poolState_.rate != newInterestRate) {
                     interestRate       = newInterestRate;
                     interestRateUpdate = block.timestamp;

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -25,6 +25,7 @@ abstract contract Pool is Clone, Multicall, IPool {
 
     uint256 internal constant LAMBDA_EMA_7D      = 0.905723664263906671 * 1e18; // Lambda used for interest EMAs calculated as exp(-1/7   * ln2)
     uint256 internal constant EMA_7D_RATE_FACTOR = 1e18 - LAMBDA_EMA_7D;
+    int256 internal constant PERCENT_102         = 1.02 * 10**18;
 
     /***********************/
     /*** State Variables ***/
@@ -708,31 +709,35 @@ abstract contract Pool is Clone, Multicall, IPool {
             debtEma   = curDebtEma;
             lupColEma = curLupColEma;
 
-            if (poolState_.accruedDebt != 0) {
-                int256 actualUtilization = int256(
+            if (poolState_.accruedDebt != 0) {                
+                int256 mau = int256(                                       // meaningful actual utilization                   
                     deposits.utilization(
                         poolState_.accruedDebt,
                         poolState_.collateral
                     )
                 );
-                // raise rates if mau > 99% or 4*(targetUtilization-mau) < (targetUtilization+mau-1)^2-1
-                // decrease rates if 4*(targetUtilization-mau) > -(targetUtilization+mau-1)^2+1
+                int256 tu = int256(Maths.wdiv(curDebtEma, curLupColEma));  // target utilization
+
+                if (!poolState_.isNewInterestAccrued) poolState_.rate = interestRate;
+                // raise rates if 4*(tu-1.02*mau) < (tu+1.02*mau-1)^2-1
+                // decrease rates if 4*(tu-mau) > 1-(tu+mau-1)^2
+                int256 mau102 = mau * PERCENT_102 / 10**18;
+
                 uint256 newInterestRate = poolState_.rate;
-                if (actualUtilization > 0.99 * 10**18) {
+                if (4 * (tu - mau102) < ((tu + mau102 - 10**18) ** 2) / 10**18 - 10**18) {
                     newInterestRate = Maths.wmul(poolState_.rate, INCREASE_COEFFICIENT);
-                } else {                
-                    int256 targetUtilization = int256(Maths.wdiv(curDebtEma, curLupColEma));
-                    int256 decreaseFactor = 4 * (targetUtilization - actualUtilization);
-                    int256 increaseFactor = ((targetUtilization + actualUtilization - 10**18) ** 2) / 10**18;
-
-                    if (!poolState_.isNewInterestAccrued) poolState_.rate = interestRate;
-
-                    if (decreaseFactor < increaseFactor - 10**18) {
-                        newInterestRate = Maths.wmul(poolState_.rate, INCREASE_COEFFICIENT);
-                    } else if (decreaseFactor > 10**18 - increaseFactor) {
-                        newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
-                    }
+                } else if (4 * (tu - mau) > 10**18 - ((tu + mau - 10**18) ** 2) / 10**18) {
+                    newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
                 }
+
+                // int256 decreaseFactor = 4 * (tu - mau);
+                // int256 increaseFactor = ((tu + mau - 10**18) ** 2) / 10**18;
+                // uint256 newInterestRate = poolState_.rate;
+                // if (decreaseFactor < increaseFactor - 10**18) {
+                //     newInterestRate = Maths.wmul(poolState_.rate, INCREASE_COEFFICIENT);
+                // } else if (decreaseFactor > 10**18 - increaseFactor) {
+                //     newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
+                // }
 
                 if (poolState_.rate != newInterestRate) {
                     interestRate       = newInterestRate;


### PR DESCRIPTION
Changes to formulas used to update interest rates every 12 hours were incorporated into the spec today.  These changes favor interest rate increases in overutilized pools.

**Performance**
Contract size is about the same as Friday's implementation.  Gas is a bit worse.
```
============ develop Bytecode Sizes ============
  ERC20Pool                -  23,897B  (97.23%)
  ERC721Pool               -  23,878B  (97.16%)
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ addQuoteToken                              ┆ 17190           ┆ 220211 ┆ 171520 ┆ 637712 ┆ 235     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 640             ┆ 207205 ┆ 202604 ┆ 403635 ┆ 113     │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```

```
======== interest-shift Bytecode Sizes =========
  ERC20Pool          -  23,994B  (97.63%)
  ERC721Pool         -  23,975B  (97.55%)
╭────────────────────────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ src/erc20/ERC20Pool.sol:ERC20Pool contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ addQuoteToken                              ┆ 17190           ┆ 221848 ┆ 171520 ┆ 637712 ┆ 237     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ borrow                                     ┆ 640             ┆ 207423 ┆ 202604 ┆ 405465 ┆ 114     │
╰────────────────────────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```