### PR TITLE
NFT auction settlement 

### DIFF
--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -37,11 +37,7 @@ abstract contract FlashloanablePool is Pool {
 
     function maxFlashLoan(
         address token_
-    ) external view override returns (uint256) {
-        if (token_ == _getArgAddress(20)) {
-            return _getPoolQuoteTokenBalance();
-        } else {
-            return 0;
-        }
+    ) external view override returns (uint256 maxLoan_) {
+        if (token_ == _getArgAddress(20)) maxLoan_ = _getPoolQuoteTokenBalance();
     }
 }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.14;
 
 import '@clones/Clone.sol';
+import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/utils/Multicall.sol';
 
 import './interfaces/IPool.sol';
@@ -14,7 +15,7 @@ import '../libraries/Loans.sol';
 import '../libraries/Maths.sol';
 import '../libraries/PoolUtils.sol';
 
-abstract contract Pool is Clone, Multicall, IPool {
+abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     using Auctions for Auctions.Data;
     using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
@@ -361,7 +362,7 @@ abstract contract Pool is Clone, Multicall, IPool {
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
-    ) external override {
+    ) external override nonReentrant {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -365,7 +365,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
-    ) external override nonReentrant {
+    ) external override {
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
         if (borrower.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -703,7 +703,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /******************************/
 
     /**
-     *  @notice Default collateralization calculation (to be overridden in pool implementations).
+     *  @notice Collateralization calculation (implemented by each pool accordingly).
      *  @param debt_       Debt to calculate collateralization for.
      *  @param collateral_ Collateral to calculate collateralization for.
      *  @param price_      Price to calculate collateralization for.
@@ -715,11 +715,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 price_
     ) internal virtual returns (bool);
 
-   /**
-     *  @notice Settle an auction when it exits the auction queue (to be overridden in pool implementations).
-     *  @param borrowerAddress_    Address of the borrower that exits auction.
-     *  @param borrowerCollateral_ Borrower collateral amount before auction exit.
-     *  @return floorCollateral_   Remaining borrower collateral after auction exit.
+    /**
+     *  @notice Settle an auction when it exits the auction queue (implemented by each pool accordingly).
+     *  @param  borrowerAddress_    Address of the borrower that exits auction.
+     *  @param  borrowerCollateral_ Borrower collateral amount before auction exit.
+     *  @return Remaining borrower collateral after auction exit.
      */
     function _settleAuction(
         address borrowerAddress_,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -115,6 +115,7 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
         );
         toBucketLPs_ = Buckets.addCollateral(
             buckets[toIndex_],
+            msg.sender,
             deposits.valueAt(toIndex_),
             collateralAmountToMove_,
             PoolUtils.indexToPrice(toIndex_)

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -152,6 +152,16 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         borrower.collateral  -= params.collateralAmount;
         poolState.collateral -= params.collateralAmount;
 
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
+
+        emit Take(
+            borrowerAddress_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
+
         _transferCollateral(callee_, params.collateralAmount);
 
         if (data_.length != 0) {
@@ -163,16 +173,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         }
 
         _transferQuoteTokenFrom(callee_, params.quoteTokenAmount);
-
-        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
-
-        emit Take(
-            borrowerAddress_,
-            params.quoteTokenAmount,
-            params.collateralAmount,
-            params.bondChange,
-            params.isRewarded
-        );
     }
 
     /*******************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -197,6 +197,18 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
         borrower.collateral  -= params.collateralAmount;
         poolState.collateral -= params.collateralAmount;
 
+        _transferCollateral(callee_, params.collateralAmount);
+
+        if (data_.length != 0) {
+            IERC20Taker(callee_).atomicSwapCallback(
+                params.collateralAmount / collateralScale, 
+                params.quoteTokenAmount / _getArgUint256(40), 
+                data_
+            );
+        }
+
+        _transferQuoteTokenFrom(callee_, params.quoteTokenAmount);
+
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
         emit Take(
@@ -206,18 +218,6 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
             params.bondChange,
             params.isRewarded
         );
-
-        _transferCollateral(callee_, params.collateralAmount);
-
-        if (data_.length > 0) {
-            IERC20Taker(callee_).atomicSwapCallback(
-                params.collateralAmount / collateralScale, 
-                params.quoteTokenAmount / _getArgUint256(40), 
-                data_
-            );
-        }
-
-        _transferQuoteTokenFrom(callee_, params.quoteTokenAmount);
     }
 
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -2,12 +2,11 @@
 
 pragma solidity 0.8.14;
 
-import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import './interfaces/IERC20Pool.sol';
 import './interfaces/IERC20Taker.sol';
 import '../base/FlashloanablePool.sol';
 
-contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
+contract ERC20Pool is IERC20Pool, FlashloanablePool {
     using Auctions for Auctions.Data;
     using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -152,8 +152,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         borrower.collateral  -= params.collateralAmount;
         poolState.collateral -= params.collateralAmount;
 
-        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
-
         emit Take(
             borrowerAddress_,
             params.quoteTokenAmount,
@@ -161,6 +159,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             params.bondChange,
             params.isRewarded
         );
+
+        _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
         _transferCollateral(callee_, params.collateralAmount);
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -219,6 +219,40 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         );
     }
 
+    /*******************************/
+    /*** Pool Override Functions ***/
+    /*******************************/
+
+    /**
+     *  @notice ERC20 collateralization calculation.
+     *  @param debt_       Debt to calculate collateralization for.
+     *  @param collateral_ Collateral to calculate collateralization for.
+     *  @param price_      Price to calculate collateralization for.
+     *  @return True if collateralization calculated is equal or greater than 1.
+     */
+    function _isCollateralized(
+        uint256 debt_,
+        uint256 collateral_,
+        uint256 price_
+    ) internal pure override returns (bool) {
+        return Maths.wmul(collateral_, price_) >= debt_;
+    }
+
+   /**
+     *  @notice Settle an ERC20 pool auction, remove from auction queue and emit event.
+     *  @param borrowerAddress_    Address of the borrower that exits auction.
+     *  @param borrowerCollateral_ Borrower collateral amount before auction exit.
+     *  @return floorCollateral_   Remaining borrower collateral after auction exit.
+     */
+    function _settleAuction(
+        address borrowerAddress_,
+        uint256 borrowerCollateral_
+    ) internal override returns (uint256) {
+        Auctions.settleERC20Auction(auctions, borrowerAddress_);
+        emit AuctionSettle(borrowerAddress_, borrowerCollateral_);
+        return borrowerCollateral_;
+    }
+
     /************************/
     /*** Helper Functions ***/
     /************************/

--- a/src/erc20/interfaces/pool/IERC20PoolEvents.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolEvents.sol
@@ -19,6 +19,16 @@ interface IERC20PoolEvents {
     );
 
     /**
+     *  @notice Emitted when auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
+     */
+    event AuctionSettle(
+        address indexed borrower,
+        uint256 collateral
+    );
+
+    /**
      *  @notice Emitted when lender moves collateral from a bucket price to another.
      *  @param  lender Recipient that moved collateral.
      *  @param  from   Price bucket from which collateral was moved.

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -9,6 +9,7 @@ import '../base/FlashloanablePool.sol';
 
 contract ERC721Pool is ReentrancyGuard, IERC721Pool, FlashloanablePool {
     using Auctions for Auctions.Data;
+    using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
     /***********************/
@@ -196,6 +197,50 @@ contract ERC721Pool is ReentrancyGuard, IERC721Pool, FlashloanablePool {
         //slither-disable-next-line divide-before-multiply
         collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
         return Maths.wmul(collateral_, price_) >= debt_;
+    }
+
+    /**
+     *  @notice Performs NFT auction settlement by rounding down borrower's collateral amount and by moving borrower's token ids to pool claimable array.
+     *  @param borrowerAddress_    Address of the borrower that exits auction.
+     *  @param borrowerCollateral_ Borrower collateral amount before auction exit (could be fragmented as result of partial takes).
+     *  @return floorCollateral_   Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
+     */
+    function _settleAuction(
+        address borrowerAddress_,
+        uint256 borrowerCollateral_
+    ) internal override returns (uint256 floorCollateral_) {
+        floorCollateral_ = (borrowerCollateral_ / Maths.WAD) * Maths.WAD; // this should be set as new collateral of borrower
+
+        // if there's fraction of NFTs remaining then reward difference to borrower as LPs in auction price bucket
+        if (floorCollateral_ != borrowerCollateral_) {
+            // cover borrower's fractional amount with LPs in auction price bucket
+            uint256 fractionalCollateral = borrowerCollateral_ - floorCollateral_;
+            uint256 auctionPrice = PoolUtils.auctionPrice(
+                auctions.liquidations[borrowerAddress_].kickMomp,
+                auctions.liquidations[borrowerAddress_].kickTime
+            );
+            uint256 bucketIndex = PoolUtils.priceToIndex(auctionPrice);
+            Buckets.addCollateral(
+                buckets[bucketIndex],
+                borrowerAddress_,
+                deposits.valueAt(bucketIndex),
+                fractionalCollateral,
+                PoolUtils.indexToPrice(bucketIndex)
+            );
+        }
+
+        // rebalance borrower's collateral, transfer difference to floor collateral from borrower to pool claimable array
+        uint256[] storage pledgedTokens = borrowerTokenIds[borrowerAddress_];
+        uint256 noOfTokensPledged    = pledgedTokens.length;
+        uint256 noOfTokensToTransfer = noOfTokensPledged - floorCollateral_ / 1e18;
+        for (uint256 i = 0; i < noOfTokensToTransfer;) {
+            uint256 tokenId = pledgedTokens[--noOfTokensPledged]; // start with moving the last token pledged by borrower
+            pledgedTokens.pop();                                  // remove token id from borrower
+            bucketTokenIds.push(tokenId);                         // add token id to pool claimable tokens
+            unchecked {
+                ++i;
+            }
+        }
     }
 
     /**

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -2,12 +2,11 @@
 
 pragma solidity 0.8.14;
 
-import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import './interfaces/IERC721Pool.sol';
 import './interfaces/IERC721Taker.sol';
 import '../base/FlashloanablePool.sol';
 
-contract ERC721Pool is ReentrancyGuard, IERC721Pool, FlashloanablePool {
+contract ERC721Pool is IERC721Pool, FlashloanablePool {
     using Auctions for Auctions.Data;
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -137,6 +137,14 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         borrower.collateral  -= collateralTaken;
         poolState.collateral -= collateralTaken;
 
+        emit Take(
+            borrowerAddress_,
+            params.quoteTokenAmount,
+            params.collateralAmount,
+            params.bondChange,
+            params.isRewarded
+        );
+
         // transfer rounded collateral from pool to taker
         uint256[] memory tokensTaken = _transferFromPoolToAddress(callee_, borrowerTokenIds[borrowerAddress_], collateralTaken / 1e18);
 
@@ -156,13 +164,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
 
-        emit Take(
-            borrowerAddress_,
-            params.quoteTokenAmount,
-            params.collateralAmount,
-            params.bondChange,
-            params.isRewarded
-        );
     }
 
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -202,13 +202,13 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
      *  @notice Performs NFT auction settlement by rounding down borrower's collateral amount and by moving borrower's token ids to pool claimable array.
      *  @param borrowerAddress_    Address of the borrower that exits auction.
      *  @param borrowerCollateral_ Borrower collateral amount before auction exit (could be fragmented as result of partial takes).
-     *  @return floorCollateral_   Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
+     *  @return Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
      */
     function _settleAuction(
         address borrowerAddress_,
         uint256 borrowerCollateral_
-    ) internal override returns (uint256 floorCollateral_) {
-        floorCollateral_ = Auctions.settleNFTAuction(
+    ) internal override returns (uint256) {
+        (uint256 floorCollateral, uint256 lps, uint256 bucketIndex) = Auctions.settleNFTAuction(
             auctions,
             buckets,
             deposits,
@@ -217,6 +217,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             borrowerAddress_,
             borrowerCollateral_
         );
+        emit AuctionNFTSettle(borrowerAddress_, floorCollateral, lps, bucketIndex);
+        return floorCollateral;
     }
 
 

--- a/src/erc721/interfaces/pool/IERC721PoolEvents.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolEvents.sol
@@ -19,6 +19,20 @@ interface IERC721PoolEvents {
     );
 
     /**
+     *  @notice Emitted when NFT auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
+     *  @param  lps        Amount of LPs given to the borrower to compensate fractional collateral (if any).
+     *  @param  index      Index of the bucket with LPs to compensate fractional collateral.
+     */
+    event AuctionNFTSettle(
+        address indexed borrower,
+        uint256 collateral,
+        uint256 lps,
+        uint256 index
+    );
+
+    /**
      *  @notice Emitted when borrower locks collateral in the pool.
      *  @param  borrower `msg.sender`.
      *  @param  tokenIds Array of tokenIds to be added to the pool.

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -388,7 +388,7 @@ library Auctions {
     function settleERC20Auction(
         Data storage self,
         address borrower_
-    ) internal {
+    ) external {
         _removeAuction(self, borrower_);
     }
 
@@ -515,7 +515,7 @@ library Auctions {
             params_.bucketPrice
         );
 
-        // taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
+        // if arb take - taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
         if (!depositTake_) Buckets.addLPs(
             bucket_,
             msg.sender,

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.14;
 import './Buckets.sol';
 import './Loans.sol';
 import './Maths.sol';
+import './PoolUtils.sol';
 
 library Auctions {
 
@@ -412,6 +413,56 @@ library Auctions {
 
         // delete liquidation
          delete self.liquidations[borrower_];
+    }
+
+    /**
+     *  @notice Performs NFT auction settlement by rounding down borrower's collateral amount and by moving borrower's token ids to pool claimable array.
+     *  @param borrowerTokens_     Array of borrower NFT token ids.
+     *  @param poolTokens_         Array of claimable NFT token ids in pool.
+     *  @param borrowerAddress_    Address of the borrower that exits auction.
+     *  @param borrowerCollateral_ Borrower collateral amount before auction exit (could be fragmented as result of partial takes).
+     *  @return floorCollateral_   Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
+     */
+    function settleNFTAuction(
+        Data storage self,
+        mapping(uint256 => Buckets.Bucket) storage buckets_,
+        Deposits.Data storage deposits_,
+        uint256[] storage borrowerTokens_,
+        uint256[] storage poolTokens_,
+        address borrowerAddress_,
+        uint256 borrowerCollateral_
+    ) external returns (uint256 floorCollateral_) {
+        floorCollateral_ = (borrowerCollateral_ / Maths.WAD) * Maths.WAD; // floor collateral of borrower
+
+        // if there's fraction of NFTs remaining then reward difference to borrower as LPs in auction price bucket
+        if (floorCollateral_ != borrowerCollateral_) {
+            // cover borrower's fractional amount with LPs in auction price bucket
+            uint256 fractionalCollateral = borrowerCollateral_ - floorCollateral_;
+            uint256 auctionPrice = PoolUtils.auctionPrice(
+                self.liquidations[borrowerAddress_].kickMomp,
+                self.liquidations[borrowerAddress_].kickTime
+            );
+            uint256 bucketIndex = PoolUtils.priceToIndex(auctionPrice);
+            Buckets.addCollateral(
+                buckets_[bucketIndex],
+                borrowerAddress_,
+                Deposits.valueAt(deposits_, bucketIndex),
+                fractionalCollateral,
+                PoolUtils.indexToPrice(bucketIndex)
+            );
+        }
+
+        // rebalance borrower's collateral, transfer difference to floor collateral from borrower to pool claimable array
+        uint256 noOfTokensPledged    = borrowerTokens_.length;
+        uint256 noOfTokensToTransfer = noOfTokensPledged - floorCollateral_ / 1e18;
+        for (uint256 i = 0; i < noOfTokensToTransfer;) {
+            uint256 tokenId = borrowerTokens_[--noOfTokensPledged]; // start with moving the last token pledged by borrower
+            borrowerTokens_.pop();                                  // remove token id from borrower
+            poolTokens_.push(tokenId);                              // add token id to pool claimable tokens
+            unchecked {
+                ++i;
+            }
+        }
     }
 
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -58,6 +58,7 @@ library Buckets {
 
     /**
      *  @notice Add collateral to a bucket and updates LPs for bucket and lender with the amount coresponding to collateral amount added.
+     *  @param  lender_                Address of the lender.
      *  @param  deposit_               Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
      *  @param  collateralAmountToAdd_ Additional collateral amount to add to bucket.
      *  @param  bucketPrice_           Bucket price.
@@ -65,6 +66,7 @@ library Buckets {
      */
     function addCollateral(
         Bucket storage bucket_,
+        address lender_,
         uint256 deposit_,
         uint256 collateralAmountToAdd_,
         uint256 bucketPrice_
@@ -83,7 +85,7 @@ library Buckets {
         if (bucket_.bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
         bucket_.collateral += collateralAmountToAdd_;
         // update bucket and lender LPs balance and deposit timestamp
-        addLPs(bucket_, msg.sender, addedLPs_);
+        addLPs(bucket_, lender_, addedLPs_);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -26,6 +26,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
 
     // Pool events
     event AddCollateral(address indexed actor_, uint256 indexed price_, uint256 amount_);
+    event AuctionSettle(address indexed borrower, uint256 collateral);
     event PledgeCollateral(address indexed borrower_, uint256 amount_);
 
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -202,6 +203,24 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         borrowers.add(borrower);
     }
 
+    function _pledgeCollateralAndSettleAuction(
+        address from,
+        address borrower,
+        uint256 amount,
+        uint256 collateral
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit AuctionSettle(borrower, collateral);
+        vm.expectEmit(true, true, false, true);
+        emit PledgeCollateral(borrower, amount);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
+        ERC20Pool(address(_pool)).pledgeCollateral(borrower, amount);
+
+        borrowers.add(borrower);
+    }
+
     function _removeAllCollateral(
         address from,
         uint256 amount,
@@ -216,6 +235,23 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         (uint256 collateralRemoved, uint256 lpAmount) = ERC20Pool(address(_pool)).removeAllCollateral(index);
         assertEq(collateralRemoved, amount);
         assertEq(lpAmount, lpRedeem);
+    }
+
+    function _repayAndSettleAuction(
+        address from,
+        address borrower,
+        uint256 amount,
+        uint256 repaid,
+        uint256 collateral,
+        uint256 newLup
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit AuctionSettle(borrower, collateral);
+        vm.expectEmit(true, true, false, true);
+        emit Repay(borrower, newLup, repaid);
+        _assertTokenTransferEvent(from, address(_pool), repaid);
+        _pool.repay(borrower, amount);
     }
 
     function _transferLpTokens(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -346,13 +346,14 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             }
         );
 
-        _repay(
+        _repayAndSettleAuction(
             {
-                from:      _borrower,
-                borrower:  _borrower,
-                amount:    2 * 1e18,
-                repaid:    2 * 1e18,
-                newLup:    9.721295865031779605 * 1e18
+                from:       _borrower,
+                borrower:   _borrower,
+                amount:     2 * 1e18,
+                repaid:     2 * 1e18,
+                collateral: 2 * 1e18,
+                newLup:     9.721295865031779605 * 1e18
             }
         );
         _assertAuction(
@@ -507,11 +508,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             }
         );
 
-        _pledgeCollateral(
+        _pledgeCollateralAndSettleAuction(
             {
-                from:     _borrower,
-                borrower: _borrower,
-                amount:   2 * 1e18
+                from:       _borrower,
+                borrower:   _borrower,
+                amount:     2 * 1e18,
+                collateral: 4 * 1e18 // collateral after auction settled = 2 new pledged + initial 2 collateral pledged 
             }
         );
         _assertAuction(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -321,9 +321,9 @@ abstract contract DSTestPlus is Test {
         bool isReward
     ) internal virtual {
         changePrank(from);
-        _assertTokenTransferEvent(from, address(_pool), givenAmount);
         vm.expectEmit(true, true, false, true);
         emit Take(borrower, givenAmount, collateralTaken, bondChange, isReward);
+        _assertTokenTransferEvent(from, address(_pool), givenAmount);
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -321,9 +321,9 @@ abstract contract DSTestPlus is Test {
         bool isReward
     ) internal virtual {
         changePrank(from);
+        _assertTokenTransferEvent(from, address(_pool), givenAmount);
         vm.expectEmit(true, true, false, true);
         emit Take(borrower, givenAmount, collateralTaken, bondChange, isReward);
-        _assertTokenTransferEvent(from, address(_pool), givenAmount);
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 

--- a/tests/forge/utils/QueueInstance.sol
+++ b/tests/forge/utils/QueueInstance.sol
@@ -21,7 +21,7 @@ contract QueueInstance is DSTestPlus {
     }
 
     function remove(address borrower_) external {
-        Auctions.removeAuction(auctions, borrower_);
+        auctions._removeAuction(borrower_);
     }
 
     function getHead() external view returns (address) {


### PR DESCRIPTION
Pools changes:
- define virtual `_settleAuction` function in base class that is implemented by ERC20 and NFT pool implementations
  - ERC20 removes auction from queue and emits `AuctionSettle` event (containing borrower address and collateral after auction settle)
  - ERC721 rounds down borrower's collateral amount and compensate borrower with LPBs for the difference, then moves borrower's token ids to pool claimable array. Then it removes auction from queue and emits `AuctionNFTSettle` event  (containing borrower address, rounded collateral after auction settle, amount of compensated LPBs and bucket index)
- moved `_payLoan` at the end of `take` methods (that is after token transfers happens) in NFT pool to make sure settle doesn't affect atomic swaps - since `take` is nonReentrant there's no risk of reentrancy atack
- used `!=` instead `>` to verify calldata length, for a minor gas improvement
- contract size related: renamed `_transferFromPoolToSender`  to `_transferFromPoolToAddress` and return array of token ids transferred, reused this function in `take` to transfer to callee

`Auctions` library changes:
- renamed `settle` to `settlePoolDebt`
- added `settleERC20Auction` function (called by ERC20 `_settleAuction` implementation)
- added `settleNFTAuction` function (called by NFT pool `_settleAuction` implementation)
- made `removeAuction` function internal and called it only from `settle*Auction` functions
- moved `bucketTake` logic from Pool to be inline with `take` function layout and for saving contract size

`Buckets` library changes:
- `addCollateral` receives now the address to award LPs for (previously `msg.sender` was used)

Tests:
- ERC20: added `_pledgeCollateralAndSettleAuction` and `_repayAndSettleAuction` to assert auction settle event, updated couple of tests to use them. 
TBD: add `_takeAndSettle` functions, update all tests that settle collateral to use these functions. Add similar NFT assert functions. More tests.

Notes:
- when we compensate fractional NFT to borrower with LPs in bucket, we increment the collateral accumulator of the bucket too. if `settleAuction` happens in the same block as bucket going insolvent then transaction reverts
- in `bucketTake` where we award LPs to taker and kicker we don't revert if this happens in same transaction as bucket marked insolvent (unlikely to happen)
