### PR TITLE
Pool gas improvements:

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -953,10 +953,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 index_,
         uint256 inflator_
     ) internal view {
-        uint256 debtInAuction = t0DebtInAuction;
-        if (debtInAuction != 0 ) {
+        uint256 t0AuctionDebt = t0DebtInAuction;
+        if (t0AuctionDebt != 0 ) {
             // deposit in buckets within liquidation debt from the top-of-book down are frozen.
-            if (index_ <= deposits.findIndexOfSum(Maths.wmul(debtInAuction, inflator_))) revert RemoveDepositLockedByAuctionDebt();
+            if (index_ <= deposits.findIndexOfSum(Maths.wmul(t0AuctionDebt, inflator_))) revert RemoveDepositLockedByAuctionDebt();
         } 
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -48,7 +48,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     uint256 internal t0DebtInAuction;         // Total debt in auction used to restrict LPB holder from withdrawing [WAD]
 
     uint256 internal poolInitializations;
-    uint256 internal t0poolDebt; // Pool debt as if the whole amount was incurred upon the first loan. [WAD]
+    uint256 internal t0poolDebt;              // Pool debt as if the whole amount was incurred upon the first loan. [WAD]
 
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -512,13 +512,18 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 newLup = _lup(poolState.accruedDebt);
 
         if (
+            auctions.isActive(borrowerAddress_)
+            &&
             _isCollateralized(
                 Maths.wmul(borrower.t0debt, poolState.inflator),
                 borrower.collateral,
                 newLup
-            ) && auctions.isActive(borrowerAddress_)) { // borrower becomes collateralized, settle auction
-                t0DebtInAuction     -= borrower.t0debt;
-                borrower.collateral = _settleAuction(borrowerAddress_, borrower.collateral);
+            )
+        )
+        {
+            // borrower becomes collateralized, remove debt from pool accumulator and settle auction
+            t0DebtInAuction     -= borrower.t0debt;
+            borrower.collateral = _settleAuction(borrowerAddress_, borrower.collateral);
         }
 
         loans.update(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -946,8 +946,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
     /**
      *  @notice Called by LPB removal functions assess whether or not LPB is locked.
-     *  @param  index_          The bucket index from which LPB is attempting to be removed.
-     *  @param  inflator_       The pool inflator used to properly assess t0 debt in auctions.
+     *  @param  index_    The bucket index from which LPB is attempting to be removed.
+     *  @param  inflator_ The pool inflator used to properly assess t0 debt in auctions.
      */
     function _revertIfAuctionDebtLocked(
         uint256 index_,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,7 +37,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         loans.init();
 
-        poolInitializations += 1; // increment initializations count to ensure these values can't be updated
+        // increment initializations count to ensure these values can't be updated
+        poolInitializations += 1;
     }
 
     /***********************************/
@@ -51,7 +52,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _pledgeCollateral(borrower_, collateralAmountToPledge_);
 
         emit PledgeCollateral(borrower_, collateralAmountToPledge_);
-        _transferCollateralFrom(msg.sender, collateralAmountToPledge_); // move collateral from sender to pool
+        // move collateral from sender to pool
+        _transferCollateralFrom(msg.sender, collateralAmountToPledge_);
     }
 
     function pullCollateral(
@@ -60,7 +62,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _pullCollateral(collateralAmountToPull_);
 
         emit PullCollateral(msg.sender, collateralAmountToPull_);
-        _transferCollateral(msg.sender, collateralAmountToPull_); // move collateral from pool to sender
+        // move collateral from pool to sender
+        _transferCollateral(msg.sender, collateralAmountToPull_);
     }
 
     /*********************************/
@@ -74,7 +77,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         bucketLPs_ = _addCollateral(collateralAmountToAdd_, index_);
 
         emit AddCollateral(msg.sender, index_, collateralAmountToAdd_);
-        _transferCollateralFrom(msg.sender, collateralAmountToAdd_); // move required collateral from sender to pool
+        // move required collateral from sender to pool
+        _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
     }
 
     function removeAllCollateral(
@@ -108,7 +112,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
         emit RemoveCollateral(msg.sender, index_, collateralAmountRemoved_);
-        _transferCollateral(msg.sender, collateralAmountRemoved_); // move collateral from pool to lender
+        // move collateral from pool to lender
+        _transferCollateral(msg.sender, collateralAmountRemoved_);
     }
 
     function removeCollateral(
@@ -118,7 +123,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         bucketLPs_ = _removeCollateral(collateralAmountToRemove_, index_);
 
         emit RemoveCollateral(msg.sender, index_, collateralAmountToRemove_);
-        _transferCollateral(msg.sender, collateralAmountToRemove_); // move collateral from pool to lender
+        // move collateral from pool to lender
+        _transferCollateral(msg.sender, collateralAmountToRemove_);
     }
 
     /*******************************/
