### PR TITLE
Do not return LP change from add/remove quote/collateral methods

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -89,10 +89,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function addQuoteToken(
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override {
         PoolState memory poolState = _accruePoolInterest();
 
-        bucketLPs_ = LenderActions.addQuoteToken(
+        uint256 bucketLPs = LenderActions.addQuoteToken(
             buckets,
             deposits,
             quoteTokenAmountToAdd_,
@@ -102,7 +102,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 newLup = _lup(poolState.accruedDebt);
         _updateInterestParams(poolState, newLup);
 
-        emit AddQuoteToken(msg.sender, index_, quoteTokenAmountToAdd_, bucketLPs_, newLup);
+        emit AddQuoteToken(msg.sender, index_, quoteTokenAmountToAdd_, bucketLPs, newLup);
         // move quote token amount from lender to pool
         _transferQuoteTokenFrom(msg.sender, quoteTokenAmountToAdd_);
     }
@@ -150,7 +150,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function removeQuoteToken(
         uint256 maxAmount_,
         uint256 index_
-    ) external override returns (uint256 removedAmount_, uint256 redeemedLPs_) {
+    ) external override returns (uint256 removedAmount_) {
         Auctions.revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
@@ -159,7 +159,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 newLup;
         (
             removedAmount_,
-            redeemedLPs_,
             newLup
         ) = LenderActions.removeQuoteToken(
             buckets,

--- a/src/base/interfaces/pool/IPoolLenderActions.sol
+++ b/src/base/interfaces/pool/IPoolLenderActions.sol
@@ -10,12 +10,11 @@ interface IPoolLenderActions {
      *  @notice Called by lenders to add an amount of credit at a specified price bucket.
      *  @param  amount    The amount of quote token to be added by a lender.
      *  @param  index     The index of the bucket to which the quote tokens will be added.
-     *  @return lpbChange The amount of LP Tokens changed for the added quote tokens.
      */
     function addQuoteToken(
         uint256 amount,
         uint256 index
-    ) external returns (uint256 lpbChange);
+    ) external;
 
     /**
      *  @notice Called by lenders to approve transfer of LP tokens to a new owner.
@@ -49,24 +48,22 @@ interface IPoolLenderActions {
      *  @param  maxAmount        The amount of unencumbered collateral (or the number of NFT tokens) to claim.
      *  @param  index            The bucket index from which unencumbered collateral will be removed.
      *  @return collateralAmount The amount of collateral removed.
-     *  @return lpAmount         The amount of LP used for removing collateral amount.
      */
     function removeCollateral(
         uint256 maxAmount,
         uint256 index
-    ) external returns (uint256 collateralAmount, uint256 lpAmount);
+    ) external returns (uint256 collateralAmount);
 
     /**
      *  @notice Called by lenders to remove an amount of credit at a specified price bucket.
      *  @param  maxAmount        The max amount of quote token to be removed by a lender.
      *  @param  index            The bucket index from which quote tokens will be removed.
      *  @return quoteTokenAmount The amount of quote token removed.
-     *  @return lpAmount         The amount of LP used for removing quote tokens amount.
      */
     function removeQuoteToken(
         uint256 maxAmount,
         uint256 index
-    ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
+    ) external returns (uint256 quoteTokenAmount);
 
     /**
      *  @notice Called by lenders to transfers their LP tokens to a different address.

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -146,10 +146,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function addCollateral(
         uint256 collateralAmountToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override {
         PoolState memory poolState = _accruePoolInterest();
 
-        bucketLPs_ = LenderActions.addCollateral(
+        uint256 bucketLPs = LenderActions.addCollateral(
             buckets,
             deposits,
             collateralAmountToAdd_,
@@ -158,7 +158,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         _updateInterestParams(poolState, _lup(poolState.accruedDebt));
 
-        emit AddCollateral(msg.sender, index_, collateralAmountToAdd_, bucketLPs_);
+        emit AddCollateral(msg.sender, index_, collateralAmountToAdd_, bucketLPs);
         // move required collateral from sender to pool
         _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
     }
@@ -166,12 +166,13 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function removeCollateral(
         uint256 maxAmount_,
         uint256 index_
-    ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
+    ) external override returns (uint256 collateralAmount_) {
         Auctions.revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 
-        (collateralAmount_, lpAmount_) = LenderActions.removeMaxCollateral(
+        uint256 lpAmount;
+        (collateralAmount_, lpAmount) = LenderActions.removeMaxCollateral(
             buckets,
             deposits,
             maxAmount_,
@@ -180,7 +181,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         _updateInterestParams(poolState, _lup(poolState.accruedDebt));
 
-        emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);
+        emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount);
         // move collateral from pool to lender
         _transferCollateral(msg.sender, collateralAmount_);
     }

--- a/src/erc20/interfaces/pool/IERC20PoolLenderActions.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolLenderActions.sol
@@ -14,5 +14,5 @@ interface IERC20PoolLenderActions {
     function addCollateral(
         uint256 amount,
         uint256 index
-    ) external returns (uint256 lpbChange);
+    ) external;
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -123,10 +123,10 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     function addCollateral(
         uint256[] calldata tokenIdsToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override {
         PoolState memory poolState = _accruePoolInterest();
 
-        bucketLPs_ = LenderActions.addCollateral(
+        uint256 bucketLPs = LenderActions.addCollateral(
             buckets,
             deposits,
             Maths.wad(tokenIdsToAdd_.length),
@@ -135,7 +135,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         _updateInterestParams(poolState, _lup(poolState.accruedDebt));
 
-        emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_, bucketLPs_);
+        emit AddCollateralNFT(msg.sender, index_, tokenIdsToAdd_, bucketLPs);
         // move required collateral from sender to pool
         _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_);
     }
@@ -173,13 +173,13 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     function removeCollateral(
         uint256 noOfNFTsToRemove_,
         uint256 index_
-    ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
+    ) external override returns (uint256 collateralAmount_) {
         Auctions.revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 
         collateralAmount_ = Maths.wad(noOfNFTsToRemove_);
-        lpAmount_ = LenderActions.removeCollateral(
+        uint256 lpAmount = LenderActions.removeCollateral(
             buckets,
             deposits,
             collateralAmount_,
@@ -188,7 +188,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         _updateInterestParams(poolState, _lup(poolState.accruedDebt));
 
-        emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);
+        emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount);
         _transferFromPoolToAddress(msg.sender, bucketTokenIds, noOfNFTsToRemove_);
     }
 

--- a/src/erc721/interfaces/pool/IERC721PoolLenderActions.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolLenderActions.sol
@@ -14,7 +14,7 @@ interface IERC721PoolLenderActions {
     function addCollateral(
         uint256[] calldata tokenIds,
         uint256 index
-    ) external returns (uint256);
+    ) external;
 
     /**
      *  @notice Merge collateral accross a number of buckets, removeAmountAtIndex_to reconstitute an NFT

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -247,7 +247,7 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
         RemoveQuoteParams calldata params_
-    ) external returns (uint256 removedAmount_, uint256 redeemedLPs_, uint256 lup_) {
+    ) external returns (uint256 removedAmount_, uint256 lup_) {
         uint256 unscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.index);
 
         if (unscaledDeposit == 0) revert InsufficientLiquidity(); // revert if there's no liquidity in bucket
@@ -263,7 +263,8 @@ library LenderActions {
 
         uint256 price = _priceAt(params_.index);
         uint256 unscaledRemoveAmount;
-        (unscaledRemoveAmount, redeemedLPs_) = _getUnscaledConstrainedDeposit(
+        uint256 redeemedLPs;
+        (unscaledRemoveAmount, redeemedLPs) = _getUnscaledConstrainedDeposit(
             unscaledDeposit,
             params_.maxAmount,
             lenderLPs,
@@ -289,10 +290,10 @@ library LenderActions {
         if (params_.htp > lup_) revert LUPBelowHTP();
 
         // update lender and bucket LPs balances
-        lender.lps -= redeemedLPs_;
-        bucket.lps -= redeemedLPs_;
+        lender.lps -= redeemedLPs;
+        bucket.lps -= redeemedLPs;
 
-        emit RemoveQuoteToken(msg.sender, params_.index, removedAmount_, redeemedLPs_, lup_);
+        emit RemoveQuoteToken(msg.sender, params_.index, removedAmount_, redeemedLPs, lup_);
     }
 
     function removeCollateral(

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -95,7 +95,6 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
             uint256 lpsAsCollateral = _poolUtils.lpsToCollateral(address(_pool), lenderLpBalance, bucketIndex);
 
             // Deposit additional quote token to redeem for all NFTs
-            uint256 lpsRedeemed;
             if (bucketCollateral != 0) {
                 if (lpsAsCollateral % 1e18 != 0) {
                     uint256 depositRequired;
@@ -116,11 +115,11 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
                 // First redeem LP for collateral
                 uint256 noOfNftsToRemove = Maths.min(Maths.wadToIntRoundingDown(lpsAsCollateral), noOfBucketNftsRedeemable);
-                (, lpsRedeemed) = _pool.removeCollateral(noOfNftsToRemove, bucketIndex);
+                _pool.removeCollateral(noOfNftsToRemove, bucketIndex);
             }
 
             // Then redeem LP for quote token
-            (, lpsRedeemed) = _pool.removeQuoteToken(type(uint256).max, bucketIndex);
+            _pool.removeQuoteToken(type(uint256).max, bucketIndex);
         
             // Confirm all lp balance has been redeemed            
             (lenderLpBalance, ) = _pool.lenderInfo(bucketIndex, lender);
@@ -171,7 +170,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         uint256[] memory tokenIds,
         uint256 index,
         uint256 lpAward
-    ) internal returns (uint256 lps_){
+    ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit AddCollateralNFT(from, index, tokenIds, lpAward);
@@ -181,7 +180,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
             emit Transfer(from, address(_pool), tokenIds[i]);
         }
 
-        lps_ = ERC721Pool(address(_pool)).addCollateral(tokenIds, index);
+        ERC721Pool(address(_pool)).addCollateral(tokenIds, index);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             assertEq(_collateral.ownerOf(tokenIds[i]), address(_pool));  // token is owned by pool after add
@@ -325,7 +324,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         uint256 amount,
         uint256 index,
         uint256 lpRedeem
-    ) internal override returns (uint256 lpRedeemed_) {
+    ) internal override {
         uint256[] memory tokenIds = new uint256[](amount);
         (, uint256 noOfTokens, , , ) = _pool.bucketInfo(index);
         noOfTokens = noOfTokens / 1e18;
@@ -335,7 +334,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
             tokenIds[i] = tokenId;
         }
 
-        lpRedeemed_ = super._removeCollateral(from, amount, index, lpRedeem);
+        super._removeCollateral(from, amount, index, lpRedeem);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
             assertEq(_collateral.ownerOf(tokenIds[i]), from); // token is owned by lender address after remove

--- a/tests/forge/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
@@ -93,7 +93,8 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 70;
         tokenIdsToAdd[2] = 73;
 
-        uint256 lpBalanceChange = _addCollateral(
+        (uint256 lenderLpBalanceBefore, ) = _pool.lenderInfo(testIndex, _bidder);
+        _addCollateral(
             {
                 from:     _bidder,
                 tokenIds: tokenIdsToAdd,
@@ -101,6 +102,8 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
                 lpAward:  9_032.676066593644673535 * 1e27
             }
         );
+        (uint256 lenderLpBalanceAfter, ) = _pool.lenderInfo(testIndex, _bidder);
+        uint256 lpBalanceChange = lenderLpBalanceAfter - lenderLpBalanceBefore;
 
         // check bucket state
         _assertBucket(
@@ -328,7 +331,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
         );
 
         // bidder withdraws unused collateral
-        (uint256 amount) = _removeCollateral(
+        _removeCollateral(
             {
                 from:     _bidder,
                 amount:   1,
@@ -350,7 +353,7 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
 
         changePrank(_lender);
         // lender exchanges their lp for collateral
-        (amount) = _removeCollateral(
+        _removeCollateral(
             {
                 from:     _lender,
                 amount:   1,

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -135,15 +135,14 @@ contract BalancerUniswapPurchaser {
         // approve ajna pool to transfer flash loaned collateral
         collateral.approve(decoded.ajnaPool, loanAmount);
         // purchase USDC with 1 WETH from ajna
-        uint256 lps             = IAjnaPool(decoded.ajnaPool).addCollateral(loanAmount, decoded.bucketIndex);
-        (uint256 quoteAmount, ) = IAjnaPool(decoded.ajnaPool).removeQuoteToken(type(uint256).max, decoded.bucketIndex);
-        assert(lps                                 == 83008350.10362729922336157 * 1e27);   // LPS in bucket
-        assert(quoteAmount                         == 4995.19230769230769 * 1e18);          // Purchased quote amount
+        IAjnaPool(decoded.ajnaPool).addCollateral(loanAmount, decoded.bucketIndex);
+        uint256 removed = IAjnaPool(decoded.ajnaPool).removeQuoteToken(type(uint256).max, decoded.bucketIndex);
+        assert(removed                             == 4995.19230769230769 * 1e18);  // Purchased quote amount
         assert(quote.balanceOf(address(this))      == 4995.192307 * 1e6); // USDC balance after Ajna purchase
         assert(collateral.balanceOf(address(this)) == 0);                 // WETH balance after Ajna purchase
 
         // swap USDC to WETH on Uniswap, approve router to spend USDC purchased from ajna
-        quote.approve(address(router), quoteAmount);
+        quote.approve(address(router), removed);
 
         ISwapRouter.ExactInputSingleParams memory params =
             ISwapRouter.ExactInputSingleParams({

--- a/tests/forge/interactions/Interfaces.sol
+++ b/tests/forge/interactions/Interfaces.sol
@@ -13,12 +13,12 @@ interface IAjnaPool {
     function addCollateral(
         uint256 amount,
         uint256 index
-    ) external returns (uint256 lpbChange);
+    ) external;
 
     function removeQuoteToken(
         uint256 maxAmount,
         uint256 index
-    ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
+    ) external returns (uint256 quoteTokenAmount);
 
     function collateralAddress() external pure returns (address);
 

--- a/tests/forge/interactions/PurchaseQuoteWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/PurchaseQuoteWithExternalLiquidity.t.sol
@@ -53,5 +53,4 @@ contract PurchaseQuoteWithExternalLiquidityTest is Test {
         purchaseContract.purchase(tokens, amounts, data);
         assertGt(weth.balanceOf(address(this)), 1e18); // could vary
     }
-
 }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -251,9 +251,8 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amount, lpRedeem, newLup);
         _assertTokenTransferEvent(address(_pool), from, amount);
-        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, index);
+        uint256 removedAmount = _pool.removeQuoteToken(type(uint256).max, index);
         assertEq(removedAmount, amount);
-        assertEq(lpRedeemed,    lpRedeem);
     }
 
     function _removeCollateral(
@@ -261,13 +260,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 amount,
         uint256 index,
         uint256 lpRedeem
-    ) internal virtual returns (uint256 lpRedeemed_) {
+    ) internal virtual {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(from, index, amount, lpRedeem);
         _assertTokenTransferEvent(address(_pool), from, amount);
-        (, lpRedeemed_) = _pool.removeCollateral(amount, index);
-        assertEq(lpRedeemed_, lpRedeem);
+        _pool.removeCollateral(amount, index);
     }
 
     function _removeLiquidity(
@@ -292,9 +290,8 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amountRemoved, lpRedeem, newLup);
         _assertTokenTransferEvent(address(_pool), from, amountRemoved);
-        (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
+        uint256 removedAmount = _pool.removeQuoteToken(amount, index);
         assertEq(removedAmount, amountRemoved);
-        assertEq(lpRedeemed,    lpRedeem);
     }
 
     function _startClaimableReserveAuction(


### PR DESCRIPTION
From Thursday's Discord conversation, it was suggested there is redundancy with both emitting and returning LP amounts.  I made this change as an exploratory endeavor.  In doing so, I discovered `PositionManager` still offers a `moveQuoteToken` facility, which is valuable, and relies on `Pool.moveQuoteToken` returning LP change.

As such, this change reduces consistency.  Presented for discussion purposes.