### PR TITLE
Interest rate limits

### DIFF
--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -129,7 +129,7 @@ contract PoolInfoUtils {
         (, uint256 maxThresholdPrice, ) = pool.loansInfo();
         (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
         htp_      = Maths.wmul(maxThresholdPrice, inflatorSnapshot);
-        if (htp_ != 0) htpIndex_ = _indexOf(htp_);
+        htpIndex_ = htp_ >= MIN_PRICE ? _indexOf(htp_) : 7_388;
         lupIndex_ = pool.depositIndex(debt);
         lup_      = _priceAt(lupIndex_);
     }

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -86,6 +86,7 @@ library PoolCommons {
                 newInterestRate = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
             }
 
+            newInterestRate = Maths.min(500 * 1e18, Maths.max(0.001 * 1e18, newInterestRate));
             if (poolState_.rate != newInterestRate) {
                 interestParams_.interestRate       = uint208(newInterestRate);
                 interestParams_.interestRateUpdate = uint48(block.timestamp);

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -120,7 +120,8 @@ library PoolCommons {
         newInflator_ = Maths.wmul(inflator_, pendingFactor);
 
         uint256 htp = Maths.wmul(thresholdPrice_, newInflator_);
-        uint256 htpIndex = (htp != 0) ? _indexOf(htp) : 7_388; // if HTP is 0 then accrue interest at max index (min price)
+        // if HTP is under the lowest price bucket then accrue interest at max index (min price)
+        uint256 htpIndex = (htp >= MIN_PRICE) ? _indexOf(htp) : 7_388;
 
         // Scale the fenwick tree to update amount of debt owed to lenders
         uint256 depositAboveHtp = Deposits.prefixSum(deposits_, htpIndex);
@@ -211,7 +212,8 @@ library PoolCommons {
             uint256 ptp = _ptp(debt_, collateral_);
 
             if (ptp != 0) {
-                uint256 depositAbove = Deposits.prefixSum(deposits, _indexOf(ptp));
+                uint256 depositAbove = ptp >= MIN_PRICE ? Deposits.prefixSum(deposits, _indexOf(ptp)) 
+                    : Deposits.treeSum(deposits);
 
                 if (depositAbove != 0) utilization_ = Maths.wdiv(
                     debt_,
@@ -230,11 +232,11 @@ library PoolCommons {
         uint256 mau_
     ) internal pure returns (uint256) {
         // TODO: Consider pre-calculating and storing a conversion table in a library or shared contract.
-        // cubic root of the percentage of meaningful unutilized deposit
         uint256 base = 1000000 * 1e18 - Maths.wmul(Maths.min(mau_, 1e18), 1000000 * 1e18);
         if (base < 1e18) {
             return 1e18;
         } else {
+            // cubic root of the percentage of meaningful unutilized deposit
             uint256 crpud = PRBMathUD60x18.pow(base, ONE_THIRD);
             return 1e18 - Maths.wmul(Maths.wdiv(crpud, CUBIC_ROOT_1000000), 0.15 * 1e18);
         }

--- a/tests/brownie/test_stable_volatile.py
+++ b/tests/brownie/test_stable_volatile.py
@@ -13,9 +13,9 @@ from conftest import LoansHeapUtils, MAX_PRICE, PoolHelper, TestUtils
 MAX_BUCKET = 2532  # 3293.70191, highest bucket for initial deposits, is exceeded after initialization
 MIN_BUCKET = 2612  # 2210.03602, lowest bucket involved in the test
 SECONDS_PER_DAY = 3600 * 24
-MIN_UTILIZATION = 0.4
-MAX_UTILIZATION = 0.8
-GOAL_UTILIZATION = 0.6      # borrowers should collateralize such that target utilization approaches this
+MIN_UTILIZATION = 0.3
+MAX_UTILIZATION = 0.7
+GOAL_UTILIZATION = 0.5      # borrowers should collateralize such that target utilization approaches this
 MIN_PARTICIPATION = 25000   # in quote token, the minimum amount to lend
 NUM_LENDERS = 50
 NUM_BORROWERS = 50
@@ -28,7 +28,7 @@ buckets_deposited = {lender_id: set() for lender_id in range(0, NUM_LENDERS)}
 # timestamp when a lender/borrower last interacted with the pool
 last_triggered = {}
 # list of threshold prices for borrowers to attain in test setup, to start heap in a worst-case state
-threshold_prices = LoansHeapUtils.worst_case_heap_orientation(NUM_BORROWERS, scale=10)
+threshold_prices = LoansHeapUtils.worst_case_heap_orientation(NUM_BORROWERS, scale=2210/NUM_BORROWERS)
 assert len(threshold_prices) == NUM_BORROWERS
 
 
@@ -103,7 +103,7 @@ def add_initial_liquidity(lenders, pool_helper):
 def draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilization):
     pool = pool_helper.pool
     target_debt = (pool.depositSize() - pool_helper.debt()) * target_utilization
-    sleep_amount = max(1, int(12 * 3600 / NUM_LENDERS))
+    sleep_amount = max(1, int(12 * 3600 / NUM_BORROWERS))
     for borrower_index in range(0, len(borrowers) - 1):
         # determine amount we want to borrow and how much collateral should be deposited
         borrower = borrowers[borrower_index]
@@ -115,19 +115,21 @@ def draw_initial_debt(borrowers, pool_helper, test_utils, chain, target_utilizat
             pool_price = pool_helper.hpb()  # use the highest-priced bucket with deposit
 
         # determine amount of collateral to deposit
-        collateralization_ratio = min((1 / target_utilization) + 0.05, 2.5)  # cap at 250% collateralization
         if threshold_prices:
+            # order the loan heap in a specific manner
             tp = threshold_prices.pop(0)
             if tp:
-                collateral_to_deposit = int((borrow_amount / tp) * collateralization_ratio)
+                collateral_to_deposit = int(borrow_amount / tp)
             else:  # 0 TP implies empty node on the tree
-                collateral_to_deposit = borrow_amount * 10**18 / pool_price * collateralization_ratio
+                collateral_to_deposit = 0
         else:
+            collateralization_ratio = 1/GOAL_UTILIZATION
             collateral_to_deposit = borrow_amount * 10**18 / pool_price * collateralization_ratio  # WAD
 
-        pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
-        test_utils.validate_pool(pool_helper, borrowers)
+        if collateral_to_deposit > 0:
+            pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_deposit, borrow_amount, test_utils, debug=True)
         chain.sleep(sleep_amount)
+    test_utils.validate_pool(pool_helper, borrowers)
 
 
 def ensure_pool_is_funded(pool, quote_token_amount: int, action: str) -> bool:
@@ -191,7 +193,7 @@ def pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_depos
     pool = pool_helper.pool
 
     # prevent invalid actions
-    (debt, collateral_deposited, _) = pool_helper.borrowerInfo(borrower.address)
+    (debt, pledged, _) = pool_helper.borrowerInfo(borrower.address)
     if not ensure_pool_is_funded(pool, borrow_amount, "borrow"):
         # ensure_pool_is_funded logs a message
         return
@@ -207,17 +209,14 @@ def pledge_and_borrow(pool_helper, borrower, borrower_index, collateral_to_depos
         log(f" WARN: borrower {borrower_index} only has {collateral_balance/1e18:.1f} collateral "
               f"and cannot deposit {collateral_to_deposit/1e18:.1f} to draw debt")
         return
-    borrower_collateral = collateral_deposited + collateral_to_deposit
-    if debug:
-        log(f" borrower {borrower_index:>4} pledging {collateral_to_deposit / 1e18:.8f} collateral")
     assert collateral_to_deposit > 0.001 * 10**18
 
     # draw debt
-    collateral_deposited = collateral_balance + collateral_to_deposit
+    pledged += collateral_to_deposit
     new_total_debt = debt + borrow_amount + pool_helper.get_origination_fee(borrow_amount)
-    threshold_price = new_total_debt * 10**18 / collateral_deposited
+    threshold_price = new_total_debt * 10**18 / pledged
     log(f" borrower {borrower_index:>4} drawing {borrow_amount / 1e18:>8.1f} from bucket {pool_helper.lup() / 1e18:>6.3f} "
-        f"with {collateral_deposited / 1e18:>6.1f} collateral deposited, "
+        f"with {pledged / 1e18:>6.1f} collateral pledged, "
         f"with {new_total_debt/1e18:>9.1f} total debt "
         f"at a TP of {threshold_price/1e18:8.1f}")
     tx = pool.drawDebt(borrower, borrow_amount, MIN_BUCKET, collateral_to_deposit, {"from": borrower})
@@ -237,7 +236,7 @@ def draw_and_bid(lenders, borrowers, start_from, pool_helper, chain, test_utils,
                 (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
                 utilization = poolActualUtilization / 10**18
                 if utilization < MAX_UTILIZATION:
-                    target_collateralization = max(1.1, 1/GOAL_UTILIZATION)
+                    target_collateralization = random.uniform(1.01, 1/GOAL_UTILIZATION)
                     draw_debt(borrowers[user_index], user_index, pool_helper, test_utils, collateralization=target_collateralization)
                 elif utilization > MIN_UTILIZATION:  # start repaying debt if interest grows too high
                     repay(borrowers[user_index], user_index, pool_helper, test_utils)
@@ -246,15 +245,15 @@ def draw_and_bid(lenders, borrowers, start_from, pool_helper, chain, test_utils,
 
             # Add or remove liquidity
             if user_index < NUM_LENDERS:
-                (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
-                utilization = poolActualUtilization / 10**18
-                if utilization < MAX_UTILIZATION and len(buckets_deposited[user_index]) > 0:
-                    price = buckets_deposited[user_index].pop()
-                    remove_quote_token(lenders[user_index], user_index, price, pool_helper)
-                else:
+                if random.choice([True, False]):
                     price = add_quote_token(lenders[user_index], user_index, pool_helper)
                     if price:
                         buckets_deposited[user_index].add(price)
+                else:
+                    if len(buckets_deposited[user_index]) > 0:
+                        price = buckets_deposited[user_index].pop()
+                        if not remove_quote_token(lenders[user_index], user_index, price, pool_helper):
+                            buckets_deposited[user_index].add(price)
                 chain.sleep(14)
 
             try:
@@ -309,7 +308,7 @@ def add_quote_token(lender, lender_index, pool_helper):
     return deposit_price
 
 
-def remove_quote_token(lender, lender_index, price, pool_helper):
+def remove_quote_token(lender, lender_index, price, pool_helper) -> bool:
     price_index = pool_helper.priceToIndex(price)
     (lp_balance, _) = pool_helper.lenderInfo(price_index, lender)
     if lp_balance > 0:
@@ -318,8 +317,13 @@ def remove_quote_token(lender, lender_index, price, pool_helper):
         log(f" lender   {lender_index:>4} removing {claimable_quote / 10**18:.1f} quote"
               f" from bucket {price_index} ({price / 10**18:.1f}); exchange rate is {exchange_rate/1e27:.8f}")
         if not ensure_pool_is_funded(pool_helper.pool, claimable_quote * 2, "withdraw"):
-            return
-        tx = pool_helper.pool.removeQuoteToken(2**256 - 1, price_index, {"from": lender})
+            return False
+        try:
+            tx = pool_helper.pool.removeQuoteToken(2**256 - 1, price_index, {"from": lender})
+            return True
+        except VirtualMachineError as ex:
+            log(f"WARN: Could not remove quote token: {ex.message}")
+            return False
     else:
         log(f" lender   {lender_index:>4} has no claim to bucket {price / 10**18:.1f}")
 
@@ -393,4 +397,4 @@ def test_stable_volatile_one(pool_helper, lenders, borrowers, test_utils, chain)
     (_, _, poolActualUtilization, _) = pool_helper.utilizationInfo()
     utilization = poolActualUtilization / 10**18
     print(f"elapsed time: {(chain.time()-start_time) / 3600 / 24} days   actual utilization: {utilization}")
-    assert MIN_UTILIZATION * 0.9 < utilization < MAX_UTILIZATION * 1.1
+    assert utilization > MIN_UTILIZATION

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1095,7 +1095,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         _assertPoolPrices(
             {
                 htp:      0,
-                htpIndex: 0,
+                htpIndex: 7_388,
                 hpb:      3_010.892022197881557845 * 1e18,
                 hpbIndex: 2550,
                 lup:      MAX_PRICE,

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -350,7 +350,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             }
         }
 
-        // show that the rate maxed out at 500%
+        // show the rate maxed out at 50000%
         _assertPool(
             PoolState({
                 htp:                  32229.862501923749497041 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -292,6 +292,84 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         );
     }
 
+    function testMaxInterestRate() external {
+        _addLiquidity(
+            {
+                from:   _lender,
+                amount: 10_000 * 1e18,
+                index:  _i1505_26,
+                newLup: MAX_PRICE
+            }
+        );
+
+        // pledge a lot of collateral, but draw a tiny amount of debt
+        _drawDebt(
+            {
+                from:               _borrower,
+                borrower:           _borrower,
+                amountToBorrow:     0.00001 * 1e18,
+                limitIndex:         _i1505_26,
+                collateralToPledge: 10_000 * 1e18,
+                newLup:             _p1505_26
+            }
+        );
+
+        // confirm interest rate starts out at 5%
+        // _assertPool(
+        //     PoolState({
+        //         htp:                  0.000000100096153846 * 1e18,
+        //         lup:                  _p1505_26,
+        //         poolSize:             10_000 * 1e18,
+        //         pledgedCollateral:    10_000 * 1e18,
+        //         encumberedCollateral: 0.000000664974196568 * 1e18,
+        //         poolDebt:             0.001000961538461538 * 1e18,
+        //         actualUtilization:    0.000000100096153846 * 1e18,
+        //         targetUtilization:    1e18,
+        //         minDebtAmount:        0.000100096153846154 * 1e18,
+        //         loans:                1,
+        //         maxBorrower:          _borrower,
+        //         interestRate:         0.05 * 1e18,
+        //         interestRateUpdate:   _startTime
+        //     })
+        // );
+
+        uint8 i = 0;
+        while (i < 2 * 7 * 52) {
+            // trigger an interest accumulation
+            skip(12 hours);
+            // FIXME: OOB
+            _borrow(
+                {
+                    from:       _borrower,
+                    amount:     0,
+                    indexLimit: _i1505_26,
+                    newLup:     _p1505_26
+                }
+            );
+            unchecked {
+                ++i;
+            }
+        }
+
+        // _assertPool(
+        //     PoolState({
+        //         htp:                  0.000000100096153846 * 1e18,
+        //         lup:                  _p1505_26,
+        //         poolSize:             10_000 * 1e18,
+        //         pledgedCollateral:    10_000 * 1e18,
+        //         encumberedCollateral: 0.000000664974196568 * 1e18,
+        //         poolDebt:             0.001000961538461538 * 1e18,
+        //         actualUtilization:    0.000000100096153846 * 1e18,
+        //         targetUtilization:    1e18,
+        //         minDebtAmount:        0.000100096153846154 * 1e18,
+        //         loans:                1,
+        //         maxBorrower:          _borrower,
+        //         interestRate:         0.05 * 1e18,
+        //         interestRateUpdate:   _startTime
+        //     })
+        // );
+    }
+
     function testPendingInflator() external tearDown {
         // add liquidity
         _addLiquidity(

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -315,29 +315,28 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         );
 
         // confirm interest rate starts out at 5%
-        // _assertPool(
-        //     PoolState({
-        //         htp:                  0.000000100096153846 * 1e18,
-        //         lup:                  _p1505_26,
-        //         poolSize:             10_000 * 1e18,
-        //         pledgedCollateral:    10_000 * 1e18,
-        //         encumberedCollateral: 0.000000664974196568 * 1e18,
-        //         poolDebt:             0.001000961538461538 * 1e18,
-        //         actualUtilization:    0.000000100096153846 * 1e18,
-        //         targetUtilization:    1e18,
-        //         minDebtAmount:        0.000100096153846154 * 1e18,
-        //         loans:                1,
-        //         maxBorrower:          _borrower,
-        //         interestRate:         0.05 * 1e18,
-        //         interestRateUpdate:   _startTime
-        //     })
-        // );
+        _assertPool(
+            PoolState({
+                htp:                  0.000000001000961538 * 1e18,
+                lup:                  _p1505_26,
+                poolSize:             10_000 * 1e18,
+                pledgedCollateral:    10_000 * 1e18,
+                encumberedCollateral: 0.000000006649741966 * 1e18,
+                poolDebt:             0.000010009615384615 * 1e18,
+                actualUtilization:    0.000000001000961538 * 1e18,
+                targetUtilization:    1e18,
+                minDebtAmount:        0.000001000961538462 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
 
-        uint8 i = 0;
-        while (i < 2 * 7 * 52) {
+        uint i = 0;
+        while (i < 196) {
             // trigger an interest accumulation
             skip(12 hours);
-            // FIXME: OOB
             _borrow(
                 {
                     from:       _borrower,
@@ -351,23 +350,24 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             }
         }
 
-        // _assertPool(
-        //     PoolState({
-        //         htp:                  0.000000100096153846 * 1e18,
-        //         lup:                  _p1505_26,
-        //         poolSize:             10_000 * 1e18,
-        //         pledgedCollateral:    10_000 * 1e18,
-        //         encumberedCollateral: 0.000000664974196568 * 1e18,
-        //         poolDebt:             0.001000961538461538 * 1e18,
-        //         actualUtilization:    0.000000100096153846 * 1e18,
-        //         targetUtilization:    1e18,
-        //         minDebtAmount:        0.000100096153846154 * 1e18,
-        //         loans:                1,
-        //         maxBorrower:          _borrower,
-        //         interestRate:         0.05 * 1e18,
-        //         interestRateUpdate:   _startTime
-        //     })
-        // );
+        // show that the rate maxed out at 500%
+        _assertPool(
+            PoolState({
+                htp:                  32229.862501923749497041 * 1e18,
+                lup:                  _p1505_26,
+                poolSize:             10_048.284243805461810000 * 1e18,
+                pledgedCollateral:    10_000 * 1e18,
+                encumberedCollateral: 0.037733346596011819 * 1e18,
+                poolDebt:             56.798637984728374088 * 1e18,
+                actualUtilization:    0.005652570787867933 * 1e18,
+                targetUtilization:    0.000000466616755449 * 1e18,
+                minDebtAmount:        5.679863798472837409 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         500 * 1e18,
+                interestRateUpdate:   _startTime + (194*12 hours)
+            })
+        );
     }
 
     function testPendingInflator() external tearDown {

--- a/tests/forge/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -60,7 +60,7 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
         _assertPoolPrices(
             {
                 htp:      0,
-                htpIndex: 0,
+                htpIndex: 7388,
                 hpb:      3_010.892022197881557845 * 1e18,
                 hpbIndex: 2550,
                 lup:      MAX_PRICE,

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -110,7 +110,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertPoolPrices(
             {
                 htp:      0,
-                htpIndex: 0,
+                htpIndex: 7388,
                 hpb:      3_025.946482308870940904 * 1e18,
                 hpbIndex: 2549,
                 lup:      MAX_PRICE,
@@ -166,7 +166,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertPoolPrices(
             {
                 htp:      0,
-                htpIndex: 0,
+                htpIndex: 7388,
                 hpb:      3_025.946482308870940904 * 1e18,
                 hpbIndex: 2549,
                 lup:      MAX_PRICE,
@@ -256,7 +256,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertPoolPrices(
             {
                 htp:      0,
-                htpIndex: 0,
+                htpIndex: 7388,
                 hpb:      3_025.946482308870940904 * 1e18,
                 hpbIndex: 2549,
                 lup:      MAX_PRICE,


### PR DESCRIPTION
**Changes**
- Limit interest rates by boundaries as documented in v10.
- Fix issue handling threshold prices > 0 but below the lowest bucket price.
- Fix issue with HTP index being 0 when HTP is below the lowest bucket price.
- Adjust real-world test to reduce (but not resolve) the problem of consistent interest rate growth.