### PR TITLE
Keep interest rate and inflator as uint208, timestamps as uint48

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -31,11 +31,11 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** State Variables ***/
     /***********************/
 
-    uint160 public override interestRate;       // [WAD]
-    uint96  public override interestRateUpdate; // [SEC]
+    uint208 public override interestRate;       // [WAD]
+    uint48  public override interestRateUpdate; // [SEC]
 
-    uint160 internal inflatorSnapshot;           // [WAD]
-    uint96  internal lastInflatorSnapshotUpdate; // [SEC]
+    uint208 internal inflatorSnapshot;           // [WAD]
+    uint48  internal lastInflatorSnapshotUpdate; // [SEC]
 
     uint256 public override pledgedCollateral;  // [WAD]
 
@@ -822,8 +822,8 @@ abstract contract Pool is Clone, Multicall, IPool {
                 }
 
                 if (poolState_.rate != newInterestRate) {
-                    interestRate       = uint160(newInterestRate);
-                    interestRateUpdate = uint96(block.timestamp);
+                    interestRate       = uint208(newInterestRate);
+                    interestRateUpdate = uint48(block.timestamp);
 
                     emit UpdateInterestRate(poolState_.rate, newInterestRate);
                 }
@@ -833,11 +833,11 @@ abstract contract Pool is Clone, Multicall, IPool {
         pledgedCollateral = poolState_.collateral;
 
         if (poolState_.isNewInterestAccrued) {
-            inflatorSnapshot           = uint160(poolState_.inflator);
-            lastInflatorSnapshotUpdate = uint96(block.timestamp);
+            inflatorSnapshot           = uint208(poolState_.inflator);
+            lastInflatorSnapshotUpdate = uint48(block.timestamp);
         } else if (poolState_.accruedDebt == 0) {
-            inflatorSnapshot           = uint160(Maths.WAD);
-            lastInflatorSnapshotUpdate = uint96(block.timestamp);
+            inflatorSnapshot           = uint208(Maths.WAD);
+            lastInflatorSnapshotUpdate = uint48(block.timestamp);
         }
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -31,19 +31,23 @@ abstract contract Pool is Clone, Multicall, IPool {
     /*** State Variables ***/
     /***********************/
 
-    uint256 public override interestRate;       // [WAD]
-    uint256 public override interestRateUpdate; // [SEC]
+    uint160 public override interestRate;       // [WAD]
+    uint96  public override interestRateUpdate; // [SEC]
+
+    uint160 internal inflatorSnapshot;           // [WAD]
+    uint96  internal lastInflatorSnapshotUpdate; // [SEC]
+
     uint256 public override pledgedCollateral;  // [WAD]
 
     uint256 internal debtEma;   // [WAD]
     uint256 internal lupColEma; // [WAD]
 
-    uint256 internal inflatorSnapshot;           // [WAD]
-    uint256 internal lastInflatorSnapshotUpdate; // [SEC]
-
     uint256 internal reserveAuctionKicked;    // Time a Claimable Reserve Auction was last kicked.
     uint256 internal reserveAuctionUnclaimed; // Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
     uint256 internal t0DebtInAuction;         // Total debt in auction used to restrict LPB holder from withdrawing [WAD]
+
+    uint256 internal poolInitializations;
+    uint256 internal t0poolDebt;           // Pool debt as if the whole amount was incurred upon the first loan. [WAD]
 
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 
@@ -51,8 +55,6 @@ abstract contract Pool is Clone, Multicall, IPool {
     mapping(uint256 => Buckets.Bucket) internal buckets;              // deposit index -> bucket
     Deposits.Data                      internal deposits;
     Loans.Data                         internal loans;
-    uint256                            internal poolInitializations;
-    uint256                            internal t0poolDebt;           // Pool debt as if the whole amount was incurred upon the first loan. [WAD]
 
     struct PoolState {
         uint256 accruedDebt;
@@ -820,8 +822,8 @@ abstract contract Pool is Clone, Multicall, IPool {
                 }
 
                 if (poolState_.rate != newInterestRate) {
-                    interestRate       = newInterestRate;
-                    interestRateUpdate = block.timestamp;
+                    interestRate       = uint160(newInterestRate);
+                    interestRateUpdate = uint96(block.timestamp);
 
                     emit UpdateInterestRate(poolState_.rate, newInterestRate);
                 }
@@ -831,11 +833,11 @@ abstract contract Pool is Clone, Multicall, IPool {
         pledgedCollateral = poolState_.collateral;
 
         if (poolState_.isNewInterestAccrued) {
-            inflatorSnapshot           = poolState_.inflator;
-            lastInflatorSnapshotUpdate = block.timestamp;
+            inflatorSnapshot           = uint160(poolState_.inflator);
+            lastInflatorSnapshotUpdate = uint96(block.timestamp);
         } else if (poolState_.accruedDebt == 0) {
-            inflatorSnapshot           = Maths.WAD;
-            lastInflatorSnapshotUpdate = block.timestamp;
+            inflatorSnapshot           = uint160(Maths.WAD);
+            lastInflatorSnapshotUpdate = uint96(block.timestamp);
         }
     }
 

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -104,13 +104,13 @@ interface IPoolState {
      *  @notice Returns the `interestRate` state variable.
      *  @return Current annual percentage rate of the pool
      */
-    function interestRate() external view returns (uint160);
+    function interestRate() external view returns (uint208);
 
     /**
      *  @notice Returns the `interestRateUpdate` state variable.
      *  @return The timestamp of the last rate update.
      */
-    function interestRateUpdate() external view returns (uint96);
+    function interestRateUpdate() external view returns (uint48);
 
     /**
      *  @notice Returns details about kicker balances.

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -104,13 +104,13 @@ interface IPoolState {
      *  @notice Returns the `interestRate` state variable.
      *  @return Current annual percentage rate of the pool
      */
-    function interestRate() external view returns (uint256);
+    function interestRate() external view returns (uint160);
 
     /**
      *  @notice Returns the `interestRateUpdate` state variable.
      *  @return The timestamp of the last rate update.
      */
-    function interestRateUpdate() external view returns (uint256);
+    function interestRateUpdate() external view returns (uint96);
 
     /**
      *  @notice Returns details about kicker balances.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -31,10 +31,10 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
 
         collateralScale = uint128(collateralScale_);
 
-        inflatorSnapshot           = uint160(10**18);
-        lastInflatorSnapshotUpdate = uint96(block.timestamp);
-        interestRate               = uint160(rate_);
-        interestRateUpdate         = uint96(block.timestamp);
+        inflatorSnapshot           = uint208(10**18);
+        lastInflatorSnapshotUpdate = uint48(block.timestamp);
+        interestRate               = uint208(rate_);
+        interestRateUpdate         = uint48(block.timestamp);
 
         loans.init();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -17,7 +17,7 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
     /*** State Variables ***/
     /***********************/
 
-    uint256 public override collateralScale;
+    uint128 public override collateralScale;
 
     /****************************/
     /*** Initialize Functions ***/
@@ -29,12 +29,12 @@ contract ERC20Pool is ReentrancyGuard, IERC20Pool, FlashloanablePool {
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
-        collateralScale = collateralScale_;
+        collateralScale = uint128(collateralScale_);
 
-        inflatorSnapshot           = 10**18;
-        lastInflatorSnapshotUpdate = block.timestamp;
-        interestRate               = rate_;
-        interestRateUpdate         = block.timestamp;
+        inflatorSnapshot           = uint160(10**18);
+        lastInflatorSnapshotUpdate = uint96(block.timestamp);
+        interestRate               = uint160(rate_);
+        interestRateUpdate         = uint96(block.timestamp);
 
         loans.init();
 

--- a/src/erc20/interfaces/pool/IERC20PoolState.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolState.sol
@@ -10,6 +10,6 @@ interface IERC20PoolState {
      *  @notice Returns the `collateralScale` state variable.
      *  @return The precision of the collateral ERC-20 token based on decimals.
      */
-    function collateralScale() external view returns (uint256);
+    function collateralScale() external view returns (uint128);
 
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -31,10 +31,10 @@ contract ERC721Pool is ReentrancyGuard, IERC721Pool, FlashloanablePool {
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
-        inflatorSnapshot           = uint160(10**18);
-        lastInflatorSnapshotUpdate = uint96(block.timestamp);
-        interestRate               = uint160(rate_);
-        interestRateUpdate         = uint96(block.timestamp);
+        inflatorSnapshot           = uint208(10**18);
+        lastInflatorSnapshotUpdate = uint48(block.timestamp);
+        interestRate               = uint208(rate_);
+        interestRateUpdate         = uint48(block.timestamp);
 
         uint256 noOfTokens = tokenIds_.length;
         if (noOfTokens > 0) {

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -31,10 +31,10 @@ contract ERC721Pool is ReentrancyGuard, IERC721Pool, FlashloanablePool {
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
-        inflatorSnapshot           = 10**18;
-        lastInflatorSnapshotUpdate = block.timestamp;
-        interestRate               = rate_;
-        interestRateUpdate         = block.timestamp;
+        inflatorSnapshot           = uint160(10**18);
+        lastInflatorSnapshotUpdate = uint96(block.timestamp);
+        interestRate               = uint160(rate_);
+        interestRateUpdate         = uint96(block.timestamp);
 
         uint256 noOfTokens = tokenIds_.length;
         if (noOfTokens > 0) {


### PR DESCRIPTION
There is some more room for gas improvement by improving contract storage and especially when the pool accrues interest.  This implies following changes:
- `interestRate` and `inflatorSnapshot` stored as uint208
- `interestRate` and `inflator` udpate timestamp as uint48 (https://twitter.com/PaulRBerg/status/1591832937179250693)

@mattcushman please validate above

with these changes gas is looking better and especially for the max consumed for functions that accumulate pool interest
before
```
| Function Name                              | min             | avg    | median | max     | # calls |
| addQuoteToken                              | 101837          | 161938 | 144446 | 684747  | 56003   |
| borrow                                     | 143079          | 193534 | 163555 | 749866  | 128002  |
| bucketTake                                 | 307302          | 368396 | 368378 | 429529  | 4       |
| kick                                       | 148050          | 172796 | 171503 | 1026517 | 48000   |
| moveQuoteToken                             | 295234          | 295234 | 295234 | 295234  | 1       |
| pledgeCollateral                           | 62113           | 62458  | 62433  | 554587  | 120001  |
| removeQuoteToken                           | 160278          | 179420 | 179322 | 213455  | 4000    |
| repay                                      | 530459          | 563394 | 553694 | 712263  | 16002   |
| take                                       | 51257           | 52443  | 52179  | 274647  | 15998   |
```
with this PR
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101822          | 160966 | 144431 | 658050 | 56003   |
| borrow                                     | 143203          | 191984 | 163679 | 723205 | 128002  |
| bucketTake                                 | 307304          | 368399 | 368380 | 429532 | 4       |
| kick                                       | 148138          | 172881 | 171591 | 999820 | 48000   |
| moveQuoteToken                             | 295237          | 295237 | 295237 | 295237 | 1       |
| pledgeCollateral                           | 62237           | 62582  | 62557  | 527926 | 120001  |
| removeQuoteToken                           | 160281          | 179423 | 179325 | 213458 | 4000    |
| repay                                      | 505762          | 537697 | 526997 | 685566 | 16002   |
| take                                       | 51354           | 52539  | 52276  | 274718 | 15998   |
```

Note: At the moment ERC721 pool contract size exceeds max