### PR TITLE
Fenwick bite settleremove mergedev

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -270,7 +270,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
 
         // slither-disable-next-line incorrect-equality
-        if (remainingt0Debt == 0) remainingCollateral= _settleAuction(params.borrower, remainingCollateral);
+        if (remainingt0Debt == 0) remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
 
         uint256 t0settledDebt = params.t0debt - remainingt0Debt;
         t0poolDebt      -= t0settledDebt;

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -268,8 +268,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             deposits,
             params
         );
+
         // slither-disable-next-line incorrect-equality
-        if (remainingt0Debt == 0) remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
+        if (remainingt0Debt == 0) remainingCollateral= _settleAuction(params.borrower, remainingCollateral);
 
         uint256 t0settledDebt = params.t0debt - remainingt0Debt;
         t0poolDebt      -= t0settledDebt;

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -262,7 +262,7 @@ library Deposits {
     ) internal view returns (uint256 depositValue_) {
         if (index_ >= SIZE) revert InvalidIndex();
 
-	depositValue_ = Maths.wmul(unscaledValueAt(deposits_, index_), scale(deposits_,index_));
+        depositValue_ = Maths.wmul(unscaledValueAt(deposits_, index_), scale(deposits_,index_));
     }
 
     function unscaledValueAt(

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -195,20 +195,6 @@ library Deposits {
         }
     }
 
-    function remove(
-        Data storage self,
-        uint256 index_,
-        uint256 removeAmount_,
-	uint256 currentAmount_
-    ) internal {
-	if (removeAmount_ == currentAmount_) {
-	    unscaledRemove(self, index_, unscaledValueAt(self,index_));
-	} else {
-	    unscaledRemove(self, index_, Maths.wdiv(removeAmount_, scale(self, index_)));
-	}
-    }
-
-    
     /**
      *  @notice Decrease a node in the FenwickTree at an index.
      *  @dev    Starts at leaf/target and moved up towards root

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.14;
 
+import { DepositsState } from '../base/interfaces/IPool.sol';
+
 import '../base/PoolHelper.sol';
 
 library Deposits {
@@ -23,24 +25,24 @@ library Deposits {
      *  @param  addAmount_ The amount to increase deposit by.
      */    
     function add(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_,
         uint256 addAmount_
     ) internal {
         if (index_ >= SIZE) revert InvalidIndex();
 
         ++index_;
-        addAmount_ = Maths.wdiv(addAmount_, scale(self, index_));
+        addAmount_ = Maths.wdiv(addAmount_, scale(deposits_, index_));
 
         while (index_ <= SIZE) {
-            uint256 value    = self.values[index_];
-            uint256 scaling  = self.scaling[index_];
+            uint256 value    = deposits_.values[index_];
+            uint256 scaling  = deposits_.scaling[index_];
             uint256 newValue = value + addAmount_;
             // Note: we can't just multiply addAmount_ by scaling[i_] due to rounding
-            // We need to track the precice change in self.values[i_] in order to ensure
+            // We need to track the precice change in deposits_.values[i_] in order to ensure
             // obliterated indices remain zero after subsequent adding to related indices
             if (scaling != 0) addAmount_ = Maths.wmul(newValue, scaling) - Maths.wmul(value, scaling);
-            self.values[index_] = newValue;
+            deposits_.values[index_] = newValue;
             index_ += lsb(index_);
         }
     }
