### PR TITLE
Read only once from storage structs

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -19,6 +19,8 @@ import '../libraries/external/LenderActions.sol';
 import '../libraries/external/PoolCommons.sol';
 
 abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
+    using Auctions for Auctions.Data;
+    using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
@@ -134,7 +136,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 maxAmount_,
         uint256 index_
     ) external override returns (uint256 removedAmount_, uint256 redeemedLPs_) {
-        Auctions.revertIfAuctionClearable(auctions, loans);
+        auctions.revertIfAuctionClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
         _revertIfAuctionDebtLocked(index_, poolState.inflator);
@@ -193,7 +195,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 limitIndex_
     ) external override {
         // if borrower auctioned then it cannot draw more debt
-        Auctions.revertIfActive(auctions, msg.sender);
+        auctions.revertIfActive(msg.sender);
 
         PoolState memory poolState     = _accruePoolInterest();
         Loans.Borrower memory borrower = loans.getBorrowerInfo(msg.sender);
@@ -339,7 +341,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     function kick(address borrowerAddress_) external override {
-        Auctions.revertIfActive(auctions, borrowerAddress_);
+        auctions.revertIfActive(borrowerAddress_);
 
         PoolState memory poolState = _accruePoolInterest();
         Loans.Borrower storage borrower = loans.borrowers[borrowerAddress_];
@@ -428,7 +430,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 newLup = _lup(poolState.accruedDebt);
 
         if (
-            Auctions.isActive(auctions, borrowerAddress_)
+            auctions.isActive(borrowerAddress_)
             &&
             _isCollateralized(
                 Maths.wmul(borrower.t0debt, poolState.inflator),
@@ -504,7 +506,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         newLup_ = _lup(poolState_.accruedDebt);
 
-        if (Auctions.isActive(auctions, borrowerAddress_)) {
+        if (auctions.isActive(borrowerAddress_)) {
             if (_isCollateralized(borrowerDebt, borrower_.collateral, newLup_)) {
                 // borrower becomes re-collateralized
                 // remove entire borrower debt from pool auctions debt accumulator
@@ -753,7 +755,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 index_,
         address lender_
     ) external view override returns (uint256, uint256) {
-        return Buckets.getLenderInfo(buckets, index_, lender_);
+        return buckets.getLenderInfo(index_, lender_);
     }
 
     function loansInfo() external view override returns (address, uint256, uint256) {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -184,7 +184,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _transferQuoteToken(msg.sender, claimable);
     }
 
-
     /***********************************/
     /*** Borrower External Functions ***/
     /***********************************/
@@ -381,7 +380,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if(kickAuctionAmount != 0) _transferQuoteTokenFrom(msg.sender, kickAuctionAmount);
     }
 
-
     /*********************************/
     /*** Reserve Auction Functions ***/
     /*********************************/
@@ -412,7 +410,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         ajnaToken.burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);
     }
-
 
     /***********************************/
     /*** Borrower Internal Functions ***/
@@ -547,7 +544,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         }
     }
 
-
     /******************************/
     /*** Pool Virtual Functions ***/
     /******************************/
@@ -575,7 +571,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         address borrowerAddress_,
         uint256 borrowerCollateral_
     ) internal virtual returns (uint256);
-
 
     /*****************************/
     /*** Pool Helper Functions ***/
@@ -648,7 +643,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function _lup(uint256 debt_) internal view returns (uint256) {
         return _priceAt(_lupIndex(debt_));
     }
-
 
     /**************************/
     /*** External Functions ***/

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -280,7 +280,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Auctions.TakeParams memory params;
         params.borrower    = borrowerAddress_;
         params.collateral  = borrower.collateral;
-        params.debt        = borrower.t0debt;
+        params.t0debt      = borrower.t0debt;
         params.inflator    = poolState.inflator;
         params.depositTake = depositTake_;
         params.index       = index_;
@@ -313,7 +313,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Auctions.SettleParams memory params;
         params.borrower    = borrowerAddress_;
         params.collateral  = borrower.collateral;
-        params.debt        = borrower.t0debt;
+        params.t0debt      = borrower.t0debt;
         params.reserves    = reserves;
         params.inflator    = poolState.inflator;
         params.bucketDepth = maxDepth_;
@@ -326,11 +326,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         if (remainingt0Debt == 0) remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
 
-        uint256 t0settledDebt = borrower.t0debt - remainingt0Debt;
+        uint256 t0settledDebt = params.t0debt - remainingt0Debt;
         t0poolDebt      -= t0settledDebt;
         t0DebtInAuction -= t0settledDebt;
 
-        poolState.collateral -= borrower.collateral - remainingCollateral;
+        poolState.collateral -= params.collateral - remainingCollateral;
 
         borrower.t0debt     = remainingt0Debt;
         borrower.collateral = remainingCollateral;
@@ -346,10 +346,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         PoolState memory poolState = _accruePoolInterest();
         Loans.Borrower storage borrower = loans.borrowers[borrowerAddress_];
+        uint256 borrowerT0debt = borrower.t0debt;
 
         Auctions.KickParams memory params;
         params.borrower     = borrowerAddress_;
-        params.debt         = Maths.wmul(borrower.t0debt, poolState.inflator);
+        params.debt         = Maths.wmul(borrowerT0debt, poolState.inflator);
         params.collateral   = borrower.collateral;
         params.momp         = deposits.momp(poolState.accruedDebt, loans.noOfLoans());
         params.neutralPrice = Maths.wmul(borrower.t0Np, poolState.inflator);
@@ -357,7 +358,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         uint256 lup = _lup(poolState.accruedDebt);
         if (
-            _isCollateralized(params.debt , borrower.collateral, lup)
+            _isCollateralized(params.debt , params.collateral, lup)
         ) revert BorrowerOk();
 
         // kick auction
@@ -370,11 +371,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         loans.remove(params.borrower);
 
         poolState.accruedDebt += kickPenalty;
-        // convert kick penalty to t0 amount
+        // convert kick penalty to t0 amount, update borrower t0 debt and pool t0 debt accumulators
         kickPenalty     =  Maths.wdiv(kickPenalty, poolState.inflator);
-        borrower.t0debt += kickPenalty;
+        borrowerT0debt  += kickPenalty;
+        borrower.t0debt = borrowerT0debt;
+        t0DebtInAuction += borrowerT0debt;
         t0poolDebt      += kickPenalty;
