### PR TITLE
Redeem LP for tokens

### DIFF
--- a/src/base/interfaces/pool/IPoolLenderActions.sol
+++ b/src/base/interfaces/pool/IPoolLenderActions.sol
@@ -52,16 +52,13 @@ interface IPoolLenderActions {
      *  @return redeemedLPs    The amount of LP redeemed for deposit.           [RAY]
      */
     function redeemLPforQuoteToken(uint256 maxLPAmount, uint256 index)
-        external returns (
-            uint256 depositRemoved,
-            uint256 redeemedLPs
-        );
+        external returns (uint256 depositRemoved, uint256 redeemedLPs);
 
     /**
      *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
      *  @param  amount   The amount of unencumbered collateral (or the number of NFT tokens) to claim.
      *  @param  index    The bucket index from which unencumbered collateral will be removed.
-     *  @return lpAmount The amount of LP used for removing collateral amount.
+     *  @return lpAmount The amount of LP redeemed for collateral.
      */
     function removeCollateral(
         uint256 amount,
@@ -69,16 +66,16 @@ interface IPoolLenderActions {
     ) external returns (uint256 lpAmount);
 
     /**
-     *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
-     *  @param  maxAmount        The max amount of quote token to be removed by a lender.
-     *  @param  index            The bucket index from which quote tokens will be removed.
-     *  @return quoteTokenAmount The amount of quote token removed.
-     *  @return lpAmount         The amount of LP used for removing quote tokens amount.
+     *  @notice Called by lenders to remove an amount of deposit at a specified price bucket.
+     *  @param  amount         The amount of quote token to be removed by a lender.     [WAD]
+     *  @param  index          The bucket index from which quote tokens will be removed.
+     *  @return depositRemoved The amount of deposit removed.                           [WAD]
+     *  @return redeemedLPs    The amount of LP redeemed for deposit.                   [RAY]
      */
     function removeQuoteToken(
-        uint256 maxAmount,
+        uint256 amount,
         uint256 index
-    ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
+    ) external returns (uint256 depositRemoved, uint256 redeemedLPs);
 
     /**
      *  @notice Called by lenders to transfers their LP tokens to a different address.

--- a/src/base/interfaces/pool/IPoolLenderActions.sol
+++ b/src/base/interfaces/pool/IPoolLenderActions.sol
@@ -45,6 +45,19 @@ interface IPoolLenderActions {
     ) external returns (uint256 lpbAmountFrom, uint256 lpbAmountTo);
 
     /**
+     *  @notice Called by lenders to redeem the maximum amount of LP for deposit.
+     *  @param  maxLPAmount    The maximum amount of LP to redeem for deposit.  [RAY]
+     *  @param  index          The bucket index from which unencumbered deposit will be removed.
+     *  @return depositRemoved The amount of deposit removed.                   [WAD]
+     *  @return redeemedLPs    The amount of LP redeemed for deposit.           [RAY]
+     */
+    function redeemLPforQuoteToken(uint256 maxLPAmount, uint256 index)
+        external returns (
+            uint256 depositRemoved,
+            uint256 redeemedLPs
+        );
+
+    /**
      *  @notice Called by lenders to claim unencumbered collateral from a price bucket.
      *  @param  amount   The amount of unencumbered collateral (or the number of NFT tokens) to claim.
      *  @param  index    The bucket index from which unencumbered collateral will be removed.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -82,7 +82,8 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
         _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
     }
 
-    function removeAllCollateral(
+    function redeemLPforCollateral(
+        uint256 maxLPAmount_,
         uint256 index_
     ) external override returns (uint256 collateralAmountRemoved_, uint256 redeemedLenderLPs_) {
         auctions.revertIfAuctionClearable(loans);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -91,6 +91,7 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
             index_,
             msg.sender
         );
+        maxLPAmount_ = Maths.min(maxLPAmount_, lenderLPsBalance);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -99,7 +100,7 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
             bucket.collateral,
             bucket.lps,
             deposits.valueAt(index_),
-            lenderLPsBalance,
+            maxLPAmount_,
             PoolUtils.indexToPrice(index_)
         );
         if (collateralAmountRemoved_ == 0) revert NoClaim();

--- a/src/erc20/interfaces/pool/IERC20PoolLenderActions.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolLenderActions.sol
@@ -18,14 +18,15 @@ interface IERC20PoolLenderActions {
 
     /**
      *  @notice Called by lenders to redeem the maximum amount of LP for unencumbered collateral.
-     *  @param  index    The bucket index from which unencumbered collateral will be removed.
-     *  @return amount   The amount of collateral removed.
-     *  @return lpAmount The amount of LP used for removing collateral.
+     *  @param  maxLPAmount             The maximum amount of LP to redeem for collateral.  [RAY]
+     *  @param  index                   The bucket index from which unencumbered collateral will be removed.
+     *  @return collateralAmountRemoved The amount of collateral removed.                   [WAD]
+     *  @return redeemedLenderLPs       The amount of LP redeemed for collateral.           [RAY]
      */
-    function removeAllCollateral(uint256 index)
+    function redeemLPforCollateral(uint256 maxLPAmount, uint256 index)
         external
         returns (
-            uint256 amount,
-            uint256 lpAmount
+            uint256 collateralAmountRemoved,
+            uint256 redeemedLenderLPs
         );
 }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -85,7 +85,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
             // redeem LP for quote token if available
             uint256 lpRedeemed;
             if(lenderLpBalance != 0 && bucketQuote != 0) {
-                (, lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, bucketIndex);
+                (, lpRedeemed) = _pool.redeemLPforQuoteToken(type(uint256).max, bucketIndex);
                 lenderLpBalance -= lpRedeemed;
             }
 

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -345,6 +345,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
             }
         );
 