@@ -52,11 +54,11 @@ library Deposits {
      *  @return sumIndex_ Smallest index where prefixsum greater than the sum
      */    
     function findIndexOfSum(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 sum_
     ) internal view returns (uint256 sumIndex_) {
         // Avoid looking for a sum greater than the tree size
-        if (treeSum(self) < sum_) return MAX_FENWICK_INDEX;
+        if (treeSum(deposits_) < sum_) return MAX_FENWICK_INDEX;
 
         uint256 i     = 4096; // 1 << (_numBits - 1) = 1 << (13 - 1) = 4096
         uint256 ss    = 0;
@@ -64,8 +66,8 @@ library Deposits {
         uint256 index = sumIndex_ + i;
 
         while (i > 0) {
-            uint256 value       = self.values[index];
-            uint256 scaling     = self.scaling[index];
+            uint256 value       = deposits_.values[index];
+            uint256 scaling     = deposits_.scaling[index];
             uint256 scaledValue = scaling != 0 ? ss + Maths.wmul(Maths.wmul(sc, scaling), value) : ss + Maths.wmul(sc, value);
             if (scaledValue  < sum_) {
                 sumIndex_ += i;
@@ -100,7 +102,7 @@ library Deposits {
      */    
     // TODO: add check to ensure scaling factor is at least a WAD? 
     function mult(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_,
         uint256 factor_
     ) internal {
@@ -124,8 +126,8 @@ library Deposits {
         //             (in sum) which was set in a prior interation in case 1.
         while (bit <= SIZE) {
             if((bit & index_) != 0) {
-                value   = self.values[index_];
-                scaling = self.scaling[index_];
+                value   = deposits_.values[index_];
+                scaling = deposits_.scaling[index_];
             
                 // Calc sum, will only be stored in range parents of starting node, index_
                 if (scaling != 0) {
@@ -135,17 +137,17 @@ library Deposits {
                     uint256 scaledFactor = Maths.wmul(factor_, scaling);
                     sum += Maths.wmul(scaledFactor, value) - Maths.wmul(scaling, value);
                     // Apply scaling to all range parents less then starting node, index_
-                    self.scaling[index_] = scaledFactor;
+                    deposits_.scaling[index_] = scaledFactor;
                 } else {
                     sum += Maths.wmul(factor_, value) - value;
-                    self.scaling[index_] = factor_;
+                    deposits_.scaling[index_] = factor_;
                 }
 
                 index_ -= bit;
             } else {
                 uint256 superRangeIndex = index_ + bit;
-                value = (self.values[superRangeIndex] += sum);
-                scaling = self.scaling[superRangeIndex];
+                value = (deposits_.values[superRangeIndex] += sum);
+                scaling = deposits_.scaling[superRangeIndex];
                 // again, in following line, need to be careful due to rounding
                 if (scaling != 0) sum = Maths.wmul(value, scaling) - Maths.wmul(value - sum, scaling);
             } 
@@ -160,7 +162,7 @@ library Deposits {
      *  @param  sum_       The prefix sum from current index downwards.
      */    
     function prefixSum(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 sumIndex_
     ) internal view returns (uint256 sum_) {
 
@@ -173,8 +175,8 @@ library Deposits {
         
         while (j > 0 && index <= SIZE) {
 
-            uint256 scaled = self.scaling[index];
-            uint256 value  = self.values[index];
+            uint256 scaled = deposits_.scaling[index];
+            uint256 value  = deposits_.values[index];
 
             // If requested node is in current range, compute sum with running multiplier.
             if (sumIndex_ & j != 0) {
@@ -197,7 +199,7 @@ library Deposits {
      *  @param  unscaledRemoveAmount_   Unscaled amount to decrease deposit by.
      */    
     function unscaledRemove(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_,
         uint256 unscaledRemoveAmount_
     ) internal {
@@ -206,11 +208,11 @@ library Deposits {
         ++index_;
 
         while (index_ <= SIZE) {
-            uint256 value    = (self.values[index_] -= unscaledRemoveAmount_);
-            uint256 scaling  = self.scaling[index_];
+            uint256 value    = (deposits_.values[index_] -= unscaledRemoveAmount_);
+            uint256 scaling  = deposits_.scaling[index_];
             // On the line below, it would be tempting to replace this with:
             // unscaledRemoveAmount_ = Maths.wmul(unscaledRemoveAmount, scaling).  This will introduce nonzero values up
-            // the tree due to rounding.  It's important to compute the actual change in self.values[index_]
+            // the tree due to rounding.  It's important to compute the actual change in deposits_.values[index_]
             // and propogate that upwards.
             if (scaling != 0) unscaledRemoveAmount_ = Maths.wmul(value + unscaledRemoveAmount_, scaling) - Maths.wmul(value,  scaling);
             index_ += lsb(index_);
@@ -224,7 +226,7 @@ library Deposits {
      *  @return scaled_ Scaled value.
      */   
     function scale(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 scaled_) {
         if (index_ > SIZE) revert InvalidIndex();
@@ -232,7 +234,7 @@ library Deposits {
         
         scaled_ = Maths.WAD;
         while (index_ <= SIZE) {
-            uint256 scaling = self.scaling[index_];
+            uint256 scaling = deposits_.scaling[index_];
             if (scaling != 0) scaled_ = Maths.wmul(scaled_, scaling);
             index_ += lsb(index_);
         }
@@ -242,11 +244,11 @@ library Deposits {
      *  @notice Returns sum of all deposits.
      */ 
     function treeSum(
-        Data storage self
+        DepositsState storage deposits_
     ) internal view returns (uint256) {
-        uint256 scaling = self.scaling[SIZE];
+        uint256 scaling = deposits_.scaling[SIZE];
         if (scaling==0) scaling = Maths.WAD;
-        return Maths.wmul(scaling,self.values[SIZE]);
+        return Maths.wmul(scaling,deposits_.values[SIZE]);
     }
 
     /**
@@ -255,16 +257,16 @@ library Deposits {
      *  @return depositValue_ Value of the deposit.
      */  
     function valueAt(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 depositValue_) {
         if (index_ >= SIZE) revert InvalidIndex();
 
-	depositValue_ = Maths.wmul(unscaledValueAt(self, index_), scale(self,index_));
+	depositValue_ = Maths.wmul(unscaledValueAt(deposits_, index_), scale(deposits_,index_));
     }
 
     function unscaledValueAt(
-        Data storage self,
+        DepositsState storage deposits_,
         uint256 index_
     ) internal view returns (uint256 unscaledDepositValue_) {
         if (index_ >= SIZE) revert InvalidIndex();
@@ -273,10 +275,10 @@ library Deposits {
 
         uint256 j = 1;
 
-        unscaledDepositValue_ = self.values[index_];
+        unscaledDepositValue_ = deposits_.values[index_];
         while (j & index_ == 0) {
-            uint256 value   = self.values[index_ - j];
-            uint256 scaling = self.scaling[index_ - j];
+            uint256 value   = deposits_.values[index_ - j];
+            uint256 scaling = deposits_.scaling[index_ - j];
             unscaledDepositValue_ -= scaling != 0 ? Maths.wmul(scaling, value) : value;
             j = j << 1;
         }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -340,14 +340,14 @@ library Auctions {
         // if deposit take then price to use when calculating take is bucket price
         if (params_.depositTake) result.auctionPrice = result.bucketPrice;
 
-        int256  bpf
-          = _takeParameters(
-            liquidation,
+        int256 bpf = _bpf(
+            Maths.wmul(params_.t0debt, params_.inflator),
             params_.collateral,
-            params_.t0debt,
-            result.auctionPrice,
-            params_.inflator
+            liquidation.neutralPrice,
+            liquidation.bondFactor,
+            result.auctionPrice
         );
+
         result.kicker = liquidation.kicker;
         result.isRewarded = (bpf >= 0);
         result.bucketScale = Deposits.scale(deposits_, params_.index);
@@ -418,14 +418,14 @@ library Auctions {
         );
         result.kicker = liquidation.kicker;
 
-        int256 bpf
-          = _takeParameters(
-            liquidation,
+        int256 bpf = _bpf(
+            Maths.wmul(params_.t0debt, params_.inflator),
             params_.collateral,
-            params_.t0debt,
-            result.auctionPrice,
-            params_.inflator
+            liquidation.neutralPrice,
+            liquidation.bondFactor,
+            result.auctionPrice
         );
+
         result.isRewarded = (bpf >= 0);
 
         uint256 collateralBound = Maths.min(params_.collateral, params_.takeCollateral);
@@ -794,32 +794,6 @@ library Auctions {
         }
 
         return PRBMathSD59x18.mul(int256(bondFactor_), sign);
-    }
-
-    /**
-     *  @notice Utility function to calculate take's parameters.
-     *  @param  liquidation_  Liquidation struct holding auction details.
-     *  @param  t0debt_       Borrower t0 debt.
-     *  @param  price_        Price of take in auction (not nec. bucket price)
-     *  @param  poolInflator_ The pool's inflator, used to calculate borrower debt.
-     */
-    function _takeParameters(
-        Liquidation storage liquidation_,
-        uint256 collateral_,
-        uint256 t0debt_,
-        uint256 price_,
-        uint256 poolInflator_
-    ) internal view returns (
-        int256  bpf_
-    ) {
-        // calculate the bond payment factor
-        bpf_ = _bpf(
-            Maths.wmul(t0debt_, poolInflator_),
-            collateral_,
-            liquidation_.neutralPrice,
-            liquidation_.bondFactor,
-            price_
-        );
     }
 
     /**********************/

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -330,8 +330,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                quoteTokenAmount: 19.637503712157446080 * 1e18,
                bondChange:       0.196375037121574461 * 1e18,
                isReward:         true,
-               lpAwardTaker:     0.194243053548020465062464152 * 1e27,
-               lpAwardKicker:    0.193758656905756398832457540 * 1e27
+               lpAwardTaker:     0.194243053548020465000000000 * 1e27,
+               lpAwardKicker:    0.193758656905756399000000000 * 1e27
            }
         );
 
@@ -458,7 +458,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 quoteTokenAmount: 19.778964466685025779 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     1_496.328084309964105327000000000 * 1e27,
+                lpAwardTaker:     1_496.328084309964105326536033959 * 1e27,
                 lpAwardKicker:    0
             }
         );
@@ -562,7 +562,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 quoteTokenAmount: 15.000000000000000000 * 1e18,
                 bondChange:       0.15 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     1134.787481035970172219 * 1e27,
+                lpAwardTaker:     1134.787481035970172246990767313 * 1e27,
                 lpAwardKicker:    0
             }
         );
@@ -712,7 +712,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 quoteTokenAmount: 19.778761259189860403 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     2502.359445445046938391 * 1e27,
+                lpAwardTaker:     2502.359445445046938391797441582 * 1e27,
                 lpAwardKicker:    0
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -357,8 +357,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                index:        _i9_91,
                lpBalance:    2_000.388001710453776863894921692 * 1e27,
                collateral:   2 * 1e18,
-               deposit:      2_007.565460425038880381 * 1e18,
-               exchangeRate: 1.013503294550037375999999999 * 1e27
+               deposit:      2_007.565460425038880380 * 1e18,
+               exchangeRate: 1.013503294550037375999500096 * 1e27
            }
         );
         // reserves should remain the same after arb take
@@ -374,7 +374,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
            {
                borrower:                  _borrower,
-               borrowerDebt:              0.337937396179645130 * 1e18,
+               borrowerDebt:              0.337937396179645129 * 1e18,
                borrowerCollateral:        0,
                borrowert0Np:              10.115967548076923081 * 1e18,
                borrowerCollateralization: 0
@@ -391,7 +391,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.195342779771472726 * 1e18,
                auctionPrice:      9.818751856078723040 * 1e18,
-               debtInAuction:     0.337937396179645130 * 1e18,
+               debtInAuction:     0.337937396179645129 * 1e18,
                thresholdPrice:    0,
                neutralPrice:      10.255495938002318100 * 1e18
            })
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i1505_26,
                 collateralArbed:  1.007203601669595219 * 1e18,
-                quoteTokenAmount: 19.778964466685025779 * 1e18,
+                quoteTokenAmount: 19.778964466685025769 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false
             }
@@ -700,7 +700,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i10016,
                 collateralArbed:  0.251798313435135887 * 1e18,
-                quoteTokenAmount: 19.778761259189860403 * 1e18,
+                quoteTokenAmount: 19.778761259189860430 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false
             }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -340,7 +340,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            {
                lender:      _taker,
                index:       _i9_91,
-               lpBalance:   0.194243053548020465062464152 * 1e27,
+               lpBalance:   0.194243053548020465000000000 * 1e27,
                depositTime: _startTime + 100 days + 6 hours
            }
         );
@@ -348,17 +348,17 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            {
                lender:      _lender,
                index:       _i9_91,
-               lpBalance:   2_000.193758656905756398832457540 * 1e27, // rewarded with LPs in bucket
+               lpBalance:   2_000.193758656905756399000000000* 1e27, // rewarded with LPs in bucket
                depositTime: _startTime + 100 days + 6 hours
            }
         );
         _assertBucket(
            {
                index:        _i9_91,
-               lpBalance:    2_000.388001710453776863894921692 * 1e27,
+               lpBalance:    2_000.388001710453776864000000000 * 1e27,
                collateral:   2 * 1e18,
                deposit:      2_007.565460425038880380 * 1e18,
-               exchangeRate: 1.013503294550037375999500096 * 1e27
+               exchangeRate: 1.013503294550037375999446858 * 1e27
            }
         );
         // reserves should remain the same after arb take
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i1505_26,
                 collateralArbed:  1.007203601669595219 * 1e18,
-                quoteTokenAmount: 19.778964466685025769 * 1e18,
+                quoteTokenAmount: 19.778964466685025779 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false
             }
@@ -474,7 +474,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i1505_26,
-                lpBalance:   1_496.328084309964105327000000000 * 1e27,
+                lpBalance:   1_496.328084309964105326536033959 * 1e27,
                 depositTime: block.timestamp
             }
         );
@@ -489,10 +489,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i1505_26,
-                lpBalance:    26_496.328084309964105327000000000 * 1e27,
+                lpBalance:    26_496.328084309964105326536033959 * 1e27,
                 collateral:   1.007203601669595219 * 1e18,
                 deposit:      24_980.221035533314974222 * 1e18,
-                exchangeRate: 0.999999999999999999999693447 * 1e27
+                exchangeRate: 0.999999999999999999999710958 * 1e27
             }
         );
 
@@ -554,7 +554,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i1505_26,
                 collateralArbed:  0.763844540521390261 * 1e18,
-                quoteTokenAmount: 15.0 * 1e18,
+                quoteTokenAmount: 15.000000000000000000 * 1e18,
                 bondChange:       0.15 * 1e18,
                 isReward:         false
             }
@@ -580,10 +580,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i1505_26,
-                lpBalance:    1_149.787481035970172219000000000 * 1e27,
+                lpBalance:    1_149.787481035970172246990767313 * 1e27,
                 collateral:   0.763844540521390261 * 1e18,
                 deposit:      0,
-                exchangeRate: 0.999999999999999999995151547 * 1e27
+                exchangeRate: 0.999999999999999999970807251 * 1e27
             }
         );
 
@@ -601,7 +601,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i1505_26,
-                lpBalance:   1_134.787481035970172219000000000 * 1e27,
+                lpBalance:   1_134.787481035970172246990767313 * 1e27,
                 depositTime: block.timestamp
             }
         );
@@ -700,7 +700,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i10016,
                 collateralArbed:  0.251798313435135887 * 1e18,
-                quoteTokenAmount: 19.778761259189860430 * 1e18,
+                quoteTokenAmount: 19.778761259189860403 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false
             }
@@ -710,7 +710,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i10016,
-                lpBalance:   2_502.359445445046938391 * 1e27, // arb taker was rewarded LPBs in arbed bucket
+                lpBalance:   2_502.359445445046938391797441582 * 1e27, // arb taker was rewarded LPBs in arbed bucket
                 depositTime: _startTime + 100 days + 3 hours
             }
         );
@@ -732,10 +732,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i10016,
-                lpBalance:    3_502.359445445046938391 * 1e27,       // LP balance in arbed bucket increased with LPs awarded for arb taker
+                lpBalance:    3_502.359445445046938391797441582 * 1e27,       // LP balance in arbed bucket increased with LPs awarded for arb taker
                 collateral:   0.251798313435135887 * 1e18,          // arbed collateral added to the arbed bucket
                 deposit:      980.221238740810139596 * 1e18,        // quote token amount is diminished in arbed bucket
-                exchangeRate: 1.000000000000000000007614372 * 1e27
+                exchangeRate: 1.000000000000000000007386685 * 1e27
             }
         );
         _assertBorrower(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -290,7 +290,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                timeRemaining:              0
            }
         );
