### PR TITLE
Fenwick optimize

### DIFF
--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -122,8 +122,7 @@ library Auctions {
 
         // auction has debt to cover with remaining collateral
         while (bucketDepth_ != 0 && t0DebtToSettle_ != 0 && collateral_ != 0) {
-            hpbVars.index   = Deposits.findIndexOfSum(deposits_, 1);
-            hpbVars.deposit = Deposits.valueAt(deposits_, hpbVars.index);
+            (hpbVars.index, hpbVars.deposit) = Deposits.findIndexAndSumOfSum(deposits_, 1);
             hpbVars.price   = _indexToPrice(hpbVars.index);
 
             uint256 depositToRemove = hpbVars.deposit;
@@ -163,8 +162,7 @@ library Auctions {
 
             // if there's still debt after settling from reserves then start to forgive amount from next HPB
             while (bucketDepth_ != 0 && t0DebtToSettle_ != 0) { // loop through remaining buckets if there's still debt to settle
-                hpbVars.index   = Deposits.findIndexOfSum(deposits_, 1);
-                hpbVars.deposit = Deposits.valueAt(deposits_, hpbVars.index);
+                (hpbVars.index, hpbVars.deposit)   = Deposits.findIndexAndSumOfSum(deposits_, 1);
 
                 uint256 depositToRemove = hpbVars.deposit;
                 uint256 debtToSettle    = Maths.wmul(t0DebtToSettle_, poolInflator_);

--- a/src/libraries/Auctions.sol
+++ b/src/libraries/Auctions.sol
@@ -59,6 +59,7 @@ library Auctions {
         uint256 index;
         uint256 deposit;
         uint256 price;
+        uint256 scale;
     }
 
     /**
@@ -122,7 +123,7 @@ library Auctions {
 
         // auction has debt to cover with remaining collateral
         while (bucketDepth_ != 0 && t0DebtToSettle_ != 0 && collateral_ != 0) {
-            (hpbVars.index, hpbVars.deposit) = Deposits.findIndexAndSumOfSum(deposits_, 1);
+            (hpbVars.index, hpbVars.deposit, hpbVars.scale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
             hpbVars.price   = _indexToPrice(hpbVars.index);
 
             uint256 depositToRemove = hpbVars.deposit;
@@ -162,7 +163,7 @@ library Auctions {
 
             // if there's still debt after settling from reserves then start to forgive amount from next HPB
             while (bucketDepth_ != 0 && t0DebtToSettle_ != 0) { // loop through remaining buckets if there's still debt to settle
-                (hpbVars.index, hpbVars.deposit)   = Deposits.findIndexAndSumOfSum(deposits_, 1);
+                (hpbVars.index, hpbVars.deposit, hpbVars.scale)   = Deposits.findIndexAndSumOfSum(deposits_, 1);
 
                 uint256 depositToRemove = hpbVars.deposit;
                 uint256 debtToSettle    = Maths.wmul(t0DebtToSettle_, poolInflator_);

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -218,6 +218,26 @@ library Buckets {
             (bucketDeposit_ * 1e18 + bucketPrice_ * bucketCollateral_) * 1e18 / bucketLPs_;
             // 10^36 * 1e18 / 10^27 = 10^54 / 10^27 = 10^27
     }
+    /**
+     *  @notice Returns the exchange rate for a given bucket.
+     *  @param  bucketCollateral_ Amount of collateral in bucket.
+     *  @param  bucketLPs_        Amount of LPs in bucket.
+     *  @param  bucketRawDeposit_ The amount of unscaled Fenwick tree amount in bucket.
+     *  @param  bucketScale_      Bucket scale factor
+     *  @param  bucketPrice_      Bucket's price.
+     */
+
+    function getRawExchangeRate(
+        uint256 bucketCollateral_,
+        uint256 bucketLPs_,
+        uint256 bucketRawDeposit_,
+	uint256 bucketScale_,
+        uint256 bucketPrice_
+    ) internal pure returns (uint256) {
+        return bucketLPs_ == 0 ? Maths.RAY :
+            (bucketRawDeposit_ + bucketPrice_ * bucketCollateral_ / bucketScale_ ) * 10**36 / bucketLPs_;
+            // 10^18 * 1e36 / 10^27 = 10^54 / 10^27 = 10^27
+    }
 
     /**
      *  @notice Returns the lender info for a given bucket.

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -116,6 +116,36 @@ library Deposits {
     }
 
     /**
+     *  @notice Finds index and sum of first bucket that EXCEEDS the given sum
+     *  @dev    Used in lup calculation
+     *  @param  targetSum_     The sum to find index for.
+     *  @return sumIndex_      Smallest index where prefixsum greater than the sum
+     *  @return sumIndexSum_   Sum at index FOLLOWING sumIndex_ 
+     */    
+    function findIndexAndSumOfSum(
+        Data storage self,
+        uint256 targetSum_
+    ) internal view returns (uint256 sumIndex_, uint256 sumIndexSum_) {
+        uint256 i             = 4096; // 1 << (_numBits - 1) = 1 << (13 - 1) = 4096
+        uint256 sc            = Maths.WAD;
+        uint256 lowerIndexSum;
+
+        while (i > 0) {
+            uint256 value       = self.values[sumIndex_ + i];
+            uint256 scaling     = self.scaling[sumIndex_ + i];
+            uint256 scaledValue = lowerIndexSum + (scaling != 0 ?  Maths.wmul(Maths.wmul(sc, scaling), value) : Maths.wmul(sc, value));
+            if (scaledValue  < targetSum_) {
+                sumIndex_ += i;
+                lowerIndexSum = scaledValue;
+            } else {
+                if (scaling != 0) sc = Maths.wmul(sc, scaling);
+                sumIndexSum_ = scaledValue;
+            }
+            i = i >> 1;
+        }
+    }
+
+    /**
      *  @notice Finds index of passed sum
      *  @dev    Used in lup calculation
      *  @param  sum_      The sum to find index for.
@@ -125,24 +155,7 @@ library Deposits {
         Data storage self,
         uint256 sum_
     ) internal view returns (uint256 sumIndex_) {
-        uint256 i     = 4096; // 1 << (_numBits - 1) = 1 << (13 - 1) = 4096
-        uint256 ss    = 0;
-        uint256 sc    = Maths.WAD;
-        uint256 index = sumIndex_ + i;
-
-        while (i > 0) {
-            uint256 value       = self.values[index];
-            uint256 scaling     = self.scaling[index];
-            uint256 scaledValue = scaling != 0 ? ss + Maths.wmul(Maths.wmul(sc, scaling), value) : ss + Maths.wmul(sc, value);
-            if (scaledValue  < sum_) {
-                sumIndex_ += i;
-                ss = scaledValue;
-            } else {
-                if (scaling != 0) sc = Maths.wmul(sc, scaling);
-            }
-            i = i >> 1;
-            index = sumIndex_ + i;
-        }
+        (sumIndex_,) = findIndexAndSumOfSum(self, sum_);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -282,8 +282,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                index:        _i9_91,
                lpBalance:    2_000 * 1e27,
                collateral:   0,
-               deposit:      2_027.006589100074751447 * 1e18,
-               exchangeRate: 1.013503294550037375723500000 * 1e27
+               deposit:      2_027.006589100074752000 * 1e18,
+               exchangeRate: 1.013503294550037376000000000 * 1e27
            }
         );
         _assertReserveAuction(
@@ -340,7 +340,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            {
                lender:      _taker,
                index:       _i9_91,
-               lpBalance:   0.194243053548020465115456781 * 1e27,
+               lpBalance:   0.194243053548020465062464152 * 1e27,
                depositTime: _startTime + 100 days + 6 hours
            }
         );
@@ -348,17 +348,17 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            {
                lender:      _lender,
                index:       _i9_91,
-               lpBalance:   2_000.193758656905756398885318018 * 1e27, // rewarded with LPs in bucket
+               lpBalance:   2_000.193758656905756398832457540 * 1e27, // rewarded with LPs in bucket
                depositTime: _startTime + 100 days + 6 hours
            }
         );
         _assertBucket(
            {
                index:        _i9_91,
-               lpBalance:    2_000.388001710453776864000774799 * 1e27,
+               lpBalance:    2_000.388001710453776863894921692 * 1e27,
                collateral:   2 * 1e18,
-               deposit:      2_007.565460425038879833 * 1e18,
-               exchangeRate: 1.013503294550037375725999515 * 1e27
+               deposit:      2_007.565460425038880381 * 1e18,
+               exchangeRate: 1.013503294550037375999999999 * 1e27
            }
         );
         // reserves should remain the same after arb take

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -174,7 +174,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:    _i9_91,
                 penalty:  0,
                 newLup:   9.721295865031779605 * 1e18,
-                lpRedeem: 1999891367962935869240493669537
+                lpRedeem: 1999891367962935869240000000000
             }
         );
 
@@ -185,7 +185,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:    _i9_81,
                 penalty:  0,
                 newLup:   9.721295865031779605 * 1e18,
-                lpRedeem: 4999728419907339673101234173842
+                lpRedeem: 4999728419907339673101000000000
             }
         );
 
@@ -196,7 +196,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:    _i9_72,
                 penalty:  0,
                 newLup:   9721295865031779605,
-                lpRedeem: 2992637443019737234731474727095
+                lpRedeem: 2992637443019737234731000000000
             }
         );
 
@@ -211,10 +211,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i9_72,
-                lpBalance:    8_007.362556980262765268525272905 * 1e27, 
+                lpBalance:    8_007.362556980262765269000000000 * 1e27, 
                 collateral:   0,
                 deposit:      8_007.797508658144068000 * 1e18,
-                exchangeRate: 1.000054318968922188000000000 * 1e27
+                exchangeRate: 1.000054318968922187999940710 * 1e27
             }
         );
 
@@ -261,10 +261,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i9_72,
-                lpBalance:    8_007.362556980262765268525272905 * 1e27,
+                lpBalance:    8_007.362556980262765269000000000 * 1e27,
                 collateral:   0,          
                 deposit:      8_008.361347558277120605 * 1e18,
-                exchangeRate: 1.000124734027079076000086027 * 1e27
+                exchangeRate: 1.000124734027079076000026734 * 1e27
             }
         );
 
@@ -388,16 +388,16 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:    _i9_72,
                 penalty:  0,
                 newLup:   9.624807173121239337 * 1e18,
-                lpRedeem: 8_007.362556980262765268525272905 * 1e27
+                lpRedeem: 8_007.362556980262762824000000000 * 1e27
             }
         );
         
         _assertBucket(
         {
                 index:        _i9_72,
-                lpBalance:    0,
+                lpBalance:    2445000000000,   // here
                 collateral:   0,          
-                deposit:      0,
+                deposit:      2445,
                 exchangeRate: 1 * 1e27
             }
         );
@@ -430,17 +430,17 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 penalty:  0,
                 index:    _i9_52,
                 newLup:   9.529276179422528643 * 1e18,
-                lpRedeem: 22_010.012066955906216160936672387 * 1e27
+                lpRedeem: 22_010.012066955906216161000000000 * 1e27
             }
         );
 
         _assertBucket(
             {
                 index:        _i9_52,
-                lpBalance:    7_989.987933044093783839063327613 * 1e27,
+                lpBalance:    7_989.987933044093783839000000000 * 1e27,
                 collateral:   0,          
                 deposit:      7_990.0 * 1e18,
-                exchangeRate: 1.000001510259590795000000000 * 1e27
+                exchangeRate: 1.000001510259590795000007925 * 1e27
             }
         );
 
@@ -455,7 +455,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  7.991488192808991114 * 1e18,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             7_990.380260129405182606 * 1e18,
+                poolSize:             7_990.380260129405185051 * 1e18,
                 pledgedCollateral:    1_001.749391266909416578 * 1e18,
                 encumberedCollateral: 80036071881.142911713937910614 * 1e18,
                 poolDebt:             7_990.503913730158190391 * 1e18,
@@ -491,7 +491,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  7.993335753787741967 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
-                poolSize:             7_991.297334721700255549 * 1e18,
+                poolSize:             7_991.297334721700257995 * 1e18,
                 pledgedCollateral:    1_001.749391266909416578 * 1e18,
                 encumberedCollateral: 838.521600516187410670 * 1e18,
                 poolDebt:             7_990.503913730158190391 * 1e18,
@@ -581,7 +581,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             8_105.800538156165696386 * 1e18,
+                poolSize:             8_105.800538156165698866 * 1e18,
                 pledgedCollateral:    1.749391266909416578 * 1e18,
                 encumberedCollateral: 82_095_199_803.074941485714603011 * 1e18,
                 poolDebt:             8_196.079591450862150038 * 1e18,
@@ -624,7 +624,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  1_004_968_987.606512354182109771 * 1e18,
-                poolSize:             9.176161196119415534 * 1e18,
+                poolSize:             9.176161196119415537 * 1e18,
                 pledgedCollateral:    1.749391266909416578 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
@@ -641,10 +641,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBucket( 
             {
                 index:        _i9_52,
-                lpBalance:    7_989.987933044093783839063327613 * 1e27,
+                lpBalance:    7_989.987933044093783839000000000 * 1e27,
                 collateral:   0,          
-                deposit:      9.176161196119415534 * 1e18,
-                exchangeRate: 1_148_457.453630146264614048 * 1e18
+                deposit:      9.176161196119415541 * 1e18,
+                exchangeRate: 1_148_457.453630146265490153 * 1e18
             }
         );
 
@@ -655,7 +655,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 penalty:  0,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
-                lpRedeem: 7_989.982554203124383518185819249 * 1e27
+                lpRedeem: 7_989.982554203124377221091268981 * 1e27
             }
         );
         _assertBucket(
@@ -679,7 +679,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i9_72,
-                lpBalance:    0,
+                lpBalance:    0,  
                 collateral:   0,          
                 deposit:      0,
                 exchangeRate: 1 * 1e27
@@ -697,10 +697,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i9_52,
-                lpBalance:    0.005378840969400320877508364 * 1e27,
+                lpBalance:    0.005378840969406617908731019 * 1e27,
                 collateral:   0,          
-                deposit:      0.000006177370003204 * 1e18,
-                exchangeRate: 0.001148457453631075833426706 * 1e27
+                deposit:      0.000006177370003206 * 1e18,
+                exchangeRate: 0.001148457453630103156882974 * 1e27
             }
         );
 
@@ -721,7 +721,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  1_004_968_987.606512354182109771 * 1e18,
-                poolSize:             0.000006177370003204 * 1e18,
+                poolSize:             0.000006177370003207 * 1e18,
                 pledgedCollateral:    0.002512352549233095 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -341,8 +341,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 index:        _i9_91,
                 lpBalance:    2_000 * 1e27,
                 collateral:   0,
-                deposit:      2_118.911507166546111004 * 1e18,
-                exchangeRate: 1.059455753583273055502 * 1e27
+                deposit:      2_118.911507166546112000 * 1e18,
+                exchangeRate: 1.059455753583273056000 * 1e27
             }
         );
         _assertBucket(
@@ -431,8 +431,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_776.320825456302135751 * 1e18,
-                exchangeRate: 0.797847347768754739613727272 * 1e27
+                deposit:      8_776.320825456302135815 * 1e18,
+                exchangeRate: 0.797847347768754739619545454 * 1e27
             }
         );
         _assertBucket(
@@ -813,7 +813,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             {
                 lender:      _lender1,
                 index:       _i9_91,
-                lpBalance:   94.388085261495553091346700232 * 1e27,
+                lpBalance:   94.388085261495553046979329248 * 1e27,
                 depositTime: _startTime + 100 days + 10 hours
             }
         );
@@ -910,7 +910,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             {
                 lender:      _lender1,
                 index:       _i9_91,
-                lpBalance:   149.668739373743648321147432044 * 1e27,
+                lpBalance:   149.668739373743648296000000000 * 1e27,
                 depositTime: _startTime + 100 days + 10 hours + 1 hours
             }
         );
@@ -918,10 +918,10 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i9_91,
-                lpBalance:    149.668739373743648321147432044 * 1e27,
+                lpBalance:    149.668739373743648296000000000 * 1e27,
                 collateral:   4 * 1e18,
-                deposit:      109.999999999999999948 * 1e18,
-                exchangeRate: 0.999999999999999999484545454 * 1e27
+                deposit:      110.000000000000000000 * 1e18,
+                exchangeRate: 1.000000000000000000000000000 * 1e27
             }
         );
 
@@ -940,7 +940,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             {
                 lender:      _lender,
                 index:       _i9_91,
-                lpBalance:   1_000.000000000000000515454546000 * 1e27,
+                lpBalance:   1_000.000000000000000000000000000 * 1e27,
                 depositTime: _startTime + 100 days + 10 hours + 1 // _i9_91 bucket insolvency time + 1 (since deposit in _i9_52 from bucket was done before _i9_91 target bucket become insolvent)
             }
         );
@@ -950,7 +950,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             {
                 lender:      _lender,
                 index:       _i9_91,
-                lpBalance:   2_000.000000000000001438852689000 * 1e27,
+                lpBalance:   1_999.999999999999999999130185000 * 1e27,
                 depositTime: _startTime + 100 days + 10 hours + 1 hours // time of deposit in _i9_52 from bucket (since deposit in _i9_52 from bucket was done after _i9_91 target bucket become insolvent)
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1649,8 +1649,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        3_696,
                 lpBalance:    2_000 * 1e27,
                 collateral:   0,
-                deposit:      2_118.911507166546111004 * 1e18,
-                exchangeRate: 1.059455753583273055502000000 * 1e27
+                deposit:      2_118.911507166546112000 * 1e18,
+                exchangeRate: 1.059455753583273056000000000 * 1e27
             }
         );
         _settle(
@@ -1732,8 +1732,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_897.820552570976601535 * 1e18,
-                exchangeRate: 0.808892777506452418321363636 * 1e27
+                deposit:      8_897.820552570976602531 * 1e18,
+                exchangeRate: 0.808892777506452418411909090 * 1e27
             }
         );
         _assertLenderLpBalance(

--- a/tests/forge/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -310,7 +310,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 amount:   amountWithInterest,
                 index:    2550,
                 newLup:   PoolUtils.indexToPrice(2552),
-                lpRedeem: 10_000.349513872212134187552326469 * 1e27
+                lpRedeem: 10_000.349513872212134187863727799 * 1e27
             }
         );
 
@@ -321,7 +321,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
                 from:     _bidder,
                 amount:   expectedCollateral,
                 index:    2550,
-                lpRedeem: 200.034347595268741480953543034 * 1e27
+                lpRedeem: 200.034347595268741480642141704 * 1e27
             }
         );
         _assertLenderLpBalance(

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -815,7 +815,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 index:    1606,
                 penalty:  penalty,
                 newLup:   PoolUtils.indexToPrice(1663),
-                lpRedeem: 1_699.992488670769259236317168938 * 1e27
+                lpRedeem: 1_699.992488670769259236000000000 * 1e27
             }
         );
 
@@ -829,7 +829,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 amount:   expectedWithdrawal2,
                 index:    1606,
                 newLup:   PoolUtils.indexToPrice(1663),
-                lpRedeem: 1_700.007511329230740763682831062 * 1e27
+                lpRedeem: 1_700.007511329230740764000000000 * 1e27
             }
         );
         assertEq(_quote.balanceOf(_lender), lenderBalanceBefore + expectedWithdrawal1 + expectedWithdrawal2);
@@ -1174,7 +1174,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 fromIndex:    2873,
                 toIndex:      2954,
                 newLup:       _lup(),
-                lpRedeemFrom: 2_499.899333909953254268257527496 * 1e27,
+                lpRedeemFrom: 2_499.899333909953254268000000000 * 1e27,
                 lpRedeemTo:   2_497.596153846153845 * 1e27
             }
         );
@@ -1200,7 +1200,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 fromIndex:    2873,
                 toIndex:      2954,
                 newLup:       _lup(),
-                lpRedeemFrom: 2_499.810182702901761331141452320 * 1e27,
+                lpRedeemFrom: 2_499.810182702901761330952408614 * 1e27,
                 lpRedeemTo:   2_500 * 1e27
             }
         );
@@ -1225,7 +1225,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 amount:   5_003.981613396490344248 * 1e18,
                 index:    2873,
                 newLup:   601.252968524772188572 * 1e18,
-                lpRedeem: 5_000.290483387144984400601020184 * 1e27
+                lpRedeem: 5_000.290483387144984401047591386 * 1e27
             }
         );
         _removeAllLiquidity(

--- a/tests/forge/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
@@ -316,7 +316,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 amount:   amountWithInterest,
                 index:    2350,
                 newLup:   PoolUtils.indexToPrice(2352),
-                lpRedeem: 24_000.766696558404292700519565293 * 1e27
+                lpRedeem: 24_000.766696558404292700773653981 * 1e27
             }
         );
 
@@ -326,10 +326,10 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         _assertBucket(
             {
                 index:        2350,
-                lpBalance:    32_653.643978812540062283980727635 * 1e27,
+                lpBalance:    32_653.643978812540062283726638947 * 1e27,
                 collateral:   Maths.wad(4),
                 deposit:      0,
-                exchangeRate: 1.000082597676179283352112746 * 1e27
+                exchangeRate: 1.000082597676179283352120528 * 1e27
             }
         );
 
@@ -339,7 +339,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 from:     _bidder,
                 amount:   1,
                 index:    2350,
-                lpRedeem: 8_163.410994703135015570995187758 * 1e27
+                lpRedeem: 8_163.410994703135015570931665340 * 1e27
             }
         );
 
@@ -347,7 +347,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
             {
                 lender:      _bidder,
                 index:       2350,
-                lpBalance:   490.232984109405046712985539877 * 1e27,
+                lpBalance:   490.232984109405046712794973607 * 1e27,
                 depositTime: _startTime + 25 hours
             }
         );
@@ -361,7 +361,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 from:     _lender,
                 amount:   1,
                 index:    2350,
-                lpRedeem: 8_163.410994703135015570995187758 * 1e27
+                lpRedeem: 8_163.410994703135015570931665340 * 1e27
             }
         );
 
@@ -369,7 +369,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
             {
                 lender:      _bidder,
                 index:       2350,
-                lpBalance:   490.232984109405046712985539877 * 1e27,
+                lpBalance:   490.232984109405046712794973607 * 1e27,
                 depositTime: _startTime + 25 hours
             }
         );
@@ -380,10 +380,10 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         _assertBucket(
             {
                 index:        2350,
-                lpBalance:    16_326.821989406270031141990352119 * 1e27,
+                lpBalance:    16_326.821989406270031141863308267 * 1e27,
                 collateral:   Maths.wad(2),
                 deposit:      0,
-                exchangeRate: 1.000082597676179283352112747 * 1e27
+                exchangeRate: 1.000082597676179283352120529 * 1e27
             }
         );
 

--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -145,7 +145,7 @@ contract FenwickTreeTest is DSTestPlus {
         _tree.mult(  3_701, 1.000070411233491284 * 1e18);
         _tree.mult(  3_739, 1.000001510259590795 * 1e18);
 
-        assertEq(_tree.valueAt(3_700), 8_008.373442262808822463 * 1e18);
+        assertEq(_tree.valueAt(3_700), 8_008.373442262808824908 * 1e18);
         _tree.obliterate(3_700);
         assertEq(_tree.valueAt(3_700), 0);
     }


### PR DESCRIPTION
Changes:
 *   Added "raw" version of Fenwick tree updates to avoid having to recompute scale factors
 *   Streamlined searching the tree to return index and value in the same call (if desired)
 *   Remove some redundant traversals in move and remove quote token


