### PR TITLE
Lib cleanup

### DIFF
--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -24,7 +24,7 @@ abstract contract FlashloanablePool is Pool {
     }
 
     function _flashFee(uint256 amount_) internal view  returns (uint256) {
-        return Maths.wmul(amount_, PoolUtils.feeRate(interestRate));
+        return Maths.wmul(amount_, BucketMath.feeRate(interestRate));
     }
 
     function flashFee(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -439,17 +439,16 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if (
             _isCollateralized(borrowerDebt, borrower.collateral, lup)
         ) revert BorrowerOk();
-
-        uint256 neutralPrice = Maths.wmul(borrower.t0Np, poolState.inflator);
  
         // kick auction
+        uint256 mompIndex = deposits.findIndexOfSum(Maths.wdiv(poolState.accruedDebt, loans.noOfLoans() * 1e18));
         (uint256 kickAuctionAmount, uint256 bondSize) = Auctions.kick(
             auctions,
             borrowerAddress_,
             borrowerDebt,
             borrowerDebt * Maths.WAD / borrower.collateral,
-            deposits.momp(poolState.accruedDebt, loans.noOfLoans()),
-            neutralPrice
+            mompIndex,
+            Maths.wmul(borrower.t0Np, poolState.inflator)
         );
 
         loans.remove(borrowerAddress_);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -116,6 +116,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             msg.sender
         );
         uint256 amountToMove;
+        uint256 fromPrice = PoolUtils.indexToPrice(fromIndex_);
         uint256 fromDeposit = deposits.valueAt(fromIndex_);
         Buckets.Bucket storage fromBucket = buckets[fromIndex_];
         (amountToMove, fromBucketLPs_, ) = Buckets.lpsToQuoteToken(
@@ -124,19 +125,19 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             fromDeposit,
             lender.lps,
             maxAmountToMove_,
-            PoolUtils.indexToPrice(fromIndex_)
+            fromPrice
         );
 
         deposits.remove(fromIndex_, amountToMove, fromDeposit);
 
         // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
-        amountToMove = PoolUtils.applyEarlyWithdrawalPenalty(
-            poolState,
-            lender.depositTime,
-            fromIndex_,
-            toIndex_,
-            amountToMove
-        );
+        uint256 toPrice = PoolUtils.indexToPrice(toIndex_);
+        if (lender.depositTime != 0 && block.timestamp - lender.depositTime < 1 days) {
+            uint256 ptp = poolState.collateral != 0 ? Maths.wdiv(poolState.accruedDebt, poolState.collateral) : 0;
+            if (fromPrice > ptp && toPrice < ptp) {
+                amountToMove = Maths.wmul(amountToMove, Maths.WAD - BucketMath.feeRate(poolState.rate));
+            }
+        }
 
         Buckets.Bucket storage toBucket = buckets[toIndex_];
         toBucketLPs_ = Buckets.quoteTokensToLPs(
@@ -144,7 +145,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             toBucket.lps,
             deposits.valueAt(toIndex_),
             amountToMove,
-            PoolUtils.indexToPrice(toIndex_)
+            toPrice
         );
 
         deposits.add(toIndex_, amountToMove);
@@ -182,12 +183,14 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 deposit = deposits.valueAt(index_);
         if (deposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
 
+        uint256 price = PoolUtils.indexToPrice(index_);
+
         Buckets.Bucket storage bucket = buckets[index_];
         uint256 exchangeRate = Buckets.getExchangeRate(
             bucket.collateral,
             bucket.lps,
             deposit,
-            PoolUtils.indexToPrice(index_)
+            price
         );
         removedAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance, exchangeRate));
         uint256 removedAmountBefore = removedAmount_;
@@ -206,17 +209,17 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 newLup = _lup(poolState.accruedDebt);
         if (_htp(poolState.inflator) > newLup) revert LUPBelowHTP();
 
+        // apply early withdrawal penalty if quote token is removed from above the PTP
+        if (lastDeposit != 0 && block.timestamp - lastDeposit < 1 days) {
+            uint256 ptp = poolState.collateral != 0 ? Maths.wdiv(poolState.accruedDebt, poolState.collateral) : 0;
+            if (price > ptp) {
+                removedAmount_ = Maths.wmul(removedAmount_, Maths.WAD - BucketMath.feeRate(poolState.rate));
+            }
+        }
+
         // update bucket and lender LPs balances
         bucket.lps -= redeemedLPs_;
         bucket.lenders[msg.sender].lps -= redeemedLPs_;
-
-        removedAmount_ = PoolUtils.applyEarlyWithdrawalPenalty(
-            poolState,
-            lastDeposit,
-            index_,
-            0,
-            removedAmount_
-        );
 
         _updateInterestParams(poolState, newLup);
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -119,7 +119,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 fromPrice = PoolUtils.indexToPrice(fromIndex_);
         uint256 fromDeposit = deposits.valueAt(fromIndex_);
         Buckets.Bucket storage fromBucket = buckets[fromIndex_];
