### PR TITLE
Remove zero amount transfer call in kick

### DIFF
--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -167,11 +167,12 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -167,11 +167,12 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsHeal.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsHeal.t.sol
@@ -170,11 +170,12 @@ contract ERC20PoolLiquidationsHealTest is ERC20HelperContract {
         skip(100 days);
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       9_976.561670003961916237 * 1e18,
-                collateral: 1_000 * 1e18,
-                bond:       98.533942419792216457 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           9_976.561670003961916237 * 1e18,
+                collateral:     1_000 * 1e18,
+                bond:           98.533942419792216457 * 1e18,
+                transferAmount: 98.533942419792216457 * 1e18
             }
         );
         _assertAuction(
@@ -397,11 +398,12 @@ contract ERC20PoolLiquidationsHealTest is ERC20HelperContract {
         skip(100 days);
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       9_976.561670003961916237 * 1e18,
-                collateral: 1_000 * 1e18,
-                bond:       98.533942419792216457 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           9_976.561670003961916237 * 1e18,
+                collateral:     1_000 * 1e18,
+                bond:           98.533942419792216457 * 1e18,
+                transferAmount: 98.533942419792216457 * 1e18
             }
         );
         _assertAuction(
@@ -560,11 +562,12 @@ contract ERC20PoolLiquidationsHealTest is ERC20HelperContract {
         uint256 kickTime = _startTime + 100 days;
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       9_976.561670003961916237 * 1e18,
-                collateral: 1_000 * 1e18,
-                bond:       98.533942419792216457 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           9_976.561670003961916237 * 1e18,
+                collateral:     1_000 * 1e18,
+                bond:           98.533942419792216457 * 1e18,
+                transferAmount: 98.533942419792216457 * 1e18
             }
         );
         _assertAuction(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -174,11 +174,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 
@@ -290,11 +291,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
         _assertAuction(
@@ -324,8 +326,8 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             {
                 from:      _borrower,
                 borrower:  _borrower,
-                amount:    15 * 1e18,
-                repaid:    15 * 1e18,
+                amount:    2 * 1e18,
+                repaid:    2 * 1e18,
                 newLup:    9.721295865031779605 * 1e18
             }
         );
@@ -340,7 +342,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          0,
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
-                debtInAuction:     4.778456451861613480 * 1e18
+                debtInAuction:     17.778456451861613479 * 1e18
             })
         );
         _assertKicker(
@@ -349,6 +351,46 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 claimable: 0.195342779771472726 * 1e18,
                 locked:    0
             }
+        );
+
+        // Skip to make borrower undercollateralized again
+        skip(750 days);
+
+        // Kick method only emit Kick event and doesn't call transfer method when kicker has enough bond amount in claimable
+        _kick(
+            {
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.720138163278334392 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195007546732047806 * 1e18,
+                transferAmount: 0
+            }
+        );
+
+        _repay(
+            {
+                from:      _borrower,
+                borrower:  _borrower,
+                amount:    10 * 1e18,
+                repaid:    10 * 1e18,
+                newLup:    9.721295865031779605 * 1e18
+            }
+        );
+
+        _assertAuction(
+            AuctionState({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     29.220892836483115000 * 1e18
+            })
         );
 
         // kicker withdraws his auction bonds
@@ -387,11 +429,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _kick(
             {
-                from:        _lender,
-                borrower:    _borrower,
-                debt:        19.778456451861613480 * 1e18,
-                collateral:  2 * 1e18,
-                bond:        0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
         _assertAuction(
@@ -481,11 +524,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _kick(
             {
-                from:        _lender,
-                borrower:    _borrower,
-                debt:        19.778456451861613480 * 1e18,
-                collateral:  2 * 1e18,
-                bond:        0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
         _assertAuction(
@@ -563,11 +607,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         // kick first loan
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       9_976.561670003961916237 * 1e18,
-                collateral: 1_000 * 1e18,
-                bond:       98.533942419792216457 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           9_976.561670003961916237 * 1e18,
+                collateral:     1_000 * 1e18,
+                bond:           98.533942419792216457 * 1e18,
+                transferAmount: 98.533942419792216457 * 1e18
             }
         );
         _assertLoans(
@@ -581,11 +626,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         // kick 2nd loan
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.534277977147272573 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.534277977147272573 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
         _assertLoans(

--- a/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -168,11 +168,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 
@@ -207,11 +208,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 
@@ -364,11 +366,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       9_976.561670003961916237 * 1e18,
-                collateral: 1_000 * 1e18,
-                bond:       98.533942419792216457 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           9_976.561670003961916237 * 1e18,
+                collateral:     1_000 * 1e18,
+                bond:           98.533942419792216457 * 1e18,
+                transferAmount: 98.533942419792216457 * 1e18
             }
         );
         _assertAuction(
@@ -821,11 +824,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.778456451861613480 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.195342779771472726 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.778456451861613480 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.195342779771472726 * 1e18,
+                transferAmount: 0.195342779771472726 * 1e18
             }
         );
 
@@ -928,11 +932,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       19.489662805046791054 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.192728433177224139 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           19.489662805046791054 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.192728433177224139 * 1e18,
+                transferAmount: 0.192728433177224139 * 1e18
             }
         );
 
@@ -1167,11 +1172,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower2,
-                debt:       8_195.704467159075241912 * 1e18,
-                collateral: 1_000.0 * 1e18,
-                bond:       81.054302378846351183 * 1e18
+                from:           _lender,
+                borrower:       _borrower2,
+                debt:           8_195.704467159075241912 * 1e18,
+                collateral:     1_000.0 * 1e18,
+                bond:           81.054302378846351183 * 1e18,
+                transferAmount: 81.054302378846351183 * 1e18
             }
         );
 

