### PR TITLE
Fix bucket 0 problem

### DIFF
--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -29,7 +29,7 @@ library Deposits {
         uint256 index_,
         uint256 addAmount_
     ) internal {
-        if (index_ >= SIZE) revert InvalidIndex();
+        if (index_ > MAX_FENWICK_INDEX) revert InvalidIndex();
 
         ++index_;
         addAmount_ = Maths.wdiv(addAmount_, scale(deposits_, index_));

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -10,11 +10,6 @@ library Deposits {
     uint256 internal constant SIZE = 8192;
 
     /**
-     *  @notice Invalid factor to scale tree.
-     */
-    error InvalidScalingFactor();
-
-    /**
      *  @notice increase a value in the FenwickTree at an index.
      *  @dev    Starts at leaf/target and moved up towards root
      *  @param  index_     The deposit index.
@@ -100,8 +95,6 @@ library Deposits {
         uint256 index_,
         uint256 factor_
     ) internal {
-        if (factor_ == 0) revert InvalidScalingFactor();
-
         ++index_;
 
         uint256 sum;

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -10,10 +10,6 @@ library Deposits {
     uint256 internal constant SIZE = 8192;
 
     /**
-     *  @notice Invalid deposit index.
-     */
-    error InvalidIndex();
-    /**
      *  @notice Invalid factor to scale tree.
      */
     error InvalidScalingFactor();
@@ -29,8 +25,6 @@ library Deposits {
         uint256 index_,
         uint256 addAmount_
     ) internal {
-        if (index_ > MAX_FENWICK_INDEX) revert InvalidIndex();
-
         ++index_;
         addAmount_ = Maths.wdiv(addAmount_, scale(deposits_, index_));
 
@@ -106,8 +100,7 @@ library Deposits {
         uint256 index_,
         uint256 factor_
     ) internal {
-        if (index_ >= SIZE) revert InvalidIndex();
-        if (factor_ == 0)   revert InvalidScalingFactor();
+        if (factor_ == 0) revert InvalidScalingFactor();
 
         ++index_;
 
@@ -165,7 +158,6 @@ library Deposits {
         DepositsState storage deposits_,
         uint256 sumIndex_
     ) internal view returns (uint256 sum_) {
-
         ++sumIndex_; // Translate from 0 -> 1 indexed array
 
         uint256 sc    = Maths.WAD;
@@ -217,8 +209,6 @@ library Deposits {
         uint256 index_,
         uint256 unscaledRemoveAmount_
     ) internal {
-        if (index_ >= SIZE) revert InvalidIndex();
-
         ++index_;
 
         while (index_ <= SIZE) {
@@ -243,8 +233,7 @@ library Deposits {
         DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 scaled_) {
-        if (index_ > SIZE) revert InvalidIndex();
-	++index_;
+	    ++index_;
         
         scaled_ = Maths.WAD;
         while (index_ <= SIZE) {
@@ -274,8 +263,6 @@ library Deposits {
         DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 depositValue_) {
-        if (index_ >= SIZE) revert InvalidIndex();
-
         depositValue_ = Maths.wmul(unscaledValueAt(deposits_, index_), scale(deposits_,index_));
     }
 
@@ -283,8 +270,6 @@ library Deposits {
         DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 unscaledDepositValue_) {
-        if (index_ >= SIZE) revert InvalidIndex();
-
         ++index_;
 
         uint256 j = 1;

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -134,7 +134,8 @@ library LenderActions {
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
     ) external returns (uint256 bucketLPs_) {
-        if (index_ == 0) revert InvalidIndex();
+        if (index_ == 0 || index_ > MAX_FENWICK_INDEX) revert InvalidIndex();
+
         Bucket storage bucket = buckets_[index_];
         uint256 bankruptcyTime = bucket.bankruptcyTime;
         // cannot deposit in the same block when bucket becomes insolvent
@@ -167,7 +168,7 @@ library LenderActions {
         MoveQuoteParams calldata params_
     ) external returns (uint256 fromBucketLPs_, uint256 toBucketLPs_, uint256 lup_) {
         if (params_.fromIndex == params_.toIndex) revert MoveToSamePrice();
-        if (params_.toIndex == 0) revert InvalidIndex();
+        if (params_.toIndex == 0 || params_.toIndex > MAX_FENWICK_INDEX) revert InvalidIndex();
 
         Bucket storage toBucket = buckets_[params_.toIndex];
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -116,6 +116,7 @@ library LenderActions {
         uint256 collateralAmountToAdd_,
         uint256 index_
     ) external returns (uint256 bucketLPs_) {
+        if (index_ == 0 || index_ > MAX_FENWICK_INDEX) revert InvalidIndex();
         uint256 bucketDeposit = Deposits.valueAt(deposits_, index_);
         uint256 bucketPrice   = _priceAt(index_);
         bucketLPs_ = Buckets.addCollateral(
@@ -133,6 +134,7 @@ library LenderActions {
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
     ) external returns (uint256 bucketLPs_) {
+        if (index_ == 0) revert InvalidIndex();
         Bucket storage bucket = buckets_[index_];
         uint256 bankruptcyTime = bucket.bankruptcyTime;
         // cannot deposit in the same block when bucket becomes insolvent
@@ -165,6 +167,7 @@ library LenderActions {
         MoveQuoteParams calldata params_
     ) external returns (uint256 fromBucketLPs_, uint256 toBucketLPs_, uint256 lup_) {
         if (params_.fromIndex == params_.toIndex) revert MoveToSamePrice();
+        if (params_.toIndex == 0) revert InvalidIndex();
 
         Bucket storage toBucket = buckets_[params_.toIndex];
 
@@ -301,7 +304,6 @@ library LenderActions {
         uint256 amount_,
         uint256 index_
     ) external returns (uint256 lpAmount_) {
-
         Bucket storage bucket = buckets_[index_];
         uint256 bucketCollateral = bucket.collateral;
         if (amount_ > bucketCollateral) revert InsufficientCollateral();
@@ -410,7 +412,7 @@ library LenderActions {
 
         for (uint256 i = 0; i < indexesLength; ) {
             uint256 index = indexes_[i];
-            if (index > 8192 ) revert InvalidIndex();
+            if (index > MAX_FENWICK_INDEX) revert InvalidIndex();
 
             uint256 transferAmount = allowances_[owner_][newOwner_][index];
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -495,7 +495,7 @@ library LenderActions {
         }
 
         // update lender LPs balance
-        lender.lps -= lpAmount_;
+        lender.lps        -= lpAmount_;
         // update bucket LPs and collateral balance
         bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
         bucket.collateral -= Maths.min(bucketCollateral, collateralAmount_);

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -163,7 +163,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         vm.expectEmit(true, true, false, true);
         emit AddCollateral(from, index, amount, lpAward);
         vm.expectEmit(true, true, false, true);
-        emit Transfer(from, address(_pool), amount);
+        emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
 
         // Add for tearDown
         bidders.add(from);

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -20,10 +20,10 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         _bidder    = makeAddr("bidder");
 
         _mintCollateralAndApproveTokens(_borrower,  150 * 1e18);
-        _mintCollateralAndApproveTokens(_borrower2,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2, 100 * 1e18);
 
-        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
-        _mintQuoteAndApproveTokens(_bidder,  200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender, 200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_bidder, 200_000 * 1e18);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -485,9 +485,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         uint16 bucketIndex
     ) external virtual tearDown {
         // setup fuzzy bounds and initialize the pool
-        uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 16, 18);
+        uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 0, 18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_), 0, 18);
-        uint256 bucketId            = bound(uint256(bucketIndex), 2000, 3000);
+        uint256 bucketId            = bound(uint256(bucketIndex), 1, 7388);
         _collateralPrecision        = uint256(10) ** boundColPrecision;
         _quotePrecision             = uint256(10) ** boundQuotePrecision;
         init(boundColPrecision, boundQuotePrecision);

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -75,6 +75,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         EnumerableSet.UintSet storage indexes
     ) internal {
         changePrank(lender);
+
         // Redeem all lps of lender from all buckets as quote token and collateral token
         for(uint256 j = 0; j < indexes.length(); j++){
             uint256 lenderLpBalance;
@@ -102,10 +103,8 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
                     {
                         uint256 fractionOfNftRemaining = lpsAsCollateral % 1e18;
                         assertLt(fractionOfNftRemaining, 1e18);
-                        // FIXME: now getting InsufficientLPs with this amount; was working two days ago
-                        // depositRequired = Maths.wmul(1e18 - fractionOfNftRemaining, price);
-                        // HACK:  deposit extra quote token which will be pulled out on line 134.
-                        depositRequired = price;
+                        // TODO: eliminate the 1 wei workaround for rounding error
+                        depositRequired = Maths.wmul(1e18 - fractionOfNftRemaining + 1, price);
                     }
                     deal(_pool.quoteTokenAddress(), lender, depositRequired);
                     Token(_pool.quoteTokenAddress()).approve(address(_pool) , depositRequired);

--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -116,11 +116,11 @@ contract FenwickTreeTest is DSTestPlus {
         _tree.fuzzyFill(insertions_, totalAmount_, false);
 
         uint256 scaleIndex = bound(scaleIndex_, 2, MAX_INDEX);
-        uint256 subIndex = randomInRange(0, scaleIndex - 1);
-        uint256 factor = bound(factor_, 1 * 1e18, 5 * 1e18);
+        uint256 subIndex   = randomInRange(1, scaleIndex - 1);
+        uint256 factor     = bound(factor_, 1 * 1e18, 5 * 1e18);
 
         uint256 scaleIndexSum = _tree.prefixSum(scaleIndex);
-        uint256 subIndexSum = _tree.prefixSum(subIndex);
+        uint256 subIndexSum   = _tree.prefixSum(subIndex);
 
         _tree.mult(scaleIndex, factor);
 
@@ -213,63 +213,62 @@ contract FenwickTreeTest is DSTestPlus {
 
 contract FenwickTreeGasLoadTest is DSTestPlus {
     FenwickTreeInstance private _tree;
-    uint256 private constant DEPOSITS_COUNT = 8_192;
 
     function setUp() public {
         _tree = new FenwickTreeInstance();
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             _tree.add(i, 100 * 1e18);
         }
     }
 
     function testLoadFenwickTreeGasExerciseDeleteOnAllDeposits() public {
 
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             uint256 snapshot = vm.snapshot();
-            assertEq(_tree.treeSum(), DEPOSITS_COUNT * 100 * 1e18);
+            assertEq(_tree.treeSum(), MAX_FENWICK_INDEX * 100 * 1e18);
 
             _tree.remove(i, 100 * 1e18);
 
-            assertEq(_tree.treeSum(), DEPOSITS_COUNT * 100 * 1e18 - 100 * 1e18);
+            assertEq(_tree.treeSum(), MAX_FENWICK_INDEX * 100 * 1e18 - 100 * 1e18);
             vm.revertTo(snapshot);
         }
     }
 
     function testLoadFenwickTreeGasExerciseAddOnAllDeposits() public {
 
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             uint256 snapshot = vm.snapshot();
-            assertEq(_tree.treeSum(), DEPOSITS_COUNT * 100 * 1e18);
+            assertEq(_tree.treeSum(), MAX_FENWICK_INDEX * 100 * 1e18);
 
             _tree.add(i, 100 * 1e18);
 
-            assertEq(_tree.treeSum(), DEPOSITS_COUNT * 100 * 1e18 + 100 * 1e18);
+            assertEq(_tree.treeSum(), MAX_FENWICK_INDEX * 100 * 1e18 + 100 * 1e18);
             vm.revertTo(snapshot);
         }
     }
 
     function testLoadFenwickTreeGasExercisefindIndexOfSumOnAllDeposits() public {
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
-            assertEq(_tree.findIndexOfSum(819_200 * 1e18 - i * 100 * 1e18), DEPOSITS_COUNT - i - 1);
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
+            assertEq(_tree.findIndexOfSum(819_200 * 1e18 - i * 100 * 1e18), MAX_FENWICK_INDEX - i - 1);
         }
     }
 
     function testLoadFenwickTreeGasExerciseFindPrefixSumOnAllDeposits() public {
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             assertEq(_tree.prefixSum(i), 100 * 1e18 + i * 100 * 1e18);
         }
     }
 
     function testLoadFenwickTreeGasExerciseGetOnAllIndexes() public {
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             assertEq(_tree.get(i), 100 * 1e18);
         }
     }
 
     function testLoadFenwickTreeGasExerciseScaleOnAllDeposits() public {
-        for (uint256 i; i < DEPOSITS_COUNT; i++) {
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
             uint256 snapshot = vm.snapshot();
-            assertEq(_tree.treeSum(), DEPOSITS_COUNT * 100 * 1e18);
+            assertEq(_tree.treeSum(), MAX_FENWICK_INDEX * 100 * 1e18);
 
             _tree.mult(i, 100 * 1e18);
             _tree.scale(2);

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -88,7 +88,7 @@ contract FenwickTreeInstance is DSTestPlus {
         while (totalAmountDec > 0 && insertsDec > 0) {
 
             // Insert at random index
-            i = randomInRange(1, 8190);
+            i = randomInRange(1, MAX_FENWICK_INDEX);
 
             // If last iteration, insert remaining
             amount = insertsDec == 1 ? totalAmountDec : (totalAmountDec % insertsDec) * randomInRange(1_000, 1 * 1e10, true);
@@ -106,6 +106,5 @@ contract FenwickTreeInstance is DSTestPlus {
 
         assertEq(deposits.treeSum(), totalAmount);
     }
-
 }
 


### PR DESCRIPTION
Discovered very bad things happen when attempting to deposit quote or collateral into bucket 0.  Block it and update tests accordingly.

Eliminated a skipped test which rotted months ago.  Implemented a new fuzz test which deposits collateral in any valid bucket.  Fixed an issue with collateral dust.  Found another issue with quote token dust, to be addressed another time.