### PR TITLE
Momp fix

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -640,10 +640,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             uint256 noOfLoans = loanId_ != 0 ? loans.loans.length - 1 : loans.loans.length;
             uint256 thresholdPrice = debt_ * Maths.WAD / collateral_;
             noOfLoans += auctions.noOfAuctions;
-            if (noOfLoans != 0) {
-                uint256 curMomp = _priceAt(deposits.findIndexOfSum(Maths.wdiv(debt_, noOfLoans * 1e18)));
-                t0Np_ = (1e18 + rate_) * curMomp * thresholdPrice / lup_ / inflator_;
-            }
+            uint256 curMomp = _priceAt(deposits.findIndexOfSum(Maths.wdiv(debt_, noOfLoans * 1e18)));
+            t0Np_ = (1e18 + rate_) * curMomp * thresholdPrice / lup_ / inflator_;
         }
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -341,13 +341,13 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             auctions,
             reserveAuction,
             StartReserveAuctionParams(
-            {
-                poolSize:    deposits.treeSum(),
-                poolDebt:    t0poolDebt,
-                poolBalance: _getPoolQuoteTokenBalance(),
-                inflator:    inflatorSnapshot
-            }
-        )
+                {
+                    poolSize:    deposits.treeSum(),
+                    poolDebt:    t0poolDebt,
+                    poolBalance: _getPoolQuoteTokenBalance(),
+                    inflator:    inflatorSnapshot
+                }
+            )
         );
         _transferQuoteToken(msg.sender, kickerAward);
     }
@@ -637,10 +637,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return Maths.wmul(loans.getMax().thresholdPrice, inflator_);
     }
 
-    function _momp(uint256 debt_, uint256 noOfLoans_) internal view returns (uint256) {
-        return noOfLoans_ != 0 ? _priceAt(deposits.findIndexOfSum(Maths.wdiv(debt_, noOfLoans_ * 1e18))) : 0;
-    }
-
     function _t0Np (
         uint256 loanId_,
         uint256 t0Debt_,
@@ -654,8 +650,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             // if loan id is 0 then it is a new loan, count it as part of total loans in pool
             uint256 noOfLoans = loanId_ != 0 ? loans.loans.length - 1 : loans.loans.length;
             uint256 thresholdPrice = debt_ * Maths.WAD / collateral_;
-            uint256 curMomp = _momp(t0Debt_, noOfLoans);
-            t0Np_ = (1e18 + rate_) * curMomp * thresholdPrice / lup_ / inflator_;
+            noOfLoans += auctions.noOfAuctions;
+            if (noOfLoans != 0) {
+                uint256 curMomp = _priceAt(deposits.findIndexOfSum(Maths.wdiv(debt_, noOfLoans * 1e18)));
+                t0Np_ = (1e18 + rate_) * curMomp * thresholdPrice / lup_ / inflator_;
+            }
         }
     }
 

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -52,17 +52,11 @@ struct MoveQuoteParams {
     uint256 maxAmountToMove; // max amount to move between deposits
     uint256 fromIndex;       // the deposit index from where amount is moved
     uint256 toIndex;         // the deposit index where amount is moved to
-    uint256 ptp;             // the Pool Threshold Price (used to determine if penalty should be applied
-    uint256 htp;             // the Highest Threshold Price in pool
-    uint256 poolDebt;        // the current debt of the pool
-    uint256 rate;            // the interest rate in pool (used to calculate penalty)
-    }
+    uint256 thresholdPrice;  // max threshold price in pool
+}
 
 struct RemoveQuoteParams {
-    uint256 maxAmount; // max amount to be removed
-    uint256 index;     // the deposit index from where amount is removed
-    uint256 ptp;       // the Pool Threshold Price (used to determine if penalty should be applied)
-    uint256 htp;       // the Highest Threshold Price in pool
-    uint256 poolDebt;  // the current debt of the pool
-    uint256 rate;      // the interest rate in pool (used to calculate penalty)
+    uint256 maxAmount;      // max amount to be removed
+    uint256 index;          // the deposit index from where amount is removed
+    uint256 thresholdPrice; // max threshold price in pool
 }

