### PR TITLE
Consolidate Auctions library

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -14,6 +14,7 @@ import '../libraries/Deposits.sol';
 import '../libraries/Loans.sol';
 import '../libraries/Maths.sol';
 import '../libraries/PoolUtils.sol';
+import '../libraries/BucketMath.sol';
 
 abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     using Auctions for Auctions.Data;
@@ -478,7 +479,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
     function startClaimableReserveAuction() external override {
         uint256 curUnclaimedAuctionReserve = reserveAuctionUnclaimed;
-        uint256 claimable = PoolUtils.claimableReserves(
+        uint256 claimable = Auctions.claimableReserves(
             Maths.wmul(t0poolDebt, inflatorSnapshot),
             deposits.treeSum(),
             auctions.totalBondEscrowed,
@@ -490,7 +491,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if (curUnclaimedAuctionReserve != 0) {
             reserveAuctionUnclaimed = curUnclaimedAuctionReserve;
             reserveAuctionKicked    = block.timestamp;
-            emit ReserveAuction(curUnclaimedAuctionReserve, PoolUtils.reserveAuctionPrice(block.timestamp));
+            emit ReserveAuction(curUnclaimedAuctionReserve, Auctions.reserveAuctionPrice(block.timestamp));
             _transferQuoteToken(msg.sender, kickerAward);
         } else revert NoReserves();
     }
@@ -500,7 +501,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         if (kicked != 0 && block.timestamp - kicked <= 72 hours) {
             amount_ = Maths.min(reserveAuctionUnclaimed, maxAmount_);
-            uint256 price = PoolUtils.reserveAuctionPrice(kicked);
+            uint256 price = Auctions.reserveAuctionPrice(kicked);
             uint256 ajnaRequired = Maths.wmul(amount_, price);
             reserveAuctionUnclaimed -= amount_;
 
@@ -747,7 +748,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
             if (poolState_.isNewInterestAccrued) {
                 // Scale the borrower inflator to update amount of interest owed by borrowers
-                uint256 factor = PoolUtils.pendingInterestFactor(poolState_.rate, elapsed);
+                uint256 factor = BucketMath.pendingInterestFactor(poolState_.rate, elapsed);
                 poolState_.inflator = Maths.wmul(poolState_.inflator, factor);
 
                 // Scale the fenwick tree to update amount of debt owed to lenders
@@ -888,7 +889,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     function debtInfo() external view returns (uint256, uint256, uint256) {
-        uint256 pendingInflator = PoolUtils.pendingInflator(
+        uint256 pendingInflator = BucketMath.pendingInflator(
             inflatorSnapshot,
             lastInflatorSnapshotUpdate,
             interestRate

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -4,8 +4,10 @@ pragma solidity 0.8.14;
 
 import './interfaces/IPool.sol';
 
+import '../libraries/Auctions.sol';
 import '../libraries/Buckets.sol';
 import '../libraries/PoolUtils.sol';
+import '../libraries/BucketMath.sol';
 
 contract PoolInfoUtils {
 
@@ -26,7 +28,7 @@ contract PoolInfoUtils {
         ) = pool.inflatorInfo();
         uint256 interestRate = pool.interestRate();
 
-        uint256 pendingInflator = PoolUtils.pendingInflator(poolInflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
+        uint256 pendingInflator = BucketMath.pendingInflator(poolInflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
         uint256 t0debt;
         (t0debt, collateral_, t0Np_)  = pool.borrowerInfo(borrower_);
         debt_ = Maths.wmul(t0debt, pendingInflator);
@@ -96,8 +98,8 @@ contract PoolInfoUtils {
         ) = pool.inflatorInfo();
         uint256 interestRate = pool.interestRate();
 
-        pendingInflator_       = PoolUtils.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
-        pendingInterestFactor_ = PoolUtils.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
+        pendingInflator_       = BucketMath.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
+        pendingInterestFactor_ = BucketMath.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
     }
 
     /**
@@ -161,7 +163,7 @@ contract PoolInfoUtils {
         (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 auctionKickTime) = pool.reservesInfo();
 
         reserves_ = poolDebt + quoteTokenBalance - poolSize - bondEscrowed - unclaimedReserve;
-        claimableReserves_ = PoolUtils.claimableReserves(
+        claimableReserves_ = Auctions.claimableReserves(
             poolDebt,
             poolSize,
             bondEscrowed,
@@ -170,7 +172,7 @@ contract PoolInfoUtils {
         );
 
         claimableReservesRemaining_ = unclaimedReserve;
-        auctionPrice_               = PoolUtils.reserveAuctionPrice(auctionKickTime);
+        auctionPrice_               = Auctions.reserveAuctionPrice(auctionKickTime);
         timeRemaining_              = 3 days - Maths.min(3 days, block.timestamp - auctionKickTime);
     }
 
@@ -221,7 +223,7 @@ contract PoolInfoUtils {
         uint256 poolCollateral = pool.pledgedCollateral();
         uint256 utilization    = pool.depositUtilization(poolDebt, poolCollateral);
 
-        lenderInterestMargin_ = PoolUtils.lenderInterestMargin(utilization);
+        lenderInterestMargin_ = BucketMath.lenderInterestMargin(utilization);
     }
 
     function indexToPrice(

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -2,12 +2,17 @@
 
 pragma solidity 0.8.14;
 
+import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
+import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
+
 import './Buckets.sol';
 import './Loans.sol';
 import './Maths.sol';
 import './PoolUtils.sol';
+import './BucketMath.sol';
 
 library Auctions {
+    uint256 internal constant MINUTE_HALF_LIFE    = 0.988514020352896135_356867505 * 1e27;  // 0.5^(1/60)
 
     struct Data {
         address head;
@@ -277,7 +282,7 @@ library Auctions {
         _validateTake(liquidation);
 
         params_.bucketPrice  = PoolUtils.indexToPrice(bucketIndex_);
-        params_.auctionPrice = PoolUtils.auctionPrice(
+        params_.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
             liquidation.kickTime
         );
@@ -342,7 +347,7 @@ library Auctions {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
         _validateTake(liquidation);
 
-        params_.auctionPrice = PoolUtils.auctionPrice(
+        params_.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
             liquidation.kickTime
         );
@@ -417,7 +422,7 @@ library Auctions {
         if (floorCollateral_ != borrowerCollateral_) {
             // cover borrower's fractional amount with LPs in auction price bucket
             uint256 fractionalCollateral = borrowerCollateral_ - floorCollateral_;
-            uint256 auctionPrice = PoolUtils.auctionPrice(
+            uint256 auctionPrice = _auctionPrice(
                 self.liquidations[borrowerAddress_].kickMomp,
                 self.liquidations[borrowerAddress_].kickTime
             );
@@ -450,6 +455,58 @@ library Auctions {
     /***************************/
     /***  Internal Functions ***/
     /***************************/
+
+    function _auctionPrice(
+        uint256 referencePrice,
+        uint256 kickTime_
+    ) internal view returns (uint256 price_) {
+        uint256 elapsedHours = Maths.wdiv((block.timestamp - kickTime_) * 1e18, 1 hours * 1e18);
+        elapsedHours -= Maths.min(elapsedHours, 1e18);  // price locked during cure period
+
+        int256 timeAdjustment = PRBMathSD59x18.mul(-1 * 1e18, int256(elapsedHours));
+        price_ = 32 * Maths.wmul(referencePrice, uint256(PRBMathSD59x18.exp2(timeAdjustment)));
+    }
+
+    /**
+     *  @notice Calculates bond penalty factor.
+     *  @dev Called in kick and take.
+     *  @param debt_             Borrower debt.
+     *  @param collateral_       Borrower collateral.
+     *  @param neutralPrice_     NP of auction.
+     *  @param bondFactor_       Factor used to determine bondSize.
+     *  @param price_            Auction price at the time of call.
+     *  @return bpf_             Factor used in determining bond Reward (positive) or penalty (negative).
+     */
+    function _bpf(
+        uint256 debt_,
+        uint256 collateral_,
+        uint256 neutralPrice_,
+        uint256 bondFactor_,
+        uint256 price_
+    ) internal pure returns (int256) {
+        int256 thresholdPrice = int256(Maths.wdiv(debt_, collateral_));
+
+        int256 sign;
+        if (thresholdPrice < int256(neutralPrice_)) {
+            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
+            sign = Maths.minInt(
+                    1e18,
+                    Maths.maxInt(
+                        -1 * 1e18,
+                        PRBMathSD59x18.div(
+                            int256(neutralPrice_) - int256(price_),
+                            int256(neutralPrice_) - thresholdPrice
+                        )
+                    )
+            );
+        } else {
+            int256 val = int256(neutralPrice_) - int256(price_);
+            if (val < 0 )      sign = -1e18;
+            else if (val != 0) sign = 1e18;
+        }
+
+        return PRBMathSD59x18.mul(int256(bondFactor_), sign);
+    }
 
     /**
      *  @notice Removes auction and repairs the queue order.
@@ -572,7 +629,7 @@ library Auctions {
     ) {
         // calculate the bond payment factor
         borrowerDebt_ = Maths.wmul(borrower_.t0debt, poolInflator_);
-        bpf_ = PoolUtils.bpf(
+        bpf_ = _bpf(
             borrowerDebt_,
             borrower_.collateral,
             liquidation_.neutralPrice,
@@ -585,6 +642,28 @@ library Auctions {
     /**********************/
     /*** View Functions ***/
     /**********************/
+
+    function claimableReserves(
+        uint256 debt_,
+        uint256 poolSize_,
+        uint256 totalBondEscrowed_,
+        uint256 reserveAuctionUnclaimed_,
+        uint256 quoteTokenBalance_
+    ) internal pure returns (uint256 claimable_) {
+        claimable_ = Maths.wmul(0.995 * 1e18, debt_) + quoteTokenBalance_;
+        claimable_ -= Maths.min(claimable_, poolSize_ + totalBondEscrowed_ + reserveAuctionUnclaimed_);
+    }
+
+    function reserveAuctionPrice(
+        uint256 reserveAuctionKicked_
+    ) internal view returns (uint256 _price) {
+        if (reserveAuctionKicked_ != 0) {
+            uint256 secondsElapsed = block.timestamp - reserveAuctionKicked_;
+            uint256 hoursComponent = 1e27 >> secondsElapsed / 3600;
+            uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
+            _price = Maths.rayToWad(1_000_000_000 * Maths.rmul(hoursComponent, minutesComponent));
+        }
+    }
 
     /**
      *  @notice Check if there is an ongoing auction for current borrower and revert if such.

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -8,11 +8,14 @@ import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 import './Buckets.sol';
 import './Loans.sol';
 import './Maths.sol';
-import './PoolUtils.sol';
-import './BucketMath.sol';
 
 library Auctions {
     uint256 internal constant MINUTE_HALF_LIFE    = 0.988514020352896135_356867505 * 1e27;  // 0.5^(1/60)
+    uint256 internal constant MIN_PRICE = 99_836_282_890;
+    uint256 internal constant MAX_PRICE = 1_004_968_987.606512354182109771 * 10**18;
+    int256 internal constant MAX_PRICE_INDEX = 4_156;
+    int256 internal constant MIN_PRICE_INDEX = -3_232;
+    int256 internal constant FLOAT_STEP_INT = 1.005 * 10**18;
 
     struct Data {
         address head;
@@ -121,7 +124,7 @@ library Auctions {
         while (bucketDepth_ != 0 && t0DebtToSettle_ != 0 && collateral_ != 0) {
             hpbVars.index   = Deposits.findIndexOfSum(deposits_, 1);
             hpbVars.deposit = Deposits.valueAt(deposits_, hpbVars.index);
-            hpbVars.price   = PoolUtils.indexToPrice(hpbVars.index);
+            hpbVars.price   = _indexToPrice(hpbVars.index);
 
             uint256 depositToRemove = hpbVars.deposit;
             uint256 collateralUsed;
@@ -281,7 +284,7 @@ library Auctions {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
         _validateTake(liquidation);
 
-        params_.bucketPrice  = PoolUtils.indexToPrice(bucketIndex_);
+        params_.bucketPrice  = _indexToPrice(bucketIndex_);
         params_.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
             liquidation.kickTime
@@ -426,13 +429,13 @@ library Auctions {
                 self.liquidations[borrowerAddress_].kickMomp,
                 self.liquidations[borrowerAddress_].kickTime
             );
-            bucketIndex_ = PoolUtils.priceToIndex(auctionPrice);
+            bucketIndex_ = _priceToIndex(auctionPrice);
             lps_ = Buckets.addCollateral(
                 buckets_[bucketIndex_],
                 borrowerAddress_,
                 Deposits.valueAt(deposits_, bucketIndex_),
                 fractionalCollateral,
-                PoolUtils.indexToPrice(bucketIndex_)
+                _indexToPrice(bucketIndex_)
             );
         }
 
@@ -638,6 +641,51 @@ library Auctions {
         );
         factor_ = uint256(1e18 - Maths.maxInt(0, bpf_));
     }
+
+
+    /***********************************/
+    /*** Bucket Conversion Functions ***/
+    /***********************************/
+
+    /**
+     * @dev replicated to avoid calling external BucketMath library
+     */
+    function _indexToPrice(
+        uint256 index_
+    ) internal pure returns (uint256) {
+        int256 bucketIndex = (index_ != 8191) ? MAX_PRICE_INDEX - int256(index_) : MIN_PRICE_INDEX;
+        require(bucketIndex >= MIN_PRICE_INDEX && bucketIndex <= MAX_PRICE_INDEX, "BM:ITP:OOB");
+
+        return uint256(
+            PRBMathSD59x18.exp2(
+                PRBMathSD59x18.mul(
+                    PRBMathSD59x18.fromInt(bucketIndex),
+                    PRBMathSD59x18.log2(FLOAT_STEP_INT)
+                )
+            )
+        );
+    }
+
+    /**
+     * @dev replicated to avoid calling external BucketMath library
+     */
+    function _priceToIndex(
+        uint256 price_
+    ) internal pure returns (uint256) {
+        require(price_ >= MIN_PRICE && price_ <= MAX_PRICE, "BM:PTI:OOB");
+
+        int256 index = PRBMathSD59x18.div(
+            PRBMathSD59x18.log2(int256(price_)),
+            PRBMathSD59x18.log2(FLOAT_STEP_INT)
+        );
+
+        int256 ceilIndex = PRBMathSD59x18.ceil(index);
+        if (index < 0 && ceilIndex - index > 0.5 * 1e18) {
+            return uint256(7067 - PRBMathSD59x18.toInt(ceilIndex));
+        }
+        return uint256(4156 - PRBMathSD59x18.toInt(ceilIndex));
+    }
+
 
     /**********************/
     /*** View Functions ***/

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.14;
 
 import './Maths.sol';
 import './PoolUtils.sol';
+import './BucketMath.sol';
 
 library Deposits {
 
@@ -33,7 +34,7 @@ library Deposits {
         uint256 depositAboveHtp = prefixSum(self, htpIndex);
 
         if (depositAboveHtp != 0) {
-            uint256 netInterestMargin = PoolUtils.lenderInterestMargin(utilization(self, debt_, collateral_));
+            uint256 netInterestMargin = BucketMath.lenderInterestMargin(utilization(self, debt_, collateral_));
             uint256 newInterest       = Maths.wmul(netInterestMargin, Maths.wmul(pendingInterestFactor_ - Maths.WAD, debt_));
 
             uint256 lenderFactor = Maths.wdiv(newInterest, depositAboveHtp) + Maths.WAD;

--- a/src/libraries/PoolUtils.sol
+++ b/src/libraries/PoolUtils.sol
@@ -7,28 +7,9 @@ import './BucketMath.sol';
 
 library PoolUtils {
     uint256 internal constant WAD_WEEKS_PER_YEAR  = 52 * 10**18;
-    uint256 internal constant MINUTE_HALF_LIFE    = 0.988514020352896135_356867505 * 1e27;  // 0.5^(1/60)
 
     // minimum fee that can be applied for early withdraw penalty
     uint256 internal constant MIN_FEE = 0.0005 * 10**18;
-
-    function auctionPrice(
-        uint256 referencePrice,
-        uint256 kickTime_
-    ) internal view returns (uint256) {
-        return BucketMath.auctionPrice(referencePrice, kickTime_);
-    }
-
-    function claimableReserves(
-        uint256 debt_,
-        uint256 poolSize_,
-        uint256 totalBondEscrowed_,
-        uint256 reserveAuctionUnclaimed_,
-        uint256 quoteTokenBalance_
-    ) internal pure returns (uint256 claimable_) {
-        claimable_ = Maths.wmul(0.995 * 1e18, debt_) + quoteTokenBalance_;
-        claimable_ -= Maths.min(claimable_, poolSize_ + totalBondEscrowed_ + reserveAuctionUnclaimed_);
-    }
 
     function encumberance(
         uint256 debt_,
@@ -60,38 +41,12 @@ library PoolUtils {
         return Maths.max(Maths.wdiv(interestRate_, WAD_WEEKS_PER_YEAR), MIN_FEE);
     }
 
-    function pendingInterestFactor(
-        uint256 interestRate_,
-        uint256 elapsed_
-    ) internal pure returns (uint256) {
-        return BucketMath.pendingInterestFactor(interestRate_, elapsed_);
-    }
-
-    function pendingInflator(
-        uint256 inflatorSnapshot_,
-        uint256 lastInflatorSnapshotUpdate_,
-        uint256 interestRate_
-    ) internal view returns (uint256) {
-        return BucketMath.pendingInflator(inflatorSnapshot_, lastInflatorSnapshotUpdate_, interestRate_);
-    }
-
     function minDebtAmount(
         uint256 debt_,
         uint256 loansCount_
     ) internal pure returns (uint256 minDebtAmount_) {
         if (loansCount_ != 0) {
             minDebtAmount_ = Maths.wdiv(Maths.wdiv(debt_, Maths.wad(loansCount_)), 10**19);
-        }
-    }
-
-    function reserveAuctionPrice(
-        uint256 reserveAuctionKicked_
-    ) internal view returns (uint256 _price) {
-        if (reserveAuctionKicked_ != 0) {
-            uint256 secondsElapsed = block.timestamp - reserveAuctionKicked_;
-            uint256 hoursComponent = 1e27 >> secondsElapsed / 3600;
-            uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
-            _price = Maths.rayToWad(1_000_000_000 * Maths.rmul(hoursComponent, minutesComponent));
         }
     }
 
@@ -123,12 +78,6 @@ library PoolUtils {
         }
     }
 
-    function lenderInterestMargin(
-        uint256 mau_
-    ) internal pure returns (uint256) {
-        return BucketMath.lenderInterestMargin(mau_);
-    }
-
     /**
      *  @dev Fenwick index to bucket index conversion
      *          1.00      : bucket index 0,     fenwick index 4146: 7388-4156-3232=0
@@ -146,32 +95,6 @@ library PoolUtils {
         uint256 price_
     ) internal pure returns (uint256) {
         return uint256(7388 - (BucketMath.priceToIndex(price_) + 3232));
-    }
-
-    /**
-     *  @notice Calculates bond penalty factor.
-     *  @dev Called in kick and take.
-     *  @param debt_             Borrower debt.
-     *  @param collateral_       Borrower collateral.
-     *  @param neutralPrice_     NP of auction.
-     *  @param bondFactor_       Factor used to determine bondSize.
-     *  @param price_            Auction price at the time of call.
-     *  @return bpf_             Factor used in determining bond Reward (positive) or penalty (negative).
-     */
-    function bpf(
-        uint256 debt_,
-        uint256 collateral_,
-        uint256 neutralPrice_,
-        uint256 bondFactor_,
-        uint256 price_
-    ) internal pure returns (int256) {
-        return BucketMath.bpf(
-            debt_,
-            collateral_,
-            neutralPrice_,
-            bondFactor_,
-            price_
-        );
     }
 
 }

--- a/tests/forge/Auctions.t.sol
+++ b/tests/forge/Auctions.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import './utils/DSTestPlus.sol';
+
+import 'src/libraries/Auctions.sol';
+
+contract AuctionsTest is DSTestPlus {
+
+    /**
+     *  @notice Tests bond penalty/reward factor calculation for varying parameters
+     */
+    function testBpf() external {
+        uint256 debt  = 11_000 * 1e18;
+        uint256 price = 10 * 1e18;
+        uint256 collateral = 1000 * 1e18;
+        uint256 neutralPrice = 15 * 1e18;
+        uint256 bondFactor = 0.1 *  1e18;
+
+        assertEq(Auctions._bpf(debt, collateral, neutralPrice, bondFactor, price),             0.1 * 1e18);
+        assertEq(Auctions._bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, price),      0.083333333333333333 * 1e18);
+        assertEq(Auctions._bpf(debt, collateral, neutralPrice, bondFactor, 9.5 * 1e18),        0.1 * 1e18);
+        assertEq(Auctions._bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, 9.5 * 1e18), 0.091666666666666667 * 1e18);
+        assertEq(Auctions._bpf(9000 * 1e18, collateral, 10 * 1e18, bondFactor, 10.5 * 1e18),   -0.05 * 1e18);
+        assertEq(Auctions._bpf(debt, collateral, 5 * 1e18, bondFactor, 10.5 * 1e18),           -0.1 * 1e18);
+    }
+
+    /**
+     *  @notice Tests auction price multiplier for reverse dutch auction at different times
+     */
+    function testAuctionPrice() external {
+        skip(6238);
+        uint256 referencePrice = 8_678.5 * 1e18;
+        uint256 kickTime = block.timestamp;
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
+        skip(1444); // price should not change in the first hour
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
+
+        skip(5756);     // 2 hours
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 138_856 * 1e18);
+        skip(2394);     // 2 hours, 39 minutes, 54 seconds
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 87_574.910740335995562528 * 1e18);
+        skip(2586);     // 3 hours, 23 minutes
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 53_227.960156860514117568 * 1e18);
+        skip(3);        // 3 seconds later
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 53_197.223359425583052544 * 1e18);
+        skip(20153);    // 8 hours, 35 minutes, 53 seconds
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 1_098.26293050754894624 * 1e18);
+        skip(97264);    // 36 hours
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 0.00000808248283696 * 1e18);
+        skip(129600);   // 72 hours
+        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 0);
+    }
+
+    /**
+     *  @notice Tests reserve price multiplier for reverse dutch auction at different times
+     */
+    function testReserveAuctionPrice() external {
+        skip(5 days);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp),            1e27);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 1 hours),  500000000 * 1e18);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 2 hours),  250000000 * 1e18);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 4 hours),  62500000 * 1e18);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 16 hours), 15258.789062500000000000 * 1e18);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 24 hours), 59.604644775390625000 * 1e18);
+        assertEq(Auctions.reserveAuctionPrice(block.timestamp - 90 hours), 0);
+    }
+
+    /**
+     *  @notice Tests claimable reserves calculation for varying parameters
+     */
+    function testClaimableReserves() external {
+        uint256 debt = 11_000 * 1e18;
+        uint256 poolSize = 1_001 * 1e18;
+        uint256 liquidationBondEscrowed = 1_001 * 1e18;
+        uint256 reserveAuctionUnclaimed = 1_001 * 1e18;
+        uint256 quoteTokenBalance = 11_000 * 1e18;
+
+        assertEq(Auctions.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, quoteTokenBalance),  18_942 * 1e18);
+        assertEq(Auctions.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, 0),                  7_942 * 1e18);
+        assertEq(Auctions.claimableReserves(0, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, quoteTokenBalance),     7_997 * 1e18);
+        assertEq(Auctions.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, Maths.WAD),          7_943 * 1e18);
+        assertEq(Auctions.claimableReserves(debt, 11_000 * 1e18, liquidationBondEscrowed, reserveAuctionUnclaimed, 0),             0);
+        assertEq(Auctions.claimableReserves(debt, poolSize, 11_000 * 1e18, reserveAuctionUnclaimed, 0),                            0);
+        assertEq(Auctions.claimableReserves(debt, poolSize, liquidationBondEscrowed, 11_000 * 1e18, 0),                            0);
+        assertEq(Auctions.claimableReserves(debt, 11_000 * 1e18, 11_000 * 1e18, reserveAuctionUnclaimed, 0),                       0);
+        assertEq(Auctions.claimableReserves(debt, poolSize, 11_000 * 1e18, 10_895 * 1e18, quoteTokenBalance),                      0);
+
+    }
+
+}