@@ -133,7 +139,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override nonReentrant {
         PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
-        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
+        // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
+        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral();
 
         Auctions.TakeParams memory params = Auctions.take(
             auctions,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -37,8 +37,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         loans.init();
 
-        // increment initializations count to ensure these values can't be updated
-        poolInitializations += 1;
+        poolInitializations += 1; // increment initializations count to ensure these values can't be updated
     }
 
     /***********************************/
@@ -51,9 +50,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override {
         _pledgeCollateral(borrower_, collateralAmountToPledge_);
 
-        // move collateral from sender to pool
         emit PledgeCollateral(borrower_, collateralAmountToPledge_);
-        _transferCollateralFrom(msg.sender, collateralAmountToPledge_);
+        _transferCollateralFrom(msg.sender, collateralAmountToPledge_); // move collateral from sender to pool
     }
 
     function pullCollateral(
@@ -61,9 +59,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override {
         _pullCollateral(collateralAmountToPull_);
 
-        // move collateral from pool to sender
         emit PullCollateral(msg.sender, collateralAmountToPull_);
-        _transferCollateral(msg.sender, collateralAmountToPull_);
+        _transferCollateral(msg.sender, collateralAmountToPull_); // move collateral from pool to sender
     }
 
     /*********************************/
@@ -76,9 +73,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override returns (uint256 bucketLPs_) {
         bucketLPs_ = _addCollateral(collateralAmountToAdd_, index_);
 
-        // move required collateral from sender to pool
         emit AddCollateral(msg.sender, index_, collateralAmountToAdd_);
-        _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
+        _transferCollateralFrom(msg.sender, collateralAmountToAdd_); // move required collateral from sender to pool
     }
 
     function removeAllCollateral(
@@ -111,9 +107,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         _updatePool(poolState, _lup(poolState.accruedDebt));
 
-        // move collateral from pool to lender
         emit RemoveCollateral(msg.sender, index_, collateralAmountRemoved_);
-        _transferCollateral(msg.sender, collateralAmountRemoved_);
+        _transferCollateral(msg.sender, collateralAmountRemoved_); // move collateral from pool to lender
     }
 
     function removeCollateral(
@@ -122,9 +117,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override returns (uint256 bucketLPs_) {
         bucketLPs_ = _removeCollateral(collateralAmountToRemove_, index_);
 
-        // move collateral from pool to lender
         emit RemoveCollateral(msg.sender, index_, collateralAmountToRemove_);
-        _transferCollateral(msg.sender, collateralAmountToRemove_);
+        _transferCollateral(msg.sender, collateralAmountToRemove_); // move collateral from pool to lender
     }
 
     /*******************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -109,7 +109,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             redeemedLenderLPs_)
         ;
 
-        _updatePool(poolState, _lup(poolState.accruedDebt));
+        _updateInterestParams(poolState, _lup(poolState.accruedDebt));
 
         emit RemoveCollateral(msg.sender, index_, collateralAmountRemoved_);
         // move collateral from pool to lender
@@ -162,6 +162,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         );
 
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
+        pledgedCollateral = poolState.collateral;
 
         _transferCollateral(callee_, params.collateralAmount);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -37,9 +37,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         interestRateUpdate         = uint48(block.timestamp);
 
         uint256 noOfTokens = tokenIds_.length;
-        if (noOfTokens > 0) {
+        if (noOfTokens > 0) { // add subset of tokenIds allowed in the pool
             isSubset = true;
-            // add subset of tokenIds allowed in the pool
             for (uint256 id = 0; id < noOfTokens;) {
                 tokenIdsAllowed[tokenIds_[id]] = true;
                 unchecked {
@@ -50,8 +49,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         loans.init();
 
-        // increment initializations count to ensure these values can't be updated
-        poolInitializations += 1;
+        poolInitializations += 1; // increment initializations count to ensure these values can't be updated
     }
 
     /***********************************/
@@ -64,9 +62,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     ) external override {
         _pledgeCollateral(borrower_, Maths.wad(tokenIdsToPledge_.length));
 
-        // move collateral from sender to pool
         emit PledgeCollateralNFT(borrower_, tokenIdsToPledge_);
-        _transferFromSenderToPool(borrowerTokenIds[borrower_], tokenIdsToPledge_);
+        _transferFromSenderToPool(borrowerTokenIds[borrower_], tokenIdsToPledge_); // move collateral from sender to pool
     }
 
     function pullCollateral(
@@ -88,9 +85,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     ) external override returns (uint256 bucketLPs_) {
         bucketLPs_ = _addCollateral(Maths.wad(tokenIdsToAdd_.length), index_);
 
-        // move required collateral from sender to pool
         emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_);
-        _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_);
+        _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_); // move required collateral from sender to pool
     }
 
     function removeCollateral(

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -37,8 +37,9 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         interestRateUpdate         = uint48(block.timestamp);
 
         uint256 noOfTokens = tokenIds_.length;
-        if (noOfTokens > 0) { // add subset of tokenIds allowed in the pool
+        if (noOfTokens > 0) {
             isSubset = true;
+            // add subset of tokenIds allowed in the pool
             for (uint256 id = 0; id < noOfTokens;) {
                 tokenIdsAllowed[tokenIds_[id]] = true;
                 unchecked {
@@ -49,7 +50,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         loans.init();
 
-        poolInitializations += 1; // increment initializations count to ensure these values can't be updated
+        // increment initializations count to ensure these values can't be updated
+        poolInitializations += 1;
     }
 
     /***********************************/
@@ -63,7 +65,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         _pledgeCollateral(borrower_, Maths.wad(tokenIdsToPledge_.length));
 
         emit PledgeCollateralNFT(borrower_, tokenIdsToPledge_);
-        _transferFromSenderToPool(borrowerTokenIds[borrower_], tokenIdsToPledge_); // move collateral from sender to pool
+        // move collateral from sender to pool
+        _transferFromSenderToPool(borrowerTokenIds[borrower_], tokenIdsToPledge_);
     }
 
     function pullCollateral(
@@ -72,6 +75,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         _pullCollateral(Maths.wad(noOfNFTsToPull_));
 
         emit PullCollateral(msg.sender, noOfNFTsToPull_);
+        // move collateral from pool to sender
         _transferFromPoolToAddress(msg.sender, borrowerTokenIds[msg.sender], noOfNFTsToPull_);
     }
 
@@ -86,7 +90,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         bucketLPs_ = _addCollateral(Maths.wad(tokenIdsToAdd_.length), index_);
 
         emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_);
-        _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_); // move required collateral from sender to pool
+        // move required collateral from sender to pool
+        _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_);
     }
 
     function removeCollateral(
@@ -111,7 +116,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     ) external override nonReentrant {
         PoolState      memory poolState = _accruePoolInterest();
         Loans.Borrower memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
-        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
+        // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
+        if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral();
 
         Auctions.TakeParams memory params = Auctions.take(
             auctions,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -165,7 +165,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         if (excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, excessQuoteToken);
 
         _payLoan(params.t0repayAmount, poolState, borrowerAddress_, borrower);
-
+        pledgedCollateral = poolState.collateral;
     }
 
 


### PR DESCRIPTION
- read t0 debt in auctions only once from storage when checking if debt locked
- no need to check if borrower collateral is 0 as it is already covered by isCollateralized function
- check both allowance conditions for lp tokens transfer at the same time
- in pledge collateral, when settling auction, check first if borrower is auctioned and then if collateralized
- update pool's pledged collateral accumulator only when needed and rename `_updatePool` to `_updateInterestParams`
- style improvements

develop
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101793          | 160935 | 144402 | 657998 | 56003   |
| borrow                                     | 143179          | 191958 | 163655 | 723157 | 128002  |
| bucketTake                                 | 307388          | 368513 | 368495 | 429677 | 4       |
| kick                                       | 148114          | 172857 | 171567 | 999772 | 48000   |
| moveQuoteToken                             | 285578          | 285578 | 285578 | 285578 | 1       |
| pledgeCollateral                           | 62200           | 62545  | 62520  | 527865 | 120001  |
| removeQuoteToken                           | 160229          | 179371 | 179273 | 213930 | 4000    |
| repay                                      | 505714          | 537649 | 526949 | 685518 | 16002   |
| take                                       | 52649           | 53835  | 53571  | 276004 | 15998   |
```
vs
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101793          | 160935 | 144402 | 657998 | 56003   |
| borrow                                     | 143142          | 191921 | 163618 | 723120 | 128002  |
| bucketTake                                 | 307387          | 368512 | 368493 | 429675 | 4       |
| kick                                       | 148114          | 172857 | 171567 | 999772 | 48000   |
| moveQuoteToken                             | 281035          | 281035 | 281035 | 281035 | 1       |
| pledgeCollateral                           | 61576           | 61921  | 61896  | 527241 | 120001  |
| removeQuoteToken                           | 160234          | 179376 | 179278 | 213935 | 4000    |
| repay                                      | 505712          | 537647 | 526947 | 685516 | 16002   |
| take                                       | 52648           | 53833  | 53569  | 276003 | 15998   |