-        (amountToMove, fromBucketLPs_, ) = Buckets.lpsToQuoteToken(
+        (amountToMove, fromBucketLPs_) = Buckets.lpsToQuoteToken(
             fromBucket.lps,
             fromBucket.collateral,
             fromDeposit,

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -441,13 +441,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         ) revert BorrowerOk();
  
         // kick auction
-        uint256 mompIndex = deposits.findIndexOfSum(Maths.wdiv(poolState.accruedDebt, loans.noOfLoans() * 1e18));
         (uint256 kickAuctionAmount, uint256 bondSize) = Auctions.kick(
             auctions,
             borrowerAddress_,
             borrowerDebt,
             borrowerDebt * Maths.WAD / borrower.collateral,
-            mompIndex,
+            deposits.findIndexOfSum(Maths.wdiv(poolState.accruedDebt, loans.noOfLoans() * 1e18)),
             Maths.wmul(borrower.t0Np, poolState.inflator)
         );
 
@@ -719,7 +718,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                 poolState_.inflator = Maths.wmul(poolState_.inflator, factor);
 
                 // Scale the fenwick tree to update amount of debt owed to lenders
-                deposits.accrueInterest(
+                BucketMath.accrueInterest(
+                    deposits,
                     poolState_.accruedDebt,
                     poolState_.collateral,
                     _htp(poolState_.inflator),

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -286,7 +286,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 borrowerDebt           = Maths.wmul(borrower.t0debt, poolState.inflator);
 
         // add origination fee to the amount to borrow and add to borrower's debt
-        uint256 debtChange = Maths.wmul(amountToBorrow_, PoolUtils.feeRate(interestRate) + Maths.WAD);
+        uint256 debtChange = Maths.wmul(amountToBorrow_, BucketMath.feeRate(interestRate) + Maths.WAD);
         borrowerDebt += debtChange;
         _checkMinDebt(poolState.accruedDebt, borrowerDebt);
 
@@ -641,7 +641,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             if (
                 loansCount >= 10
                 &&
-                (borrowerDebt_ < PoolUtils.minDebtAmount(accruedDebt_, loansCount))
+                (borrowerDebt_ < BucketMath.minDebtAmount(accruedDebt_, loansCount))
             ) revert AmountLTMinDebt();
         }
     }

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -199,12 +199,12 @@ contract PoolInfoUtils {
         uint256 poolCollateral  = pool.pledgedCollateral();
         (, , uint256 noOfLoans) = pool.loansInfo();
 
-        if (poolDebt != 0) poolMinDebtAmount_ = PoolUtils.minDebtAmount(poolDebt, noOfLoans);
+        if (poolDebt != 0) poolMinDebtAmount_ = BucketMath.minDebtAmount(poolDebt, noOfLoans);
         uint256 currentLup      = PoolUtils.indexToPrice(pool.depositIndex(poolDebt));
-        poolCollateralization_ = PoolUtils.collateralization(poolDebt, poolCollateral, currentLup);
+        poolCollateralization_ = BucketMath.collateralization(poolDebt, poolCollateral, currentLup);
         poolActualUtilization_ = pool.depositUtilization(poolDebt, poolCollateral);
         (uint256 debtEma, uint256 lupColEma) = pool.emasInfo();
-        poolTargetUtilization_ = PoolUtils.poolTargetUtilization(debtEma, lupColEma);
+        poolTargetUtilization_ = BucketMath.poolTargetUtilization(debtEma, lupColEma);
     }
 
     /**

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -296,7 +296,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256 quoteAmount_) {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
-        (quoteAmount_, , ) = Buckets.lpsToQuoteToken(
+        (quoteAmount_, ) = Buckets.lpsToQuoteToken(
             bucketLPs_,
             bucketCollateral,
             bucketDeposit,

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -6,7 +6,6 @@ import './interfaces/IPool.sol';
 
 import '../libraries/Auctions.sol';
 import '../libraries/Buckets.sol';
-import '../libraries/PoolUtils.sol';
 import '../libraries/BucketMath.sol';
 
 contract PoolInfoUtils {
@@ -58,7 +57,7 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        price_ = PoolUtils.indexToPrice(index_);
+        price_ = BucketMath._indexToPrice(index_);
 
         (bucketLPs_, collateral_, , quoteTokens_, scale_) = pool.bucketInfo(index_);
         if (bucketLPs_ == 0) {
@@ -126,13 +125,13 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
         (uint256 debt,,) = pool.debtInfo();
         hpbIndex_ = pool.depositIndex(1);
-        hpb_      = PoolUtils.indexToPrice(hpbIndex_);
+        hpb_      = BucketMath._indexToPrice(hpbIndex_);
         (, uint256 maxThresholdPrice, ) = pool.loansInfo();
         (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
         htp_      = Maths.wmul(maxThresholdPrice, inflatorSnapshot);
-        if (htp_ != 0) htpIndex_ = PoolUtils.priceToIndex(htp_);
+        if (htp_ != 0) htpIndex_ = BucketMath._priceToIndex(htp_);
         lupIndex_ = pool.depositIndex(debt);
-        lup_      = PoolUtils.indexToPrice(lupIndex_);
+        lup_      = BucketMath._indexToPrice(lupIndex_);
     }
 
     /**
@@ -200,7 +199,7 @@ contract PoolInfoUtils {
         (, , uint256 noOfLoans) = pool.loansInfo();
 
         if (poolDebt != 0) poolMinDebtAmount_ = BucketMath.minDebtAmount(poolDebt, noOfLoans);
-        uint256 currentLup      = PoolUtils.indexToPrice(pool.depositIndex(poolDebt));
+        uint256 currentLup      = BucketMath._indexToPrice(pool.depositIndex(poolDebt));
         poolCollateralization_ = BucketMath.collateralization(poolDebt, poolCollateral, currentLup);
         poolActualUtilization_ = pool.depositUtilization(poolDebt, poolCollateral);
         (uint256 debtEma, uint256 lupColEma) = pool.emasInfo();
@@ -230,14 +229,14 @@ contract PoolInfoUtils {
         uint256 index_
     ) external pure returns (uint256)
     {
-        return PoolUtils.indexToPrice(index_);
+        return BucketMath._indexToPrice(index_);
     }
 
     function priceToIndex(
         uint256 price_
     ) external pure returns (uint256)
     {
-        return PoolUtils.priceToIndex(price_);
+        return BucketMath._priceToIndex(price_);
     }
 
     function lup(
@@ -246,7 +245,7 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
         (uint256 debt,,) = pool.debtInfo();
         uint256 currentLupIndex = pool.depositIndex(debt);
-        return PoolUtils.indexToPrice(currentLupIndex);
+        return BucketMath._indexToPrice(currentLupIndex);
     }
 
     function lupIndex(
@@ -264,7 +263,7 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
 
         uint256 hbpIndex = pool.depositIndex(1);
-        return PoolUtils.indexToPrice(hbpIndex);
+        return BucketMath._indexToPrice(hbpIndex);
     }
 
     function hpbIndex(
@@ -303,7 +302,7 @@ contract PoolInfoUtils {
             bucketDeposit,
             lpTokens_,
             bucketDeposit,
-            PoolUtils.indexToPrice(index_)
+            BucketMath._indexToPrice(index_)
         );
     }
 
@@ -325,7 +324,7 @@ contract PoolInfoUtils {
             bucketLPs_,
             bucketDeposit,
             lpTokens_,
-            PoolUtils.indexToPrice(index_)
+            BucketMath._indexToPrice(index_)
         );
     }
 

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -113,7 +113,7 @@ contract PositionManager is IPositionManager, Multicall, PositionNFT, PermitERC2
 
         IPool pool = IPool(params_.pool);
         (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = pool.bucketInfo(params_.fromIndex);
-        (uint256 maxQuote, , ) = Buckets.lpsToQuoteToken(
+        (uint256 maxQuote, ) = Buckets.lpsToQuoteToken(
             bucketLPs,
             bucketCollateral,
             bucketDeposit,

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -2,20 +2,13 @@
 
 pragma solidity 0.8.14;
 
-import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
-import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
-
 import './Buckets.sol';
+import './BucketMath.sol';
 import './Loans.sol';
 import './Maths.sol';
 
 library Auctions {
     uint256 internal constant MINUTE_HALF_LIFE    = 0.988514020352896135_356867505 * 1e27;  // 0.5^(1/60)
-    uint256 internal constant MIN_PRICE = 99_836_282_890;
-    uint256 internal constant MAX_PRICE = 1_004_968_987.606512354182109771 * 10**18;
-    int256 internal constant MAX_PRICE_INDEX = 4_156;
-    int256 internal constant MIN_PRICE_INDEX = -3_232;
-    int256 internal constant FLOAT_STEP_INT = 1.005 * 10**18;
 
     struct Data {
         address head;
@@ -124,7 +117,7 @@ library Auctions {
         while (bucketDepth_ != 0 && t0DebtToSettle_ != 0 && collateral_ != 0) {
             hpbVars.index   = Deposits.findIndexOfSum(deposits_, 1);
             hpbVars.deposit = Deposits.valueAt(deposits_, hpbVars.index);
-            hpbVars.price   = _indexToPrice(hpbVars.index);
+            hpbVars.price   = BucketMath._indexToPrice(hpbVars.index);
 
             uint256 depositToRemove = hpbVars.deposit;
             uint256 collateralUsed;
@@ -211,7 +204,7 @@ library Auctions {
         uint256 neutralPrice_
     ) external returns (uint256 kickAuctionAmount_, uint256 bondSize_) {
 
-        uint256 momp = _indexToPrice(mompIndex_);
+        uint256 momp = BucketMath._indexToPrice(mompIndex_);
         uint256 bondFactor;
         // bondFactor = min(30%, max(1%, (MOMP - thresholdPrice) / MOMP))
         if (thresholdPrice_ >= momp) {
@@ -285,7 +278,7 @@ library Auctions {
         Liquidation storage liquidation = self.liquidations[borrowerAddress_];
         _validateTake(liquidation);
 
-        params_.bucketPrice  = _indexToPrice(bucketIndex_);
+        params_.bucketPrice  = BucketMath._indexToPrice(bucketIndex_);
         params_.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
             liquidation.kickTime
@@ -430,13 +423,13 @@ library Auctions {
                 self.liquidations[borrowerAddress_].kickMomp,
                 self.liquidations[borrowerAddress_].kickTime
             );
-            bucketIndex_ = _priceToIndex(auctionPrice);
+            bucketIndex_ = BucketMath._priceToIndex(auctionPrice);
             lps_ = Buckets.addCollateral(
                 buckets_[bucketIndex_],
                 borrowerAddress_,
                 Deposits.valueAt(deposits_, bucketIndex_),
                 fractionalCollateral,
-                _indexToPrice(bucketIndex_)
+                BucketMath._indexToPrice(bucketIndex_)
             );
         }
 
@@ -641,50 +634,6 @@ library Auctions {
             price_
         );
         factor_ = uint256(1e18 - Maths.maxInt(0, bpf_));
-    }
-
-
-    /***********************************/
-    /*** Bucket Conversion Functions ***/
-    /***********************************/
-
-    /**
-     * @dev replicated to avoid calling external BucketMath library
-     */
-    function _indexToPrice(
-        uint256 index_
-    ) internal pure returns (uint256) {
-        int256 bucketIndex = (index_ != 8191) ? MAX_PRICE_INDEX - int256(index_) : MIN_PRICE_INDEX;
-        require(bucketIndex >= MIN_PRICE_INDEX && bucketIndex <= MAX_PRICE_INDEX, "BM:ITP:OOB");
-
-        return uint256(
-            PRBMathSD59x18.exp2(
-                PRBMathSD59x18.mul(
-                    PRBMathSD59x18.fromInt(bucketIndex),
-                    PRBMathSD59x18.log2(FLOAT_STEP_INT)
-                )
-            )
-        );
-    }
-
-    /**
-     * @dev replicated to avoid calling external BucketMath library
-     */
-    function _priceToIndex(
-        uint256 price_
-    ) internal pure returns (uint256) {
-        require(price_ >= MIN_PRICE && price_ <= MAX_PRICE, "BM:PTI:OOB");
-
-        int256 index = PRBMathSD59x18.div(
-            PRBMathSD59x18.log2(int256(price_)),
-            PRBMathSD59x18.log2(FLOAT_STEP_INT)
-        );
-
-        int256 ceilIndex = PRBMathSD59x18.ceil(index);
-        if (index < 0 && ceilIndex - index > 0.5 * 1e18) {
-            return uint256(7067 - PRBMathSD59x18.toInt(ceilIndex));
-        }
-        return uint256(4156 - PRBMathSD59x18.toInt(ceilIndex));
     }
 
 

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -197,7 +197,7 @@ library Auctions {
      *  @param  borrower_          Borrower address to liquidate.
      *  @param  borrowerDebt_      Borrower debt to be recovered.
      *  @param  thresholdPrice_    Current threshold price (used to calculate bond factor).
-     *  @param  momp_              Current MOMP (used to calculate bond factor).
+     *  @param  mompIndex_         Current MOMP index (used to calculate bond factor).
      *  @param  neutralPrice_      Neutral Price of auction.
      *  @return kickAuctionAmount_ The amount that kicker should send to pool in order to kick auction.
      *  @return bondSize_          The amount that kicker locks in pool to kick auction.
@@ -207,20 +207,21 @@ library Auctions {
         address borrower_,
         uint256 borrowerDebt_,
         uint256 thresholdPrice_,
-        uint256 momp_,
+        uint256 mompIndex_,
         uint256 neutralPrice_
     ) external returns (uint256 kickAuctionAmount_, uint256 bondSize_) {
 
+        uint256 momp = _indexToPrice(mompIndex_);
         uint256 bondFactor;
         // bondFactor = min(30%, max(1%, (MOMP - thresholdPrice) / MOMP))
-        if (thresholdPrice_ >= momp_) {
+        if (thresholdPrice_ >= momp) {
             bondFactor = 0.01 * 1e18;
         } else {
             bondFactor = Maths.min(
                 0.3 * 1e18,
                 Maths.max(
                     0.01 * 1e18,
-                    1e18 - Maths.wdiv(thresholdPrice_, momp_)
+                    1e18 - Maths.wdiv(thresholdPrice_, momp)
                 )
             );
         }
@@ -242,7 +243,7 @@ library Auctions {
         Liquidation storage liquidation = self.liquidations[borrower_];
         liquidation.kicker              = msg.sender;
         liquidation.kickTime            = uint96(block.timestamp);
-        liquidation.kickMomp            = uint96(momp_);
+        liquidation.kickMomp            = uint96(momp);
         liquidation.bondSize            = uint160(bondSize_);
         liquidation.bondFactor          = uint96(bondFactor);
         liquidation.neutralPrice        = uint96(neutralPrice_);

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -208,9 +208,11 @@ library BucketMath {
 
         int256 ceilIndex = PRBMathSD59x18.ceil(index);
         if (index < 0 && ceilIndex - index > 0.5 * 1e18) {
-            return uint256(7067 - PRBMathSD59x18.toInt(ceilIndex));
+            int256 bucketIndex = PRBMathSD59x18.toInt(ceilIndex) - 1;
+            return uint256(7388 - (bucketIndex + 3232));
         }
-        return uint256(4156 - PRBMathSD59x18.toInt(ceilIndex));
+        int256 bucketIndex = PRBMathSD59x18.toInt(ceilIndex);
+        return uint256(7388 - (bucketIndex + 3232));
     }
 
     function _lenderInterestMargin(

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -208,11 +208,9 @@ library BucketMath {
 
         int256 ceilIndex = PRBMathSD59x18.ceil(index);
         if (index < 0 && ceilIndex - index > 0.5 * 1e18) {
-            int256 bucketIndex = PRBMathSD59x18.toInt(ceilIndex) - 1;
-            return uint256(7388 - (bucketIndex + 3232));
+            return uint256(4157 - PRBMathSD59x18.toInt(ceilIndex));
         }
-        int256 bucketIndex = PRBMathSD59x18.toInt(ceilIndex);
-        return uint256(7388 - (bucketIndex + 3232));
+        return uint256(4156 - PRBMathSD59x18.toInt(ceilIndex));
     }
 
     function _lenderInterestMargin(

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -160,8 +160,8 @@ library BucketMath {
         uint256 elapsed_
     ) external returns (uint256 newInflator_) {
         // Scale the borrower inflator to update amount of interest owed by borrowers
-        uint256 pendingInterestFactor = PRBMathUD60x18.exp((interestRate_ * elapsed_) / 365 days);
-        newInflator_ = Maths.wmul(inflator_, pendingInterestFactor);
+        uint256 pendingFactor = PRBMathUD60x18.exp((interestRate_ * elapsed_) / 365 days);
+        newInflator_ = Maths.wmul(inflator_, pendingFactor);
 
         uint256 htp = Maths.wmul(thresholdPrice_, newInflator_);
         uint256 htpIndex = (htp != 0) ? _priceToIndex(htp) : 7_388; // if HTP is 0 then accrue interest at max index (min price)
@@ -172,7 +172,7 @@ library BucketMath {
         if (depositAboveHtp != 0) {
             uint256 newInterest = Maths.wmul(
                 _lenderInterestMargin(deposits, debt_, collateral_),
-                Maths.wmul(pendingInterestFactor - Maths.WAD, debt_)
+                Maths.wmul(pendingFactor - Maths.WAD, debt_)
             );
 
             uint256 lenderFactor = Maths.wdiv(newInterest, depositAboveHtp) + Maths.WAD;

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -39,6 +39,11 @@ library BucketMath {
      */
     int256 public constant FLOAT_STEP_INT = 1.005 * 10**18;
 
+    uint256 internal constant WAD_WEEKS_PER_YEAR  = 52 * 10**18;
+
+    // minimum fee that can be applied for early withdraw penalty
+    uint256 internal constant MIN_FEE = 0.0005 * 10**18;
+
     /**
      *  @notice Calculates the index for a given bucket price
      *  @dev    Throws if price exceeds maximum constant
@@ -255,6 +260,45 @@ library BucketMath {
                     depositAbove
                 );
             }
+        }
+    }
+
+    function encumberance(
+        uint256 debt_,
+        uint256 price_
+    ) internal pure returns (uint256 encumberance_) {
+        return price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
+    }
+
+    function collateralization(
+        uint256 debt_,
+        uint256 collateral_,
+        uint256 price_
+    ) internal pure returns (uint256) {
+        uint256 encumbered = encumberance(debt_, price_);
+        return encumbered != 0 ? Maths.wdiv(collateral_, encumbered) : Maths.WAD;
+    }
+
+    function poolTargetUtilization(
+        uint256 debtEma_,
+        uint256 lupColEma_
+    ) internal pure returns (uint256) {
+        return (debtEma_ != 0 && lupColEma_ != 0) ? Maths.wdiv(debtEma_, lupColEma_) : Maths.WAD;
+    }
+
+    function feeRate(
+        uint256 interestRate_
+    ) internal pure returns (uint256) {
+        // greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps
+        return Maths.max(Maths.wdiv(interestRate_, WAD_WEEKS_PER_YEAR), MIN_FEE);
+    }
+
+    function minDebtAmount(
+        uint256 debt_,
+        uint256 loansCount_
+    ) internal pure returns (uint256 minDebtAmount_) {
+        if (loansCount_ != 0) {
+            minDebtAmount_ = Maths.wdiv(Maths.wdiv(debt_, Maths.wad(loansCount_)), 10**19);
         }
     }
 

--- a/src/libraries/BucketMath.sol
+++ b/src/libraries/BucketMath.sol
@@ -159,7 +159,7 @@ library BucketMath {
         newInflator_ = Maths.wmul(inflator_, pendingInterestFactor);
 
         uint256 htp = Maths.wmul(thresholdPrice_, newInflator_);
-        uint256 htpIndex = (htp != 0) ? _priceToIndex(htp) : 4_156; // if HTP is 0 then accrue interest at max index (min price)
+        uint256 htpIndex = (htp != 0) ? _priceToIndex(htp) : 7_388; // if HTP is 0 then accrue interest at max index (min price)
 
         // Scale the fenwick tree to update amount of debt owed to lenders
         uint256 depositAboveHtp = Deposits.prefixSum(deposits, htpIndex);
@@ -173,6 +173,22 @@ library BucketMath {
             uint256 lenderFactor = Maths.wdiv(newInterest, depositAboveHtp) + Maths.WAD;
             Deposits.mult(deposits, htpIndex, lenderFactor);
         }
+    }
+
+    function _indexToPrice(
+        uint256 index_
+    ) internal pure returns (uint256) {
+        int256 bucketIndex = (index_ != 8191) ? MAX_PRICE_INDEX - int256(index_) : MIN_PRICE_INDEX;
+        require(bucketIndex >= MIN_PRICE_INDEX && bucketIndex <= MAX_PRICE_INDEX, "BM:ITP:OOB");
+
+        return uint256(
+            PRBMathSD59x18.exp2(
+                PRBMathSD59x18.mul(
+                    PRBMathSD59x18.fromInt(bucketIndex),
+                    PRBMathSD59x18.log2(FLOAT_STEP_INT)
+                )
+            )
+        );
     }
 
     function _priceToIndex(

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -274,7 +274,6 @@ library Buckets {
      *  @param  bucketPrice_      Bucket price.
      *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given LPs amount.
      *  @return lps_              Amount of bucket LPs corresponding for calculated collateral amount.
-     *  @return lenderLPs_        Lender LPs balance in current bucket.
      */
     function lpsToQuoteToken(
         uint256 bucketLPs_,
@@ -283,13 +282,11 @@ library Buckets {
         uint256 lenderLPsBalance_,
         uint256 maxQuoteToken_,
         uint256 bucketPrice_
-    ) internal pure returns (uint256 quoteTokenAmount_, uint256 lps_, uint256 lenderLPs_) {
-        lenderLPs_   = lenderLPsBalance_;
+    ) internal pure returns (uint256 quoteTokenAmount_, uint256 lps_) {
         uint256 rate = getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
         quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
         if (quoteTokenAmount_ > deposit_) {
             quoteTokenAmount_ = deposit_;
-            lenderLPs_        = Maths.wrdivr(quoteTokenAmount_, rate);
         }
         if (maxQuoteToken_ != quoteTokenAmount_) quoteTokenAmount_ = Maths.min(maxQuoteToken_,quoteTokenAmount_);
         lps_ = Maths.wrdivr(quoteTokenAmount_, rate);

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -61,14 +61,6 @@ library Deposits {
         }
     }
 
-    function momp(
-        Data storage self,
-        uint256 curDebt_,
-        uint256 numLoans_
-    ) internal view returns (uint256 momp_) {
-        if (numLoans_ != 0) momp_ = PoolUtils.indexToPrice(findIndexOfSum(self, Maths.wdiv(curDebt_, numLoans_ * 1e18)));
-    }
-
     function t0Np(
         Data storage self,
         uint256 inflator_,
@@ -81,7 +73,8 @@ library Deposits {
     ) internal view returns (uint256 t0Np_) {
         uint256 borrowerDebt = Maths.wmul(borrowerT0debt_, inflator_);
         uint256 thresholdPrice = borrowerDebt * Maths.WAD / borrowerCollateral_; 
-        uint256 curMomp = momp(self, curDebt_, numLoans_);
+        uint256 curMomp;
+        if (numLoans_ != 0) curMomp = PoolUtils.indexToPrice(findIndexOfSum(self, Maths.wdiv(curDebt_, numLoans_ * 1e18)));
         // t0Np = ((1 + rate) * MOMP * (TP / LUP)) / Inflator
         if (curMomp != 0) t0Np_ = (1e18 + interestRate_) * curMomp * thresholdPrice / lup_ / inflator_;
     }

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -23,25 +23,6 @@ library Deposits {
         uint256[8193] scaling; // Array of values which scale (multiply) the FenwickTree accross indexes.
     }
 
-    function utilization(
-        Data storage self,
-        uint256 debt_,
-        uint256 collateral_
-    ) internal view returns (uint256 utilization_) {
-        if (collateral_ != 0) {
-            uint256 ptp = Maths.wdiv(debt_, collateral_);
-
-            if (ptp != 0) {
-                uint256 depositAbove = prefixSum(self, PoolUtils.priceToIndex(ptp));
-
-                if (depositAbove != 0) utilization_ = Maths.wdiv(
-                    debt_,
-                    depositAbove
-                );
-            }
-        }
-    }
-
     /**
      *  @notice increase a value in the FenwickTree at an index.
      *  @dev    Starts at leaf/target and moved up towards root

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -61,24 +61,6 @@ library Deposits {
         }
     }
 
-    function t0Np(
-        Data storage self,
-        uint256 inflator_,
-        uint256 curDebt_,
-        uint256 numLoans_,
-        uint256 interestRate_,
-        uint256 lup_,
-        uint256 borrowerT0debt_,
-        uint256 borrowerCollateral_
-    ) internal view returns (uint256 t0Np_) {
-        uint256 borrowerDebt = Maths.wmul(borrowerT0debt_, inflator_);
-        uint256 thresholdPrice = borrowerDebt * Maths.WAD / borrowerCollateral_; 
-        uint256 curMomp;
-        if (numLoans_ != 0) curMomp = PoolUtils.indexToPrice(findIndexOfSum(self, Maths.wdiv(curDebt_, numLoans_ * 1e18)));
-        // t0Np = ((1 + rate) * MOMP * (TP / LUP)) / Inflator
-        if (curMomp != 0) t0Np_ = (1e18 + interestRate_) * curMomp * thresholdPrice / lup_ / inflator_;
-    }
-
     /**
      *  @notice increase a value in the FenwickTree at an index.
      *  @dev    Starts at leaf/target and moved up towards root

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -23,25 +23,6 @@ library Deposits {
         uint256[8193] scaling; // Array of values which scale (multiply) the FenwickTree accross indexes.
     }
 
-    function accrueInterest(
-        Data storage self,
-        uint256 debt_,
-        uint256 collateral_,
-        uint256 htp_,
-        uint256 pendingInterestFactor_
-    ) internal {
-        uint256 htpIndex = (htp_ != 0) ? PoolUtils.priceToIndex(htp_) : 4_156; // if HTP is 0 then accrue interest at max index (min price)
-        uint256 depositAboveHtp = prefixSum(self, htpIndex);
-
-        if (depositAboveHtp != 0) {
-            uint256 netInterestMargin = BucketMath.lenderInterestMargin(utilization(self, debt_, collateral_));
-            uint256 newInterest       = Maths.wmul(netInterestMargin, Maths.wmul(pendingInterestFactor_ - Maths.WAD, debt_));
-
-            uint256 lenderFactor = Maths.wdiv(newInterest, depositAboveHtp) + Maths.WAD;
-            mult(self, htpIndex, lenderFactor);
-        }
-    }
-
     function utilization(
         Data storage self,
         uint256 debt_,

--- a/src/libraries/PoolUtils.sol
+++ b/src/libraries/PoolUtils.sol
@@ -8,34 +8,6 @@ import './BucketMath.sol';
 library PoolUtils {
 
     /**
-     *  @notice Returns amount plus calculated early withdrawal penalty (if case).
-     *  @param  poolState_         Struct containing pool state details.
-     *  @param  depositTime_       Time when deposit happened.
-     *  @param  fromIndex_         Index of the bucket from where liquidity is removed or moved.
-     *  @param  toIndex_           Index of the bucket where liquidity is moved. 0 in case of withdrawing.
-     *  @param  amount_            Amount to calculate early withdrawal penalty for.
-     *  @return amountWithPenalty_ The amount plus applied early withdrawal penalty. Same amount if not subject of penalty.
-     */
-    function applyEarlyWithdrawalPenalty(
-        Pool.PoolState memory poolState_,
-        uint256 depositTime_,
-        uint256 fromIndex_,
-        uint256 toIndex_,
-        uint256 amount_
-    ) internal view returns (uint256 amountWithPenalty_){
-        amountWithPenalty_ = amount_;
-        if (depositTime_ != 0 && block.timestamp - depositTime_ < 1 days) {
-            uint256 ptp = poolState_.collateral != 0 ? Maths.wdiv(poolState_.accruedDebt, poolState_.collateral) : 0;
-            bool applyPenalty = indexToPrice(fromIndex_) > ptp; // apply penalty if withdrawal from above PTP
-            if (toIndex_ != 0) {
-                // move quote token between buckets scenario, apply penalty only if moved to below PTP
-                applyPenalty = applyPenalty && indexToPrice(toIndex_) < ptp;
-            }
-            if (applyPenalty) amountWithPenalty_ = Maths.wmul(amountWithPenalty_, Maths.WAD - BucketMath.feeRate(poolState_.rate));
-        }
-    }
-
-    /**
      *  @dev Fenwick index to bucket index conversion
      *          1.00      : bucket index 0,     fenwick index 4146: 7388-4156-3232=0
      *          MAX_PRICE : bucket index 4156,  fenwick index 0:    7388-0-3232=4156.

--- a/src/libraries/PoolUtils.sol
+++ b/src/libraries/PoolUtils.sol
@@ -6,49 +6,6 @@ import './Maths.sol';
 import './BucketMath.sol';
 
 library PoolUtils {
-    uint256 internal constant WAD_WEEKS_PER_YEAR  = 52 * 10**18;
-
-    // minimum fee that can be applied for early withdraw penalty
-    uint256 internal constant MIN_FEE = 0.0005 * 10**18;
-
-    function encumberance(
-        uint256 debt_,
-        uint256 price_
-    ) internal pure returns (uint256 encumberance_) {
-        return price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
-    }
-
-    function collateralization(
-        uint256 debt_,
-        uint256 collateral_,
-        uint256 price_
-    ) internal pure returns (uint256) {
-        uint256 encumbered = encumberance(debt_, price_);
-        return encumbered != 0 ? Maths.wdiv(collateral_, encumbered) : Maths.WAD;
-    }
-
-    function poolTargetUtilization(
-        uint256 debtEma_,
-        uint256 lupColEma_
-    ) internal pure returns (uint256) {
-        return (debtEma_ != 0 && lupColEma_ != 0) ? Maths.wdiv(debtEma_, lupColEma_) : Maths.WAD;
-    }
-
-    function feeRate(
-        uint256 interestRate_
-    ) internal pure returns (uint256) {
-        // greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps
-        return Maths.max(Maths.wdiv(interestRate_, WAD_WEEKS_PER_YEAR), MIN_FEE);
-    }
-
-    function minDebtAmount(
-        uint256 debt_,
-        uint256 loansCount_
-    ) internal pure returns (uint256 minDebtAmount_) {
-        if (loansCount_ != 0) {
-            minDebtAmount_ = Maths.wdiv(Maths.wdiv(debt_, Maths.wad(loansCount_)), 10**19);
-        }
-    }
 
     /**
      *  @notice Returns amount plus calculated early withdrawal penalty (if case).
@@ -74,7 +31,7 @@ library PoolUtils {
                 // move quote token between buckets scenario, apply penalty only if moved to below PTP
                 applyPenalty = applyPenalty && indexToPrice(toIndex_) < ptp;
             }
-            if (applyPenalty) amountWithPenalty_ = Maths.wmul(amountWithPenalty_, Maths.WAD - feeRate(poolState_.rate));
+            if (applyPenalty) amountWithPenalty_ = Maths.wmul(amountWithPenalty_, Maths.WAD - BucketMath.feeRate(poolState_.rate));
         }
     }
 

--- a/src/libraries/PoolUtils.sol
+++ b/src/libraries/PoolUtils.sol
@@ -48,10 +48,4 @@ library PoolUtils {
         return BucketMath.indexToPrice(bucketIndex);
     }
 
-    function priceToIndex(
-        uint256 price_
-    ) internal pure returns (uint256) {
-        return uint256(7388 - (BucketMath.priceToIndex(price_) + 3232));
-    }
-
 }

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1097,7 +1097,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             {
                 from:   _lender,
                 amount: 10_000 * 1e18,
-                index:  PoolUtils.priceToIndex(200 * 1e18),
+                index:  BucketMath._priceToIndex(200 * 1e18),
                 newLup: 2_981.007422784467321543 * 1e18
             }
         );
@@ -1106,7 +1106,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             {
                 from:     _lender,
                 amount:   10_000 * 1e18,
-                index:    PoolUtils.priceToIndex(200 * 1e18),
+                index:    BucketMath._priceToIndex(200 * 1e18),
                 newLup:   2_981.007422784467321543 * 1e18,
                 lpRedeem: 10_000 * 1e27
             }

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -164,7 +164,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         _pullCollateral(
             {
                 from:   _borrower,
-                amount: 50 * 1e18 - PoolUtils.encumberance(21_049.006823139002918431 * 1e18, _lup())
+                amount: 50 * 1e18 - BucketMath.encumberance(21_049.006823139002918431 * 1e18, _lup())
             }
         );
 

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -659,7 +659,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
     function testPoolRemoveQuoteTokenWithCollateral() external {
         // add 10 collateral into the 100 bucket, for LP worth 1000 quote tokens
         _mintCollateralAndApproveTokens(_lender, 10 * 1e18);
-        uint256 i100 = PoolUtils.priceToIndex(100 * 1e18);
+        uint256 i100 = BucketMath._priceToIndex(100 * 1e18);
         _addCollateral(
             {
                 from:   _lender,

--- a/tests/forge/ERC721Pool/ERC721FlashloanQuote.t.sol
+++ b/tests/forge/ERC721Pool/ERC721FlashloanQuote.t.sol
@@ -30,7 +30,7 @@ contract ERC721PoolFlashloanTest is ERC721HelperContract {
 
         // lender adds liquidity and borrower draws debt
         _bucketPrice = 251.186576139566121965 * 1e18;
-        _bucketId = PoolUtils.priceToIndex(_bucketPrice);
+        _bucketId = BucketMath._priceToIndex(_bucketPrice);
         assertEq(_bucketId, 3048);
         _addLiquidity(
             {

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -477,7 +477,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         // check collateralization after pledge
         (uint256 poolDebt,,) = _pool.debtInfo();
-        assertEq(PoolUtils.encumberance(poolDebt, _lup()), 0);
+        assertEq(BucketMath.encumberance(poolDebt, _lup()), 0);
 
         // borrower borrows some quote
         _borrow(
@@ -491,7 +491,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         // check collateralization after borrow
         (poolDebt,,) = _pool.debtInfo();
-        assertEq(PoolUtils.encumberance(poolDebt, _lup()), 2.992021560300836411 * 1e18);
+        assertEq(BucketMath.encumberance(poolDebt, _lup()), 2.992021560300836411 * 1e18);
 
         // should revert if borrower attempts to pull more collateral than is unencumbered
         _assertPullInsufficientCollateralRevert(

--- a/tests/forge/PoolUtilsTest.t.sol
+++ b/tests/forge/PoolUtilsTest.t.sol
@@ -16,10 +16,10 @@ contract PoolUtilsTest is DSTestPlus {
         uint256 debt  = 11_000.143012091382543917 * 1e18;
         uint256 price = 1_001.6501589292607751220 * 1e18;
 
-        assertEq(PoolUtils.encumberance(debt, price),   10.98202093218880245 * 1e18);
-        assertEq(PoolUtils.encumberance(0, price),      0);
-        assertEq(PoolUtils.encumberance(debt, 0),       0);
-        assertEq(PoolUtils.encumberance(0, 0),          0);
+        assertEq(BucketMath.encumberance(debt, price),   10.98202093218880245 * 1e18);
+        assertEq(BucketMath.encumberance(0, price),      0);
+        assertEq(BucketMath.encumberance(debt, 0),       0);
+        assertEq(BucketMath.encumberance(0, 0),          0);
     }
 
     /**
@@ -30,11 +30,11 @@ contract PoolUtilsTest is DSTestPlus {
         uint256 price = 1_001.6501589292607751220 * 1e18;
         uint256 collateral = 10.98202093218880245 * 1e18;
 
-        assertEq(PoolUtils.collateralization(debt, collateral, price),   1 * 1e18);
-        assertEq(PoolUtils.collateralization(0, collateral, price),      Maths.WAD);
-        assertEq(PoolUtils.collateralization(debt, collateral, 0),       Maths.WAD);
-        assertEq(PoolUtils.collateralization(0, collateral, 0),          Maths.WAD);
-        assertEq(PoolUtils.collateralization(debt, 0, price),            0);
+        assertEq(BucketMath.collateralization(debt, collateral, price),   1 * 1e18);
+        assertEq(BucketMath.collateralization(0, collateral, price),      Maths.WAD);
+        assertEq(BucketMath.collateralization(debt, collateral, 0),       Maths.WAD);
+        assertEq(BucketMath.collateralization(0, collateral, 0),          Maths.WAD);
+        assertEq(BucketMath.collateralization(debt, 0, price),            0);
     }
 
     /**
@@ -44,10 +44,10 @@ contract PoolUtilsTest is DSTestPlus {
         uint256 debtEma  = 11_000.143012091382543917 * 1e18;
         uint256 lupColEma = 1_001.6501589292607751220 * 1e18;
 
-        assertEq(PoolUtils.poolTargetUtilization(debtEma, lupColEma),   10.98202093218880245 * 1e18);
-        assertEq(PoolUtils.poolTargetUtilization(0, lupColEma),         Maths.WAD);
-        assertEq(PoolUtils.poolTargetUtilization(debtEma, 0),           Maths.WAD);
-        assertEq(PoolUtils.poolTargetUtilization(0, 0),                 Maths.WAD);
+        assertEq(BucketMath.poolTargetUtilization(debtEma, lupColEma),   10.98202093218880245 * 1e18);
+        assertEq(BucketMath.poolTargetUtilization(0, lupColEma),         Maths.WAD);
+        assertEq(BucketMath.poolTargetUtilization(debtEma, 0),           Maths.WAD);
+        assertEq(BucketMath.poolTargetUtilization(0, 0),                 Maths.WAD);
     }
 
     /**
@@ -55,9 +55,9 @@ contract PoolUtilsTest is DSTestPlus {
      */
     function testFeeRate() external {
         uint256 interestRate = 0.12 * 1e18;
-        assertEq(PoolUtils.feeRate(interestRate),  0.002307692307692308 * 1e18);
-        assertEq(PoolUtils.feeRate(0.52 * 1e18),     0.01 * 1e18);
-        assertEq(PoolUtils.feeRate(0.26 * 1e18),     0.005 * 1e18);
+        assertEq(BucketMath.feeRate(interestRate),  0.002307692307692308 * 1e18);
+        assertEq(BucketMath.feeRate(0.52 * 1e18),     0.01 * 1e18);
+        assertEq(BucketMath.feeRate(0.26 * 1e18),     0.005 * 1e18);
     }
 
     /**
@@ -67,10 +67,10 @@ contract PoolUtilsTest is DSTestPlus {
         uint256 debt = 11_000 * 1e18;
         uint256 loansCount = 50;
 
-        assertEq(PoolUtils.minDebtAmount(debt, loansCount), 22 * 1e18);
-        assertEq(PoolUtils.minDebtAmount(debt, 10),         110 * 1e18);
-        assertEq(PoolUtils.minDebtAmount(debt, 0),          0);
-        assertEq(PoolUtils.minDebtAmount(0, loansCount),    0);
+        assertEq(BucketMath.minDebtAmount(debt, loansCount), 22 * 1e18);
+        assertEq(BucketMath.minDebtAmount(debt, 10),         110 * 1e18);
+        assertEq(BucketMath.minDebtAmount(debt, 0),          0);
+        assertEq(BucketMath.minDebtAmount(0, loansCount),    0);
     }
 
     /**

--- a/tests/forge/PoolUtilsTest.t.sol
+++ b/tests/forge/PoolUtilsTest.t.sol
@@ -74,31 +74,6 @@ contract PoolUtilsTest is DSTestPlus {
     }
 
     /**
-     *  @notice Tests early withdrawal amount after penalty for varying parameters
-     */
-    function testApplyEarlyWithdrawalPenalty() external {
-        Pool.PoolState memory poolState_;
-        poolState_.collateral = 5 * 1e18;
-        poolState_.accruedDebt = 8000 * 1e18; 
-        poolState_.rate = 0.05 * 1e18;
-        skip(4 days);
-        uint256 depositTime = block.timestamp - 2 days;
-        uint256 fromIndex  = 1524; // price -> 2_000.221618840727700609 * 1e18
-        uint256 toIndex  = 1000; // price -> 146.575625611106531706 * 1e18
-        uint256 amount  = 100000 * 1e18;
-
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount), amount);
-
-        poolState_.collateral = 2 * 1e18;
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, depositTime, fromIndex, toIndex, amount), amount);
-
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount), 99903.8461538461538 * 1e18);
-
-        poolState_.collateral = 0; // should apply penalty also when no collateral in pool
-        assertEq(PoolUtils.applyEarlyWithdrawalPenalty(poolState_, block.timestamp - 4 hours, fromIndex, 0, amount), 99903.8461538461538 * 1e18);
-    }
-
-    /**
      *  @notice Tests fenwick index calculation from varying bucket prices
      */
     function testPriceToIndex() external {

--- a/tests/forge/PoolUtilsTest.t.sol
+++ b/tests/forge/PoolUtilsTest.t.sol
@@ -103,33 +103,33 @@ contract PoolUtilsTest is DSTestPlus {
      */
     function testPriceToIndex() external {
 
-        assertEq(PoolUtils.priceToIndex(1_004_968_987.606512354182109771 * 10**18), 0);
+        assertEq(BucketMath._priceToIndex(1_004_968_987.606512354182109771 * 10**18), 0);
 
-        assertEq(PoolUtils.priceToIndex(99_836_282_890),                            7388);
+        assertEq(BucketMath._priceToIndex(99_836_282_890),                            7388);
 
-        assertEq(PoolUtils.priceToIndex(49_910.043670274810022205 * 1e18),          1987);
+        assertEq(BucketMath._priceToIndex(49_910.043670274810022205 * 1e18),          1987);
 
-        assertEq(PoolUtils.priceToIndex(2_000.221618840727700609 * 1e18),           2632);
+        assertEq(BucketMath._priceToIndex(2_000.221618840727700609 * 1e18),           2632);
 
-        assertEq(PoolUtils.priceToIndex(146.575625611106531706 * 1e18),             3156);
+        assertEq(BucketMath._priceToIndex(146.575625611106531706 * 1e18),             3156);
 
-        assertEq(PoolUtils.priceToIndex(145.846393642892072537 * 1e18),             3157);
+        assertEq(BucketMath._priceToIndex(145.846393642892072537 * 1e18),             3157);
 
-        assertEq(PoolUtils.priceToIndex(5.263790124045347667 * 1e18),               3823);
+        assertEq(BucketMath._priceToIndex(5.263790124045347667 * 1e18),               3823);
 
-        assertEq(PoolUtils.priceToIndex(1.646668492116543299 * 1e18),               4056);
+        assertEq(BucketMath._priceToIndex(1.646668492116543299 * 1e18),               4056);
 
-        assertEq(PoolUtils.priceToIndex(1.315628874808846999 * 1e18),               4101);
+        assertEq(BucketMath._priceToIndex(1.315628874808846999 * 1e18),               4101);
 
-        assertEq(PoolUtils.priceToIndex(1.051140132040790557 * 1e18),               4146);
+        assertEq(BucketMath._priceToIndex(1.051140132040790557 * 1e18),               4146);
 
-        assertEq(PoolUtils.priceToIndex(0.000046545370002462 * 1e18),               6156);
+        assertEq(BucketMath._priceToIndex(0.000046545370002462 * 1e18),               6156);
 
-        assertEq(PoolUtils.priceToIndex(0.006822416727411372 * 1e18),               5156);
+        assertEq(BucketMath._priceToIndex(0.006822416727411372 * 1e18),               5156);
 
-        assertEq(PoolUtils.priceToIndex(0.006856528811048429 * 1e18),               5155);
+        assertEq(BucketMath._priceToIndex(0.006856528811048429 * 1e18),               5155);
 
-        assertEq(PoolUtils.priceToIndex(0.951347940696068854 * 1e18),               4166);
+        assertEq(BucketMath._priceToIndex(0.951347940696068854 * 1e18),               4166);
         
     }
 

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -52,7 +52,7 @@ contract ERC721TakeWithExternalLiquidityTest is Test {
         nftc.setApprovalForAll(address(_ajnaPool), true);
 
         // lender adds liquidity
-        uint256 bucketId = PoolUtils.priceToIndex(1_000 * 1e18);
+        uint256 bucketId = BucketMath._priceToIndex(1_000 * 1e18);
         assertEq(bucketId, 2770);
         changePrank(_lender);
         _ajnaPool.addQuoteToken(50_000 * 1e18, 2770);

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -412,7 +412,7 @@ abstract contract DSTestPlus is Test {
         assertEq(poolSize,                   state_.poolSize);
         assertEq(_pool.pledgedCollateral(),  state_.pledgedCollateral);
         assertEq(
-            PoolUtils.encumberance(
+            BucketMath.encumberance(
                 state_.poolDebt,
                 state_.lup
             ),                               state_.encumberedCollateral
@@ -484,7 +484,7 @@ abstract contract DSTestPlus is Test {
         assertEq(col,         borrowerCollateral);
         assertEq(t0Np,  borrowert0Np);
         assertEq(
-            PoolUtils.collateralization(
+            BucketMath.collateralization(
                 borrowerDebt,
                 borrowerCollateral,
                 lup


### PR DESCRIPTION
- consolidate PoolUtils and BucketMaths in a single library, reduce contract size and number of external calls

```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  23,465B  (95.48%)
  ERC20Pool                -  21,912B  (89.16%)
```
vs `develop`
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,519B  (99.76%)
  ERC20Pool                -  22,966B  (93.45%)
```


```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101802          | 160779 | 144411 | 655658 | 56003   |
| borrow                                     | 142996          | 191628 | 163472 | 720624 | 128002  |
| bucketTake                                 | 345651          | 410929 | 410946 | 476175 | 4       |
| kick                                       | 150436          | 175176 | 173888 | 996648 | 48000   |
| moveQuoteToken                             | 274156          | 274156 | 274156 | 274156 | 1       |
| pledgeCollateral                           | 61700           | 62045  | 62020  | 525016 | 120001  |
| removeQuoteToken                           | 157936          | 177073 | 176980 | 197546 | 4000    |
| repay                                      | 503350          | 535285 | 524584 | 683153 | 16002   |
| take                                       | 49956           | 50581  | 50370  | 338009 | 15998   |
```
vs `develop`
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101758          | 160886 | 144367 | 657764 | 56003   |
| borrow                                     | 143107          | 191874 | 163583 | 722886 | 128002  |
| bucketTake                                 | 318621          | 380419 | 380424 | 442209 | 4       |
| kick                                       | 150879          | 175622 | 174332 | 999538 | 48000   |
| moveQuoteToken                             | 285327          | 285327 | 285327 | 285327 | 1       |
| pledgeCollateral                           | 61678           | 62023  | 61998  | 527144 | 120001  |
| removeQuoteToken                           | 160000          | 179142 | 179044 | 213679 | 4000    |
| repay                                      | 505500          | 537435 | 526735 | 685304 | 16002   |
| take                                       | 49939           | 50472  | 50198  | 286025 | 15998   |
```