### PR TITLE
Fix repay debt - double calculation of EMAs in same block

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -464,9 +464,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         bool repay = maxQuoteTokenAmountToRepay_ != 0;
         bool pull  = collateralAmountToPull_ != 0;
+
         uint256 borrowerDebt = Maths.wmul(borrower.t0debt, poolState.inflator);
         // loan can only be in auction when repaying debt
-        // if loan in auction and pull collateral then borrower collateralization check should revert
+        // if loan in auction and pull collateral attempted then borrower collateralization check should revert
         bool inAuction;
 
         if (repay) {
@@ -501,8 +502,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             }
 
             borrower.t0debt -= t0repaidDebt;
-
-            t0poolDebt -= t0repaidDebt;
+            t0poolDebt      -= t0repaidDebt;
         }
 
         if (pull) {
@@ -517,8 +517,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
             borrower.collateral  -= collateralAmountToPull_;
             poolState.collateral -= collateralAmountToPull_;
-
-            pledgedCollateral = poolState.collateral;
+            pledgedCollateral    = poolState.collateral;
         }
 
         // update loan state
@@ -534,6 +533,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             inAuction,
             pull // stamp borrower t0Np only for pull collateral action
         );
+
+        // update pool global interest rate state
         _updateInterestParams(poolState, newLup_);
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -536,6 +536,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _updateInterestParams(poolState, newLup_);
     }
 
+    /***********************************/
+    /*** Auctions Internal Functions ***/
+    /***********************************/
+
     /**
      *  @notice Updates loan with result of a take action. Settles auction if borrower becomes collateralized.
      *  @notice Saves loan state, t0 debt and collateral pledged pool accumulators and updates pool interest state.
@@ -601,17 +605,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         pledgedCollateral = poolState_.collateral;
     }
 
-    function _checkMinDebt(uint256 accruedDebt_,  uint256 borrowerDebt_) internal view {
-        if (borrowerDebt_ != 0) {
-            uint256 loansCount = Loans.noOfLoans(loans);
-            if (
-                loansCount >= 10
-                &&
-                (borrowerDebt_ < _minDebtAmount(accruedDebt_, loansCount))
-            ) revert AmountLTMinDebt();
-        }
-    }
-
     /******************************/
     /*** Pool Virtual Functions ***/
     /******************************/
@@ -671,6 +664,17 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         } else if (poolState_.accruedDebt == 0) {
             inflatorSnapshot           = uint208(Maths.WAD);
             lastInflatorSnapshotUpdate = uint48(block.timestamp);
+        }
+    }
+
+    function _checkMinDebt(uint256 accruedDebt_,  uint256 borrowerDebt_) internal view {
+        if (borrowerDebt_ != 0) {
+            uint256 loansCount = Loans.noOfLoans(loans);
+            if (
+                loansCount >= 10
+                &&
+                (borrowerDebt_ < _minDebtAmount(accruedDebt_, loansCount))
+            ) revert AmountLTMinDebt();
         }
     }
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -216,11 +216,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             params
         );
 
-        borrower.collateral  -= collateralAmount;
-        poolState.collateral -= collateralAmount;
-
-        _payLoan(t0repayAmount, poolState, params.borrower, borrower);
-        pledgedCollateral = poolState.collateral;
+        _takeFromLoan(poolState, borrower, params.borrower, collateralAmount, t0repayAmount);
 
         _transferCollateral(callee_, collateralAmount);
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -233,9 +233,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             excessQuoteToken = Maths.wmul(collateralTaken - collateralAmount, auctionPrice);
         }
 
-        borrower.collateral  -= collateralTaken;
-        poolState.collateral -= collateralTaken;
-
         // transfer rounded collateral from pool to taker
         uint256[] memory tokensTaken = _transferFromPoolToAddress(callee_, borrowerTokenIds[params.borrower], collateralTaken / 1e18);
 
@@ -253,8 +250,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (excessQuoteToken != 0) _transferQuoteToken(params.borrower, excessQuoteToken);
 
-        _payLoan(t0repayAmount, poolState, params.borrower, borrower);
-        pledgedCollateral = poolState.collateral;
+        _takeFromLoan(poolState, borrower, params.borrower, collateralTaken, t0repayAmount);
     }
 
 

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -399,7 +399,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    0.000000452724663788 * 1e18,
+                targetUtilization:    0.166838815388013307 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
@@ -409,8 +409,8 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         );
         _assertEMAs(
             {
-                debtEma:   116.548760023014994270 * 1e18,
-                lupColEma: 257_438_503.676217090117659874 * 1e18
+                debtEma:   128.680263773096486341 * 1e18,
+                lupColEma: 771.284928353319164825 * 1e18
             }
         );
 


### PR DESCRIPTION
- `_updateInterestRate` was called twice (through `_repayDebt` function) in the same block so EMAs were updated twice to unreasonable values
- renamed `_payLoan` to `_takeFromLoan` and called only from `*Take` functions
- logic to handle `_repayDebt` is now in line and follows the same flow as `_drawDebt`, updating states at the end of the call
- slightly gas optimization

```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 105530          | 161040 | 145740 | 654646 | 60004   |
| bucketTake                                 | 341017          | 406169 | 406186 | 471289 | 4       |
| drawDebt                                   | 201660          | 246324 | 222117 | 738921 | 136003  |
| kick                                       | 130118          | 158805 | 154972 | 936228 | 48000   |
| kickWithDeposit                            | 184158          | 218989 | 213878 | 947512 | 8000    |
| moveQuoteToken                             | 282780          | 282780 | 282780 | 282780 | 1       |
| removeQuoteToken                           | 142371          | 164411 | 168673 | 191328 | 4000    |
| repayDebt                                  | 499837          | 531867 | 521261 | 679831 | 16002   |
| settle                                     | 254532          | 254532 | 254532 | 254532 | 1       |
| take                                       | 41724           | 50006  | 51706  | 331992 | 15998   |

vs

| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 105530          | 161040 | 145740 | 654646 | 60004   |
| bucketTake                                 | 341198          | 406373 | 406389 | 471515 | 4       |
| drawDebt                                   | 202066          | 246731 | 222523 | 739330 | 136003  |
| kick                                       | 130118          | 158805 | 154972 | 936228 | 48000   |
| kickWithDeposit                            | 184158          | 218989 | 213878 | 947512 | 8000    |
| moveQuoteToken                             | 279731          | 279731 | 279731 | 279731 | 1       |
| removeQuoteToken                           | 142371          | 164411 | 169267 | 192516 | 4000    |
| repayDebt                                  | 499900          | 531930 | 521324 | 679894 | 16002   |
| settle                                     | 254532          | 254532 | 254532 | 254532 | 1       |
| take                                       | 41907           | 50189  | 51888  | 332175 | 15998   |
```