### PR TITLE
Externalize auctions lib

### DIFF
--- a/scripts/ajna_setup.py
+++ b/scripts/ajna_setup.py
@@ -7,6 +7,7 @@ def main():
     # deploy Ajna pool factories and dump them in json config file
     Deposits.deploy({"from": accounts[0]})
     BucketMath.deploy({"from": accounts[0]})
+    Auctions.deploy({"from": accounts[0]})
     erc20_pool_factory = ERC20PoolFactory.deploy({"from": accounts[0]})
     erc721_pool_factory = ERC721PoolFactory.deploy({"from": accounts[0]})
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -354,19 +354,90 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** Liquidation Functions ***/
     /*****************************/
 
+    function bucketTake(
+        address borrowerAddress_,
+        bool    depositTake_,
+        uint256 index_
+    ) external override {
+        Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
+        if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
+
+        PoolState memory poolState = _accruePoolInterest();
+        uint256 bucketDeposit = deposits.valueAt(index_);
+        if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
+
+        uint256 bucketPrice = PoolUtils.indexToPrice(index_);
+        Auctions.TakeParams memory params = Auctions.bucketTake(
+            auctions,
+            borrowerAddress_,
+            borrower,
+            bucketDeposit,
+            bucketPrice,
+            depositTake_,
+            poolState.inflator
+        );
+
+        Buckets.Bucket storage bucket = buckets[index_];
+        uint256 bucketExchangeRate = Buckets.getExchangeRate(
+            bucket.collateral,
+            bucket.lps,
+            bucketDeposit,
+            bucketPrice
+        );
+        // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
+        Buckets.addLPs(
+            bucket,
+            msg.sender,
+            Maths.wrdivr(
+                Maths.wmul(params.collateralAmount, bucketPrice - params.auctionPrice),
+                bucketExchangeRate
+            )
+        );
+
+        uint256 depositAmountToRemove = params.quoteTokenAmount;
+        // the bondholder/kicker is awarded bond change worth of LPB in the bucket
+        if (params.isRewarded) {
+            Buckets.addLPs(
+                bucket,
+                params.kicker,
+                Maths.wrdivr(params.bondChange, bucketExchangeRate)
+            );
+            depositAmountToRemove -= params.bondChange;
+        }
+
+        borrower.collateral  -= params.collateralAmount; // collateral is removed from the loan
+        poolState.collateral -= params.collateralAmount; // collateral is removed from pledged collateral accumulator
+        bucket.collateral    += params.collateralAmount; // collateral is added to the bucket’s claimable collateral
+
+        deposits.remove(index_, depositAmountToRemove); // quote tokens are removed from the bucket’s deposit
+
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
+
+        emit BucketTake(
+            borrowerAddress_,
+            index_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
+    }
+
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
     ) external override {
         PoolState memory poolState = _accruePoolInterest();
+        uint256 reserves = Maths.wmul(t0poolDebt, poolState.inflator) + _getPoolQuoteTokenBalance() - deposits.treeSum() - auctions.totalBondEscrowed - reserveAuctionUnclaimed;
         Loans.Borrower storage borrower = loans.borrowers[borrowerAddress_];
-        (uint256 remainingCollateral, uint256 remainingt0Debt) = auctions.settle(
+        (uint256 remainingCollateral, uint256 remainingt0Debt) = Auctions.settle(
+            auctions,
             buckets,
             deposits,
             borrower.collateral,
             borrower.t0debt,
             borrowerAddress_,
-            Maths.wmul(t0poolDebt, poolState.inflator) + _getPoolQuoteTokenBalance() - deposits.treeSum() - auctions.totalBondEscrowed - reserveAuctionUnclaimed, // reserves
+            reserves,
             poolState.inflator,
             maxDepth_
         );
@@ -408,7 +479,8 @@ abstract contract Pool is Clone, Multicall, IPool {
         loans.remove(borrowerAddress_);
  
         // kick auction
-        (uint256 kickAuctionAmount, uint256 bondSize) = auctions.kick(
+        (uint256 kickAuctionAmount, uint256 bondSize) = Auctions.kick(
+            auctions,
             borrowerAddress_,
             borrowerDebt,
             borrowerDebt * Maths.WAD / borrower.collateral,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -105,15 +105,6 @@ contract ERC721Pool is IERC721Pool, Pool {
     /*** Pool External Functions ***/
     /*******************************/
 
-    function bucketTake(
-        address borrowerAddress_,
-        bool    depositTake_,
-        uint256 index_
-    ) external override {
-        // TODO: implement
-        emit BucketTake(borrowerAddress_, index_, 0, 0, 0, true);
-    }
-
     function take(
         address borrowerAddress_,
         uint256 collateral_,
@@ -123,7 +114,8 @@ contract ERC721Pool is IERC721Pool, Pool {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
 
-        Auctions.TakeParams memory params = auctions.take(
+        Auctions.TakeParams memory params = Auctions.take(
+            auctions,
             borrowerAddress_,
             borrower,
             Maths.wad(collateral_),

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -92,7 +92,7 @@ library Auctions {
         uint256 reserves_,
         uint256 poolInflator_,
         uint256 bucketDepth_
-    ) internal returns (uint256, uint256) {
+    ) external returns (uint256, uint256) {
         uint256 kickTime = self.liquidations[borrower_].kickTime;
         if (kickTime == 0) revert NoAuction();
 
@@ -175,7 +175,7 @@ library Auctions {
         Data storage self,
         address borrower_,
         bool    isCollateralized_
-    ) internal {
+    ) external {
 
         if (isCollateralized_ && self.liquidations[borrower_].kickTime != 0) {
             removeAuction(self, borrower_);
@@ -197,7 +197,7 @@ library Auctions {
         uint256 borrowerDebt_,
         uint256 thresholdPrice_,
         uint256 momp_
-    ) internal returns (uint256 kickAuctionAmount_, uint256 bondSize_) {
+    ) external returns (uint256 kickAuctionAmount_, uint256 bondSize_) {
 
         uint256 bondFactor;
         // bondFactor = min(30%, max(1%, (neutralPrice - thresholdPrice) / neutralPrice))
@@ -266,7 +266,7 @@ library Auctions {
         uint256 bucketPrice_,
         bool    depositTake_,
         uint256 poolInflator_
-    ) internal returns (TakeParams memory params_) {
+    ) external returns (TakeParams memory params_) {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
         _validateTake(liquidation);
 
@@ -329,7 +329,7 @@ library Auctions {
         Loans.Borrower memory borrower_,
         uint256 maxCollateral_,
         uint256 poolInflator_
-    ) internal returns (TakeParams memory params_) {
+    ) external returns (TakeParams memory params_) {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
         _validateTake(liquidation);
 

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -8,7 +8,7 @@ import 'src/erc20/ERC20Pool.sol';
 import 'src/erc20/ERC20PoolFactory.sol';
 
 contract ERC20PoolFactoryTest is ERC20HelperContract {
-    address immutable poolAddress = 0xFEF2B43759152290FD53215EF2E904B0087Ef520;
+    address immutable poolAddress = 0x918ebA623C6291984Eeea4EE07335c3DDa03c0d3;
 
     ERC20PoolFactory internal _poolFactory;
 


### PR DESCRIPTION
- made settle, checkAndRemove, kick, take and bucketTake functions external (for further size savings we can change them to public but external is good for now and better on gas)
- move bucketTake in base class to reserve contract size for its implementation
- add Auctions library in sdk startup script

```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  23,116B  (94.06%)
  ERC20Pool          -  22,389B  (91.10%)
```