-        t0DebtInAuction += borrower.t0debt;
 
         _updateInterestParams(poolState, lup);
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -7,6 +7,7 @@ import './interfaces/IERC20Taker.sol';
 import '../base/FlashloanablePool.sol';
 
 contract ERC20Pool is IERC20Pool, FlashloanablePool {
+    using Auctions for Auctions.Data;
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
@@ -134,7 +135,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 maxAmount_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        Auctions.revertIfAuctionClearable(auctions, loans);
+        auctions.revertIfAuctionClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -172,7 +172,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         Auctions.TakeParams memory params;
         params.borrower       = borrowerAddress_;
         params.collateral     = borrower.collateral;
-        params.debt           = borrower.t0debt;
+        params.t0debt         = borrower.t0debt;
         params.takeCollateral = collateral_;
         params.inflator       = poolState.inflator;
         (

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -7,8 +7,6 @@ import './interfaces/IERC20Taker.sol';
 import '../base/FlashloanablePool.sol';
 
 contract ERC20Pool is IERC20Pool, FlashloanablePool {
-    using Auctions for Auctions.Data;
-    using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
@@ -136,7 +134,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 maxAmount_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        auctions.revertIfAuctionClearable(loans);
+        Auctions.revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -7,8 +7,6 @@ import './interfaces/IERC721Taker.sol';
 import '../base/FlashloanablePool.sol';
 
 contract ERC721Pool is IERC721Pool, FlashloanablePool {
-    using Auctions for Auctions.Data;
-    using Buckets  for mapping(uint256 => Buckets.Bucket);
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
@@ -109,7 +107,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 noOfNFTsToRemove_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        auctions.revertIfAuctionClearable(loans);
+        Auctions.revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -7,6 +7,7 @@ import './interfaces/IERC721Taker.sol';
 import '../base/FlashloanablePool.sol';
 
 contract ERC721Pool is IERC721Pool, FlashloanablePool {
+    using Auctions for Auctions.Data;
     using Deposits for Deposits.Data;
     using Loans    for Loans.Data;
 
@@ -107,7 +108,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 noOfNFTsToRemove_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        Auctions.revertIfAuctionClearable(auctions, loans);
+        auctions.revertIfAuctionClearable(loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -145,7 +145,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         Auctions.TakeParams memory params;
         params.borrower       = borrowerAddress_;
         params.collateral     = borrower.collateral;
-        params.debt           = borrower.t0debt;
+        params.t0debt         = borrower.t0debt;
         params.takeCollateral = Maths.wad(collateral_);
         params.inflator       = poolState.inflator;
         (

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -82,7 +82,6 @@ library Buckets {
         lender.depositTime = block.timestamp;
     }
 
-
     /**********************/
     /*** View Functions ***/
     /**********************/

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -27,43 +27,6 @@ library Buckets {
     /***********************************/
 
     /**
-     *  @notice Updates LP balances for bucket and lender with the amount coresponding to quote token amount added.
-     *  @param  deposit_               Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
-     *  @param  quoteTokenAmountToAdd_ Additional quote tokens amount to add to bucket deposit.
-     *  @param  bucketPrice_           Bucket price.
-     *  @return addedLPs_              Amount of bucket LPs for the quote tokens amount added.
-     */
-    function addQuoteToken(
-        Bucket storage bucket_,
-        uint256 deposit_,
-        uint256 quoteTokenAmountToAdd_,
-        uint256 bucketPrice_
-    ) internal returns (uint256 addedLPs_) {
-
-        // calculate amount of LPs to be added for the amount of quote tokens added to bucket
-        addedLPs_ = quoteTokensToLPs(
-            bucket_.collateral,
-            bucket_.lps,
-            deposit_,
-            quoteTokenAmountToAdd_,
-            bucketPrice_
-        );
-
-        // update bucket LPs balance
-        // cannot deposit in the same block when bucket becomes insolvent
-        uint256 bankruptcyTime = bucket_.bankruptcyTime;
-        if (bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
-
-        // update bucket and lender LPs balance and deposit timestamp
-        bucket_.lps += addedLPs_;
-
-        Lender storage lender = bucket_.lenders[msg.sender];
-        if (bankruptcyTime >= lender.depositTime) lender.lps = addedLPs_;
-        else lender.lps += addedLPs_;
-        lender.depositTime = block.timestamp;
-    }
-
-    /**
      *  @notice Add collateral to a bucket and updates LPs for bucket and lender with the amount coresponding to collateral amount added.
      *  @param  lender_                Address of the lender.
      *  @param  deposit_               Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
@@ -78,6 +41,9 @@ library Buckets {
         uint256 collateralAmountToAdd_,
         uint256 bucketPrice_
     ) internal returns (uint256 addedLPs_) {
+        // cannot deposit in the same block when bucket becomes insolvent
+        uint256 bankruptcyTime = bucket_.bankruptcyTime;
+        if (bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
 
         // calculate amount of LPs to be added for the amount of collateral added to bucket
         addedLPs_ = collateralToLPs(
@@ -88,108 +54,32 @@ library Buckets {
             bucketPrice_
         );
         // update bucket LPs balance and collateral
-        // cannot deposit in the same block when bucket becomes insolvent
-        uint256 bankruptcyTime = bucket_.bankruptcyTime;
-        if (bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
 
         // update bucket collateral
         bucket_.collateral += collateralAmountToAdd_;
         // update bucket and lender LPs balance and deposit timestamp
         bucket_.lps += addedLPs_;
 
-        Lender storage lender = bucket_.lenders[lender_];
-        if (bankruptcyTime >= lender.depositTime) lender.lps = addedLPs_;
-        else lender.lps += addedLPs_;
-        lender.depositTime = block.timestamp;
+        addLenderLPs(bucket_, bankruptcyTime, lender_, addedLPs_);
     }
 
     /**
      *  @notice Add amount of LPs for a given lender in a given bucket.
-     *  @param  bucket_    Bucket to record lender LPs.
-     *  @param  lender_    Lender address to add LPs for in the given bucket.
-     *  @param  lpsAmount_ Amount of LPs to be recorded for the given lender.
+     *  @param  bucket_         Bucket to record lender LPs.
+     *  @param  bankruptcyTime_ Time when bucket become insolvent.
+     *  @param  lender_         Lender address to add LPs for in the given bucket.
+     *  @param  lpsAmount_      Amount of LPs to be recorded for the given lender.
      */
-    function addLPs(
+    function addLenderLPs(
         Bucket storage bucket_,
+        uint256 bankruptcyTime_,
         address lender_,
         uint256 lpsAmount_
     ) internal {
-        bucket_.lps += lpsAmount_;
-
         Lender storage lender = bucket_.lenders[lender_];
-        if (bucket_.bankruptcyTime >= lender.depositTime) lender.lps = lpsAmount_;
+        if (bankruptcyTime_ >= lender.depositTime) lender.lps = lpsAmount_;
         else lender.lps += lpsAmount_;
         lender.depositTime = block.timestamp;
-    }
-
-    /**
-     *  @notice Moves LPs between buckets and updates lender balance accordingly.
-     *  @param  fromLPsAmount_ The amount of LPs to move from origin bucket.
-     *  @param  toLPsAmount_   The amount of LPs to move to destination bucket.
-     */
-    function moveLPs(
-        Bucket storage fromBucket_,
-        Bucket storage toBucket_,
-        uint256 fromLPsAmount_,
-        uint256 toLPsAmount_
-    ) internal {
-
-        uint256 toBucketBankruptcyTime = toBucket_.bankruptcyTime;
-        // cannot move in the same block when target bucket becomes insolvent
-        if (toBucketBankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
-
-        // update buckets LPs balance
-        fromBucket_.lps -= fromLPsAmount_;
-        toBucket_.lps   += toLPsAmount_;
-        // update lender LPs balance in from bucket
-        Lender storage fromLender = fromBucket_.lenders[msg.sender];
-        fromLender.lps -= fromLPsAmount_;
-
-        // update lender LPs balance and deposit time in target bucket
-        Lender storage lender = toBucket_.lenders[msg.sender];
-        if (toBucketBankruptcyTime >= lender.depositTime) lender.lps = toLPsAmount_;
-        else lender.lps += toLPsAmount_;
-        // set deposit time to the greater of the lender's from bucket and the target bucket's last bankruptcy timestamp + 1 so deposit won't get invalidated
-        lender.depositTime = Maths.max(fromLender.depositTime, toBucketBankruptcyTime + 1);
-    }
-
-    /**
-     *  @notice Removes collateral from a bucket and subtracts LPs (coresponding to collateral amount removed) from bucket and lender balances.
-     *  @param  collateralAmountToRemove_ Collateral amount to be removed from bucket.
-     *  @param  lpsAmountToRemove_        The amount of LPs to be removed from bucket.
-     */
-    function removeCollateral(
-        Bucket storage bucket_,
-        uint256 collateralAmountToRemove_,
-        uint256 lpsAmountToRemove_
-    ) internal {
-        // update bucket collateral and LPs balance
-        bucket_.lps        -= Maths.min(bucket_.lps, lpsAmountToRemove_);
-        bucket_.collateral -= Maths.min(bucket_.collateral, collateralAmountToRemove_);
-        // update lender LPs balance
-        bucket_.lenders[msg.sender].lps -= lpsAmountToRemove_;
-    }
-
-    /**
-     *  @notice Transfer LPs from owner to an allowed address.
-     *  @param  owner_     The current owner of LPs.
-     *  @param  newOwner_  The new owner address.
-     *  @param  lpsAmount_ The amount of LPs to transfer to new owner.
-     */
-    function transferLPs(
-        mapping(uint256 => Bucket) storage self,
-        address owner_,
-        address newOwner_,
-        uint256 lpsAmount_,
-        uint256 index_,
-        uint256 depositTime_
-    ) internal {
-        // move lp tokens to the new owner address
-        Lender storage newOwner = self[index_].lenders[newOwner_];
-        newOwner.lps         += lpsAmount_;
-        newOwner.depositTime = Maths.max(depositTime_, newOwner.depositTime);
-        // reset owner lp balance for this index
-        delete self[index_].lenders[owner_];
     }
 
 

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -49,7 +49,7 @@ library Auctions {
     struct SettleParams {
         address borrower;    // borrower address to settle
         uint256 collateral;  // remaining collateral pledged by borrower that can be used to settle debt
-        uint256 debt;        // borrower debt to settle 
+        uint256 t0debt;      // borrower t0 debt to settle 
         uint256 reserves;    // current reserves in pool
         uint256 inflator;    // current pool inflator
         uint256 bucketDepth; // number of buckets to use when settle debt
@@ -67,7 +67,7 @@ library Auctions {
     struct TakeParams {
         address borrower;       // borrower address to take from
         uint256 collateral;     // borrower available collateral to take
-        uint256 debt;           // borrower debt
+        uint256 t0debt;         // borrower t0 debt
         uint256 takeCollateral; // desired amount to take
         uint256 inflator;       // current pool inflator
         bool    depositTake;    // deposit or arb take, used by bucket take
@@ -176,7 +176,7 @@ library Auctions {
         // HpbLocalVars memory hpbVars;
 
         // auction has debt to cover with remaining collateral
-        while (params_.bucketDepth != 0 && params_.debt != 0 && params_.collateral != 0) {
+        while (params_.bucketDepth != 0 && params_.t0debt != 0 && params_.collateral != 0) {
             uint256 index   = Deposits.findIndexOfSum(deposits_, 1);
             uint256 deposit = Deposits.valueAt(deposits_, index);
             uint256 price   = _priceAt(index);
@@ -185,21 +185,21 @@ library Auctions {
             uint256 collateralUsed;
 
             {
-                uint256 debtToSettle      = Maths.wmul(params_.debt, params_.inflator);     // current debt to be settled
+                uint256 debtToSettle      = Maths.wmul(params_.t0debt, params_.inflator);     // current debt to be settled
                 uint256 maxSettleableDebt = Maths.wmul(params_.collateral, price);          // max debt that can be settled with existing collateral
 
                 if (depositToRemove >= debtToSettle && maxSettleableDebt >= debtToSettle) { // enough deposit in bucket and collateral avail to settle entire debt
                     depositToRemove    = debtToSettle;                                      // remove only what's needed to settle the debt
-                    params_.debt       = 0;                                                 // no remaining debt to settle
+                    params_.t0debt    = 0;                                                 // no remaining debt to settle
                     collateralUsed     = Maths.wdiv(debtToSettle, price);
                     params_.collateral -= collateralUsed;
                 } else if (maxSettleableDebt >= depositToRemove) {                          // enough collateral, therefore not enough deposit to settle entire debt, we settle only deposit amount
-                    params_.debt       -= Maths.wdiv(depositToRemove, params_.inflator);    // subtract from debt the corresponding t0 amount of deposit
+                    params_.t0debt     -= Maths.wdiv(depositToRemove, params_.inflator);    // subtract from debt the corresponding t0 amount of deposit
                     collateralUsed     = Maths.wdiv(depositToRemove, price);
                     params_.collateral -= collateralUsed;
                 } else {                                                                    // constrained by collateral available
                     depositToRemove    = maxSettleableDebt;
-                    params_.debt       -= Maths.wdiv(maxSettleableDebt, params_.inflator);
+                    params_.t0debt     -= Maths.wdiv(maxSettleableDebt, params_.inflator);
                     collateralUsed     = params_.collateral;
                     params_.collateral = 0;
                 }
@@ -212,27 +212,27 @@ library Auctions {
         }
 
         // if there's still debt and no collateral
-        if (params_.debt != 0 && params_.collateral == 0) {
+        if (params_.t0debt != 0 && params_.collateral == 0) {
             // settle debt from reserves
-            params_.debt -= Maths.min(params_.debt, Maths.wdiv(params_.reserves, params_.inflator));
+            params_.t0debt -= Maths.min(params_.t0debt, Maths.wdiv(params_.reserves, params_.inflator));
 
             // if there's still debt after settling from reserves then start to forgive amount from next HPB
-            while (params_.bucketDepth != 0 && params_.debt != 0) { // loop through remaining buckets if there's still debt to settle
+            while (params_.bucketDepth != 0 && params_.t0debt != 0) { // loop through remaining buckets if there's still debt to settle
                 uint256 index   = Deposits.findIndexOfSum(deposits_, 1);
                 uint256 deposit = Deposits.valueAt(deposits_, index);
 
                 uint256 depositToRemove = deposit;
-                uint256 debtToSettle    = Maths.wmul(params_.debt, params_.inflator);
+                uint256 debtToSettle    = Maths.wmul(params_.t0debt, params_.inflator);
 
-                if (depositToRemove >= debtToSettle) {                             // enough deposit in bucket to settle entire debt
-                    depositToRemove = debtToSettle;                                // remove only what's needed to settle the debt
-                    params_.debt    = 0;                                           // no remaining debt to settle
+                if (depositToRemove >= debtToSettle) {                               // enough deposit in bucket to settle entire debt
+                    depositToRemove = debtToSettle;                                  // remove only what's needed to settle the debt
+                    params_.t0debt  = 0;                                             // no remaining debt to settle
 
-                } else {                                                           // not enough deposit to settle entire debt, we settle only deposit amount
-                    params_.debt -= Maths.wdiv(depositToRemove, params_.inflator); // subtract from remaining debt the corresponding t0 amount of deposit
+                } else {                                                             // not enough deposit to settle entire debt, we settle only deposit amount
+                    params_.t0debt -= Maths.wdiv(depositToRemove, params_.inflator); // subtract from remaining debt the corresponding t0 amount of deposit
 
                     Buckets.Bucket storage hpbBucket = buckets_[index];
-                    if (hpbBucket.collateral == 0) {                               // existing LPB and LP tokens for the bucket shall become unclaimable.
+                    if (hpbBucket.collateral == 0) {                                 // existing LPB and LP tokens for the bucket shall become unclaimable.
                         hpbBucket.lps = 0;
                         hpbBucket.bankruptcyTime = block.timestamp;
                     }
@@ -244,7 +244,7 @@ library Auctions {
             }
         }
 
-        return (params_.collateral, params_.debt);
+        return (params_.collateral, params_.t0debt);
     }
 
     /**
@@ -276,10 +276,11 @@ library Auctions {
         uint256 bondSize = Maths.wmul(bondFactor,  params_.debt);
         Kicker storage kicker = self.kickers[msg.sender];
         kicker.locked += bondSize;
-        if (kicker.claimable >= bondSize) {
+        uint256 kickerClaimable = kicker.claimable;
+        if (kickerClaimable >= bondSize) {
             kicker.claimable -= bondSize;
         } else {
-            kickAuctionAmount_ = bondSize - kicker.claimable;
+            kickAuctionAmount_ = bondSize - kickerClaimable;
             kicker.claimable = 0;
         }
         // update totalBondEscrowed accumulator
@@ -334,13 +335,16 @@ library Auctions {
         if (bucketDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
         Liquidation storage liquidation = self.liquidations[params_.borrower];
-        _validateTake(liquidation);
+
+        uint256 kickTime = liquidation.kickTime;
+        if (kickTime == 0) revert NoAuction();
+        if (block.timestamp - kickTime <= 1 hours) revert TakeNotPastCooldown();
 
         TakeResult memory result;
         result.bucketPrice  = _priceAt(params_.index);
         result.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
-            liquidation.kickTime
+            kickTime
         );
         // cannot arb with a price lower than the auction price
         if (result.auctionPrice > result.bucketPrice) revert AuctionPriceGtBucketPrice();
@@ -351,7 +355,7 @@ library Auctions {
             uint256 borrowerDebt,
             int256  bpf,
             uint256 factor
-        ) = _takeParameters(liquidation, params_.collateral, params_.debt, price, params_.inflator);
+        ) = _takeParameters(liquidation, params_.collateral, params_.t0debt, price, params_.inflator);
         result.kicker = liquidation.kicker;
         result.isRewarded = (bpf >= 0);
 
@@ -360,7 +364,7 @@ library Auctions {
             result.t0repayAmount    = Maths.wdiv(bucketDeposit, params_.inflator);
             result.quoteTokenAmount = Maths.wdiv(bucketDeposit, factor);
         } else {
-            result.t0repayAmount    = params_.debt;
+            result.t0repayAmount    = params_.t0debt;
             result.quoteTokenAmount = Maths.wdiv(borrowerDebt, factor);
         }
 
@@ -416,12 +420,15 @@ library Auctions {
         TakeParams calldata params_
     ) external returns (uint256, uint256, uint256, uint256) {
         Liquidation storage liquidation = self.liquidations[params_.borrower];
-        _validateTake(liquidation);
+
+        uint256 kickTime = liquidation.kickTime;
+        if (kickTime == 0) revert NoAuction();
+        if (block.timestamp - kickTime <= 1 hours) revert TakeNotPastCooldown();
 
         TakeResult memory result;
         result.auctionPrice = _auctionPrice(
             liquidation.kickMomp,
-            liquidation.kickTime
+            kickTime
         );
         result.kicker = liquidation.kicker;
         (
@@ -431,7 +438,7 @@ library Auctions {
         ) = _takeParameters(
             liquidation,
             params_.collateral,
-            params_.debt,
+            params_.t0debt,
             result.auctionPrice,
             params_.inflator
         );
@@ -442,8 +449,8 @@ library Auctions {
         result.quoteTokenAmount = Maths.wmul(result.auctionPrice, result.collateralAmount);
         result.t0repayAmount    = Maths.wdiv(Maths.wmul(result.quoteTokenAmount, factor), params_.inflator);
 
-        if (result.t0repayAmount >= params_.debt) {
-            result.t0repayAmount    = params_.debt;
+        if (result.t0repayAmount >= params_.t0debt) {
+            result.t0repayAmount    = params_.t0debt;
             result.quoteTokenAmount = Maths.wdiv(borrowerDebt, factor);
             result.collateralAmount = Maths.min(Maths.wdiv(result.quoteTokenAmount, result.auctionPrice), result.collateralAmount);
         }
@@ -594,58 +601,6 @@ library Auctions {
     /***  Internal Functions ***/
     /***************************/
 
-    function _auctionPrice(
-        uint256 referencePrice,
-        uint256 kickTime_
-    ) internal view returns (uint256 price_) {
-        uint256 elapsedHours = Maths.wdiv((block.timestamp - kickTime_) * 1e18, 1 hours * 1e18);
-        elapsedHours -= Maths.min(elapsedHours, 1e18);  // price locked during cure period
-
-        int256 timeAdjustment = PRBMathSD59x18.mul(-1 * 1e18, int256(elapsedHours));
-        price_ = 32 * Maths.wmul(referencePrice, uint256(PRBMathSD59x18.exp2(timeAdjustment)));
-    }
-
-    /**
-     *  @notice Calculates bond penalty factor.
-     *  @dev Called in kick and take.
-     *  @param debt_             Borrower debt.
-     *  @param collateral_       Borrower collateral.
-     *  @param neutralPrice_     NP of auction.
-     *  @param bondFactor_       Factor used to determine bondSize.
-     *  @param price_            Auction price at the time of call.
-     *  @return bpf_             Factor used in determining bond Reward (positive) or penalty (negative).
-     */
-    function _bpf(
-        uint256 debt_,
-        uint256 collateral_,
-        uint256 neutralPrice_,
-        uint256 bondFactor_,
-        uint256 price_
-    ) internal pure returns (int256) {
-        int256 thresholdPrice = int256(Maths.wdiv(debt_, collateral_));
-
-        int256 sign;
-        if (thresholdPrice < int256(neutralPrice_)) {
-            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
-            sign = Maths.minInt(
-                    1e18,
-                    Maths.maxInt(
-                        -1 * 1e18,
-                        PRBMathSD59x18.div(
-                            int256(neutralPrice_) - int256(price_),
-                            int256(neutralPrice_) - thresholdPrice
-                        )
-                    )
-            );
-        } else {
-            int256 val = int256(neutralPrice_) - int256(price_);
-            if (val < 0 )      sign = -1e18;
-            else if (val != 0) sign = 1e18;
-        }
-
-        return PRBMathSD59x18.mul(int256(bondFactor_), sign);
-    }
-
     /**
      *  @notice Removes auction and repairs the queue order.
      *  @notice Updates kicker's claimable balance with bond size awarded and subtracts bond size awarded from liquidationBondEscrowed.
@@ -734,15 +689,56 @@ library Auctions {
         Deposits.remove(deposits_, bucketIndex_, depositAmountToRemove, bucketDeposit_); // remove quote tokens from bucket’s deposit
     }
 
+    function _auctionPrice(
+        uint256 referencePrice,
+        uint256 kickTime_
+    ) internal view returns (uint256 price_) {
+        uint256 elapsedHours = Maths.wdiv((block.timestamp - kickTime_) * 1e18, 1 hours * 1e18);
+        elapsedHours -= Maths.min(elapsedHours, 1e18);  // price locked during cure period
+
+        int256 timeAdjustment = PRBMathSD59x18.mul(-1 * 1e18, int256(elapsedHours));
+        price_ = 32 * Maths.wmul(referencePrice, uint256(PRBMathSD59x18.exp2(timeAdjustment)));
+    }
+
     /**
-     *  @notice Utility function to validate take action.
-     *  @param  liquidation_  Liquidation struct holding auction details.
+     *  @notice Calculates bond penalty factor.
+     *  @dev Called in kick and take.
+     *  @param debt_             Borrower debt.
+     *  @param collateral_       Borrower collateral.
+     *  @param neutralPrice_     NP of auction.
+     *  @param bondFactor_       Factor used to determine bondSize.
+     *  @param price_            Auction price at the time of call.
+     *  @return bpf_             Factor used in determining bond Reward (positive) or penalty (negative).
      */
-    function _validateTake(
-        Liquidation storage liquidation_
-    ) internal view {
-        if (liquidation_.kickTime == 0) revert NoAuction();
-        if (block.timestamp - liquidation_.kickTime <= 1 hours) revert TakeNotPastCooldown();
+    function _bpf(
+        uint256 debt_,
+        uint256 collateral_,
+        uint256 neutralPrice_,
+        uint256 bondFactor_,
+        uint256 price_
+    ) internal pure returns (int256) {
+        int256 thresholdPrice = int256(Maths.wdiv(debt_, collateral_));
+
+        int256 sign;
+        if (thresholdPrice < int256(neutralPrice_)) {
+            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
+            sign = Maths.minInt(
+                    1e18,
+                    Maths.maxInt(
+                        -1 * 1e18,
+                        PRBMathSD59x18.div(
+                            int256(neutralPrice_) - int256(price_),
+                            int256(neutralPrice_) - thresholdPrice
+                        )
+                    )
+            );
+        } else {
+            int256 val = int256(neutralPrice_) - int256(price_);
+            if (val < 0 )      sign = -1e18;
+            else if (val != 0) sign = 1e18;
+        }
+
+        return PRBMathSD59x18.mul(int256(bondFactor_), sign);
     }
 
     /**
@@ -818,15 +814,12 @@ library Auctions {
     ) internal view {
         address head     = self.head;
         uint256 kickTime = self.liquidations[head].kickTime;
-        if (
-            kickTime != 0
-            &&
-            (
-                block.timestamp - kickTime > 72 hours
-                ||
-                (loans_.borrowers[head].t0debt != 0 && loans_.borrowers[head].collateral == 0)
-            )
-        ) revert AuctionNotCleared();
+        if (kickTime != 0) {
+            if (block.timestamp - kickTime > 72 hours) revert AuctionNotCleared();
+
+            Loans.Borrower storage borrower = loans_.borrowers[head];
+            if (borrower.t0debt != 0 && borrower.collateral == 0) revert AuctionNotCleared();
+        }
     }
 
 }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -355,7 +355,13 @@ library Auctions {
             uint256 borrowerDebt,
             int256  bpf,
             uint256 factor
-        ) = _takeParameters(liquidation, params_.collateral, params_.t0debt, price, params_.inflator);
+        ) = _takeParameters(
+            liquidation,
+            params_.collateral,
+            params_.t0debt,
+            price,
+            params_.inflator
+        );
         result.kicker = liquidation.kicker;
         result.isRewarded = (bpf >= 0);
 
@@ -553,7 +559,6 @@ library Auctions {
     /***********************/
     /*** Reserve Auction ***/
     /***********************/
-
 
     function startClaimableReserveAuction(
         Data storage self,

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -14,6 +14,10 @@ import '../../base/PoolHelper.sol';
 library LenderActions {
 
     /**
+     *  @notice Operation cannot be executed in the same block when bucket becomes insolvent.
+     */
+    error BucketBankruptcyBlock();
+    /**
      *  @notice Owner of the LP tokens must have approved the new owner prior to transfer.
      */
     error NoAllowance();
@@ -46,6 +50,19 @@ library LenderActions {
      *  @notice From and to deposit indexes to move are the same.
      */
     error MoveToSamePrice();
+
+    /**
+     *  @dev Struct to hold move quote token details, used to prevent stack too deep error.
+     */
+    struct MoveQuoteLocalVars {
+        uint256 amountToMove;
+        uint256 fromBucketPrice;
+        uint256 fromBucketDeposit;
+        uint256 fromBucketLPs;
+        uint256 fromBucketDepositTime;
+        uint256 toBucketPrice;
+        uint256 toBucketBankruptcyTime;
+    }
 
     struct MoveQuoteParams {
         uint256 maxAmountToMove; // max amount to move between deposits
@@ -111,15 +128,30 @@ library LenderActions {
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
     ) external returns (uint256 bucketLPs_) {
+        Buckets.Bucket storage bucket = buckets_[index_];
+        uint256 bankruptcyTime = bucket.bankruptcyTime;
+        // cannot deposit in the same block when bucket becomes insolvent
+        if (bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
+
         uint256 bucketDeposit = Deposits.valueAt(deposits_, index_);
         uint256 bucketPrice   = _priceAt(index_);
-        bucketLPs_ = Buckets.addQuoteToken(
-            buckets_[index_],
+        bucketLPs_ = Buckets.quoteTokensToLPs(
+            bucket.collateral,
+            bucket.lps,
             bucketDeposit,
             quoteTokenAmountToAdd_,
             bucketPrice
         );
+
         Deposits.add(deposits_, index_, quoteTokenAmountToAdd_);
+
+        // update lender LPs
+        Buckets.Lender storage lender = bucket.lenders[msg.sender];
+        if (bankruptcyTime >= lender.depositTime) lender.lps = bucketLPs_;
+        else lender.lps += bucketLPs_;
+        lender.depositTime = block.timestamp;
+        // update bucket LPs
+        bucket.lps += bucketLPs_;
     }
 
     function moveQuoteToken(
@@ -129,59 +161,68 @@ library LenderActions {
     ) external returns (uint256 fromBucketLPs_, uint256 toBucketLPs_, uint256 lup_) {
         if (params_.fromIndex == params_.toIndex) revert MoveToSamePrice();
 
-        uint256 fromPrice   = _priceAt(params_.fromIndex);
-        uint256 toPrice     = _priceAt(params_.toIndex);
-        uint256 fromDeposit = Deposits.valueAt(deposits_, params_.fromIndex);
-        uint256 amountToMove;
+        Buckets.Bucket storage toBucket = buckets_[params_.toIndex];
+
+        MoveQuoteLocalVars memory vars;
+        vars.toBucketBankruptcyTime = toBucket.bankruptcyTime;
+        // cannot move in the same block when target bucket becomes insolvent
+        if (vars.toBucketBankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
 
         Buckets.Bucket storage fromBucket = buckets_[params_.fromIndex];
-        {
-            (uint256 lenderLPs, uint256 depositTime) = Buckets.getLenderInfo(
-                buckets_,
-                params_.fromIndex,
-                msg.sender
-            );
-            (amountToMove, fromBucketLPs_) = Buckets.lpsToQuoteToken(
-                fromBucket.lps,
-                fromBucket.collateral,
-                fromDeposit,
-                lenderLPs,
-                params_.maxAmountToMove,
-                fromPrice
-            );
+        Buckets.Lender storage fromBucketLender = fromBucket.lenders[msg.sender];
 
-            Deposits.remove(deposits_, params_.fromIndex, amountToMove, fromDeposit);
+        vars.fromBucketPrice       = _priceAt(params_.fromIndex);
+        vars.toBucketPrice         = _priceAt(params_.toIndex);
+        vars.fromBucketDeposit     = Deposits.valueAt(deposits_, params_.fromIndex);
+        vars.fromBucketDepositTime = fromBucketLender.depositTime;
 
-            // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
-            if (depositTime != 0 && block.timestamp - depositTime < 1 days) {
-                if (fromPrice > params_.ptp && toPrice < params_.ptp) {
-                    amountToMove = Maths.wmul(amountToMove, Maths.WAD - _feeRate(params_.rate));
-                }
+        if (fromBucket.bankruptcyTime < vars.fromBucketDepositTime) vars.fromBucketLPs = fromBucketLender.lps;
+        (vars.amountToMove, fromBucketLPs_) = Buckets.lpsToQuoteToken(
+            fromBucket.lps,
+            fromBucket.collateral,
+            vars.fromBucketDeposit,
+            vars.fromBucketLPs,
+            params_.maxAmountToMove,
+            vars.fromBucketPrice
+        );
+
+        Deposits.remove(deposits_, params_.fromIndex, vars.amountToMove, vars.fromBucketDeposit);
+
+        // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
+        if (vars.fromBucketDepositTime != 0 && block.timestamp - vars.fromBucketDepositTime < 1 days) {
+            if (vars.fromBucketPrice > params_.ptp && vars.toBucketPrice < params_.ptp) {
+                vars.amountToMove = Maths.wmul(vars.amountToMove, Maths.WAD - _feeRate(params_.rate));
             }
         }
 
-        Buckets.Bucket storage toBucket = buckets_[params_.toIndex];
         toBucketLPs_ = Buckets.quoteTokensToLPs(
             toBucket.collateral,
             toBucket.lps,
             Deposits.valueAt(deposits_, params_.toIndex),
-            amountToMove,
-            toPrice
+            vars.amountToMove,
+            vars.toBucketPrice
         );
 
-        Deposits.add(deposits_, params_.toIndex, amountToMove);
-
-        Buckets.moveLPs(
-            fromBucket,
-            toBucket,
-            fromBucketLPs_,
-            toBucketLPs_
-        );
+        Deposits.add(deposits_, params_.toIndex, vars.amountToMove);
 
         lup_ = _lup(deposits_, params_.poolDebt);
         // check loan book's htp against new lup
         if (params_.fromIndex < params_.toIndex) if(params_.htp > lup_) revert LUPBelowHTP();
-        emit MoveQuoteToken(msg.sender, params_.fromIndex, params_.toIndex, amountToMove, lup_);
+
+        // update lender LPs balance in from bucket
+        fromBucketLender.lps -= fromBucketLPs_;
+        // update lender LPs balance and deposit time in target bucket
+        Buckets.Lender storage toBucketLender = toBucket.lenders[msg.sender];
+        if (vars.toBucketBankruptcyTime >= toBucketLender.depositTime) toBucketLender.lps = toBucketLPs_;
+        else toBucketLender.lps += toBucketLPs_;
+        // set deposit time to the greater of the lender's from bucket and the target bucket's last bankruptcy timestamp + 1 so deposit won't get invalidated
+        toBucketLender.depositTime = Maths.max(vars.fromBucketDepositTime, vars.toBucketBankruptcyTime + 1);
+
+        // update buckets LPs balance
+        fromBucket.lps -= fromBucketLPs_;
+        toBucket.lps   += toBucketLPs_;
+
+        emit MoveQuoteToken(msg.sender, params_.fromIndex, params_.toIndex, vars.amountToMove, lup_);
     }
 
     function removeQuoteToken(
@@ -189,20 +230,17 @@ library LenderActions {
         Deposits.Data storage deposits_,
         RemoveQuoteParams calldata params_
     ) external returns (uint256 removedAmount_, uint256 redeemedLPs_, uint256 lup_) {
-
-        (uint256 lenderLPs, uint256 depositTime) = Buckets.getLenderInfo(
-            buckets_,
-            params_.index,
-            msg.sender
-        );
-        if (lenderLPs == 0) revert NoClaim();      // revert if no LP to claim
-
         uint256 deposit = Deposits.valueAt(deposits_, params_.index);
         if (deposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
 
-        uint256 price = _priceAt(params_.index);
-
         Buckets.Bucket storage bucket = buckets_[params_.index];
+        Buckets.Lender storage lender = bucket.lenders[msg.sender];
+        uint256 depositTime = lender.depositTime;
+        uint256 lenderLPs;
+        if (bucket.bankruptcyTime < lender.depositTime) lenderLPs = lender.lps;
+        if (lenderLPs == 0) revert NoClaim();      // revert if no LP to claim
+
+        uint256 price = _priceAt(params_.index);
         uint256 exchangeRate = Buckets.getExchangeRate(
             bucket.collateral,
             bucket.lps,
@@ -230,13 +268,14 @@ library LenderActions {
             }
         }
 
-        // update bucket and lender LPs balances
-        bucket.lps -= redeemedLPs_;
-        bucket.lenders[msg.sender].lps -= redeemedLPs_;
-
         lup_ = _lup(deposits_, params_.poolDebt);
         // check loan book's htp against new lup
         if (params_.htp > lup_) revert LUPBelowHTP();
+
+        // update lender and bucket LPs balances
+        lender.lps -= redeemedLPs_;
+        bucket.lps -= redeemedLPs_;
+
         emit RemoveQuoteToken(msg.sender, params_.index, removedAmount_, lup_);
     }
 
@@ -248,21 +287,25 @@ library LenderActions {
     ) external returns (uint256 collateralAmount_, uint256 lpAmount_) {
 
         Buckets.Bucket storage bucket = buckets_[index_];
-        if (bucket.collateral == 0) revert InsufficientCollateral(); // revert if there's no collateral in bucket
+        uint256 bucketCollateral = bucket.collateral;
+        if (bucketCollateral == 0) revert InsufficientCollateral(); // revert if there's no collateral in bucket
 
-        (uint256 lenderLpBalance, ) = Buckets.getLenderInfo(buckets_, index_, msg.sender);
+        Buckets.Lender storage lender = bucket.lenders[msg.sender];
+        uint256 lenderLpBalance;
+        if (bucket.bankruptcyTime < lender.depositTime) lenderLpBalance = lender.lps;
         if (lenderLpBalance == 0) revert NoClaim();                  // revert if no LP to redeem
 
         uint256 bucketPrice = _priceAt(index_);
+        uint256 bucketLPs   = bucket.lps;
         uint256 exchangeRate = Buckets.getExchangeRate(
-            bucket.collateral,
-            bucket.lps,
+            bucketCollateral,
+            bucketLPs,
             Deposits.valueAt(deposits_, index_),
             bucketPrice
         );
 
         // limit amount by what is available in the bucket
-        collateralAmount_ = Maths.min(maxAmount_, bucket.collateral);
+        collateralAmount_ = Maths.min(maxAmount_, bucketCollateral);
 
         // determine how much LP would be required to remove the requested amount
         uint256 requiredLPs = (collateralAmount_ * bucketPrice * 1e18 + exchangeRate / 2) / exchangeRate;
@@ -275,11 +318,11 @@ library LenderActions {
             collateralAmount_ = ((lpAmount_ * exchangeRate + 1e27 / 2) / 1e18 + bucketPrice / 2) / bucketPrice;
         }
 
-        Buckets.removeCollateral(
-            bucket,
-            collateralAmount_,
-            lpAmount_
-        );
+        // update lender LPs balance
+        lender.lps -= lpAmount_;
+        // update bucket LPs and collateral balance
+        bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
+        bucket.collateral -= Maths.min(bucketCollateral, collateralAmount_);
     }
 
     function removeCollateral(
@@ -290,26 +333,29 @@ library LenderActions {
     ) external returns (uint256 lpAmount_) {
 
         Buckets.Bucket storage bucket = buckets_[index_];
-        if (amount_ > bucket.collateral) revert InsufficientCollateral();
+        uint256 bucketCollateral = bucket.collateral;
+        if (amount_ > bucketCollateral) revert InsufficientCollateral();
 
         uint256 bucketPrice = _priceAt(index_);
+        uint256 bucketLPs   = bucket.lps;
         lpAmount_ = Buckets.collateralToLPs(
-            bucket.collateral,
-            bucket.lps,
+            bucketCollateral,
+            bucketLPs,
             Deposits.valueAt(deposits_, index_),
             amount_,
             bucketPrice
         );
 
-        (uint256 lenderLpBalance, ) = Buckets.getLenderInfo(buckets_, index_, msg.sender);
-        // ensure lender has enough balance to remove collateral amount
+        Buckets.Lender storage lender = bucket.lenders[msg.sender];
+        uint256 lenderLpBalance;
+        if (bucket.bankruptcyTime < lender.depositTime) lenderLpBalance = lender.lps;
         if (lenderLpBalance == 0 || lpAmount_ > lenderLpBalance) revert InsufficientLPs();
 
-        Buckets.removeCollateral(
-            bucket,
-            amount_,
-            lpAmount_
-        );
+        // update lender LPs balance
+        lender.lps -= lpAmount_;
+        // update bucket LPs and collateral balance
+        bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
+        bucket.collateral -= Maths.min(bucketCollateral, amount_);
     }
 
     /**
@@ -330,26 +376,27 @@ library LenderActions {
         uint256 tokensTransferred;
 
         for (uint256 i = 0; i < indexesLength; ) {
-            if (indexes_[i] > 8192 ) revert InvalidIndex();
+            uint256 index = indexes_[i];
+            if (index > 8192 ) revert InvalidIndex();
 
-            uint256 transferAmount = allowances_[owner_][newOwner_][indexes_[i]];
-            (uint256 lenderLpBalance, uint256 lenderLastDepositTime) = Buckets.getLenderInfo(
-                buckets_,
-                indexes_[i],
-                owner_
-            );
+            uint256 transferAmount = allowances_[owner_][newOwner_][index];
+            Buckets.Bucket storage bucket = buckets_[index];
+
+            Buckets.Lender storage lender = bucket.lenders[owner_];
+            uint256 lenderDepositTime = lender.depositTime;
+            uint256 lenderLpBalance;
+            if (bucket.bankruptcyTime < lenderDepositTime) lenderLpBalance = lender.lps;
+
             if (transferAmount == 0 || transferAmount != lenderLpBalance) revert NoAllowance();
 
-            delete allowances_[owner_][newOwner_][indexes_[i]]; // delete allowance
+            delete allowances_[owner_][newOwner_][index]; // delete allowance
 
-            Buckets.transferLPs(
-                buckets_,
-                owner_,
-                newOwner_,
-                transferAmount,
-                indexes_[i],
-                lenderLastDepositTime
-            );
+            // move lp tokens to the new owner address
+            Buckets.Lender storage newLender = bucket.lenders[newOwner_];
+            newLender.lps         += transferAmount;
+            newLender.depositTime = Maths.max(lenderDepositTime, newLender.depositTime);
+            // reset owner lp balance for this index
+            delete bucket.lenders[owner_];
 
             tokensTransferred += transferAmount;
 

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -191,7 +191,6 @@ library PoolCommons {
         return _utilization(deposits, debt_, collateral_);
     }
 
-
     /**************************/
     /*** Internal Functions ***/
     /**************************/

--- a/tests/brownie/test_scaled_pool.py
+++ b/tests/brownie/test_scaled_pool.py
@@ -10,7 +10,7 @@ def test_quote_deposit_move_remove_scaled(
     capsys,
     test_utils
 ):
-    with test_utils.GasWatcher(["addQuoteToken"]):
+    with test_utils.GasWatcher(["addQuoteToken", "moveQuoteToken", "removeQuoteToken"]):
         add_txes = []
         for i in range(2530, 2550):
             tx = scaled_pool.addQuoteToken(100 * 10**18, i, {"from": lenders[0]})
@@ -52,7 +52,7 @@ def test_borrow_repay_scaled(
     capsys,
     test_utils
 ):
-    with test_utils.GasWatcher(["borrow"]):
+    with test_utils.GasWatcher(["addQuoteToken", "pledgeCollateral", "borrow", "repay"]):
 
         scaled_pool.addQuoteToken(100 * 10**18, 2550, {"from": lenders[0]})
         scaled_pool.addQuoteToken(100 * 10**18, 2560, {"from": lenders[0]})


### PR DESCRIPTION
rationale: when loading struct as `storage` each time we access structs's members is a `SLOAD` opcode
- access borrower only once (and if really needed) in revertIfAuctionClearable
- kick: reuse already loaded borrower collateral and t0 debt
- Buckets library:
    - remove functions that are not used by other libraries but LenderActions library (add/move/remove quote tokens, remove collateral and transfer LP tokens). Contains only add lender LPs and add collateral functions (used by LenderActions and Auctions library as well)
- LenderActions library:
    - reuse storage struct already loaded in code inline
    - added MoveQuoteLocalVars struct to hold local move quote token vars and prevent stack too deep
    

Extra:
- Auctions library: renamed auctions function params to reflect if `t0` debt or regular debt passed; reordered internal functions to list first those that are changing state 
- some style

```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101010          | 160132 | 143625 | 658094 | 56003   |
| borrow                                     | 141746          | 190424 | 162222 | 720102 | 128002  |
| bucketTake                                 | 345679          | 410809 | 410826 | 475907 | 4       |
| kick                                       | 150123          | 174863 | 173572 | 997349 | 48000   |
| moveQuoteToken                             | 261622          | 261622 | 261622 | 261622 | 1       |
| pledgeCollateral                           | 60998           | 61343  | 61318  | 525037 | 120001  |
| removeQuoteToken                           | 158538          | 177806 | 177715 | 198282 | 4000    |
| repay                                      | 503393          | 535328 | 524628 | 683197 | 16002   |
| take                                       | 49256           | 49881  | 49674  | 337387 | 15998   |

vs develop

| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101229          | 160351 | 143844 | 658313 | 56003   |
| borrow                                     | 141746          | 190424 | 162222 | 720102 | 128002  |
| bucketTake                                 | 345808          | 411111 | 411127 | 476381 | 4       |
| kick                                       | 150518          | 175258 | 173967 | 997744 | 48000   |
| moveQuoteToken                             | 283814          | 283814 | 283814 | 283814 | 1       |
| pledgeCollateral                           | 60998           | 61343  | 61318  | 525037 | 120001  |
| removeQuoteToken                           | 159107          | 178247 | 178151 | 201869 | 4000    |
| repay                                      | 503393          | 535328 | 524628 | 683197 | 16002   |
| take                                       | 49407           | 50032  | 49825  | 337538 | 15998   |
```


ERC20 tests comparison (current / develop)
```
| src/erc20/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                              | min             | avg    | median | max    | # calls |
| addCollateral                              | 16585           | 179882 | 175562 | 398720 | 11      |
|                                            | 17326           | 180035 | 175656 | 398814 | 11      |
| addQuoteToken                              | 2371            | 227992 | 171646 | 676123 | 311     |
|                                            | 17376           | 228258 | 171865 | 676342 | 311     |
| borrow                                     | 719             | 173788 | 167331 | 389209 | 161     |
|                                            | 719             | 173788 | 167331 | 389209 | 161     |
| bucketTake                                 | 3740            | 100818 | 75254  | 330867 | 28      |
|                                            | 3740            | 100899 | 75407  | 331141 | 28      |
| kick                                       | 771             | 484913 | 552620 | 665873 | 34      |
|                                            | 771             | 485284 | 553015 | 666268 | 34      |
| moveQuoteToken                             | 4853            | 164458 | 130053 | 622778 | 15      |
|                                            | 7234            | 172635 | 130497 | 623215 | 15      |
| pledgeCollateral                           | 25893           | 85395  | 51094  | 377823 | 145     |
|                                            | 25893           | 85395  | 51094  | 377823 | 145     |
| pullCollateral                             | 24232           | 42019  | 40902  | 333272 | 140     |
|                                            | 24232           | 42019  | 40902  | 333272 | 140     |
| removeCollateral                           | 1142            | 49400  | 55114  | 132387 | 32      |
|                                            | 1244            | 50020  | 55802  | 133247 | 32      |
| removeQuoteToken                           | 1141            | 57404  | 50220  | 563444 | 273     |
|                                            | 1243            | 57756  | 50569  | 563880 | 273     |
| repay                                      | 4701            | 49134  | 31609  | 428104 | 129     |
|                                            | 4701            | 49134  | 31609  | 428104 | 129     |
| settle                                     | 5746            | 179953 | 159821 | 371186 | 9       |
|                                            | 5746            | 180076 | 159974 | 371339 | 9       |
| take                                       | 2956            | 159310 | 185876 | 514697 | 24      |
|                                            | 2956            | 159462 | 186027 | 515880 | 24      |
| transferLPTokens                           | 2923            | 38231  | 39237  | 115461 | 33      |
|                                            | 3131            | 38825  | 39686  | 116808 | 33      |
| withdrawBonds                              | 3560            | 3560   | 3560   | 3560   | 3       |
|                                            | 3560            | 3560   | 3560   | 3560   | 3       |
```

NFT tests comparison (current / develop)
```
| src/erc721/ERC721Pool.sol:ERC721Pool contract |                 |        |        |        |         |
|-----------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                                 | min             | avg    | median | max    | # calls |
| addCollateral                                 | 232983          | 365375 | 266412 | 596731 | 3       |
|                                               | 233077          | 365469 | 266506 | 596825 | 3       |
| addQuoteToken                                 | 70371           | 238104 | 195386 | 457325 | 75      |
|                                               | 70590           | 238323 | 195605 | 457544 | 75      |
| borrow                                        | 5029            | 168424 | 164806 | 297655 | 56      |
|                                               | 5029            | 168424 | 164806 | 297655 | 56      |
| kick                                          | 726             | 298944 | 414744 | 457118 | 6       |
|                                               | 726             | 299222 | 415139 | 457513 | 6       |
| moveQuoteToken                                | 60762           | 60762  | 60762  | 60762  | 1       |
|                                               | 61117           | 61117  | 61117  | 61117  | 1       |
| pledgeCollateral                              | 92654           | 170894 | 155417 | 366048 | 60      |
|                                               | 92654           | 170894 | 155417 | 366048 | 60      |
| pullCollateral                                | 23358           | 48553  | 42456  | 239635 | 59      |
|                                               | 23358           | 48553  | 42456  | 239635 | 59      |
| removeCollateral                              | 6340            | 56852  | 41543  | 142558 | 9       |
|                                               | 6363            | 57356  | 42148  | 143314 | 9       |
| removeQuoteToken                              | 42056           | 53470  | 47602  | 188615 | 59      |
|                                               | 42404           | 53821  | 47951  | 189051 | 59      |
| repay                                         | 4723            | 108516 | 32493  | 507519 | 51      |
|                                               | 4723            | 108516 | 32493  | 507519 | 51      |
| settle                                        | 81776           | 81776  | 81776  | 81776  | 1       |
|                                               | 81929           | 81929  | 81929  | 81929  | 1       |
| take                                          | 358480          | 429330 | 387108 | 584623 | 4       |
|                                               | 358631          | 429500 | 387278 | 584812 | 4       |
| takeReserves                                  | 1121            | 35197  | 31502  | 71756  | 6       |
|                                               | 1121            | 35197  | 31502  | 71756  | 6       |
| transferLPTokens                              | 10440           | 66482  | 78248  | 110760 | 3       |
|                                               | 11787           | 67680  | 79146  | 112107 | 3       |
| withdrawBonds                                 | 3578            | 3578   | 3578   | 3578   | 1       |
|                                               | 3578            | 3578   | 3578   | 3578   | 1       |
```