### PR TITLE
Packed structs

### DIFF
--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -18,11 +18,11 @@ library Auctions {
 
     struct Liquidation {
         address kicker;      // address that initiated liquidation
+        uint96  bondFactor;  // bond factor used to start liquidation
         uint256 bondSize;    // liquidation bond size
-        uint256 bondFactor;  // bond factor used to start liquidation
-        uint256 kickTime;    // timestamp when liquidation was started
-        uint256 kickMomp;    // Momp when liquidation was started
+        uint96  kickTime;     // timestamp when liquidation was started
         address prev;        // previous liquidated borrower in auctions queue
+        uint96  kickMomp;    // Momp when liquidation was started
         address next;        // next liquidated borrower in auctions queue
     }
 
@@ -228,10 +228,10 @@ library Auctions {
         // record liquidation info
         Liquidation storage liquidation = self.liquidations[borrower_];
         liquidation.kicker     = msg.sender;
-        liquidation.kickTime   = block.timestamp;
-        liquidation.kickMomp   = momp_;
+        liquidation.kickTime   = uint96(block.timestamp);
+        liquidation.kickMomp   = uint96(momp_);
         liquidation.bondSize   = bondSize_;
-        liquidation.bondFactor = bondFactor;
+        liquidation.bondFactor = uint96(bondFactor);
 
         if (self.head != address(0)) {
             // other auctions in queue, liquidation doesn't exist or overwriting.

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -18,7 +18,7 @@ library Loans {
 
     struct Loan {
         address borrower;       // borrower address
-        uint256 thresholdPrice; // [WAD] Loan's threshold price.
+        uint96  thresholdPrice; // [WAD] Loan's threshold price.
     }
 
     struct Borrower {
@@ -76,7 +76,7 @@ library Loans {
             _upsert(
                 self,
                 borrowerAddress_,
-                Maths.wdiv(borrower_.t0debt, borrower_.collateral)
+                uint96(Maths.wdiv(borrower_.t0debt, borrower_.collateral))
             );
         } else if (self.indices[borrowerAddress_] != 0) {
             remove(self, borrowerAddress_);
@@ -184,7 +184,7 @@ library Loans {
     function _upsert(
         Data storage self,
         address borrower_,
-        uint256 thresholdPrice_
+        uint96 thresholdPrice_
     ) internal {
         if (thresholdPrice_ == 0) revert ZeroThresholdPrice();
         uint256 i = self.indices[borrower_];

--- a/tests/forge/utils/HeapInstance.sol
+++ b/tests/forge/utils/HeapInstance.sol
@@ -33,7 +33,7 @@ contract HeapInstance is DSTestPlus {
     }
 
     function upsertTp(address borrower_, uint256 tp_) public {
-        _heap._upsert(borrower_, tp_);
+        _heap._upsert(borrower_, uint96(tp_));
     }
 
     function removeTp(address borrower_) external {


### PR DESCRIPTION
```============ Deployment Bytecode Sizes ============
  ERC721Pool               -  23,558B  (95.85%)
  ERC20Pool                -  22,488B  (91.50%)
```
vs develop
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  23,502B  (95.63%)
  ERC20Pool                -  22,433B  (91.28%)
```

gas
```
| Function Name                              | min             | avg    | median | max     | # calls |
| addQuoteToken                              | 101881          | 161990 | 144490 | 684901  | 56003   |
| borrow                                     | 142451          | 192913 | 162927 | 749348  | 128002  |
| bucketTake                                 | 367415          | 398800 | 398820 | 430147  | 4       |
| kick                                       | 102928          | 170457 | 169169 | 1024305 | 48000   |
| moveQuoteToken                             | 285631          | 285631 | 285631 | 285631  | 1       |
| pledgeCollateral                           | 62108           | 62453  | 62428  | 554692  | 120001  |
| removeQuoteToken                           | 160410          | 179552 | 179454 | 214112  | 4000    |
| repay                                      | 528564          | 591623 | 612047 | 770616  | 16002   |
| take
```
vs develop

```
| Function Name                              | min             | avg    | median | max     | # calls |
| addQuoteToken                              | 101881          | 162066 | 144490 | 686968  | 56003   |
| borrow                                     | 164731          | 217854 | 188045 | 813106  | 128002  |
| bucketTake                                 | 367400          | 398694 | 398714 | 429950  | 4       |
| kick                                       | 164019          | 238383 | 234201 | 1117606 | 48000   |
| moveQuoteToken                             | 285765          | 285765 | 285765 | 285765  | 1       |
| pledgeCollateral                           | 62049           | 62394  | 62369  | 554700  | 120001  |
| removeQuoteToken                           | 160529          | 179671 | 179573 | 214231  | 4000    |
| repay                                      | 528800          | 602901 | 614303 | 853882  | 16002   |
| take                                       | 55271           | 56530  | 56256  | 296283  | 15998   |