+        // actor withdraws half their collateral as token amount
         _removeCollateral(
             {
                 from:     _bidder,
@@ -353,7 +354,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 lpRedeem: 243_808.1263305875209909205 * 1e27
             }
         );
-        // check bucket state and bidder's LPs
         _assertBucket(
             {
                 index:        1530,
@@ -371,21 +371,51 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 depositTime: _startTime
             }
         );
-        // check balances
         assertEq(_collateral.balanceOf(_bidder),        0.5 * 1e18);
         assertEq(_collateral.balanceOf(address(_pool)), 0.5 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),      0);
 
-        // actor withdraws remainder of their _collateral
+        // actor redeems half their LPS for collateral
+        (uint256 lpBalance, ) = _pool.lenderInfo(1530, _bidder);
+        _reedemLPforCollateral(
+            {
+                from:             _bidder,
+                lpAmount:         Maths.wmul(lpBalance, 0.5 * 1e18),
+                index:            1530,
+                collateralRemove: 0.25 * 1e18,
+                lpRedeem:         121_904.063165293760495460250000000 * 1e27
+            }
+        );
+        _assertBucket(
+            {
+                index:        1530,
+                lpBalance:    121_904.063165293760495460250000000 * 1e27,
+                collateral:   0.25 * 1e18,
+                deposit:      0,
+                exchangeRate: 1 * 1e27
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _bidder,
+                index:       1530,
+                lpBalance:   121_904.063165293760495460250000000 * 1e27,
+                depositTime: _startTime
+            }
+        );
+        assertEq(_collateral.balanceOf(_bidder),        0.75 * 1e18);
+        assertEq(_collateral.balanceOf(address(_pool)), 0.25 * 1e18);
+        assertEq(_quote.balanceOf(address(_pool)),      0);
+
+        // actor withdraws remainder of their collateral
         _removeAllCollateral(
             {
                 from:     _bidder,
-                amount:   0.5 * 1e18,
+                amount:   0.25 * 1e18,
                 index:    1530,
-                lpRedeem: 243_808.1263305875209909205 * 1e27
+                lpRedeem: 121_904.063165293760495460250000000 * 1e27
             }
         );
-        // check bucket state and bidder's LPs
         _assertBucket(
             {
                 index:        1530,
@@ -403,7 +433,6 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 depositTime: _startTime
             }
         );
-        // check balances
         assertEq(_collateral.balanceOf(_bidder),        1 * 1e18);
         assertEq(_collateral.balanceOf(address(_pool)), 0 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)),      0);

--- a/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -226,7 +226,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         skip(15 hours);
         _pool.moveQuoteToken(1_000 * 1e18, index_, index_ + 1);
         skip(15 hours);
-        _pool.removeQuoteToken(type(uint256).max, index_);
+        _pool.redeemLPforQuoteToken(type(uint256).max, index_);
         vm.stopPrank();
     }
 
@@ -244,7 +244,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             skip(15 hours);
             _pool.removeQuoteToken(5_000 * 1e18, 7388 - i);
             skip(15 hours);