-        
+
         _assertAuction(
            AuctionParams({
                borrower:          _borrower,
@@ -333,7 +333,6 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                lpAwardKicker:    0.198343102933742890000000000 * 1e27
            }
         );
-
         _assertLenderLpBalance(
            {
                lender:      _taker,
@@ -359,7 +358,6 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                exchangeRate: 1.000002994482624129000538562 * 1e27
            }
         );
-
         // reserves should remain the same after deposit take
         _assertReserveAuction(
            {
@@ -370,7 +368,6 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                timeRemaining:              0
            }
         );
-
         _assertAuction(
            AuctionParams({
                borrower:          _borrower,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -294,7 +294,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                timeRemaining:              0
            }
         );
-
+        
         _assertAuction(
            AuctionState({
                borrower:          _borrower,
@@ -334,6 +334,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                isReward:         true
            }
         );
+
         _assertLenderLpBalance(
            {
                lender:      _taker,
@@ -355,10 +356,11 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                index:        _i9_91,
                lpBalance:    2_000.198343102933742890077232102 * 1e27,
                collateral:   2 * 1e18,
-               deposit:      1_980.369962975245152093 * 1e18,
-               exchangeRate: 1.000002994482624128999999999 * 1e27
+               deposit:      1_980.369962975245152094 * 1e18,
+               exchangeRate: 1.000002994482624129000499950 * 1e27
            }
         );
+
         // reserves should remain the same after deposit take
         _assertReserveAuction(
            {
@@ -369,6 +371,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                timeRemaining:              0
            }
         );
+
         _assertAuction(
            AuctionState({
                borrower:          _borrower,
@@ -377,10 +380,10 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                bondSize:          0.199398195043779403 * 1e18,
                bondFactor:        0.01 * 1e18,
                kickTime:          block.timestamp - 6 hours,
-               kickMomp:          9.818751856078723036 * 1e18, 
+               kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
                auctionPrice:      9.818751856078723040 * 1e18,
-               debtInAuction:     0.553663533540717533 * 1e18,
+               debtInAuction:     0.553663533540717534 * 1e18,
                thresholdPrice:    0,
                neutralPrice:      10.468405239798418677 * 1e18
            })
@@ -389,7 +392,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              0.553663533540717533 * 1e18,
+                borrowerDebt:              0.553663533540717534 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.115967548076923081 * 1e18,
                 borrowerCollateralization: 0
@@ -463,7 +466,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i1505_26,
                 collateralArbed:  0.013412656817410703 * 1e18,
-                quoteTokenAmount: 20.189585809651700719 * 1e18,
+                quoteTokenAmount: 20.189585809651701255 * 1e18,
                 bondChange:       0.199398195043779403 * 1e18,
                 isReward:         false
             }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -347,17 +347,17 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
            {
                lender:      _lender,
                index:       _i9_91,
-               lpBalance:   2_000.198343102933742890077232102 * 1e27,
+               lpBalance:   2_000.198343102933742890000000000 * 1e27,
                depositTime: _startTime + 250 days + 6 hours
            }
         );
         _assertBucket(
            {
                index:        _i9_91,
-               lpBalance:    2_000.198343102933742890077232102 * 1e27,
+               lpBalance:    2_000.198343102933742890000000000 * 1e27,
                collateral:   2 * 1e18,
                deposit:      1_980.369962975245152094 * 1e18,
-               exchangeRate: 1.000002994482624129000499950 * 1e27
+               exchangeRate: 1.000002994482624129000538562 * 1e27
            }
         );
 
@@ -466,7 +466,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 index:            _i1505_26,
                 collateralArbed:  0.013412656817410703 * 1e18,
-                quoteTokenAmount: 20.189585809651701255 * 1e18,
+                quoteTokenAmount: 20.189585809651700719 * 1e18,
                 bondChange:       0.199398195043779403 * 1e18,
                 isReward:         false
             }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -330,7 +330,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                bondChange:       0.198343696868718241 * 1e18,
                isReward:         true,
                lpAwardTaker:     0,
-               lpAwardKicker:    0.198343102933742890077232102 * 1e27
+               lpAwardKicker:    0.198343102933742890000000000 * 1e27
            }
         );
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -567,7 +567,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   1_000.0 * 1e18,
                 bondChange:      0.000000062397676800 * 1e18,
