### PR TITLE
Packed bondSize with neutralPrice in Liquidation struct

### DIFF
--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -19,12 +19,12 @@ library Auctions {
     struct Liquidation {
         address kicker;         // address that initiated liquidation
         uint96  bondFactor;     // bond factor used to start liquidation
-        uint256 bondSize;       // liquidation bond size
         uint96  kickTime;       // timestamp when liquidation was started
         address prev;           // previous liquidated borrower in auctions queue
         uint96  kickMomp;       // Momp when liquidation was started
         address next;           // next liquidated borrower in auctions queue
-        uint256 neutralPrice;   // Neutral Price when liquidation was started
+        uint160 bondSize;       // liquidation bond size
+        uint96  neutralPrice;   // Neutral Price when liquidation was started
     }
 
     struct Kicker {
@@ -233,9 +233,9 @@ library Auctions {
         liquidation.kicker              = msg.sender;
         liquidation.kickTime            = uint96(block.timestamp);
         liquidation.kickMomp            = uint96(momp_);
-        liquidation.bondSize            = bondSize_;
+        liquidation.bondSize            = uint160(bondSize_);
         liquidation.bondFactor          = uint96(bondFactor);
-        liquidation.neutralPrice        = neutralPrice_;
+        liquidation.neutralPrice        = uint96(neutralPrice_);
 
         if (self.head != address(0)) {
             // other auctions in queue, liquidation doesn't exist or overwriting.
@@ -310,7 +310,7 @@ library Auctions {
         if (!params_.isRewarded) {
             // take is above neutralPrice, Kicker is penalized
             params_.bondChange = Maths.min(liquidation.bondSize, Maths.wmul(params_.quoteTokenAmount, uint256(-bpf)));
-            liquidation.bondSize                -= params_.bondChange;
+            liquidation.bondSize                -= uint160(params_.bondChange);
             self.kickers[params_.kicker].locked -= params_.bondChange;
             self.totalBondEscrowed              -= params_.bondChange;
         } else {
@@ -362,14 +362,14 @@ library Auctions {
         if (params_.isRewarded) {
             // take is below neutralPrice, Kicker is rewarded
             params_.bondChange = Maths.wmul(params_.quoteTokenAmount, uint256(bpf));
-            liquidation.bondSize                += params_.bondChange;
+            liquidation.bondSize                += uint160(params_.bondChange);
             self.kickers[params_.kicker].locked += params_.bondChange;
             self.totalBondEscrowed              += params_.bondChange;
 
         } else {
             // take is above neutralPrice, Kicker is penalized
             params_.bondChange = Maths.min(liquidation.bondSize, Maths.wmul(params_.quoteTokenAmount, uint256(-bpf)));
-            liquidation.bondSize                -= params_.bondChange;
+            liquidation.bondSize                -= uint160(params_.bondChange);
             self.kickers[params_.kicker].locked -= params_.bondChange;
             self.totalBondEscrowed              -= params_.bondChange;
         }


### PR DESCRIPTION
Since keeping `neutralPrice` in `Liquidation` struct, gas costs for kick increased, there is a potential improvement here by packing struct some more but implies following assumptions:
- bond size stored as `uint160` meaning bond cannot exceed 1461501637330902918203684832716.283019655932542975 
- neutral price stored as `uint96` meaning its max value can be 79228162514.264337593543950335 (max bucket price is 1004968987.606512354182109771) (this assumption is already done for threshold price stored in `Loan` struct)

@mattcushman would be great if you can validate these assumptions, additionally they can be included in a tech spec with some explanations

with these changes kick gas is reduced as
```
develop
| Function Name                              | min             | avg    | median | max     | # calls |
| kick                                       | 170121          | 194867 | 193574 | 1048600 | 48000   |
vs packed
| kick                                       | 148050          | 172796 | 171503 | 1026517 | 48000   |
```