### PR TITLE
Fix brownie deployment

### DIFF
--- a/tests/brownie/conftest.py
+++ b/tests/brownie/conftest.py
@@ -6,9 +6,10 @@ from brownie.exceptions import VirtualMachineError
 from brownie.network.state import TxHistory
 from brownie.utils import color
 
-ZRO_ADD = '0x0000000000000000000000000000000000000000'
+AJNA_ADDRESS = "0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079"
 MIN_PRICE = 99836282890
 MAX_PRICE = 1_004_968_987606512354182109771
+ZRO_ADD = '0x0000000000000000000000000000000000000000'
 
 @pytest.fixture(autouse=True)
 def get_capsys(capsys):
@@ -25,7 +26,7 @@ def ajna_protocol() -> AjnaProtocol:
         .add_token(DAI_ADDRESS, DAI_RESERVE_ADDRESS)
     )
 
-    ajna_protocol = AjnaProtocol()
+    ajna_protocol = AjnaProtocol(AJNA_ADDRESS)
     ajna_protocol.get_runner().prepare_protocol_to_state_by_definition(
         protocol_definition.build()
     )
@@ -55,7 +56,7 @@ def weth(ajna_protocol):
 
 @pytest.fixture
 def scaled_pool(deployer):
-    scaled_factory = ERC20PoolFactory.deploy({"from": deployer})
+    scaled_factory = ERC20PoolFactory.deploy(AJNA_ADDRESS, {"from": deployer})
     scaled_factory.deployPool(MKR_ADDRESS, DAI_ADDRESS, 0.05 * 1e18, {"from": deployer})
     return ERC20Pool.at(
         scaled_factory.deployedPools("2263c4378b4920f0bef611a3ff22c506afa4745b3319c50b6d704a874990b8b2", MKR_ADDRESS, DAI_ADDRESS)

--- a/tests/brownie/sdk/__init__.py
+++ b/tests/brownie/sdk/__init__.py
@@ -8,7 +8,7 @@ def create_empty_sdk():
     Creates empty AjnaProtocol with 0 lenders and 0 borrowers.
     No pool is deployed. No tokens are connected.
     """
-    return AjnaProtocol()
+    return AjnaProtocol(AJNA_ADDRESS)
 
 
 def create_default_sdk():
@@ -19,7 +19,7 @@ def create_default_sdk():
     """
     protocol_definition = InitialProtocolState.DEFAULT()
 
-    sdk = AjnaProtocol()
+    sdk = AjnaProtocol(AJNA_ADDRESS)
     sdk.get_runner().prepare_protocol_to_state_by_definition(
         protocol_definition.build()
     )

--- a/tests/brownie/sdk/ajna_protocol.py
+++ b/tests/brownie/sdk/ajna_protocol.py
@@ -25,7 +25,7 @@ class AjnaProtocol:
     # keccak256("ERC20_NON_SUBSET_HASH")
     ERC20_POOL_HASH = "2263c4378b4920f0bef611a3ff22c506afa4745b3319c50b6d704a874990b8b2"
 
-    def __init__(self) -> None:
+    def __init__(self, ajna) -> None:
         self._accounts = Accounts()
         self._tokens = {}
         self.deployer = self._accounts[0]
@@ -38,7 +38,7 @@ class AjnaProtocol:
         self.auctions = Auctions.deploy({"from": self.deployer})
         self.pool_info_utils = PoolInfoUtils.deploy({"from": self.deployer})
 
-        self.ajna_factory = ERC20PoolFactory.deploy({"from": self.deployer})
+        self.ajna_factory = ERC20PoolFactory.deploy(ajna, {"from": self.deployer})
 
         self.pools: List[ERC20Pool] = []
         self.lenders = []

--- a/tests/brownie/sdk/protocol_definition.py
+++ b/tests/brownie/sdk/protocol_definition.py
@@ -1,6 +1,7 @@
 from typing import List
 from dataclasses import dataclass, field
 
+AJNA_ADDRESS = "0x9a96ec9B57Fb64FbC60B423d1f4da7691Bd35079"
 
 DAI_ADDRESS = "0x6b175474e89094c44da98b954eedeac495271d0f"
 DAI_RESERVE_ADDRESS = "0x9759A6Ac90977b93B58547b4A71c78317f391A28"


### PR DESCRIPTION
Brownie stuff needs the mainnet Ajna token address; it only works off a mainnet fork.  I should have done this in Thursday's PR.