-                givenAmount:     0.000006239767680000 * 1e18,
+                givenAmount:     0.000006239767679798 * 1e18,
                 collateralTaken: 1_000.0 * 1e18,
                 isReward:        true
             }
@@ -579,8 +579,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             8_105.800538156165698866 * 1e18,
                 pledgedCollateral:    1.749391266909416578 * 1e18,
-                encumberedCollateral: 82_095_199_803.074941485714603011 * 1e18,
-                poolDebt:             8_196.079591450862150038 * 1e18,
+                encumberedCollateral: 82_095_199_803.074941487727899121 * 1e18,
+                poolDebt:             8_196.079591450862150239 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.174754005164844884 * 1e18,
                 minDebtAmount:        0,
@@ -594,7 +594,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              8_196.079591450862150038 * 1e18,
+                borrowerDebt:              8_196.079591450862150239 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              8.471136974495192173 * 1e18,
                 borrowerCollateralization: 0
@@ -612,7 +612,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    5,
-                settledDebt: 8_076.635779729962272432 * 1e18
+                settledDebt: 8_076.635779729962272630 * 1e18
             }
         );
 
@@ -620,7 +620,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             PoolState({
                 htp:                  0,
                 lup:                  1_004_968_987.606512354182109771 * 1e18,
-                poolSize:             9.170249839416101528 * 1e18,
+                poolSize:             9.170249839416101327 * 1e18,
                 pledgedCollateral:    1.749391266909416578 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
@@ -639,15 +639,15 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_52,
                 lpBalance:    7_989.987933044093783839000000000 * 1e27,
                 collateral:   0,          
-                deposit:      9.170249839416101532 * 1e18,
-                exchangeRate: 1_147_717.608119383166017025 * 1e18
+                deposit:      9.170249839416101331 * 1e18,
+                exchangeRate: 1_147_717.608119383140860541 * 1e18
             }
         );
 
         _removeLiquidity(
             {
                 from:     _lender,
-                amount:   9.170249839416101532 * 1e18,
+                amount:   9.170249839416101331 * 1e18,
                 penalty:  0,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -305,7 +305,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   800 * 1e18,
                 bondChange:      4.909375928039361536 * 1e18,
-                givenAmount:     490.937592803936153600 * 1e18,
+                givenAmount:     490.937592803936153535 * 1e18,
                 collateralTaken: 800 * 1e18,
                 isReward:        true
             }
@@ -321,7 +321,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 103.443318347831577993 * 1e18,
                 auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_491.045960898015198317 * 1e18,
+                debtInAuction:     9_491.045960898015198382 * 1e18,
                 thresholdPrice:    47.455229804490075991 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -329,7 +329,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_491.045960898015198317 * 1e18,
+                borrowerDebt:              9_491.045960898015198382 * 1e18,
                 borrowerCollateral:        200 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0.204851939503451289 * 1e18
@@ -379,7 +379,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_361.437181302278117323 * 1e18
+                settledDebt: 9_361.437181302278117387 * 1e18
             }
         );
         _assertAuction(
@@ -430,8 +430,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_775.731868287982080143 * 1e18,
-                exchangeRate: 0.797793806207998370922090909 * 1e27
+                deposit:      8_775.731868287982080078 * 1e18,
+                exchangeRate: 0.797793806207998370916181818 * 1e27
             }
         );
         _assertBucket(
@@ -448,7 +448,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             PoolState({
                 htp:                  48.148343567549191135 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             63_775.731868287982080143 * 1e18,
+                poolSize:             63_775.731868287982080078 * 1e18,
                 pledgedCollateral:    2 * 1e18,
                 encumberedCollateral: 2.010288427770370775 * 1e18,
                 poolDebt:             19.542608580405342754 * 1e18,
@@ -780,7 +780,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
                 bondChange:      6.136719910049201920 * 1e18,
-                givenAmount:     613.671991004920192000 * 1e18,
+                givenAmount:     613.671991004920191919 * 1e18,
                 collateralTaken: 1_000 * 1e18,
                 isReward:        true
             }
@@ -849,7 +849,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_369.538906679041000301 * 1e18,
+                borrowerDebt:              9_369.538906679041000381 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -861,7 +861,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_241.589415329770722443 * 1e18
+                settledDebt: 9_241.589415329770722522 * 1e18
             }
         );
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -422,7 +422,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   1_001 * 1e18,
                 bondChange:      3_391.760345392249653035 * 1e18,
