### PR TITLE
Draw debt reorg function

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -363,19 +363,49 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*** Borrower Internal Functions ***/
     /***********************************/
 
-    function _borrow(
-        Loans.Borrower memory borrower,
-        Pool.PoolState memory poolState,
+    function _drawDebt(
+        address borrowerAddress_,
         uint256 amountToBorrow_,
-        uint256 limitIndex_
-    ) internal returns (Loans.Borrower memory, PoolState memory, uint256 lup_) {
+        uint256 limitIndex_,
+        uint256 collateralToPledge_
+    ) internal returns (bool pledge_, bool borrow_, uint256 newLup_) {
+        PoolState memory poolState = _accruePoolInterest();
+        Loans.Borrower memory borrower = loans.getBorrowerInfo(borrowerAddress_);
+
+        pledge_ = collateralToPledge_ != 0;
+        borrow_ = amountToBorrow_ != 0 || limitIndex_ != 0;
+        newLup_ = _lup(poolState.accruedDebt);
+
+        uint256 borrowerDebt = Maths.wmul(borrower.t0debt, poolState.inflator);
+
+        // pledge collateral to pool
+        if (pledge_) {
+            borrower.collateral  += collateralToPledge_;
+            poolState.collateral += collateralToPledge_;
+
+            if (
+                auctions.isActive(borrowerAddress_)
+                &&
+                _isCollateralized(borrowerDebt, borrower.collateral, newLup_)
+            )
+            {
+                // borrower becomes collateralized, remove debt from pool accumulator and settle auction
+                t0DebtInAuction     -= borrower.t0debt;
+                borrower.collateral = _settleAuction(borrowerAddress_, borrower.collateral);
+            }
+            pledgedCollateral += collateralToPledge_;
+        }
+
+        // borrow against pledged collateral
+        // check both values to enable an intentional 0 borrow loan call to update borrower's loan state
+        if (borrow_) {
+            // only intended recipient can borrow quote
+            if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
             // if borrower auctioned then it cannot draw more debt
             auctions.revertIfActive(msg.sender);
 
-            uint256 borrowerDebt = Maths.wmul(borrower.t0debt, poolState.inflator);
-
             // add origination fee to the amount to borrow and add to borrower's debt
-            uint256 debtChange   = Maths.wmul(amountToBorrow_, _feeRate(interestParams.interestRate) + Maths.WAD);
+            uint256 debtChange = Maths.wmul(amountToBorrow_, _feeRate(interestParams.interestRate) + Maths.WAD);
             borrowerDebt += debtChange;
             _checkMinDebt(poolState.accruedDebt, borrowerDebt);
 
@@ -384,56 +414,36 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             if (lupId > limitIndex_) revert LimitIndexReached();
 
             // calculate new lup and check borrow action won't push borrower into a state of under-collateralization
-            lup_ = _priceAt(lupId);
+            newLup_ = _priceAt(lupId);
             if (
-                !_isCollateralized(borrowerDebt, borrower.collateral, lup_)
+                !_isCollateralized(borrowerDebt, borrower.collateral, newLup_)
             ) revert BorrowerUnderCollateralized();
 
             // check borrow won't push pool into a state of under-collateralization
             poolState.accruedDebt += debtChange;
             if (
-                !_isCollateralized(poolState.accruedDebt, poolState.collateral, lup_)
+                !_isCollateralized(poolState.accruedDebt, poolState.collateral, newLup_)
             ) revert PoolUnderCollateralized();
 
-            uint256 t0debtChange = Maths.wdiv(debtChange, poolState.inflator);
-            borrower.t0debt += t0debtChange;
-
-            t0poolDebt += t0debtChange;
-
-            // move borrowed amount from pool to sender
-            _transferQuoteToken(msg.sender, amountToBorrow_);
-
-            return (borrower, poolState, lup_);
-    }
-
-    function _pledgeCollateral(
-        Loans.Borrower memory borrower,
-        Pool.PoolState memory poolState,
-        address borrowerAddress_,
-        uint256 collateralToPledge_,
-        uint256 newLup
-    ) internal returns (Loans.Borrower memory, PoolState memory) {
-
-        borrower.collateral  += collateralToPledge_;
-        poolState.collateral += collateralToPledge_;
-
-        if (
-            auctions.isActive(borrowerAddress_)
-            &&
-            _isCollateralized(
-                Maths.wmul(borrower.t0debt, poolState.inflator),
-                borrower.collateral,
-                newLup
-            )
-        )
-        {
-            // borrower becomes collateralized, remove debt from pool accumulator and settle auction
-            t0DebtInAuction     -= borrower.t0debt;
-            borrower.collateral = _settleAuction(borrowerAddress_, borrower.collateral);
+            uint256 t0DebtChange = Maths.wdiv(debtChange, poolState.inflator);
+            borrower.t0debt += t0DebtChange;
+            t0poolDebt      += t0DebtChange;
         }
 
-        pledgedCollateral = poolState.collateral;
-        return (borrower, poolState);
+        // update loan state
+        loans.update(
+            deposits,
+            borrowerAddress_,
+            true,
+            borrower,
+            poolState.accruedDebt,
+            poolState.inflator,
+            poolState.rate,
+            newLup_
+        );
+
+        // update pool global interest rate state
+        _updateInterestParams(poolState, newLup_);
     }
 
     function _pullCollateral(

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -64,43 +64,24 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 amountToBorrow_,
         uint256 limitIndex_,
         uint256[] calldata tokenIdsToPledge_
-    ) external nonReentrant {
-        PoolState memory poolState = _accruePoolInterest();
-        Loans.Borrower memory borrower = loans.getBorrowerInfo(borrowerAddress_);
-
-        uint256 newLup = _lup(poolState.accruedDebt);
-
-        // pledge collateral to pool
-        if (tokenIdsToPledge_.length != 0) {
-            (borrower, poolState) = _pledgeCollateral(borrower, poolState, borrowerAddress_, Maths.wad(tokenIdsToPledge_.length), newLup);
-
-            // move collateral from sender to pool
-            _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
-        }
-
-        // borrow against pledged collateral
-        if (amountToBorrow_ != 0 || limitIndex_ != 0) {
-            // only intended recipient can borrow quote
-            if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
-
-            // borrow from the pool
-            (borrower, poolState, newLup) = _borrow(borrower, poolState, amountToBorrow_, limitIndex_);
-        }
+    ) external {
+        (
+            bool pledge,
+            bool borrow,
+            uint256 newLup
+        ) = _drawDebt(
+            borrowerAddress_,
+            amountToBorrow_,
+            limitIndex_,
+            Maths.wad(tokenIdsToPledge_.length)
+        );
 
         emit DrawDebtNFT(borrowerAddress_, amountToBorrow_, tokenIdsToPledge_, newLup);
 
-        loans.update(
-            deposits,
-            borrowerAddress_,
-            true,
-            borrower,
-            poolState.accruedDebt,
-            poolState.inflator,
-            poolState.rate,
-            newLup
-        );
-
-        _updateInterestParams(poolState, newLup);
+        // move collateral from sender to pool
+        if (pledge) _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
+        // move borrowed amount from pool to sender
+        if (borrow) _transferQuoteToken(msg.sender, amountToBorrow_);
     }
 
     function pullCollateral(

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -183,9 +183,9 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         uint256 newLup
     ) internal {
         changePrank(from);
-        _assertTokenTransferEvent(address(_pool), from, amount);
         vm.expectEmit(true, true, false, true);
         emit DrawDebt(from, amount, 0, newLup);
+        _assertTokenTransferEvent(address(_pool), from, amount);
 
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
 
@@ -203,6 +203,9 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
     ) internal {
         changePrank(from);
 
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebt(from, amountToBorrow, collateralToPledge, newLup);
+
         // pledge collateral
         if (collateralToPledge != 0) {
             vm.expectEmit(true, true, false, true);
@@ -214,8 +217,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
             _assertTokenTransferEvent(address(_pool), from, amountToBorrow);
         }
 
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebt(from, amountToBorrow, collateralToPledge, newLup);
         ERC20Pool(address(_pool)).drawDebt(borrower, amountToBorrow, limitIndex, collateralToPledge);
 
         // add for tearDown
@@ -256,9 +257,9 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
-        vm.expectEmit(true, true, false, true);
         emit DrawDebt(borrower, 0, amount, _poolUtils.lup(address(_pool)));
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
 
         // call out to drawDebt w/ amountToBorrow == 0
         ERC20Pool(address(_pool)).drawDebt(borrower, 0, 0, amount);
@@ -277,9 +278,9 @@ abstract contract ERC20DSTestPlus is DSTestPlus {
         vm.expectEmit(true, true, false, true);
         emit AuctionSettle(borrower, collateral);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
-        vm.expectEmit(true, true, false, true);
         emit DrawDebt(borrower, 0, amount, _poolUtils.lup(address(_pool)));
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
 
         // call out to drawDebt w/ amountToBorrow == 0
         ERC20Pool(address(_pool)).drawDebt(borrower, 0, 0, amount);

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -107,7 +107,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 amount: 46_000 * 1e18
             }
         );
-        // TODO fix events check
+        // TODO fix events check order, can see them in forge output but not sure why fails to assert
         // vm.expectEmit(true, true, false, true);
         // emit DrawDebt(_borrower, 46_000 * 1e18, 100 * 1e18, 2_981.007422784467321543 * 1e18);
         // vm.expectEmit(true, true, false, true);

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -93,27 +93,19 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         );
         // enforce EMA and target utilization update
         changePrank(_borrower);
-        _assertTokenTransferEvent(
+
+        vm.expectEmit(true, true, false, true);
+        emit UpdateInterestRate(0.05 * 1e18, 0.055 * 1e18);
+        _drawDebt(
             {
-                from:   _borrower,
-                to:     address(_pool),
-                amount: 100 * 1e18
+                from:               _borrower,
+                borrower:           _borrower,
+                amountToBorrow:     46_000 * 1e18,
+                limitIndex:         4_300,
+                collateralToPledge: 100 * 1e18,
+                newLup:             2_981.007422784467321543 * 1e18
             }
         );
-        _assertTokenTransferEvent(
-            {
-                from:   address(_pool),
-                to:     _borrower,
-                amount: 46_000 * 1e18
-            }
-        );
-        // TODO fix events check order, can see them in forge output but not sure why fails to assert
-        // vm.expectEmit(true, true, false, true);
-        // emit DrawDebt(_borrower, 46_000 * 1e18, 100 * 1e18, 2_981.007422784467321543 * 1e18);
-        // vm.expectEmit(true, true, false, true);
-        // emit UpdateInterestRate(0.05 * 1e18, 0.055 * 1e18);
-        IERC20Pool(address(_pool)).drawDebt(_borrower, 46_000 * 1e18, 4_300, 100 * 1e18);
-        borrowers.add(_borrower);
 
         _assertPool(
             PoolState({

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -107,10 +107,11 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 amount: 46_000 * 1e18
             }
         );
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebt(_borrower, 46_000 * 1e18, 100 * 1e18, 2_981.007422784467321543 * 1e18);
-        vm.expectEmit(true, true, false, true);
-        emit UpdateInterestRate(0.05 * 1e18, 0.055 * 1e18);
+        // TODO fix events check
+        // vm.expectEmit(true, true, false, true);
+        // emit DrawDebt(_borrower, 46_000 * 1e18, 100 * 1e18, 2_981.007422784467321543 * 1e18);
+        // vm.expectEmit(true, true, false, true);
+        // emit UpdateInterestRate(0.05 * 1e18, 0.055 * 1e18);
         IERC20Pool(address(_pool)).drawDebt(_borrower, 46_000 * 1e18, 4_300, 100 * 1e18);
         borrowers.add(_borrower);
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -217,9 +217,9 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
 
         uint256[] memory emptyArray;
 
-        _assertTokenTransferEvent(address(_pool), from, amount);
         vm.expectEmit(true, true, false, true);
         emit DrawDebtNFT(from, amount, emptyArray, newLup);
+        _assertTokenTransferEvent(address(_pool), from, amount);
 
         ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
 
@@ -237,6 +237,9 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     ) internal {
         changePrank(from);
 
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebtNFT(borrower, amountToBorrow, tokenIds, newLup);
+
         // pledge collateral
         if (tokenIds.length != 0) {
             for (uint256 i = 0; i < tokenIds.length; i++) {
@@ -253,8 +256,6 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
             _assertTokenTransferEvent(address(_pool), from, amountToBorrow);
         }
 
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebtNFT(borrower, amountToBorrow, tokenIds, newLup);
         ERC721Pool(address(_pool)).drawDebt(borrower, amountToBorrow, limitIndex, tokenIds);
 
         // check tokenIds were transferred to the pool
@@ -313,14 +314,15 @@ abstract contract ERC721DSTestPlus is DSTestPlus {
     ) internal {
         changePrank(from);
 
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
+
         for (uint256 i = 0; i < tokenIds.length; i++) {
             assertEq(_collateral.ownerOf(tokenIds[i]), from); // token is owned by pledger address
             vm.expectEmit(true, true, false, true);
             emit Transfer(from, address(_pool), tokenIds[i]);
         }
 
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
         ERC721Pool(address(_pool)).drawDebt(borrower, 0, 0, tokenIds);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {


### PR DESCRIPTION
- reorg to do balances and state update first, then token transfers, no need for reentrant
- lower contract size (only one internal `_drawDebt` function), transfers are handled in implementations. better gas costs

```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  22,073B  (89.81%)
  ERC20Pool          -  20,743B  (84.40%)
```
vs
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,280B  (90.65%)
  ERC20Pool                -  20,945B  (85.22%)
```

gas
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 100988          | 160110 | 143603 | 658072 | 56003   |
| bucketTake                                 | 345679          | 410809 | 410826 | 475907 | 4       |
| drawDebt                                   | 198787          | 245473 | 219270 | 742650 | 128003  |
| kick                                       | 150123          | 174863 | 173572 | 997349 | 48000   |
| moveQuoteToken                             | 283352          | 283352 | 283352 | 283352 | 1       |
| removeQuoteToken                           | 158671          | 177811 | 177715 | 201433 | 4000    |
| repay                                      | 503371          | 535308 | 524606 | 683175 | 16002   |
| take                                       | 49238           | 49864  | 49656  | 337369 | 15998   |
```
vs
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 100988          | 160110 | 143603 | 658072 | 56003   |
| bucketTake                                 | 345679          | 410809 | 410826 | 475907 | 4       |
| drawDebt                                   | 199416          | 246225 | 219901 | 745184 | 128003  |
| kick                                       | 150123          | 174863 | 173572 | 997349 | 48000   |
| moveQuoteToken                             | 292955          | 292955 | 292955 | 292955 | 1       |
| removeQuoteToken                           | 158671          | 177811 | 177715 | 200937 | 4000    |
| repay                                      | 503371          | 535306 | 524606 | 683175 | 16002   |
| take                                       | 51478           | 52102  | 51896  | 323689 | 15998   |
```