### PR TITLE
Keep Ajna token address as immutable arg instead storage

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -39,8 +39,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     uint256 internal t0DebtInAuction; // Total debt in auction used to restrict LPB holder from withdrawing [WAD]
     uint256 internal t0poolDebt;      // Pool debt as if the whole amount was incurred upon the first loan. [WAD]
 
-    address internal ajna;            // Address of the AJNA token for the deployment chain.
-    uint96  internal poolInitializations;
+    uint256 internal poolInitializations;
 
     mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 
@@ -408,7 +407,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             maxAmount_
         );
 
-        IERC20Token ajnaToken = IERC20Token(ajna);
+        IERC20Token ajnaToken = IERC20Token(_getArgAddress(72));
         if (!ajnaToken.transferFrom(msg.sender, address(this), ajnaRequired)) revert ERC20TransferFailed();
         ajnaToken.burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -24,8 +24,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
     function initialize(
         uint256 collateralScale_,
-        uint256 rate_,
-        address ajna_
+        uint256 rate_
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
@@ -36,8 +35,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         interestParams.interestRate       = uint208(rate_);
         interestParams.interestRateUpdate = uint48(block.timestamp);
-
-        ajna = ajna_;
 
         loans.init();
 

--- a/src/erc20/ERC20PoolFactory.sol
+++ b/src/erc20/ERC20PoolFactory.sol
@@ -31,7 +31,8 @@ contract ERC20PoolFactory is IERC20PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(
             collateral_,
             quote_,
-            quoteTokenScale
+            quoteTokenScale,
+            ajna
         );
 
         ERC20Pool pool = ERC20Pool(address(implementation).clone(data));
@@ -39,6 +40,6 @@ contract ERC20PoolFactory is IERC20PoolFactory, PoolDeployer {
         deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(collateralScale, interestRate_, ajna);
+        pool.initialize(collateralScale, interestRate_);
     }
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -24,12 +24,10 @@ interface IERC20Pool is
      *  @notice Initializes a new pool, setting initial state variables.
      *  @param  collateralScale Collateral scale. The precision of the collateral ERC-20 token based on decimals.
      *  @param  rate            Initial interest rate of the pool.
-     *  @param  ajna            Address of the AJNA token for the deployment chain.
      */
     function initialize(
         uint256 collateralScale,
-        uint256 rate,
-        address ajna
+        uint256 rate
     ) external;
 
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -28,8 +28,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     
     function initialize(
         uint256[] memory tokenIds_,
-        uint256 rate_,
-        address ajna_
+        uint256 rate_
     ) external override {
         if (poolInitializations != 0) revert AlreadyInitialized();
 
@@ -38,8 +37,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         interestParams.interestRate       = uint208(rate_);
         interestParams.interestRateUpdate = uint48(block.timestamp);
-
-        ajna = ajna_;
 
         uint256 noOfTokens = tokenIds_.length;
         if (noOfTokens > 0) {

--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -31,7 +31,8 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         bytes memory data = abi.encodePacked(
             collateral_,
             quote_,
-            quoteTokenScale
+            quoteTokenScale,
+            ajna
         );
 
         ERC721Pool pool = ERC721Pool(address(implementation).clone(data));
@@ -39,7 +40,7 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         deployedPools[getNFTSubsetHash(tokenIds_)][collateral_][quote_] = pool_;
         emit PoolCreated(pool_);
 
-        pool.initialize(tokenIds_, interestRate_, ajna);
+        pool.initialize(tokenIds_, interestRate_);
     }
 
     /*********************************/

--- a/src/erc721/interfaces/IERC721Pool.sol
+++ b/src/erc721/interfaces/IERC721Pool.sol
@@ -26,12 +26,10 @@ interface IERC721Pool is
      *  @notice Initializes a new pool, setting initial state variables.
      *  @param  tokenIds  Enumerates tokenIds to be allowed in the pool.
      *  @param  rate      Initial interest rate of the pool.
-     *  @param  ajna      Address of the AJNA token for the deployment chain.
      */
     function initialize(
         uint256[] memory tokenIds,
-        uint256 rate,
-        address ajna
+        uint256 rate
     ) external;
 
 }


### PR DESCRIPTION
- lower gas (no read from storage but from calldata https://github.com/wighawag/clones-with-immutable-args#cloneswithimmutableargs)
- less contract space as there's no additional storage var