-                givenAmount:     11_315.630002696011360000 * 1e18,
+                givenAmount:     11_315.630002696011360050 * 1e18,
                 collateralTaken: 1000.0 * 1e18,
                 isReward:        true
             }
@@ -440,7 +440,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          1_505.263728469068226832 * 1e18,
                 totalBondEscrowed: 6_338.645708801895343974 * 1e18,
                 auctionPrice:      11.315630002696011360 * 1e18,
-                debtInAuction:     2_022.535489532218366964 * 1e18,
+                debtInAuction:     2_022.535489532218366929 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      1_597.054445085392479852 * 1e18
             })
@@ -450,7 +450,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              2_022.535489532218366964 * 1e18,
+                borrowerDebt:              2_022.535489532218366929 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 0
@@ -666,12 +666,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   10 * 1e18,
                 bondChange:      72.659542640405725541 * 1e18,
-                givenAmount:     244.431127722276658880 * 1e18,
+                givenAmount:     244.431127722276658882 * 1e18,
                 collateralTaken: 10.0 * 1e18,
                 isReward:        true
             }
         );
-        return;
+
         // Residual is not collateralized, auction is active
         _assertAuction(
             AuctionState({
@@ -684,7 +684,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          1_505.263728469068226832 * 1e18,
                 totalBondEscrowed: 3_019.544906050051416480 * 1e18,
                 auctionPrice:      24.443112772227665888 * 1e18,
-                debtInAuction:     9_774.576790197253949121 * 1e18,
+                debtInAuction:     9_774.576790197253949120 * 1e18,
                 thresholdPrice:    9.873309889088135302 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
             })
@@ -693,7 +693,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_774.576790197253949121 * 1e18,
+                borrowerDebt:              9_774.576790197253949120 * 1e18,
                 borrowerCollateral:        990.0 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 0.984603539667648861 * 1e18
@@ -909,8 +909,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   577.0 * 1e18,
                 bondChange:      4_192.455610351410363728 * 1e18,
-                givenAmount:     14_103.676069575363217376 * 1e18,
-                collateralTaken: 577.0 * 1e18,
+                givenAmount:     14_103.676069575363217476 * 1e18,
+                collateralTaken: 577.000000000000000000 * 1e18,
                 isReward:        true
             }
         );
