### PR TITLE
Position manager moveLiquidity bug

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -115,8 +115,8 @@ abstract contract Pool is Clone, Multicall, IPool {
         uint256 fromDeposit = deposits.valueAt(fromIndex_);
         Buckets.Bucket storage fromBucket = buckets[fromIndex_];
         (amountToMove, fromBucketLPs_, ) = Buckets.lpsToQuoteToken(
-            fromBucket.collateral,
             fromBucket.lps,
+            fromBucket.collateral,
             fromDeposit,
             lender.lps,
             maxAmountToMove_,

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -296,8 +296,8 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
         (quoteAmount_, , ) = Buckets.lpsToQuoteToken(
-            bucketCollateral,
             bucketLPs_,
+            bucketCollateral,
             bucketDeposit,
             lpTokens_,
             bucketDeposit,

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -20,6 +20,7 @@ import './PositionNFT.sol';
 
 import '../libraries/Maths.sol';
 import '../libraries/Buckets.sol';
+import '../libraries/PoolUtils.sol';
 
 contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC20, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.UintSet;
@@ -118,7 +119,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
             bucketDeposit,
             lps[params_.tokenId][params_.fromIndex],
             bucketDeposit,
-            params_.fromIndex
+            PoolUtils.indexToPrice(params_.fromIndex)
         );
 
         // update prices set at which a position has liquidity

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -114,8 +114,8 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         IPool pool = IPool(params_.pool);
         (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
         (uint256 maxQuote, , ) = Buckets.lpsToQuoteToken(
-            bucketLPs,
             bucketCollateral,
+            bucketLPs,
             bucketDeposit,
             lps[params_.tokenId][params_.fromIndex],
             bucketDeposit,

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -114,8 +114,8 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
         IPool pool = IPool(params_.pool);
         (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
         (uint256 maxQuote, , ) = Buckets.lpsToQuoteToken(
-            bucketCollateral,
             bucketLPs,
+            bucketCollateral,
             bucketDeposit,
             lps[params_.tokenId][params_.fromIndex],
             bucketDeposit,

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -264,8 +264,8 @@ library Buckets {
 
     /**
      *  @notice Returns the amount of quote tokens calculated for the given amount of LPs.
-     *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  bucketLPs_        Amount of LPs in bucket.
+     *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
      *  @param  lenderLPsBalance_ The amount of LPs to calculate quote token amount for.
      *  @param  maxQuoteToken_    The max quote token amount to calculate LPs for.
@@ -275,8 +275,8 @@ library Buckets {
      *  @return lenderLPs_        Lender LPs balance in current bucket.
      */
     function lpsToQuoteToken(
-        uint256 bucketCollateral_,
         uint256 bucketLPs_,
+        uint256 bucketCollateral_,
         uint256 deposit_,
         uint256 lenderLPsBalance_,
         uint256 maxQuoteToken_,

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1297,10 +1297,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // generate a new address
         address testAddress1 = makeAddr("testAddress1");
         address testAddress2 = makeAddr("testAddress2");
+        address testAddress3 = makeAddr("testAddress3");
         uint256 mintIndex    = 2550;
         uint256 moveIndex    = 2551;
         _mintQuoteAndApproveManagerTokens(testAddress1, 10_000 * 1e18);
         _mintQuoteAndApproveManagerTokens(testAddress2, 10_000 * 1e18);
+        _mintCollateralAndApproveTokens(testAddress3, 10_000 * 1e18);
 
         // add initial liquidity
         _addLiquidity(
@@ -1606,11 +1608,19 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId2, address(_pool), mintIndex, moveIndex
         );
 
+        _addCollateral(
+            {
+                from:   testAddress3,
+                amount: 10_000 * 1e18,
+                index:  mintIndex
+            }
+        );
+
         // move liquidity called by testAddress2 owner
         vm.expectEmit(true, true, true, true);
         emit MoveLiquidity(testAddress2, tokenId2);
         changePrank(address(testAddress2));
-        _positionManager.moveLiquidity(moveLiquidityParams);
+        _positionManager.moveLiquidity(moveLiquidityParams); // FIXME fails with Arithmetic over/underflow
 
         // check pool state
        _assertLenderLpBalance(

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1620,7 +1620,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MoveLiquidity(testAddress2, tokenId2);
         changePrank(address(testAddress2));
-        _positionManager.moveLiquidity(moveLiquidityParams); // FIXME fails with Arithmetic over/underflow
+        _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check pool state
        _assertLenderLpBalance(


### PR DESCRIPTION
- fix order of params and pass price instead index to `Buckets.lpsToQuoteToken` in PositionManager.moveLiquidity
- change test: add collateral into bucket to exercise full exchange rate calculation