--- a/src/base/interfaces/pool/IPoolState.sol
+++ b/src/base/interfaces/pool/IPoolState.sol
@@ -18,16 +18,16 @@ interface IPoolState {
      *  @return neutralPrice      Neutral Price of auction.
      */
     function auctionInfo(address borrower)
-    external
-    view
-    returns (
-        address kicker,
-        uint256 bondFactor,
-        uint256 bondSize,
-        uint256 kickTime,
-        uint256 kickPrice,
-        uint256 neutralPrice
-    );
+        external
+        view
+        returns (
+            address kicker,
+            uint256 bondFactor,
+            uint256 bondSize,
+            uint256 kickTime,
+            uint256 kickPrice,
+            uint256 neutralPrice
+        );
 
     /**
      *  @notice Returns pool related debt values.
@@ -255,6 +255,7 @@ struct Borrower {
 /*** Auctions State ***/
 
 struct AuctionsState {
+    uint96  noOfAuctions;
     address head;
     address tail;
     uint256 totalBondEscrowed; // [WAD]

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -703,13 +703,11 @@ library Auctions {
         ) revert BorrowerOk();
 
         // calculate auction params
+        uint256 noOfLoans = Loans.noOfLoans(loans_) + auctions_.noOfAuctions;
         uint256 momp = _priceAt(
             Deposits.findIndexOfSum(
                 deposits_,
-                Maths.wdiv(
-                    poolState_.accruedDebt,
-                    (Loans.noOfLoans(loans_) + auctions_.noOfAuctions) * 1e18
-                )
+                Maths.wdiv(poolState_.accruedDebt, noOfLoans * 1e18)
             )
         );
         (uint256 bondFactor, uint256 bondSize) = _bondParams(

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -59,10 +59,8 @@ library LenderActions {
     struct MoveQuoteLocalVars {
         uint256 amountToMove;
         uint256 fromBucketPrice;
-        uint256 fromBucketUnscaledDeposit;
         uint256 fromBucketLPs;
         uint256 fromBucketDepositTime;
-        uint256 fromBucketScale;
         uint256 toBucketPrice;
         uint256 toBucketBankruptcyTime;
         uint256 ptp;
@@ -166,7 +164,7 @@ library LenderActions {
         DepositsState storage deposits_,
         PoolState calldata poolState_,
         MoveQuoteParams calldata params_
-    ) external returns (uint256 fromBucketLPs_, uint256 toBucketLPs_, uint256 lup_) {
+    ) external returns (uint256 fromBucketRedeemedLPs_, uint256 toBucketRedeemedLPs_, uint256 lup_) {
         if (params_.fromIndex == params_.toIndex) revert MoveToSamePrice();
 
         Bucket storage toBucket = buckets_[params_.toIndex];
@@ -179,27 +177,20 @@ library LenderActions {
         Bucket storage fromBucket = buckets_[params_.fromIndex];
         Lender storage fromBucketLender = fromBucket.lenders[msg.sender];
 
-        vars.fromBucketPrice            = _priceAt(params_.fromIndex);
-        vars.toBucketPrice              = _priceAt(params_.toIndex);
-        vars.fromBucketUnscaledDeposit  = Deposits.unscaledValueAt(deposits_, params_.fromIndex);
-        vars.fromBucketScale            = Deposits.scale(deposits_, params_.fromIndex);
-        vars.fromBucketDepositTime      = fromBucketLender.depositTime;
-
+        vars.fromBucketPrice       = _priceAt(params_.fromIndex);
+        vars.toBucketPrice         = _priceAt(params_.toIndex);
+        vars.fromBucketDepositTime = fromBucketLender.depositTime;
         if (fromBucket.bankruptcyTime < vars.fromBucketDepositTime) vars.fromBucketLPs = fromBucketLender.lps;
-        (vars.amountToMove, fromBucketLPs_) = _getUnscaledConstrainedDeposit(
-            vars.fromBucketUnscaledDeposit,
+
+        (vars.amountToMove, fromBucketRedeemedLPs_) = _removeMaxDeposit(
+            deposits_,
             params_.maxAmountToMove,
             vars.fromBucketLPs,
             fromBucket.lps,
             fromBucket.collateral,
-            vars.fromBucketScale,
-            vars.fromBucketPrice
+            vars.fromBucketPrice,
+            params_.fromIndex
         );
-
-        Deposits.unscaledRemove(deposits_, params_.fromIndex, vars.amountToMove);
-
-        // From here and below, amountToMove is an absolute quote token amount
-        vars.amountToMove = Maths.wmul(vars.fromBucketScale, vars.amountToMove);
 
         vars.ptp = _ptp(poolState_.accruedDebt, poolState_.collateral);
         // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
@@ -209,7 +200,7 @@ library LenderActions {
             }
         }
 
-        toBucketLPs_ = Buckets.quoteTokensToLPs(
+        toBucketRedeemedLPs_ = Buckets.quoteTokensToLPs(
             toBucket.collateral,
             toBucket.lps,
             Deposits.valueAt(deposits_, params_.toIndex),
@@ -217,33 +208,34 @@ library LenderActions {
             vars.toBucketPrice
         );
 
+        // add deposit removed from initial bucket to destination bucket
         Deposits.add(deposits_, params_.toIndex, vars.amountToMove);
 
         lup_ = _lup(deposits_, poolState_.accruedDebt);
-        // check loan book's htp against new lup
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
+        // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (params_.fromIndex < params_.toIndex) if(vars.htp > lup_) revert LUPBelowHTP();
 
         // update lender LPs balance in from bucket
-        fromBucketLender.lps -= fromBucketLPs_;
+        fromBucketLender.lps -= fromBucketRedeemedLPs_;
         // update lender LPs balance and deposit time in target bucket
         Lender storage toBucketLender = toBucket.lenders[msg.sender];
-        if (vars.toBucketBankruptcyTime >= toBucketLender.depositTime) toBucketLender.lps = toBucketLPs_;
-        else toBucketLender.lps += toBucketLPs_;
+        if (vars.toBucketBankruptcyTime >= toBucketLender.depositTime) toBucketLender.lps = toBucketRedeemedLPs_;
+        else toBucketLender.lps += toBucketRedeemedLPs_;
         // set deposit time to the greater of the lender's from bucket and the target bucket's last bankruptcy timestamp + 1 so deposit won't get invalidated
         toBucketLender.depositTime = Maths.max(vars.fromBucketDepositTime, vars.toBucketBankruptcyTime + 1);
 
         // update buckets LPs balance
-        fromBucket.lps -= fromBucketLPs_;
-        toBucket.lps   += toBucketLPs_;
+        fromBucket.lps -= fromBucketRedeemedLPs_;
+        toBucket.lps   += toBucketRedeemedLPs_;
 
         emit MoveQuoteToken(
-            msg.sender, 
-            params_.fromIndex, 
-            params_.toIndex, 
-            vars.amountToMove, 
-            fromBucketLPs_, 
-            toBucketLPs_, 
+            msg.sender,
+            params_.fromIndex,
+            params_.toIndex,
+            vars.amountToMove,
+            fromBucketRedeemedLPs_,
+            toBucketRedeemedLPs_,
             lup_
         );
     }
@@ -254,11 +246,6 @@ library LenderActions {
         PoolState calldata poolState_,
         RemoveQuoteParams calldata params_
     ) external returns (uint256 removedAmount_, uint256 redeemedLPs_, uint256 lup_) {
-        uint256 unscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.index);
-
-        if (unscaledDeposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
-
-        uint256 depositScale = Deposits.scale(deposits_, params_.index);
 
         Bucket storage bucket = buckets_[params_.index];
         Lender storage lender = bucket.lenders[msg.sender];
@@ -268,20 +255,15 @@ library LenderActions {
         if (lenderLPs == 0) revert NoClaim();      // revert if no LP to claim
 
         uint256 price = _priceAt(params_.index);
-        uint256 unscaledRemoveAmount;
-        (unscaledRemoveAmount, redeemedLPs_) = _getUnscaledConstrainedDeposit(
-            unscaledDeposit,
+        (removedAmount_, redeemedLPs_) = _removeMaxDeposit(
+            deposits_,
             params_.maxAmount,
             lenderLPs,
             bucket.lps,
             bucket.collateral,
-            depositScale,
-            price
+            price,
+            params_.index
         );
-
-        Deposits.unscaledRemove(deposits_, params_.index, unscaledRemoveAmount); // update FenwickTree
-
-        removedAmount_ = Maths.wmul(depositScale, unscaledRemoveAmount);
 
         // apply early withdrawal penalty if quote token is removed from above the PTP
         if (depositTime != 0 && block.timestamp - depositTime < 1 days) {
@@ -291,8 +273,9 @@ library LenderActions {
         }
 
         lup_ = _lup(deposits_, poolState_.accruedDebt);
+        uint256 htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
         // check loan book's htp against new lup
-        if (Maths.wmul(params_.thresholdPrice, poolState_.inflator) > lup_) revert LUPBelowHTP();
+        if (htp > lup_) revert LUPBelowHTP();
 
         // update lender and bucket LPs balances
         lender.lps -= redeemedLPs_;
@@ -498,31 +481,36 @@ library LenderActions {
 
 
     /**
-     *  @notice Returns the amount of quote tokens calculated for the given amount of LPs.
-     *  @param  unscaledDepositAvailable_   Unscaled deposit quantity in bucket
-     *  @param  depositConstraint_          Constraint on deposit in quote token
-     *  @param  lpConstraint_               Constraint in LPB terms
-     *  @param  bucketLPs_                  Total LPB in the bucket
-     *  @param  bucketCollateral_           Claimable collateral in the bucket
-     *  @param  price_                      Price of bucket
-     *  @param  depositScale_               Scale of bucket
-     *  @return unscaledDepositAmount_      Amount of unscaled deposit satistfying constraint
-     *  @return lps_                        Amount of bucket LPs corresponding for calculated unscaled deposit amount
+     *  @notice Removes the amount of quote tokens calculated for the given amount of LPs.
+     *  @param  depositConstraint_ Constraint on deposit in quote token.
+     *  @param  lpConstraint_      Constraint in LPB terms.
+     *  @param  bucketLPs_         Total LPB in the bucket.
+     *  @param  bucketCollateral_  Claimable collateral in the bucket.
+     *  @param  price_             Price of bucket.
+     *  @param  index_             Bucket index.
+     *  @return removedAmount_     Amount of scaled deposit removed.
+     *  @return redeemedLPs_       Amount of bucket LPs corresponding for calculated unscaled deposit amount.
      */
-    function _getUnscaledConstrainedDeposit(
-        uint256 unscaledDepositAvailable_,
+    function _removeMaxDeposit(
+        DepositsState storage deposits_,
         uint256 depositConstraint_,
         uint256 lpConstraint_,
         uint256 bucketLPs_,
         uint256 bucketCollateral_,
-        uint256 depositScale_,
-        uint256 price_
-    ) internal pure returns (uint256 unscaledDepositAmount_, uint256 lps_) {
+        uint256 price_,
+        uint256 index_
+    ) internal returns (uint256 removedAmount_, uint256 redeemedLPs_) {
+
+        uint256 unscaledDepositAvailable = Deposits.unscaledValueAt(deposits_, index_);
+        if (unscaledDepositAvailable == 0) revert InsufficientLiquidity(); // revert if there's no liquidity available to remove
+
+        uint256 depositScale = Deposits.scale(deposits_, index_);
+
         uint256 unscaledExchangeRate = Buckets.getUnscaledExchangeRate(
             bucketCollateral_,
             bucketLPs_,
-            unscaledDepositAvailable_,
-            depositScale_,
+            unscaledDepositAvailable,
+            depositScale,
             price_
         );
 
@@ -532,25 +520,34 @@ library LenderActions {
         // unscaledRemovedAmount = min ( maxAmount_/scale, unscaledDeposit, lenderLPsBalance*unscaledExchangeRate)
         // redeemedLPs_ = min ( maxAmount_/(unscaledExchangeRate*scale), unscaledDeposit/unscaledExchangeRate, lenderLPsBalance)
 
-        if( depositConstraint_ < Maths.wmul(unscaledDepositAvailable_, depositScale_) &&
-            Maths.wwdivr(depositConstraint_, depositScale_) < Maths.rmul(lpConstraint_, unscaledExchangeRate) ) {
+        uint256 unscaledRemovedAmount;
+        uint256 unscaledLpConstraint = Maths.rmul(lpConstraint_, unscaledExchangeRate);
+        if (
+            depositConstraint_ < Maths.wmul(unscaledDepositAvailable, depositScale)
+            &&
+            Maths.wwdivr(depositConstraint_, depositScale) < unscaledLpConstraint
+        ) {
             // depositConstraint_ is binding constraint
-            unscaledDepositAmount_ = Maths.wdiv(depositConstraint_, depositScale_);
-            lps_ = Maths.wrdivr(unscaledDepositAmount_, unscaledExchangeRate);
-        } else if ( Maths.wadToRay(unscaledDepositAvailable_) < Maths.rmul(lpConstraint_, unscaledExchangeRate ) ) {
+            unscaledRemovedAmount = Maths.wdiv(depositConstraint_, depositScale);
+            redeemedLPs_          = Maths.wrdivr(unscaledRemovedAmount, unscaledExchangeRate);
+        } else if (Maths.wadToRay(unscaledDepositAvailable) < unscaledLpConstraint) {
             // unscaledDeposit is binding constraint
-            unscaledDepositAmount_ = unscaledDepositAvailable_;
-            lps_ = Maths.wrdivr(unscaledDepositAmount_, unscaledExchangeRate);
+            unscaledRemovedAmount = unscaledDepositAvailable;
+            redeemedLPs_          = Maths.wrdivr(unscaledRemovedAmount, unscaledExchangeRate);
         } else {
             // redeeming all LPs
-            lps_ = lpConstraint_;
-            unscaledDepositAmount_ = Maths.rayToWad(Maths.rmul(lps_, unscaledExchangeRate));
+            redeemedLPs_          = lpConstraint_;
+            unscaledRemovedAmount = Maths.rayToWad(Maths.rmul(redeemedLPs_, unscaledExchangeRate));
         }
         
         // If clearing out the bucket deposit, ensure it's zeroed out
-        if (lps_ == bucketLPs_) {
-            unscaledDepositAmount_ = unscaledDepositAvailable_;
+        if (redeemedLPs_ == bucketLPs_) {
+            unscaledRemovedAmount = unscaledDepositAvailable;
         }
+        // calculate the scaled amount removed from deposits
+        removedAmount_ = Maths.wmul(depositScale, unscaledRemovedAmount);
+
+        Deposits.unscaledRemove(deposits_, index_, unscaledRemovedAmount); // update FenwickTree
     }
 
     function _lup(

--- a/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -132,13 +132,15 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         skip(15 hours);
         address borrower = _borrowers[borrowerId_];
         vm.prank(borrower);
-        _drawDebtNoCheckLup({
-            from: borrower,
-            borrower: borrower,
-            amountToBorrow: 1_000 * 1e18,
-            limitIndex: 5000,
-            collateralToPledge: 0
-        });
+        _drawDebtNoLupCheck(
+            {
+                from:               borrower,
+                borrower:           borrower,
+                amountToBorrow:     1_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 0
+            }
+        );
 
         assertEq(_noOfLoans(), LOANS_COUNT);
     }
@@ -155,21 +157,25 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
 
         vm.startPrank(newBorrower);
         skip(15 hours);
-        _drawDebtNoCheckLup({
-            from: newBorrower,
-            borrower: newBorrower,
-            amountToBorrow: 0,
-            limitIndex: 0,
-            collateralToPledge: 1_000 * 1e18
-        });
+        _drawDebtNoLupCheck(
+            {
+                from:               newBorrower,
+                borrower:           newBorrower,
+                amountToBorrow:     0,
+                limitIndex:         0,
+                collateralToPledge: 1_000 * 1e18
+            }
+        );
         skip(15 hours);
-        _drawDebtNoCheckLup({
-            from: newBorrower,
-            borrower: newBorrower,
-            amountToBorrow: 1_000 * 1e18,
-            limitIndex: 5000,
-            collateralToPledge: 0
-        });
+        _drawDebtNoLupCheck(
+            {
+                from:               newBorrower,
+                borrower:           newBorrower,
+                amountToBorrow:     1_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 0
+            }
+        );
         vm.stopPrank();
 
         assertEq(_noOfLoans(), LOANS_COUNT + 1);
@@ -226,13 +232,15 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             assertEq(_noOfLoans(), LOANS_COUNT);
 
             address borrower = _borrowers[i];
-            _drawDebtNoCheckLup({
-                from: borrower,
-                borrower: borrower,
-                amountToBorrow: 1_000 * 1e18,
-                limitIndex: 5000,
-                collateralToPledge: 0
-            });
+            _drawDebtNoLupCheck(
+                {
+                    from:               borrower,
+                    borrower:           borrower,
+                    amountToBorrow:     1_000 * 1e18,
+                    limitIndex:         5000,
+                    collateralToPledge: 0
+                }
+            );
             assertEq(_noOfLoans(), LOANS_COUNT);
             vm.revertTo(snapshot);
         }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -750,8 +750,8 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
                 borrower:           _borrower2,
                 debt:               20_269.471153846153855500 * 1e18,
                 collateral:         1_000 * 1e18,
-                bond:               200.192307692307692400 * 1e18,
-                removedFromDeposit: 200.192307692307692400 * 1e18,
+                bond:               6_005.769230769230772000 * 1e18,
+                removedFromDeposit: 6_005.769230769230772000 * 1e18,
                 transferAmount:     0,
                 lup:                99836282890
             }
@@ -761,11 +761,11 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  99836282890,
-                poolSize:             86_776.730769230769219600 * 1e18,
+                poolSize:             80_971.153846153846140000 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,
                 encumberedCollateral: 1015135508208.931167644556923668 * 1e18,
                 poolDebt:             101_347.355769230769277500 * 1e18,
-                actualUtilization:    1.167909356239154861 * 1e18,
+                actualUtilization:    1.251647666547915925 * 1e18,
                 targetUtilization:    1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -783,11 +783,11 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender1,
-                bondSize:          200.192307692307692400 * 1e18,
-                bondFactor:        0.01 * 1e18,
+                bondSize:          6_005.769230769230772000 * 1e18,
+                bondFactor:        0.3 * 1e18,
                 kickTime:          _startTime,
-                kickMomp:          99836282890, // TODO: double check if that's accurate
-                totalBondEscrowed: 24_223.269230769230780400 * 1e18,
+                kickMomp:          3_863.654368867279344664 * 1e18,
+                totalBondEscrowed: 30_028.846153846153860000 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     101_347.355769230769277500 * 1e18,
                 thresholdPrice:    20.278728733568272609 * 1e18,
@@ -954,7 +954,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
                 bondSize:          6_005.769230769230772000 * 1e18,
                 bondFactor:        0.3 * 1e18,
                 kickTime:          _startTime,
-                kickMomp:          3_844.432207828138682757 * 1e18,
+                kickMomp:          3_863.654368867279344664 * 1e18,
                 totalBondEscrowed: 6_005.769230769230772000 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     20_278.728733568272609234 * 1e18,
@@ -993,7 +993,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
                 htp:                  0,
                 lup:                  MAX_PRICE,
                 poolSize:             0,
-                pledgedCollateral:    3_978.947001291952895479 * 1e18,
+                pledgedCollateral:    2_984.214316325106204943 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
@@ -1010,7 +1010,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             {
                 lender:      _lender1,
                 index:       2500,
-                lpBalance:   25_776.7307692307692196 * 1e27,
+                lpBalance:   19_971.15384615384614 * 1e27,
                 depositTime: _startTime
             }
         );
@@ -1018,7 +1018,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender1,
-                claimable: 24_223.269230769230780400 * 1e18,
+                claimable: 30_028.846153846153860000 * 1e18,
                 locked:    0
             }
         );
@@ -1054,7 +1054,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             {
                 borrower:                  _borrower4,
                 borrowerDebt:              0,
-                borrowerCollateral:        994.745250219155848961 * 1e18,
+                borrowerCollateral:        994.737734630435747061 * 1e18,
                 borrowert0Np:              21.125293269230769068 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
@@ -1063,7 +1063,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             {
                 borrower:                  _borrower5,
                 borrowerDebt:              0,
-                borrowerCollateral:        994.725169378126588636 * 1e18,
+                borrowerCollateral:        0,
                 borrowert0Np:              21.230919735576922742 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -2063,9 +2063,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 bondSize:          0.197766022516205193 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp,
-                kickMomp:          9.721295865031779605 * 1e18,
+                kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.731708442308421650 * 1e18,
-                auctionPrice:      311.081467681016947360 * 1e18,
+                auctionPrice:      314.200059394519137152 * 1e18,
                 debtInAuction:     10_120.320801313999710974 * 1e18,
                 thresholdPrice:    9.999544513475625068 * 1e18,
                 neutralPrice:      10.382716182100772629 * 1e18

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -223,8 +223,10 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
 
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebtNFT(borrower, amountToBorrow, tokenIds, newLup);
+        if (newLup != 0) {
+            vm.expectEmit(true, true, false, true);
+            emit DrawDebtNFT(borrower, amountToBorrow, tokenIds, newLup);
+        }
 
         // pledge collateral
         if (tokenIds.length != 0) {
@@ -254,41 +256,14 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         }
     }
 
-    function _drawDebtNoCheckLup(
+    function _drawDebtNoLupCheck(
         address from,
         address borrower,
         uint256 amountToBorrow,
         uint256 limitIndex,
         uint256[] memory tokenIds
     ) internal {
-        changePrank(from);
-
-        // pledge collateral
-        if (tokenIds.length != 0) {
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                assertEq(_collateral.ownerOf(tokenIds[i]), from); // token is owned by pledger address
-                vm.expectEmit(true, true, false, true);
-                emit Transfer(from, address(_pool), tokenIds[i]);
-            }
-        }
-
-        // borrow quote
-        if (amountToBorrow != 0) {
-            _assertTokenTransferEvent(address(_pool), from, amountToBorrow);
-        }
-
-        ERC721Pool(address(_pool)).drawDebt(borrower, amountToBorrow, limitIndex, tokenIds);
-
-        // check tokenIds were transferred to the pool
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            assertEq(_collateral.ownerOf(tokenIds[i]), address(_pool));
-        }
-
-        // Add for tearDown
-        borrowers.add(borrower);
-        for (uint256 i=0; i < tokenIds.length; i++) {
-            borrowerPlegedNFTIds[borrower].add(tokenIds[i]);
-        }
+        _drawDebt(from, borrower, amountToBorrow, limitIndex, tokenIds, 0);
     }
 
     function _pledgeCollateral(
@@ -368,8 +343,11 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
                 tokenIds[i] = tokenId;
             }
 
-            vm.expectEmit(true, true, false, true);
-            emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
+            if (newLup != 0) {
+                vm.expectEmit(true, true, false, true);
+                emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
+            }
+
             ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
 
             // post pull checks
@@ -386,8 +364,11 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         }
         else {
             // only repay, don't pull collateral
-            vm.expectEmit(true, true, false, true);
-            emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
+            if (newLup != 0) {
+                vm.expectEmit(true, true, false, true);
+                emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
+            }
+
             ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
         }
     }
@@ -399,41 +380,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         uint256 amountRepaid,
         uint256 collateralToPull
     ) internal {
-        changePrank(from);
-        // repay checks
-        if (amountToRepay != 0) {
-            _assertTokenTransferEvent(from, address(_pool), amountRepaid);
-        }
-
-        // pre pull checks
-        if (collateralToPull != 0) {
-            uint256[] memory tokenIds = new uint256[](collateralToPull);
-            (, uint256 noOfTokens, ) = _pool.borrowerInfo(from);
-            noOfTokens = noOfTokens / 1e18;
-            for (uint256 i = 0; i < collateralToPull; i++) {
-                uint256 tokenId = ERC721Pool(address(_pool)).borrowerTokenIds(from, --noOfTokens);
-                assertEq(_collateral.ownerOf(tokenId), address(_pool)); // token is owned by pool
-                tokenIds[i] = tokenId;
-            }
-
-            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
-
-            // post pull checks
-            if (collateralToPull != 0) {
-                for (uint256 i = 0; i < tokenIds.length; i++) {
-                    assertEq(_collateral.ownerOf(tokenIds[i]), address(from)); // token is owned by borrower after pull
-                }
- 
-                // Add for tearDown
-                for (uint256 i = 0; i < tokenIds.length; i++) {
-                    borrowerPlegedNFTIds[from].remove(tokenIds[i]);
-                }
-            }
-        }
-        else {
-            // only repay, don't pull collateral
-            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
-        }
+        _repayDebt(from, borrower, amountToRepay, amountRepaid, collateralToPull, 0);
     }
 
     function _take(

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -632,13 +632,15 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = _collateral.totalSupply();
 
-        _drawDebtNoCheckLup({
-            from: borrower,
-            borrower: borrower,
-            amountToBorrow: loanAmount,
-            limitIndex: 7_777,
-            tokenIds: tokenIdsToAdd
-        });
+        _drawDebtNoLupCheck(
+            {
+                from:           borrower,
+                borrower:       borrower,
+                amountToBorrow: loanAmount,
+                limitIndex:     7_777,
+                tokenIds:       tokenIdsToAdd
+            }
+        );
     }
 
     function testMinBorrowAmountCheck() external tearDown {
@@ -689,13 +691,15 @@ contract ERC721CollectionPoolBorrowTest is ERC721PoolBorrowTest {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
-        _drawDebtNoCheckLup({
-            from: _borrower,
-            borrower: _borrower,
-            amountToBorrow: 1_000 * 1e18,
-            limitIndex: 3000,
-            tokenIds: tokenIdsToAdd
-        });
+        _drawDebtNoLupCheck(
+            {
+                from:           _borrower,
+                borrower:       _borrower,
+                amountToBorrow: 1_000 * 1e18,
+                limitIndex:     3000,
+                tokenIds:       tokenIdsToAdd
+            }
+        );
 
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(loansCount, 10);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -82,10 +82,6 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             }
         );
 
-    }
-
-    function testKickAndSettleSubsetPool() external { //FIXME: tearDown fails with Arithmetic over/underflow
-
         /*****************************/
         /*** Assert pre-kick state ***/
         /*****************************/
@@ -204,6 +200,10 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower),      5_100 * 1e18);
         assertEq(_quote.balanceOf(_borrower2),     13_000 * 1e18);
 
+    }
+
+    function testKickAndSettleSubsetPoolFractionalCollateral() external { //FIXME: tearDown fails with Arithmetic over/underflow
+
         // settle borrower 2
         _assertAuction(
             AuctionParams({
@@ -321,5 +321,94 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender),        104_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower),      5_100 * 1e18);
         assertEq(_quote.balanceOf(_borrower2),     13_000 * 1e18);
+    }
+
+    function testKickAndSettleSubsetPoolByRepay() external { //FIXME: tearDown fails with Arithmetic over/underflow
+        // before auction settle: NFTs pledged by auctioned borrower are owned by the pool
+        assertEq(_collateral.ownerOf(51), address(_pool));
+        assertEq(_collateral.ownerOf(53), address(_pool));
+        assertEq(_collateral.ownerOf(73), address(_pool));
+        // borrower 2 repays debt and settles auction
+        _repayDebtNoLupCheck(
+            {
+                from:             _borrower2,
+                borrower:         _borrower2,
+                amountToRepay:    6_000 * 1e18,
+                amountRepaid:     0,
+                collateralToPull: 3
+            }
+        );
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower2,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 1_501.442307692307693000 * 1e18,
+                auctionPrice:      0,
+                debtInAuction:     5_069.682183392068152308 * 1e18,
+                thresholdPrice:    0,
+                neutralPrice:      0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              0,
+                borrowerCollateral:        0,
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+        // after settle: NFTs pledged by auctioned borrower are owned by the borrower
+        assertEq(_collateral.ownerOf(51), address(_borrower2));
+        assertEq(_collateral.ownerOf(53), address(_borrower2));
+        assertEq(_collateral.ownerOf(73), address(_borrower2));
+
+
+        // before auction settle: NFTs pledged by auctioned borrower are owned by the pool
+        assertEq(_collateral.ownerOf(1), address(_pool));
+        assertEq(_collateral.ownerOf(3), address(_pool));
+        // borrower repays debt and settles auction
+        _repayDebtNoLupCheck(
+            {
+                from:             _borrower,
+                borrower:         _borrower,
+                amountToRepay:    6_000 * 1e18,
+                amountRepaid:     0,
+                collateralToPull: 2
+            }
+        );
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0,
+                thresholdPrice:    0,
+                neutralPrice:      0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              0,
+                borrowerCollateral:        0,
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+        // after settle: NFTs pledged by auctioned borrower are owned by the borrower
+        assertEq(_collateral.ownerOf(1), address(_borrower));
+        assertEq(_collateral.ownerOf(3), address(_borrower));
     }
 }

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -56,7 +56,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
 
         // borrower deposits two NFTs into the subset pool and borrows
-        _drawDebtNoCheckLup(
+        _drawDebtNoLupCheck(
             {
                 from:           _borrower,
                 borrower:       _borrower,
@@ -72,7 +72,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 53;
         tokenIdsToAdd[2] = 73;
         // borrower deposits two NFTs into the subset pool and borrows
-        _drawDebtNoCheckLup(
+        _drawDebtNoLupCheck(
             {
                 from:           _borrower2,
                 borrower:       _borrower2,


### PR DESCRIPTION
- add auctions counter (packed with head address, increments when kick, decrements when remove auction) and use number of active auctions in momp calculation. fix tests
- pass poolstate as calldata param to external libs instead decomposing, group remove unscaled deposit in single function reused by both remove and move quote tokens (can be moved in a shared library if other external library needs it)
- add settle NFT test with non fractional collateral
- used consistent *NoLupCheck namings for functions, removed duplicate code from regular function into *NoLupCheck function. Code style

prereq: PR https://github.com/ajna-finance/contracts/pull/426

```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 105604          | 161130 | 145829 | 654666 | 60004   |
| bucketTake                                 | 342284          | 406973 | 406990 | 471630 | 4       |
| drawDebt                                   | 202442          | 247101 | 222899 | 739617 | 136003  |
| kick                                       | 130117          | 158804 | 154971 | 936113 | 48000   |
| kickWithDeposit                            | 184229          | 219060 | 213949 | 947469 | 8000    |
| moveQuoteToken                             | 279623          | 279623 | 279623 | 279623 | 1       |
| removeQuoteToken                           | 142485          | 164547 | 169415 | 192265 | 4000    |
| repayDebt                                  | 522083          | 554127 | 543536 | 702106 | 16002   |
| settle                                     | 254548          | 254548 | 254548 | 254548 | 1       |
| take                                       | 41799           | 50081  | 51780  | 331985 | 15998   |

vs PR https://github.com/ajna-finance/contracts/pull/426

| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 105604          | 162489 | 145829 | 654666 | 56004   |
| bucketTake                                 | 342284          | 406973 | 406990 | 471630 | 4       |
| drawDebt                                   | 202442          | 248711 | 222927 | 739617 | 128003  |
| kick                                       | 129289          | 157990 | 154143 | 935274 | 48000   |
| kickWithDeposit                            | 171174          | 218428 | 216019 | 946652 | 8000    |
| moveQuoteToken                             | 279623          | 279623 | 279623 | 279623 | 1       |
| removeQuoteToken                           | 142472          | 164531 | 169398 | 192248 | 4000    |
| repayDebt                                  | 522083          | 554128 | 543536 | 702106 | 16001   |
| settle                                     | 257329          | 257329 | 257329 | 257329 | 1       |
| take                                       | 41363           | 49608  | 51340  | 331549 | 15998   |
```