@@ -936,8 +936,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              35.127916055172028812 * 1e18,
-                borrowerCollateral:        423.0 * 1e18,
+                borrowerDebt:              35.127916055172028742 * 1e18,
+                borrowerCollateral:        423.000000000000000000 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 18_125.941662533322157279 * 1e18
             }
@@ -1353,9 +1353,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_001 * 1e18,
-                bondChange:      4_207.314752003173273858 * 1e18,
+                bondChange:      4_207.314752003173273831 * 1e18,
                 givenAmount:     14_153.663127282298156318 * 1e18,
-                collateralTaken: 579.045036496486256685 * 1e18,
+                collateralTaken: 579.045036496486256681 * 1e18,
                 isReward:        true
             }
         );
@@ -1382,7 +1382,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 borrower:                  _borrower2,
                 borrowerDebt:              0,
-                borrowerCollateral:        420.954963503513743315 * 1e18,
+                borrowerCollateral:        420.954963503513743319 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 1.0 * 1e18
             }
@@ -1500,8 +1500,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
                 bondChange:      85.314660426337335450 * 1e18,
-                givenAmount:     10_048.254301505840000000 * 1e18,
-                collateralTaken: 1_000 * 1e18,
+                givenAmount:     10_048.254301505840000454 * 1e18,
+                collateralTaken: 1000.0 * 1e18,
                 isReward:        true
             }
         );