--- a/tests/forge/BucketMathTest.t.sol
+++ b/tests/forge/BucketMathTest.t.sol
@@ -217,49 +217,4 @@ contract BucketMathTest is DSTestPlus {
         assertEq(BucketMath.lenderInterestMargin(1.1 * 1e18),        1 * 1e18);
     }
 
-    /**
-     *  @notice Tests bond penalty/reward factor calculation for varying parameters
-     */
-    function testBpf() external {
-        uint256 debt  = 11_000 * 1e18;
-        uint256 price = 10 * 1e18;
-        uint256 collateral = 1000 * 1e18;
-        uint256 neutralPrice = 15 * 1e18;
-        uint256 bondFactor = 0.1 *  1e18;
-
-        assertEq(BucketMath.bpf(debt, collateral, neutralPrice, bondFactor, price),               0.1 * 1e18);
-        assertEq(BucketMath.bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, price),        0.083333333333333333 * 1e18);
-        assertEq(BucketMath.bpf(debt, collateral, neutralPrice, bondFactor, 9.5 * 1e18),          0.1 * 1e18);
-        assertEq(BucketMath.bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, 9.5 * 1e18),   0.091666666666666667 * 1e18);
-        assertEq(BucketMath.bpf(9000 * 1e18, collateral, 10 * 1e18, bondFactor, 10.5 * 1e18),     -0.05 * 1e18);
-        assertEq(BucketMath.bpf(debt, collateral, 5 * 1e18, bondFactor, 10.5 * 1e18),             -0.1 * 1e18);
-    }
-
-    /**
-     *  @notice Tests auction price multiplier for reverse dutch auction at different times
-     */
-    function testAuctionPrice() external {
-        skip(6238);
-        uint256 referencePrice = 8_678.5 * 1e18;
-        uint256 kickTime = block.timestamp;
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
-        skip(1444); // price should not change in the first hour
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
-
-        skip(5756);     // 2 hours
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 138_856 * 1e18);
-        skip(2394);     // 2 hours, 39 minutes, 54 seconds
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 87_574.910740335995562528 * 1e18);
-        skip(2586);     // 3 hours, 23 minutes
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 53_227.960156860514117568 * 1e18);
-        skip(3);        // 3 seconds later
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 53_197.223359425583052544 * 1e18);
-        skip(20153);    // 8 hours, 35 minutes, 53 seconds
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 1_098.26293050754894624 * 1e18);
-        skip(97264);    // 36 hours
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 0.00000808248283696 * 1e18);
-        skip(129600);   // 72 hours
-        assertEq(BucketMath.auctionPrice(referencePrice, kickTime), 0);
-    }
-
 }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -47,7 +47,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         (uint256 poolInflatorSnapshot, uint256 lastInflatorSnapshotUpdate) = _pool.inflatorInfo();
 
         uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;