--- a/src/_test/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -182,11 +182,12 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       23.012828827714740289 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.227287198298417188 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           23.012828827714740289 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.227287198298417188 * 1e18,
+                transferAmount: 0.227287198298417188 * 1e18
             }
         );
 

--- a/src/_test/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -182,11 +182,12 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _kick(
             {
-                from:       _lender,
-                borrower:   _borrower,
-                debt:       23.012828827714740289 * 1e18,
-                collateral: 2 * 1e18,
-                bond:       0.227287198298417188 * 1e18
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           23.012828827714740289 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.227287198298417188 * 1e18,
+                transferAmount: 0.227287198298417188 * 1e18
             }
         );
 

--- a/src/_test/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/src/_test/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -440,7 +440,8 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 borrower:       _borrower,
                 debt:           23.012828827714740289 * 1e18,
                 collateral:     2 * 1e18,
-                bond:           0.227287198298417188 * 1e18
+                bond:           0.227287198298417188 * 1e18,
+                transferAmount: 0.227287198298417188 * 1e18
             }
         );
 

--- a/src/_test/utils/DSTestPlus.sol
+++ b/src/_test/utils/DSTestPlus.sol
@@ -30,7 +30,7 @@ abstract contract DSTestPlus is Test {
     event ArbTake(address indexed borrower, uint256 index, uint256 amount, uint256 collateral, uint256 bondChange, bool isReward);
     event Borrow(address indexed borrower_, uint256 lup_, uint256 amount_);
     event Heal(address indexed borrower, uint256 healedDebt);
-    event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_);
+    event Kick(address indexed borrower_, uint256 debt_, uint256 collateral_, uint256 bond_);
     event MoveQuoteToken(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_, uint256 lup_);
     event MoveCollateral(address indexed lender_, uint256 indexed from_, uint256 indexed to_, uint256 amount_);
     event PullCollateral(address indexed borrower_, uint256 amount_);
@@ -167,12 +167,13 @@ abstract contract DSTestPlus is Test {
         address borrower,
         uint256 debt,
         uint256 collateral,
-        uint256 bond
+        uint256 bond,
+        uint256 transferAmount
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit Kick(borrower, debt, collateral);
-        _assertTokenTransferEvent(from, address(_pool), bond);
+        emit Kick(borrower, debt, collateral, bond);
+        if(transferAmount != 0) _assertTokenTransferEvent(from, address(_pool), transferAmount);
         _pool.kick(borrower);
     }
 

--- a/src/_test/utils/QueueInstance.sol
+++ b/src/_test/utils/QueueInstance.sol
@@ -11,7 +11,7 @@ contract QueueInstance is DSTestPlus {
 
     Auctions.Data private auctions;
 
-    function kick(address borrower_) external returns (uint256) {
+    function kick(address borrower_) external returns (uint256, uint256) {
         return auctions.kick(
             borrower_,
             1,

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -397,7 +397,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         loans._remove(borrowerAddress_);
  
         // kick auction
-        uint256 kickAuctionAmount = auctions.kick(
+        (uint256 kickAuctionAmount, uint256 bondSize) = auctions.kick(
             borrowerAddress_,
             borrowerDebt,
             borrowerDebt * Maths.WAD / borrower.collateral,
@@ -417,8 +417,8 @@ abstract contract Pool is Clone, Multicall, IPool {
         // update pool state
         _updatePool(poolState, lup);
 
-        emit Kick(borrowerAddress_, borrowerDebt, borrower.collateral);
-        _transferQuoteTokenFrom(msg.sender, kickAuctionAmount);
+        emit Kick(borrowerAddress_, borrowerDebt, borrower.collateral, bondSize);
+        if(kickAuctionAmount != 0) _transferQuoteTokenFrom(msg.sender, kickAuctionAmount);
     }
 
 

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -84,11 +84,13 @@ interface IPoolEvents {
      *  @param  borrower   Identifies the loan being liquidated.
      *  @param  debt       Debt the liquidation will attempt to cover.
      *  @param  collateral Amount of collateral up for liquidation.
+     *  @param  bond       Bond amount locked by kicker
      */
     event Kick(
         address indexed borrower,
         uint256 debt,
-        uint256 collateral
+        uint256 collateral,
+        uint256 bond
     );
 
     /**

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -172,6 +172,7 @@ library Auctions {
      *  @param  thresholdPrice_    Current threshold price (used to calculate bond factor).
      *  @param  momp_              Current MOMP (used to calculate bond factor).
      *  @return kickAuctionAmount_ The amount that kicker should send to pool in order to kick auction.
+     *  @return bondSize_          The amount that kicker locks in pool to kick auction.
      */
     function kick(
         Data storage self,


### PR DESCRIPTION
1. No transfer of bond amount if it is deducted from claimable kicker tokens.
2. Update test cases.
3. Add bond in Kick event.