@@ -1509,7 +1509,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              13.927822059266846206 * 1e18,
+                borrowerDebt:              13.927822059266845756 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1527,7 +1527,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 183.848602846129551907 * 1e18,
                 auctionPrice:      10.048254301505840000 * 1e18,
-                debtInAuction:     13.927822059266846206 * 1e18,
+                debtInAuction:     13.927822059266845756 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -1581,7 +1581,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   20 * 1e18,
                 bondChange:      0.122734398200984038 * 1e18,
-                givenAmount:     12.273439820098403840 * 1e18,
+                givenAmount:     12.273439820098403838 * 1e18,
                 collateralTaken: 20 * 1e18,
                 isReward:        true
             }
@@ -1597,7 +1597,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.656676817993200495 * 1e18,
                 auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_964.923472352014570580 * 1e18,
+                debtInAuction:     9_964.923472352014570582 * 1e18,
                 thresholdPrice:    10.168289257502055684 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -1612,7 +1612,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_964.923472352014570580 * 1e18,
+                borrowerDebt:              9_964.923472352014570582 * 1e18,
                 borrowerCollateral:        980 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0.956040452710323016 * 1e18
@@ -1637,7 +1637,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:        _borrower2,
                 maxCollateral:   981 * 1e18,
                 bondChange:      6.013985511848217882 * 1e18,
-                givenAmount:     601.398551184821788160 * 1e18,
+                givenAmount:     601.398551184821788081 * 1e18,
                 collateralTaken: 980 * 1e18,
                 isReward:        true
             }
@@ -1653,7 +1653,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 104.670662329841418377 * 1e18,
                 auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_369.538906679041000301 * 1e18,
