### PR TITLE
Simplify way to calculate collateralization

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -680,14 +680,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 collateral_,
         uint256 price_
     ) internal virtual returns (bool) {
-        if (debt_  == 0) return true;       // if debt is 0 then is collateralized
-        if (price_ == 0) return true;       // if price to calculate collateralized is 0 then is collateralized
-
-        uint256 encumbered = Maths.wdiv(debt_, price_); // calculated to avoid situation where debt dust amount
-        if (encumbered  == 0) return true;  // if encumbered is 0 then is collateralized
-        if (collateral_ == 0) return false; // if encumbered is not 0 and collateral is 0 then is not collateralized
-
-        return Maths.wdiv(collateral_, encumbered) >= Maths.WAD; // is collateralized when collateral divided by encumbered >= 1
+        return Maths.wmul(collateral_, price_) >= debt_;
     }
 
     function _updatePool(PoolState memory poolState_, uint256 lup_) internal {

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -184,16 +184,9 @@ contract ERC721Pool is IERC721Pool, Pool {
         uint256 collateral_,
         uint256 price_
     ) internal pure override returns (bool) {
-        if (debt_  == 0) return true;       // if debt is 0 then is collateralized
-        if (price_ == 0) return true;       // if price to calculate collateralized is 0 then is collateralized
-
-        uint256 encumbered = Maths.wdiv(debt_, price_); // calculated to avoid situation where debt dust amount
-        if (encumbered   == 0) return true;  // if encumbered is 0 then is collateralized
-        if (collateral_ == 0) return false; // if encumbered is not 0 and collateral is 0 then is not collateralized
-
         //slither-disable-next-line divide-before-multiply
-        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD;    // use collateral floor
-        return Maths.wdiv(collateral_, encumbered) >= Maths.WAD; // is collateralized when collateral divided by encumbered >= 1
+        collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
+        return Maths.wmul(collateral_, price_) >= debt_;
     }
 
     /**


### PR DESCRIPTION
Use simplified way proposed by @mattcushman  to calculate collateralization (shows nice improvements in both gas and contract size)

```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  23,706B  (96.46%)
  ERC721Pool               -  23,687B  (96.38%)
```
vs `develop`
```
============ Deployment Bytecode Sizes ============
  ERC20Pool                -  23,797B  (96.83%)
  ERC721Pool               -  23,778B  (96.75%)
``` 
 
gas
```
│ addQuoteToken                              ┆ 101839          ┆ 164213 ┆ 143689 ┆ 666174  ┆ 48001   │
│ arbTake                                    ┆ 415576          ┆ 415666 ┆ 415666 ┆ 415756  ┆ 2       │
│ borrow                                     ┆ 164102          ┆ 223110 ┆ 187430 ┆ 794994  ┆ 104002  │
│ kick                                       ┆ 162568          ┆ 236722 ┆ 232454 ┆ 1081884 ┆ 32000   │
│ moveQuoteToken                             ┆ 284206          ┆ 284206 ┆ 284206 ┆ 284206  ┆ 1       │
│ pledgeCollateral                           ┆ 62007           ┆ 62331  ┆ 62303  ┆ 537175  ┆ 96001   │
│ removeQuoteToken                           ┆ 155481          ┆ 174135 ┆ 174033 ┆ 206659  ┆ 4000    │
│ repay                                      ┆ 511591          ┆ 585548 ┆ 596806 ┆ 836385  ┆ 16001   │
│ take                                       ┆ 52478           ┆ 53829  ┆ 53558  ┆ 270680  ┆ 15998   │
```
vs `develop`

```
│ addQuoteToken                              ┆ 101839          ┆ 164213 ┆ 143689 ┆ 666174  ┆ 48001   │
│ arbTake                                    ┆ 415746          ┆ 415836 ┆ 415836 ┆ 415926  ┆ 2       │
│ borrow                                     ┆ 165086          ┆ 224094 ┆ 188414 ┆ 795978  ┆ 104002  │
│ kick                                       ┆ 163060          ┆ 237214 ┆ 232946 ┆ 1082376 ┆ 32000   │
│ moveQuoteToken                             ┆ 284206          ┆ 284206 ┆ 284206 ┆ 284206  ┆ 1       │
│ pledgeCollateral                           ┆ 61765           ┆ 62089  ┆ 62061  ┆ 536933  ┆ 96001   │
│ removeQuoteToken                           ┆ 155481          ┆ 174135 ┆ 174033 ┆ 206659  ┆ 4000    │
│ repay                                      ┆ 511349          ┆ 585673 ┆ 597298 ┆ 836877  ┆ 16001   │
│ take                                       ┆ 52648           ┆ 53635  ┆ 53364  ┆ 270486  ┆ 15998   │
```