### PR TITLE
Proposed changes to PR #428

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -404,8 +404,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if (borrow_) {
             // only intended recipient can borrow quote
             if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
-            // if borrower auctioned then it cannot draw more debt
-            if (inAuction) revert AuctionActive();
 
             // add origination fee to the amount to borrow and add to borrower's debt
             uint256 debtChange = Maths.wmul(amountToBorrow_, _feeRate(interestParams.interestRate) + Maths.WAD);
@@ -417,6 +415,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             if (lupId > limitIndex_) revert LimitIndexReached();
 
             // calculate new lup and check borrow action won't push borrower into a state of under-collateralization
+            // this check also covers the scenario when loan is already auctioned
             newLup_ = _priceAt(lupId);
             if (
                 !_isCollateralized(borrowerDebt, borrower.collateral, newLup_, poolState.poolType)

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -444,7 +444,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             borrowerAddress_,
             borrowerDebt,
             poolState.rate,
-            poolState.inflator,
             newLup_,
             inAuction,
             true
@@ -498,7 +497,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                 borrowerAddress_,
                 borrowerDebt,
                 poolState.rate,
-                poolState.inflator,
                 newLup_,
                 false, // cannot be in auction if able to pull collateral
                 true
@@ -552,7 +550,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             borrowerAddress_,
             borrowerDebt,
             poolState_.rate,
-            poolState_.inflator,
             newLup_,
             inAuction,
             false

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -11,6 +11,11 @@ interface IPoolErrors {
     /**************************/
 
     /**
+     *  @notice The action cannot be executed on an active auction.
+     */
+    error AuctionActive();
+
+    /**
      *  @notice Pool already initialized.
      */
     error AlreadyInitialized();

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -11,11 +11,6 @@ interface IPoolErrors {
     /**************************/
 
     /**
-     *  @notice The action cannot be executed on an active auction.
-     */
-    error AuctionActive();
-
-    /**
      *  @notice Pool already initialized.
      */
     error AlreadyInitialized();

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -10,8 +10,6 @@ import './interfaces/IERC20Taker.sol';
 import '../base/FlashloanablePool.sol';
 
 contract ERC20Pool is IERC20Pool, FlashloanablePool {
-    using Deposits  for DepositsState;
-    using Loans     for LoansState;
     using SafeERC20 for IERC20;
 
     /*****************/
@@ -36,7 +34,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         interestParams.interestRate       = uint208(rate_);
         interestParams.interestRateUpdate = uint48(block.timestamp);
 
-        loans.init();
+        Loans.init(loans);
 
         // increment initializations count to ensure these values can't be updated
         poolInitializations += 1;
@@ -196,7 +194,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         bytes calldata data_
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
-        Borrower  memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
+        Borrower  memory borrower  = Loans.getBorrowerInfo(loans, borrowerAddress_);
         // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -8,8 +8,6 @@ import '../base/FlashloanablePool.sol';
 import './interfaces/IERC721NonStandard.sol';
 
 contract ERC721Pool is IERC721Pool, FlashloanablePool {
-    using Deposits for DepositsState;
-    using Loans    for LoansState;
 
     /*****************/
     /*** Constants ***/
@@ -54,7 +52,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             }
         }
 
-        loans.init();
+        Loans.init(loans);
 
         // increment initializations count to ensure these values can't be updated
         poolInitializations += 1;
@@ -202,7 +200,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         bytes calldata data_
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
-        Borrower  memory borrower  = loans.getBorrowerInfo(borrowerAddress_);
+        Borrower  memory borrower  = Loans.getBorrowerInfo(loans, borrowerAddress_);
         // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral();
 

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -2,8 +2,9 @@
 
 pragma solidity 0.8.14;
 
-import { Borrower, LoansState, Loan } from '../base/interfaces/IPool.sol';
+import { Borrower, AuctionsState, DepositsState, LoansState, Loan } from '../base/interfaces/IPool.sol';
 
+import './Deposits.sol';
 import './Maths.sol';
 
 library Loans {
@@ -35,31 +36,58 @@ library Loans {
     /**
      *  @notice Updates a loan: updates heap (upsert if TP not 0, remove otherwise) and borrower balance.
      *  @param loans_ Holds tree loan data.
-     *  @param borrowerAddress_ Borrower's address to update.
      *  @param borrower_        Borrower struct with borrower details.
-     *  @param loanIndex_       Current index of the loan (can be 0 if new loan to be inserted in heap)
+     *  @param borrowerAddress_ Borrower's address to update.
+     *  @param borrowerDebt_    Borrower's current debt.
+     *  @param poolRate_        Pool's current rate.
+     *  @param poolInflator_    Pool's current inflator.
+     *  @param lup_             Current LUP.
      *  @param inAuction_       Whether the loan is in auction or not.
+     *  @param t0NpUpdate_      Whether the neutral price of borrower should be updated or not.
      */
     function update(
         LoansState storage loans_,
-        address borrowerAddress_,
+        AuctionsState storage auctions_,
+        DepositsState storage deposits_,
         Borrower memory borrower_,
-        uint256 loanIndex_,
-        bool inAuction_
+        address borrowerAddress_,
+        uint256 borrowerDebt_,
+        uint256 poolRate_,
+        uint256 poolInflator_,
+        uint256 lup_,
+        bool inAuction_,
+        bool t0NpUpdate_
     ) internal {
 
-        // loan not auctioned, update loan heap
+        bool activeBorrower = borrower_.t0debt != 0 && borrower_.collateral != 0;
+        uint256 t0ThresholdPrice = activeBorrower ? Maths.wdiv(borrower_.t0debt, borrower_.collateral) : 0;
+
+        // loan not auctioned, update loan threshold price heap
         if (!inAuction_ ) {
-            if (borrower_.t0debt != 0 && borrower_.collateral != 0) {
-                uint96 thresholdPrice = uint96(Maths.wdiv(borrower_.t0debt, borrower_.collateral));
+            // get the loan id inside the heap
+            uint256 loanId = loans_.indices[borrowerAddress_];
+            if (activeBorrower) {
                 // revert if threshold price is zero
-                if (thresholdPrice == 0) revert ZeroThresholdPrice();
+                if (t0ThresholdPrice == 0) revert ZeroThresholdPrice();
 
                 // update heap, insert if a new loan, update loan if already in heap
-                _upsert(loans_, borrowerAddress_, loanIndex_, thresholdPrice);
+                _upsert(loans_, borrowerAddress_, loanId, uint96(t0ThresholdPrice));
 
-            } else if (loanIndex_ != 0) {
-                remove(loans_, borrowerAddress_, loanIndex_);
+            // if loan is in heap and borrwer is no longer active (no debt, no collateral) then remove loan from heap
+            } else if (loanId != 0) {
+                remove(loans_, borrowerAddress_, loanId);
+            }
+        }
+
+        // update t0 neutral price of borrower
+        if (t0NpUpdate_) {
+            if (t0ThresholdPrice != 0) {
+                uint256 noOfLoans = loans_.loans.length - 1 + auctions_.noOfAuctions;
+                uint256 thresholdPrice = borrowerDebt_ * Maths.WAD / borrower_.collateral;
+                uint256 curMomp   = _priceAt(Deposits.findIndexOfSum(deposits_, Maths.wdiv(borrowerDebt_, noOfLoans * 1e18)));
+                borrower_.t0Np    = (1e18 + poolRate_) * curMomp * thresholdPrice / lup_ / poolInflator_;
+            } else {
+                borrower_.t0Np = 0;
             }
         }
 

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -40,7 +40,6 @@ library Loans {
      *  @param borrowerAddress_ Borrower's address to update.
      *  @param borrowerDebt_    Borrower's current debt.
      *  @param poolRate_        Pool's current rate.
-     *  @param poolInflator_    Pool's current inflator.
      *  @param lup_             Current LUP.
      *  @param inAuction_       Whether the loan is in auction or not.
      *  @param t0NpUpdate_      Whether the neutral price of borrower should be updated or not.
@@ -53,7 +52,6 @@ library Loans {
         address borrowerAddress_,
         uint256 borrowerDebt_,
         uint256 poolRate_,
-        uint256 poolInflator_,
         uint256 lup_,
         bool inAuction_,
         bool t0NpUpdate_
@@ -82,16 +80,15 @@ library Loans {
         // update t0 neutral price of borrower
         if (t0NpUpdate_) {
             if (t0ThresholdPrice != 0) {
-                uint256 noOfLoans = loans_.loans.length - 1 + auctions_.noOfAuctions;
-                uint256 thresholdPrice = borrowerDebt_ * Maths.WAD / borrower_.collateral;
-                uint256 curMomp   = _priceAt(Deposits.findIndexOfSum(deposits_, Maths.wdiv(borrowerDebt_, noOfLoans * 1e18)));
-                borrower_.t0Np    = (1e18 + poolRate_) * curMomp * thresholdPrice / lup_ / poolInflator_;
+                uint256 loansInPool = loans_.loans.length - 1 + auctions_.noOfAuctions;
+                uint256 curMomp = _priceAt(Deposits.findIndexOfSum(deposits_, Maths.wdiv(borrowerDebt_, loansInPool * 1e18)));
+                borrower_.t0Np  = (1e18 + poolRate_) * curMomp * t0ThresholdPrice / lup_ / 1e18;
             } else {
                 borrower_.t0Np = 0;
             }
         }
 
-        // update borrower details
+        // save borrower state
         loans_.borrowers[borrowerAddress_] = borrower_;
     }
 

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -60,7 +60,7 @@ library Loans {
         bool activeBorrower = borrower_.t0debt != 0 && borrower_.collateral != 0;
         uint256 t0ThresholdPrice = activeBorrower ? Maths.wdiv(borrower_.t0debt, borrower_.collateral) : 0;
 
-        // loan not auctioned, update loan threshold price heap
+        // loan not in auction, update threshold price and position in heap
         if (!inAuction_ ) {
             // get the loan id inside the heap
             uint256 loanId = loans_.indices[borrowerAddress_];

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1038,19 +1038,6 @@ library Auctions {
     /**********************/
 
     /**
-     *  @notice Check if there is an ongoing auction for current borrower and revert if such.
-     *  @dev    Used to prevent an auctioned borrower to draw more debt or while in liquidation.
-     *  @dev    Used to prevent kick on an auctioned borrower.
-     *  @param  borrower_ Borrower address to check auction status for.
-     */
-    function revertIfActive(
-        AuctionsState storage auctions_,
-        address borrower_
-    ) internal view {
-        if (isActive(auctions_, borrower_)) revert AuctionActive();
-    }
-
-    /**
      *  @notice Returns true if borrower is in auction.
      *  @dev    Used to accuratley increment and decrement t0DebtInAuction.
      *  @param  borrower_ Borrower address to check auction status for.

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -496,7 +496,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         uint256 indexLimit
     ) internal override {
         changePrank(from);
-        vm.expectRevert(abi.encodeWithSignature('AuctionActive()'));
+        vm.expectRevert(IPoolErrors.BorrowerUnderCollateralized.selector);
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
     }
 

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -420,7 +420,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        60 * 1e18,
-                borrowert0Np:              369.605048076923077092 * 1e18,
+                borrowert0Np:              369.605048076923077093 * 1e18,
                 borrowerCollateralization: 8.483377444958217435 * 1e18
             }
         );
@@ -458,7 +458,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              445.838278846153846358 * 1e18,
+                borrowert0Np:              445.838278846153846359 * 1e18,
                 borrowerCollateralization: 7.057773002983275247 * 1e18
             }
         );
@@ -497,7 +497,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              448.381722115384615590 * 1e18,
+                borrowert0Np:              448.381722115384615591 * 1e18,
                 borrowerCollateralization: 7.044916376706357984 * 1e18
             }
         );
@@ -531,7 +531,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              451.179509711538461745 * 1e18,
+                borrowert0Np:              451.179509711538461746 * 1e18,
                 borrowerCollateralization: 7.030801136225104190 * 1e18
             }
         );
@@ -561,7 +561,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              451.179509711538461745 * 1e18,
+                borrowert0Np:              451.179509711538461746 * 1e18,
                 borrowerCollateralization: 7.015307034516347067 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -152,7 +152,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              21_049.006823139002918431 * 1e18,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              441.424038461538461741 * 1e18,
+                borrowert0Np:              441.424038461538461742 * 1e18,
                 borrowerCollateralization: 7.081111825921092812 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -133,7 +133,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -133,7 +133,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -634,14 +634,6 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             })
         );
 
-        // kick should fail if borrower in liquidation
-        _assertKickAuctionActiveRevert(
-            {
-                from:       _lender,
-                borrower:   _borrower
-            }
-        );
-
         // should not allow borrower to draw more debt if auction kicked
         _assertBorrowAuctionActiveRevert(
             {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -131,7 +131,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );
@@ -225,7 +225,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              8_097.846143253778448241 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.200479200648987171 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -6,7 +6,7 @@ import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 import 'src/base/PoolHelper.sol';
 import 'src/erc20/interfaces/IERC20Pool.sol';
 
-contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
+contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
     address internal _borrower;
     address internal _borrower2;
@@ -132,7 +132,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );
@@ -464,7 +464,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_990.503913730158190391 * 1e18,
                 borrowerCollateral:        1_000.00 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 0.000000012494366309 * 1e18
             }
         );
@@ -497,7 +497,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              8_105.430237884635118282 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 0.000000012317209569 * 1e18
             }
         );
@@ -536,7 +536,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 auctionPrice:      0.000000006239767680 * 1e18,
                 debtInAuction:     8_195.704467159075241912 * 1e18,
                 thresholdPrice:    8.196079597628232153 * 1e18,
-                neutralPrice:      8.596021534820399874 * 1e18
+                neutralPrice:      8.596021534820399875 * 1e18
             })
         );
 
@@ -545,7 +545,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              8_196.079597628232153239 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 0.000000012180980150 * 1e18
             }
         );
@@ -585,7 +585,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              8_196.079591450862150038 * 1e18,
                 borrowerCollateral:        0,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 0
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -131,7 +131,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -131,7 +131,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:                  _borrower2,
                 borrowerDebt:              7_987.673076923076926760 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
-                borrowert0Np:              8.471136974495192173 * 1e18,
+                borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 1.217037273735858713 * 1e18
             }
         );

--- a/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
@@ -146,7 +146,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        4 * 1e18,
-                borrowert0Np:              1_320.018028846153846761 * 1e18,
+                borrowert0Np:              1_320.018028846153846762 * 1e18,
                 borrowerCollateralization: 2.402776420583669600 * 1e18
             }
         );
@@ -171,7 +171,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              1_769.199519230769231584 * 1e18,
+                borrowert0Np:              1_769.199519230769231585 * 1e18,
                 borrowerCollateralization: 1.799097776455867782 * 1e18
             }
         );
@@ -392,7 +392,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower3,
                 borrowerDebt:              expectedBorrower3Debt,
                 borrowerCollateral:        1 * 1e18,
-                borrowert0Np:              2_640.541083248800813686 * 1e18,
+                borrowert0Np:              2_640.541083248800813687 * 1e18,
                 borrowerCollateralization: 1.197213816827790670 * 1e18
             }
         );
@@ -444,7 +444,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower3,
                 borrowerDebt:              expectedBorrower3Debt,
                 borrowerCollateral:        1 * 1e18,
-                borrowert0Np:              2_640.541083248800813686 * 1e18,
+                borrowert0Np:              2_640.541083248800813687 * 1e18,
                 borrowerCollateralization: 1.197186483491030227 * 1e18
             }
         );
@@ -644,7 +644,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              1_768.770194990485967967 * 1e18,
+                borrowert0Np:              1_768.770194990485967968 * 1e18,
                 borrowerCollateralization: 1.798355810258620132 * 1e18
             }
         );
@@ -670,7 +670,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.944439289318232278 * 1e18,
+                borrowert0Np:              2_133.944439289318232279 * 1e18,
                 borrowerCollateralization: 1.496905435432969068 * 1e18
             }
         );
@@ -699,7 +699,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.944439289318232278 * 1e18,
+                borrowert0Np:              2_133.944439289318232279 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
         );

--- a/tests/forge/Heap.t.sol
+++ b/tests/forge/Heap.t.sol
@@ -232,17 +232,6 @@ contract HeapTest is DSTestPlus {
         assertEq(_loans.getTotalTps(),    7);
     }
 
-    function testHeapUpsertRequireChecks() public {
-        address b1 = makeAddr("b1");
-        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
-        _loans.upsertTp(b1, 0);
-
-        _loans.upsertTp(b1, 100 * 1e18);
-
-        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
-        _loans.upsertTp(b1, 0);
-    }
-
     function testLoadHeapFuzzy(uint256 inserts_) public {
 
         // test adding different TPs


### PR DESCRIPTION
- concentrate all logic to update loan in Loans.update (heap update / remove + threshold price, calculate neutral price based on same threshold price - this changed some test assertion by 1 WAD)
- check only once if auction is active
- boost coverage by getting rid of `using` for libraries