### PR TITLE
Kick with deposit

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -380,6 +380,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         borrowerT0debt  += kickPenalty;
         borrower.t0debt = borrowerT0debt;
 
+        // check if cumulative deposits above bucket less than liquidationDebt
         uint256 auctionDebt = t0DebtInAuction + borrowerT0debt;
         if (
             cumulativeDepositAboveBucket < auctionDebt

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -369,7 +369,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         // check if borrower is collateralized at the new lup and revert if so
         uint256 lup = _lup(poolState.accruedDebt);
         if (
-            _isCollateralized(params.debt + kickPenalty, params.collateral, lup)
+            _isCollateralized(params.debt, params.collateral, lup)
         ) revert BorrowerOk();
 
         // remove kicked loan from heap

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -326,13 +326,13 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     function kickWithDeposit(uint256 amount_, uint256 index_) external {
-        address topBorrower = loans.getMax().borrower;
-        auctions.revertIfActive(topBorrower);
 
         uint256 bucketDeposit = deposits.valueAt(index_);
         if (bucketDeposit == 0) revert InsufficientLiquidity();
 
         PoolState memory poolState = _accruePoolInterest();
+
+        address topBorrower = loans.getMax().borrower;
         Loans.Borrower storage borrower = loans.borrowers[topBorrower];
         uint256 borrowerT0debt = borrower.t0debt;
 

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -82,6 +82,33 @@ library Buckets {
         lender.depositTime = block.timestamp;
     }
 
+    function removeLPs(
+        mapping(uint256 => Bucket) storage self,
+        uint256 index_,
+        uint256 bucketDeposit_,
+        uint256 bucketPrice_,
+        uint256 maxAmount_
+    ) internal returns (uint256 quoteTokenAmount_) {
+        Bucket storage bucket = self[index_];
+        Lender storage lender = bucket.lenders[msg.sender];
+        uint256 lenderLPs;
+        if (bucket.bankruptcyTime < lender.depositTime) lenderLPs = lender.lps;
+
+        if (lenderLPs != 0) {
+            (quoteTokenAmount_, lenderLPs) = lpsToQuoteToken(
+                bucket.lps,
+                bucket.collateral,
+                bucketDeposit_,
+                lenderLPs,
+                maxAmount_,
+                bucketPrice_
+            );
+
+            lender.lps -= lenderLPs;
+            bucket.lps -= lenderLPs;
+        }
+    }
+
     /**********************/
     /*** View Functions ***/
     /**********************/


### PR DESCRIPTION
- alternative to `kickAndRemove`: lender should first kick as many of loans from top heap they need in order to call regular `removeQuoteToken` after
- `kickWithDeposit` receives deposit index and deposit amount (that should be properly calculated off-chain so the top loan becomes kickable) to use and to kick loan from top heap
- the min amount of available deposit, lender amount available to withdraw from deposit (calculated based on lender LPs) and amount provided as parameter to kick the top loan is subtracted from deposits
- check if borrower is collateralized at the new LUP. If it is then revert (should here be checked lup against htp too?)
- check if cumulative deposits above bucket less than liquidationDebt and revert if case (is this still needed if this action is not quite a remove quote token action?)
- follow same steps as in normal kick procedure: remove loan from heap, update borrower and pool debt
- if there's a reminder between amount needed to cover the bond and lender deposit then lender will supply such. If extra quote tokens remains after bond is covered then they're sent to lender account 
 

possible improvements: get the number of top loans to kick as parameter and kick them in a loop
Note: the lender should properly calculate the amount to send as a paremeter in order to kick the top loan