-        uint256 factor = PoolUtils.pendingInterestFactor(_pool.interestRate(), elapsed);
+        uint256 factor = BucketMath.pendingInterestFactor(_pool.interestRate(), elapsed);
 
         uint256 currentPoolInflator = Maths.wmul(poolInflatorSnapshot, factor);
 

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -8,7 +8,7 @@ import 'src/erc20/ERC20Pool.sol';
 import 'src/erc20/ERC20PoolFactory.sol';
 
 contract ERC20PoolFactoryTest is ERC20HelperContract {
-    address immutable poolAddress = 0x918ebA623C6291984Eeea4EE07335c3DDa03c0d3;
+    address immutable poolAddress = 0xC557cA6053cdF046dE138BDc41c9a11203073f2D;
 
     ERC20PoolFactory internal _poolFactory;
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -56,7 +56,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
         (uint256 poolInflatorSnapshot, uint256 lastInflatorSnapshotUpdate) = _pool.inflatorInfo();
 
         uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;
-        uint256 factor = PoolUtils.pendingInterestFactor(_pool.interestRate(), elapsed);
+        uint256 factor = BucketMath.pendingInterestFactor(_pool.interestRate(), elapsed);
 
         uint256 currentPoolInflator = Maths.wmul(poolInflatorSnapshot, factor);
 

--- a/tests/forge/PoolUtilsTest.t.sol
+++ b/tests/forge/PoolUtilsTest.t.sol
@@ -10,28 +10,6 @@ import 'src/base/Pool.sol';
 contract PoolUtilsTest is DSTestPlus {
 
     /**
-     *  @notice Tests claimable reserves calculation for varying parameters
-     */
-    function testClaimableReserves() external {
-        uint256 debt = 11_000 * 1e18;
-        uint256 poolSize = 1_001 * 1e18;
-        uint256 liquidationBondEscrowed = 1_001 * 1e18;
-        uint256 reserveAuctionUnclaimed = 1_001 * 1e18;
-        uint256 quoteTokenBalance = 11_000 * 1e18;
-
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, quoteTokenBalance),  18_942 * 1e18);
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, 0),                  7_942 * 1e18);
-        assertEq(PoolUtils.claimableReserves(0, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, quoteTokenBalance),     7_997 * 1e18);
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, liquidationBondEscrowed, reserveAuctionUnclaimed, Maths.WAD),          7_943 * 1e18);
-        assertEq(PoolUtils.claimableReserves(debt, 11_000 * 1e18, liquidationBondEscrowed, reserveAuctionUnclaimed, 0),             0);
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, 11_000 * 1e18, reserveAuctionUnclaimed, 0),                            0);
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, liquidationBondEscrowed, 11_000 * 1e18, 0),                            0);
-        assertEq(PoolUtils.claimableReserves(debt, 11_000 * 1e18, 11_000 * 1e18, reserveAuctionUnclaimed, 0),                       0);
-        assertEq(PoolUtils.claimableReserves(debt, poolSize, 11_000 * 1e18, 10_895 * 1e18, quoteTokenBalance),                      0);
-
-    }
-
-    /**
      *  @notice Tests collateral encumberance for varying values of debt and lup
      */
     function testEncumberance() external {
@@ -93,22 +71,6 @@ contract PoolUtilsTest is DSTestPlus {
         assertEq(PoolUtils.minDebtAmount(debt, 10),         110 * 1e18);
         assertEq(PoolUtils.minDebtAmount(debt, 0),          0);
         assertEq(PoolUtils.minDebtAmount(0, loansCount),    0);
-    }
-
-    /**
-     *  @notice Tests reserve price multiplier for reverse dutch auction at different times
-     */
-    function testReserveAuctionPrice() external {
-        skip(5 days);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp),            1e27);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 1 hours),  500000000 * 1e18);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 2 hours),  250000000 * 1e18);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 4 hours),  62500000 * 1e18);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 16 hours), 15258.789062500000000000 * 1e18);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 24 hours), 59.604644775390625000 * 1e18);
-        assertEq(PoolUtils.reserveAuctionPrice(block.timestamp - 90 hours), 0);
-
-
     }
 
     /**

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -11,6 +11,7 @@ import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import 'src/base/interfaces/IPool.sol';
 import 'src/base/PoolInfoUtils.sol';
 
+import 'src/libraries/Auctions.sol';
 import 'src/libraries/Maths.sol';
 
 abstract contract DSTestPlus is Test {
@@ -367,16 +368,19 @@ abstract contract DSTestPlus is Test {
         (uint256 borrowerdebt, uint256 borrowerCollateral, ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);
         uint256 borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerdebt * Maths.WAD / borrowerCollateral : 0;
 
-        assertEq(auctionKickTime != 0,                                     state_.active);
-        assertEq(auctionKicker,                                            state_.kicker);
-        assertEq(lockedBonds,                                              state_.bondSize);
-        assertEq(auctionBondFactor,                                        state_.bondFactor);
-        assertEq(auctionKickTime,                                          state_.kickTime);
-        assertEq(auctionKickMomp,                                          state_.kickMomp);
-        assertEq(auctionTotalBondEscrowed,                                 state_.totalBondEscrowed);
-        assertEq(auctionDebtInAuction,                                     state_.debtInAuction);
-        assertEq(PoolUtils.auctionPrice(auctionKickMomp, auctionKickTime), state_.auctionPrice);
-        assertEq(borrowerThresholdPrice,                                   state_.thresholdPrice);
+        assertEq(auctionKickTime != 0,     state_.active);
+        assertEq(auctionKicker,            state_.kicker);
+        assertEq(lockedBonds,              state_.bondSize);
+        assertEq(auctionBondFactor,        state_.bondFactor);
+        assertEq(auctionKickTime,          state_.kickTime);
+        assertEq(auctionKickMomp,          state_.kickMomp);
+        assertEq(auctionTotalBondEscrowed, state_.totalBondEscrowed);
+        assertEq(auctionDebtInAuction,     state_.debtInAuction);
+        assertEq(Auctions._auctionPrice(
+            auctionKickMomp,
+            auctionKickTime
+        ),                                 state_.auctionPrice);
+        assertEq(borrowerThresholdPrice,   state_.thresholdPrice);
     }
 
     function _assertPool(PoolState memory state_) internal {


### PR DESCRIPTION
- avoid calling external library BucketMath from external Auctions library (tradeoff of bucket conversion functions copy/pasted from BucketMath in Auctions library but reduction in required gas)
- move auctions related functions (auction price, bpf) in Auctions library
- move several functions in BucketMath instead proxying them through PoolUtils

TBD: `applyEarlyWithdrawalPenalty` still makes 2 external `BucketMath.indexToPrice` calls, move function in BucketMath external library to avoid such?

```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101758          | 160886 | 144367 | 657764 | 56003   |
| borrow                                     | 143107          | 191874 | 163583 | 722886 | 128002  |
| bucketTake                                 | 318621          | 380419 | 380424 | 442209 | 4       |
| kick                                       | 150879          | 175622 | 174332 | 999538 | 48000   |
| moveQuoteToken                             | 285327          | 285327 | 285327 | 285327 | 1       |
| pledgeCollateral                           | 61678           | 62023  | 61998  | 527144 | 120001  |
| removeQuoteToken                           | 160000          | 179142 | 179044 | 213679 | 4000    |
| repay                                      | 505500          | 537435 | 526735 | 685304 | 16002   |
| take                                       | 49939           | 50472  | 50198  | 286025 | 15998   |
```
vs
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101793          | 160935 | 144402 | 657998 | 56003   |
| borrow                                     | 143142          | 191921 | 163618 | 723120 | 128002  |
| bucketTake                                 | 307387          | 368512 | 368493 | 429675 | 4       |
| kick                                       | 148114          | 172857 | 171567 | 999772 | 48000   |
| moveQuoteToken                             | 281035          | 281035 | 281035 | 281035 | 1       |
| pledgeCollateral                           | 61576           | 61921  | 61896  | 527241 | 120001  |
| removeQuoteToken                           | 160234          | 179376 | 179278 | 213935 | 4000    |
| repay                                      | 505712          | 537647 | 526947 | 685516 | 16002   |
| take                                       | 52648           | 53833  | 53569  | 276003 | 15998   |
```