-            _pool.removeQuoteToken(type(uint256).max, 1 + i);
+            _pool.redeemLPforQuoteToken(type(uint256).max, 1 + i);
             vm.stopPrank();
             vm.revertTo(snapshot);
         }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1580,7 +1580,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _removeAllLiquidity(
             {
                 from:     _lender,
-                amount:   9.176155018749412335 * 1e18,
+                amount:   9.176161196119415534 * 1e18,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
                 lpRedeem: 7_989.987933044093783839063327613 * 1e27
@@ -1632,7 +1632,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
 
-        _pullCollateral(_borrower, 1.746878914360183483 * 1e18);
+        (, uint256 borrowerCollateral, ) = _pool.borrowerInfo(_borrower);
+        _pullCollateral(_borrower, borrowerCollateral);
 
         _assertBorrower(
             {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1311,12 +1311,11 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             })
         );
 
-        _removeLiquidity(
+        _removeAllLiquidity(
             {
                 from:     _lender,
                 amount:   8_008.373442262808822463 * 1e18,
                 index:    _i9_72,
-                penalty:  0,
                 newLup:   9.624807173121239337 * 1e18,
                 lpRedeem: 8_007.362556980262765268525272905 * 1e27
             }
@@ -1332,12 +1331,11 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
 
-        _removeLiquidity(
+        _removeAllLiquidity(
             {
                 from:     _lender,
                 amount:   25_000.037756489769875000 * 1e18,
                 index:    _i9_62,
-                penalty:  0,
                 newLup:   9.529276179422528643 * 1e18,
                 lpRedeem: 25_000.00 * 1e27
             }
@@ -1579,11 +1577,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
 
-        _removeLiquidity(
+        _removeAllLiquidity(
             {
                 from:     _lender,
-                amount:   9.176161196119415534 * 1e18,
-                penalty:  0,
+                amount:   9.176155018749412335 * 1e18,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
                 lpRedeem: 7_989.987933044093783839063327613 * 1e27
@@ -1635,8 +1632,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             }
         );
 
-
-        _pullCollateral(_borrower, 1.749391266909416578 * 1e18);
+        _pullCollateral(_borrower, 1.746878914360183483 * 1e18);
 
         _assertBorrower(
             {

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -131,7 +131,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
             }
 
             // Then redeem LP for quote token
-            (, lpsRedeemed) = _pool.removeQuoteToken(type(uint256).max, bucketIndex);
+            (, lpsRedeemed) = _pool.redeemLPforQuoteToken(type(uint256).max, bucketIndex);
         
             // Confirm all lp balance has been redeemed            
             (lenderLpBalance, ) = _pool.lenderInfo(bucketIndex, lender);

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -38,7 +38,7 @@ contract BalancerUniswapTaker {
     function receiveFlashLoan(
         IERC20[] calldata tokens,
         uint256[] calldata amounts,
-        uint256[] calldata feeAmounts,
+        uint256[] calldata, // feeAmounts
         bytes calldata userData
     ) public payable {
         if (msg.sender != balancerAddress) revert NotBalancer();
@@ -119,7 +119,7 @@ contract BalancerUniswapPurchaser {
     function receiveFlashLoan(
         IERC20[] calldata tokens,
         uint256[] calldata amounts,
-        uint256[] calldata feeAmounts,
+        uint256[] calldata, // feeAmounts
         bytes calldata userData
     ) public payable {
         if (msg.sender != balancerAddress) revert NotBalancer();

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -136,7 +136,11 @@ contract BalancerUniswapPurchaser {
         collateral.approve(decoded.ajnaPool, loanAmount);
         // purchase USDC with 1 WETH from ajna
         uint256 lps             = IAjnaPool(decoded.ajnaPool).addCollateral(loanAmount, decoded.bucketIndex);
-        (uint256 quoteAmount, ) = IAjnaPool(decoded.ajnaPool).removeQuoteToken(type(uint256).max, decoded.bucketIndex);
+        (uint256 quoteAmount, ) = 
+            IAjnaPool(decoded.ajnaPool).redeemLPforQuoteToken(
+                type(uint256).max, 
+                decoded.bucketIndex
+            );
         assert(lps                                 == 83008350.10362729922336157 * 1e27);   // LPS in bucket
         assert(quoteAmount                         == 4997500000000000000000);              // Purchased quote amount
         assert(quote.balanceOf(address(this))      == 4997500000);  // USDC balance after Ajna purchase

--- a/tests/forge/interactions/Interfaces.sol
+++ b/tests/forge/interactions/Interfaces.sol
@@ -15,6 +15,11 @@ interface IAjnaPool {
         uint256 index
     ) external returns (uint256 lpbChange);
 
+    function redeemLPforQuoteToken(
+        uint256 maxLPAmount, 
+        uint256 index)
+    external returns (uint256 depositRemoved, uint256 redeemedLPs);
+
     function removeQuoteToken(
         uint256 maxAmount,
         uint256 index

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -280,9 +280,9 @@ abstract contract DSTestPlus is Test {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, expectedWithdrawal, newLup);
         _assertTokenTransferEvent(address(_pool), from, expectedWithdrawal);
-        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
-        assertEq(removedAmount, expectedWithdrawal);
-        assertEq(lpRedeemed,    lpRedeem);
+        (uint256 depositRemoved, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
+        assertEq(depositRemoved, expectedWithdrawal);
+        assertEq(lpRedeemed, lpRedeem);
     }
 
     function _repay(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -475,9 +475,9 @@ abstract contract DSTestPlus is Test {
 
         uint256 lup = _poolUtils.lup(address(_pool));
 
-        assertEq(debt,        borrowerDebt);
-        assertEq(col,         borrowerCollateral);
-        assertEq(t0Np,  borrowert0Np);
+        assertEq(debt, borrowerDebt);
+        assertEq(col,  borrowerCollateral);
+        assertEq(t0Np, borrowert0Np);
         assertEq(
             PoolUtils.collateralization(
                 borrowerDebt,

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -280,7 +280,7 @@ abstract contract DSTestPlus is Test {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, expectedWithdrawal, newLup);
         _assertTokenTransferEvent(address(_pool), from, expectedWithdrawal);
-        (uint256 depositRemoved, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
+        (uint256 depositRemoved, uint256 lpRedeemed) = _pool.redeemLPforQuoteToken(lpRedeem, index);
         assertEq(depositRemoved, expectedWithdrawal);
         assertEq(lpRedeemed, lpRedeem);
     }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -242,12 +242,11 @@ abstract contract DSTestPlus is Test {
         uint256 newLup,
         uint256 lpRedeem
     ) internal {
-        // apply penalty if case
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amount, newLup);
         _assertTokenTransferEvent(address(_pool), from, amount);
-        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, index);
+        (uint256 removedAmount, uint256 lpRedeemed) = _pool.redeemLPforQuoteToken(type(uint256).max, index);
         assertEq(removedAmount, amount);
         assertEq(lpRedeemed,    lpRedeem);
     }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -915,7 +915,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
-        _pool.removeQuoteToken(type(uint256).max, index);
+        _pool.redeemLPforQuoteToken(type(uint256).max, index);
     }
 
     function _assertRemoveAllLiquidityLupBelowHtpRevert(
@@ -924,7 +924,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.LUPBelowHTP.selector);
-        _pool.removeQuoteToken(type(uint256).max, index);
+        _pool.redeemLPforQuoteToken(type(uint256).max, index);
     }
 
     function _assertRemoveDepositLockedByAuctionDebtRevert(
@@ -943,7 +943,7 @@ abstract contract DSTestPlus is Test {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.NoClaim.selector);
-        _pool.removeQuoteToken(type(uint256).max, index);
+        _pool.redeemLPforQuoteToken(type(uint256).max, index);
     }
 
     function _assertMoveLiquidityBankruptcyBlockRevert(


### PR DESCRIPTION
**Questions**
- `redeemLPforQuoteToken` costs 2554 more gas than the _develop_ implementation of `removeQuoteToken`, and this change pushes the ERC721 pool over the size limit.  Is is worth it?
- On Pool.sol:733, I could do a Maths.min instead of revert, and this should restore the ability for users to call `removeQuoteToken` with a `maxAmount`.  Thoughts?
- I tried updating bucket storage in the external methods so I wouldn't need to pass the variable to `_redeemLPforDeposit`.  Surprisingly, it only saved 3 gas on average, while increasing contract size by 62 bytes.  Any other thoughts how I could improve performance?

**Pros**
- 208 less gas for removing all collateral.
- Improved interface consistency with collateral and quote token.
- User may pass uint256.max to the reedemLP functions to remove all tokens, so they don't need to query LPB for a full withdrawal.
- Easier to remove a fraction of liquidity.

**Cons**
- Costs 150-200 bytes more contract space, exceeding contract size limit.
- Costs 2554 more gas for removing quote token.

**Performance**
Note that _develop_'s `removeQuoteToken` should be compared to this branch's `redeemLPforQuoteToken`.
```
============ develop Bytecode Sizes ============
  ERC721Pool               -  24,448B  (99.48%)
  ERC20Pool                -  23,040B  (93.75%)

| src/erc20/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 17277           | 227005 | 172473 | 683248 | 284     |
| removeAllCollateral                        | 1244            | 55005  | 56241  | 135349 | 27      |
| removeCollateral                           | 1374            | 27928  | 23757  | 70505  | 7       |
| removeQuoteToken                           | 1243            | 62333  | 54890  | 572177 | 195     |
```

```
========== remove-lps Bytecode Sizes ===========
  ERC721Pool               -  24,649B  (100.29%)
  ERC20Pool                -  23,251B  (94.60%)
| src/erc20/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 17255           | 226983 | 172451 | 683226 | 284     |
| redeemLPforCollateral                      | 1265            | 54797  | 56224  | 135465 | 28      |
| redeemLPforQuoteToken                      | 2859            | 64887  | 55769  | 572657 | 188     |
| removeCollateral                           | 1374            | 27928  | 23757  | 70505  | 7       |
| removeQuoteToken                           | 17850           | 32156  | 30247  | 57311  | 7       |
```

**TODO**
- Additional tests are needed, but I want to solidify the implementation before investing time there.
- Self-review.