### PR TITLE
Flashloan support for ERC20 collateral, eliminate flashloan fees

### DIFF
--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -10,9 +10,16 @@ abstract contract FlashloanablePool is Pool {
         address token_,
         uint256 amount_,
         bytes calldata data_
-    ) external override nonReentrant returns (bool) {
-        if (token_ != _getArgAddress(20)) revert FlashloanUnavailableForToken();
+    ) external virtual override nonReentrant returns (bool) {
+        if (token_ == _getArgAddress(20)) return _flashLoanQuoteToken(receiver_, token_, amount_, data_);
+        revert FlashloanUnavailableForToken();
+    }
 
+    function _flashLoanQuoteToken(IERC3156FlashBorrower receiver_,
+        address token_,
+        uint256 amount_,
+        bytes calldata data_
+    ) internal returns (bool) {
         _transferQuoteToken(address(receiver_), amount_);
         uint256 fee = _flashFee(amount_);
         
@@ -23,7 +30,7 @@ abstract contract FlashloanablePool is Pool {
         return true;
     }
 
-    function _flashFee(uint256 amount_) internal view  returns (uint256) {
+    function _flashFee(uint256 amount_) internal view returns (uint256) {
         return Maths.wmul(amount_, PoolUtils.feeRate(interestRate));
     }
 

--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -21,25 +21,20 @@ abstract contract FlashloanablePool is Pool {
         bytes calldata data_
     ) internal returns (bool) {
         _transferQuoteToken(address(receiver_), amount_);
-        uint256 fee = _flashFee(amount_);
         
-        if (receiver_.onFlashLoan(msg.sender, token_, amount_, fee, data_) != 
+        if (receiver_.onFlashLoan(msg.sender, token_, amount_, 0, data_) != 
             keccak256("ERC3156FlashBorrower.onFlashLoan")) revert FlashloanCallbackFailed();
 
-        _transferQuoteTokenFrom(address(receiver_), amount_ + fee);
+        _transferQuoteTokenFrom(address(receiver_), amount_);
         return true;
-    }
-
-    function _flashFee(uint256 amount_) internal view returns (uint256) {
-        return Maths.wmul(amount_, PoolUtils.feeRate(interestRate));
     }
 
     function flashFee(
         address token_,
-        uint256 amount_
+        uint256
     ) external virtual view override returns (uint256) {
         if (token_ != _getArgAddress(20)) revert FlashloanUnavailableForToken();
-        return _flashFee(amount_);
+        return 0;
     }
 
     function maxFlashLoan(

--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -37,14 +37,14 @@ abstract contract FlashloanablePool is Pool {
     function flashFee(
         address token_,
         uint256 amount_
-    ) external view override returns (uint256) {
+    ) external virtual view override returns (uint256) {
         if (token_ != _getArgAddress(20)) revert FlashloanUnavailableForToken();
         return _flashFee(amount_);
     }
 
     function maxFlashLoan(
         address token_
-    ) external view override returns (uint256 maxLoan_) {
+    ) external virtual view override returns (uint256 maxLoan_) {
         if (token_ == _getArgAddress(20)) maxLoan_ = _getPoolQuoteTokenBalance();
     }
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -45,6 +45,28 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Borrower External Functions ***/
     /***********************************/
 
+    function flashLoan(
+        IERC3156FlashBorrower receiver_,
+        address token_,
+        uint256 amount_,
+        bytes calldata data_
+    ) public override(IERC3156FlashLender, FlashloanablePool) nonReentrant returns (bool) {
+        if (token_ == _getArgAddress(20)) return _flashLoanQuoteToken(receiver_, token_, amount_, data_);
+
+        if (token_ == _getArgAddress(0)) {
+            _transferCollateral(address(receiver_), amount_);            
+            uint256 fee = 0;
+            
+            if (receiver_.onFlashLoan(msg.sender, token_, amount_, fee, data_) != 
+                keccak256("ERC3156FlashBorrower.onFlashLoan")) revert FlashloanCallbackFailed();
+
+            _transferCollateralFrom(address(receiver_), amount_ + fee);
+            return true;
+        }
+
+        revert FlashloanUnavailableForToken();
+    }
+
     function pledgeCollateral(
         address borrower_,
         uint256 collateralAmountToPledge_

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -80,12 +80,11 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         if (token_ == _getArgAddress(0)) {
             _transferCollateral(address(receiver_), amount_);            
-            uint256 fee = 0;
             
-            if (receiver_.onFlashLoan(msg.sender, token_, amount_, fee, data_) != 
+            if (receiver_.onFlashLoan(msg.sender, token_, amount_, 0, data_) != 
                 keccak256("ERC3156FlashBorrower.onFlashLoan")) revert FlashloanCallbackFailed();
 
-            _transferCollateralFrom(address(receiver_), amount_ + fee);
+            _transferCollateralFrom(address(receiver_), amount_);
             return true;
         }
 
@@ -94,11 +93,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
     function flashFee(
         address token_,
-        uint256 amount_
-    ) external view override(IERC3156FlashLender, FlashloanablePool) returns (uint256) {
-        if      (token_ == _getArgAddress(20)) return _flashFee(amount_);
-        else if (token_ == _getArgAddress(0))  return 0;
-        else    revert FlashloanUnavailableForToken();
+        uint256
+    ) external pure override(IERC3156FlashLender, FlashloanablePool) returns (uint256) {
+        if (token_ == _getArgAddress(20) || token_ == _getArgAddress(0)) return 0;
+        revert FlashloanUnavailableForToken();
     }
 
     function maxFlashLoan(

--- a/tests/forge/ERC20Pool/ERC20FlashloanCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20FlashloanCollateral.t.sol
@@ -80,6 +80,21 @@ contract ERC20PoolFlashloanTest is ERC20HelperContract {
         assertEq(_collateral.balanceOf(address(flasher)), 3.5 * 1e18);
     }
 
+    function testFlashloanFee() external tearDown {
+        uint256 loanAmount = 100 * 1e18;
+
+        // Ensure there is no fee for quote token
+        uint256 fee = _pool.flashFee(address(_quote), loanAmount);
+        assertEq(fee, 0);
+
+        // Ensure there is no fee for collateral
+        fee = _pool.flashFee(address(_collateral), loanAmount);
+        assertEq(fee, 0);
+
+        // Ensure fee reverts for a random address which isn't a token
+        _assertFlashloanFeeRevertsForToken(makeAddr("nobody"), loanAmount);
+    }
+
     function testCannotFlashloanMoreCollateralThanAvailable() external tearDown {
         FlashloanBorrower flasher = new FlashloanBorrower(address(0), new bytes(0));
 

--- a/tests/forge/ERC20Pool/ERC20FlashloanCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20FlashloanCollateral.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import { ERC20HelperContract }                 from './ERC20DSTestPlus.sol';
+import { FlashloanBorrower, SomeDefiStrategy } from '../utils/FlashloanBorrower.sol';
+
+import 'src/libraries/BucketMath.sol';
+import 'src/libraries/PoolUtils.sol';
+
+contract ERC20PoolFlashloanTest is ERC20HelperContract {
+    address internal _borrower;
+    address internal _lender;
+    uint    internal _bucketId;
+    uint    internal _bucketPrice;
+
+    function setUp() external {
+        _lender    = makeAddr("lender");
+        _borrower  = makeAddr("borrower");
+
+        _mintQuoteAndApproveTokens(_lender,        100_000 * 1e18);
+        _mintQuoteAndApproveTokens(_borrower,      5_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower, 100 * 1e18);
+
+        // lender adds liquidity
+        _bucketPrice = 502.433988063349232760 * 1e18;
+        _bucketId = PoolUtils.priceToIndex(_bucketPrice);
+        assertEq(_bucketId, 2909);
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 100_000 * 1e18,
+                index:  _bucketId,
+                newLup: BucketMath.MAX_PRICE
+            }
+        );
+
+        // borrower draws debt
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                amount:   100 * 1e18
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower,
+                amount:     25_000 * 1e18,
+                indexLimit: _bucketId,
+                newLup:     _bucketPrice
+            }
+        );
+        (uint256 poolDebt,,) = _pool.debtInfo();
+        assertEq(poolDebt, 25_024.038461538461550000 * 1e18);
+    }
+
+    function testCollateralFlashloan() external tearDown {
+        skip(1 days);
+        uint256 loanAmount = 100 * 1e18;
+        assertEq(_pool.maxFlashLoan(address(_collateral)), loanAmount);
+
+        // Create an example defi strategy
+        SomeDefiStrategy strategy = new SomeDefiStrategy(_collateral);
+        deal(address(_collateral), address(strategy), 10 * 1e18);
+
+        // Create a flashloan borrower contract which interacts with the strategy
+        bytes memory strategyCalldata = abi.encodeWithSignature("makeMoney(uint256)", loanAmount);
+        FlashloanBorrower flasher = new FlashloanBorrower(address(strategy), strategyCalldata);
+
+        // Run the token approvals
+        changePrank(address(flasher));
+        _collateral.approve(address(_pool),    loanAmount);
+        _collateral.approve(address(strategy), loanAmount);
+
+        // Use a flashloan to interact with the strategy
+        assertEq(_collateral.balanceOf(address(flasher)), 0);
+        assertTrue(!flasher.callbackInvoked());
+        _pool.flashLoan(flasher, address(_collateral), loanAmount, new bytes(0));
+        assertTrue(flasher.callbackInvoked());
+        assertEq(_collateral.balanceOf(address(flasher)), 3.5 * 1e18);
+    }
+
+    function testCannotFlashloanMoreCollateralThanAvailable() external tearDown {
+        FlashloanBorrower flasher = new FlashloanBorrower(address(0), new bytes(0));
+
+        // Cannot flashloan less than pool size but more than available quote token
+        _assertFlashloanTooLargeRevert(flasher, _pool.quoteTokenAddress(), 90_000 * 1e18);
+
+        // Cannot flashloan more collateral than pledged
+        _assertFlashloanTooLargeRevert(flasher, _pool.collateralAddress(), 150 * 1e18);
+    }
+
+    function testCannotFlashloanNonToken() external tearDown {
+        FlashloanBorrower flasher = new FlashloanBorrower(address(0), new bytes(0));
+
+        // Cannot flashloan a random address which isn't a token
+        _assertFlashloanUnavailableForToken(flasher, makeAddr("nobody"), 1);
+    }
+}

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -38,7 +38,7 @@ contract BalancerUniswapTaker {
     function receiveFlashLoan(
         IERC20[] calldata tokens,
         uint256[] calldata amounts,
-        uint256[] calldata feeAmounts,
+        uint256[] calldata,
         bytes calldata userData
     ) public payable {
         if (msg.sender != balancerAddress) revert NotBalancer();
@@ -119,7 +119,7 @@ contract BalancerUniswapPurchaser {
     function receiveFlashLoan(
         IERC20[] calldata tokens,
         uint256[] calldata amounts,
-        uint256[] calldata feeAmounts,
+        uint256[] calldata,
         bytes calldata userData
     ) public payable {
         if (msg.sender != balancerAddress) revert NotBalancer();

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -755,6 +755,14 @@ abstract contract DSTestPlus is Test {
         _pool.borrow(amount, indexLimit);
     }
 
+    function _assertFlashloanFeeRevertsForToken(
+        address token,
+        uint256 amount
+    ) internal {
+        vm.expectRevert(abi.encodeWithSignature('FlashloanUnavailableForToken()'));
+        _pool.flashFee(token, amount);
+    }
+
     function _assertFlashloanTooLargeRevert(
         IERC3156FlashBorrower flashBorrower,
         address token,

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -769,7 +769,7 @@ abstract contract DSTestPlus is Test {
         uint256 amount
     ) internal {
         changePrank(address(flashBorrower));
-        vm.expectRevert();
+        vm.expectRevert('ERC20: transfer amount exceeds balance');
         _pool.flashLoan(flashBorrower, token, amount, new bytes(0));
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -757,12 +757,12 @@ abstract contract DSTestPlus is Test {
 
     function _assertFlashloanTooLargeRevert(
         IERC3156FlashBorrower flashBorrower,
+        address token,
         uint256 amount
     ) internal {
         changePrank(address(flashBorrower));
-        address quoteTokenAddress = _pool.quoteTokenAddress();
         vm.expectRevert();
-        _pool.flashLoan(flashBorrower, quoteTokenAddress, amount, new bytes(0));
+        _pool.flashLoan(flashBorrower, token, amount, new bytes(0));
     }
 
     function _assertFlashloanUnavailableForToken(

--- a/tests/forge/utils/FlashloanBorrower.sol
+++ b/tests/forge/utils/FlashloanBorrower.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.14;
+
+import { Token }                from '../utils/Tokens.sol';
+
+import 'src/base/interfaces/IERC3156FlashBorrower.sol';
+import 'src/libraries/Maths.sol';
+
+contract FlashloanBorrower is IERC3156FlashBorrower {
+    bool    public   callbackInvoked = false;
+    address internal strategy;
+    bytes   internal strategyCallData;
+    bytes32 public constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
+
+    constructor(address strategy_, bytes memory strategyCallData_) {
+        strategy         = strategy_;
+        strategyCallData = strategyCallData_;
+    }
+
+    function onFlashLoan(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes calldata
+    ) external returns (bytes32 result_) {
+        callbackInvoked = true;
+        (bool success, ) = strategy.call(strategyCallData);
+        if (success) result_ = CALLBACK_SUCCESS;
+    }
+}
+
+// Example of some defi strategy which produces a fixed return
+contract SomeDefiStrategy {
+    Token public token;
+
+    constructor(Token token_) {
+        token = token_;
+    }
+
+    function makeMoney(uint256 amount_) external {
+        // step 1: take deposit from caller
+        token.transferFrom(msg.sender, address(this), amount_);
+        // step 2: earn tree fiddy per 100 tokens
+        uint256 reward = Maths.wmul(0.035 * 1e18, amount_);
+        // step 3: profit
+        token.transfer(msg.sender, amount_ + reward);
+    }
+}


### PR DESCRIPTION
**Changes**
- Allow actors to flashloan pledged + available collateral from the ERC20 pool, without fee.
- Eliminate flashloan fee for quote token.
- Fix some unrelated compilation warnings.

**Performance**
This implementation grows the size of the ERC20 pool by 558 bytes, as certain methods in baseclass are overridden.  Size of ERC721 pool increases by only 3 bytes.
```
============ develop Bytecode Sizes ============
  ERC721Pool               -  24,513B  (99.74%)
  ERC20Pool                -  22,960B  (93.42%)

============ collateral-flashloans Sizes ============
  ERC721Pool               -  24,516B  (99.75%)
  ERC20Pool                -  23,518B  (95.69%)
```

**Out-of-scope**
Charging fees for collateral flashloans may continue to be explored in another branch.