+                debtInAuction:     9_369.538906679041000381 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -1668,7 +1668,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_369.538906679041000301 * 1e18,
+                borrowerDebt:              9_369.538906679041000381 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1677,8 +1677,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // reserves should increase after take action
         _assertReserveAuction(
             {
-                reserves:                   148.141379552245490832 * 1e18,
-                claimableReserves :         101.196008611469757773 * 1e18,
+                reserves:                   148.141379552245490831 * 1e18,
+                claimableReserves :         101.196008611469757772 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -1711,7 +1711,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_241.589415329770722443 * 1e18
+                settledDebt: 9_241.589415329770722522 * 1e18
             }
         );
         _assertAuction(
@@ -1785,8 +1785,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_897.700538056438413215 * 1e18, 
-                exchangeRate: 0.808881867096039855746818181 * 1e27
+                deposit:      8_897.700538056438413135 * 1e18, 
+                exchangeRate: 0.808881867096039855739545454 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -1836,8 +1836,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertReserveAuction(
             {
-                reserves:                   148.141379552245490832 * 1e18,
-                claimableReserves :         101.196008611469757773 * 1e18,
+                reserves:                   148.141379552245490831 * 1e18,
+                claimableReserves :         101.196008611469757772 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -1854,7 +1854,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertReserveAuction(
              {
-                reserves:                   0.120014514538188320 * 1e18,
+                reserves:                   0.120014514538188319 * 1e18,
                 claimableReserves :         0,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
@@ -1872,7 +1872,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 104.670662329841418377 * 1e18,
                 auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     7_102.606034474787586785 * 1e18,
+                debtInAuction:     7_102.606034474787586865 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340  * 1e18
             })
@@ -1887,7 +1887,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              7_102.606034474787586785 * 1e18,
+                borrowerDebt:              7_102.606034474787586865 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1899,7 +1899,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    5,
-                settledDebt: 7_005.613552943226845160 * 1e18
+                settledDebt: 7_005.613552943226845239 * 1e18
             }
         );
         _assertAuction(
@@ -1936,9 +1936,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
 
         // kicker withdraws his auction bonds
-        assertEq(_quote.balanceOf(_lender), 46_287.794066575287591543 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_287.794066575287591624 * 1e18);
         _pool.withdrawBonds();
-        assertEq(_quote.balanceOf(_lender), 46_392.464728905129009920 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_392.464728905129010001 * 1e18);
         _assertKicker(
             {
                 kicker:    _lender,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -458,7 +458,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
     }
 
-    function testTakeCallerColConstraintBpfPosNoResidual() external tearDown {
+    function testTakeCallerColConstraintBpfPosNoResidual() external  {
  
         // Increase neutralPrice so it exceeds TP
         _addLiquidity(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -658,8 +658,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrowerCollateralization: 0.977373353339734632 * 1e18
             }
         );
- 
-        // BPF Positive, Loan Debt constraint
+
+        // BPF Positive, caller collateral is constraint
         _take(
             {
                 from:            _lender,
@@ -671,7 +671,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 isReward:        true
             }
         );
-
+        return;
         // Residual is not collateralized, auction is active
         _assertAuction(
             AuctionState({

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
     }
 
-    function testTakeCallerColConstraintBpfPosNoResidual() external  {
+    function testTakeCallerColConstraintBpfPosNoResidual() external tearDown {
  
         // Increase neutralPrice so it exceeds TP
         _addLiquidity(

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -854,7 +854,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 settledDebt: 2.021010389642603383 * 1e18
             }
         );
-        return;
+
         _assertBorrower(
             {
                 borrower:                  _borrower,

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -854,7 +854,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 settledDebt: 2.021010389642603383 * 1e18
             }
         );
-
+        return;
         _assertBorrower(
             {
                 borrower:                  _borrower,

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -105,7 +105,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
             })
         );
         vm.expectEmit(true, true, false, true);
-        emit Take(_borrower, 13.885812040442529856 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
+        emit Take(_borrower, 13.885812040442529857 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
         taker.take(tokens, amounts, data);
 
         assertGt(usdc.balanceOf(address(this)), 0); // could vary
@@ -126,7 +126,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         // call take using taker contract
         bytes memory data = abi.encode(address(_ajnaPool));
         vm.expectEmit(true, true, false, true);
-        emit Take(_borrower, 13.885812040442529856 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
+        emit Take(_borrower, 13.885812040442529857 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
         _ajnaPool.take(_borrower, takeAmount, address(taker), data);
 
         // confirm we earned some quote token

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -95,13 +95,13 @@ contract ERC721TakeWithExternalLiquidityTest is Test {
         // call take using taker contract
         bytes memory data = abi.encode(address(_ajnaPool));
         vm.expectEmit(true, true, false, true);
-        uint256 quoteTokenPaid = 502.49483121458538752 * 1e18;
+        uint256 quoteTokenPaid = 502.494831214585387519 * 1e18;
         uint256 collateralPurchased = 2 * 1e18;
         uint256 bondChange = 5.024948312145853875 * 1e18;
         emit Take(_borrower, quoteTokenPaid, collateralPurchased, bondChange, true);
         _ajnaPool.take(_borrower, 2, address(taker), data);
 
         // confirm we earned some quote token
-        assertEq(dai.balanceOf(address(taker)), 997.505168785414612480 * 1e18);
+        assertEq(dai.balanceOf(address(taker)), 997.505168785414612481 * 1e18);
     }
 }

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -29,7 +29,7 @@ contract FenwickTreeInstance is DSTestPlus {
     }
 
     function remove(uint256 i_, uint256 x_) public {
-        deposits.remove(i_, x_, deposits.valueAt(i_));
+        deposits.unscaledRemove(i_, Maths.wdiv(x_, deposits.scale(i_)));
     }
 
     function mult(uint256 i_, uint256 f_) public {
@@ -57,8 +57,8 @@ contract FenwickTreeInstance is DSTestPlus {
     }
 
     function obliterate(uint256 i_) public {
-        uint256 deposit = deposits.valueAt(i_);
-	    deposits.remove(i_, deposit, deposit);
+        uint256 deposit = deposits.unscaledValueAt(i_);
+        deposits.unscaledRemove(i_, deposit);
     }
 
     function valueAt(uint256 i_) external view returns (uint256 s_) {


### PR DESCRIPTION
Continuation of fenwick-bites-1.  Eliminated fenwick remove() in favor of unscaledRemove() everywhere, and reduced redundant iterations of the tree.  Unified take and bucketTake constraint logic.

Minor gas improvement for bucketTake and take

New:
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                              | min             | avg    | median | max    | # calls |
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| addQuoteToken                              | 105426          | 163858 | 145637 | 654260 | 52003   |
| borrowerInfo                               | 6911            | 6911   | 6911   | 6911   | 8001    |
| bucketTake                                 | 342380          | 404972 | 404989 | 467532 | 4       |
| collateralScale                            | 452             | 452    | 452    | 452    | 1       |
| drawDebt                                   | 202481          | 250560 | 222966 | 739431 | 120003  |
| inflatorInfo                               | 443             | 443    | 443    | 443    | 8001    |
| initialize                                 | 91480           | 91480  | 91480  | 91480  | 14      |
| interestRateInfo                           | 2388            | 2388   | 2388   | 2388   | 8001    |
| kick                                       | 128605          | 157313 | 153480 | 934410 | 48000   |
| loansInfo                                  | 1817            | 2515   | 2515   | 8515   | 48017   |
| moveQuoteToken                             | 251933          | 251933 | 251933 | 251933 | 1       |
| quoteTokenScale                            | 410             | 410    | 410    | 410    | 8002    |
| removeQuoteToken                           | 142169          | 164183 | 165256 | 189460 | 4000    |
| repayDebt                                  | 521778          | 553824 | 543231 | 701801 | 16001   |
| take                                       | 40942           | 49187  | 50919  | 331138 | 15998   |

Old:
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                              | min             | avg    | median | max    | # calls |
|--------------------------------------------|-----------------|--------|--------|--------|---------|
| addQuoteToken                              | 105426          | 163858 | 145637 | 654260 | 52003   |
| borrowerInfo                               | 6911            | 6911   | 6911   | 6911   | 8001    |
| bucketTake                                 | 342068          | 406744 | 406761 | 471388 | 4       |
| collateralScale                            | 452             | 452    | 452    | 452    | 1       |
| drawDebt                                   | 202481          | 250560 | 222966 | 739431 | 120003  |
| inflatorInfo                               | 443             | 443    | 443    | 443    | 8001    |
| initialize                                 | 91480           | 91480  | 91480  | 91480  | 14      |
| interestRateInfo                           | 2388            | 2388   | 2388   | 2388   | 8001    |
| kick                                       | 128605          | 157313 | 153480 | 934410 | 48000   |
| loansInfo                                  | 1817            | 2515   | 2515   | 8515   | 48017   |
| moveQuoteToken                             | 278041          | 278041 | 278041 | 278041 | 1       |
| quoteTokenScale                            | 410             | 410    | 410    | 410    | 8002    |
| removeQuoteToken                           | 142169          | 164187 | 169053 | 191936 | 4000    |
| repayDebt                                  | 521778          | 553823 | 543231 | 701801 | 16001   |
| take                                       | 41368           | 49613  | 51344  | 331564 | 15998   |
