### PR TITLE
Validate LP in bucket matches sum of lender LPB

### DIFF
--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -23,9 +23,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
 
-    mapping(address => EnumerableSet.UintSet) bidderDepositedIndex;
-    EnumerableSet.AddressSet bidders;
-
     event Transfer(address indexed from, address indexed to, uint256 value);
 
     /*****************/
@@ -126,9 +123,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             redeemLendersLp(lenders.at(i), lendersDepositedIndex[lenders.at(i)]);
         }
 
-        for(uint i = 0; i < bidders.length(); i++ ) {
-            redeemLendersLp(bidders.at(i), bidderDepositedIndex[bidders.at(i)]);
-        }
         validateEmpty(bucketsUsed);
     }
 
@@ -167,8 +161,8 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
 
         // Add for tearDown
-        bidders.add(from);
-        bidderDepositedIndex[from].add(index);
+        lenders.add(from);
+        lendersDepositedIndex[from].add(index);
         bucketsUsed.add(index); 
 
         return ERC20Pool(address(_pool)).addCollateral(amount, index);
@@ -359,10 +353,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             if(lenders.contains(from)){
                 lenders.add(to);
                 lendersDepositedIndex[to].add(indexes[i]);
-            }
-            else{
-                bidders.add(to);
-                bidderDepositedIndex[to].add(indexes[i]);
             }
         }
     }

--- a/tests/forge/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.14;
 
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
 import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
 import 'src/erc20/ERC20Pool.sol';
@@ -10,10 +12,13 @@ import 'src/base/interfaces/pool/IPoolErrors.sol';
 
 contract ERC20PoolMulticallTest is ERC20HelperContract {
 
+    using EnumerableSet for EnumerableSet.AddressSet;
+
     address internal _lender;
 
     function setUp() external {
-        _lender    = makeAddr("lender");
+        _lender = makeAddr("lender");
+        lenders.add(_lender);
 
         _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
     }

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -491,7 +491,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1, 18);
         uint256 bucketId            = bound(uint256(bucketId_),                    1, 7388);
         uint256 quoteAmount         = bound(uint256(quoteAmount_),                 0, 1e22 * 1e18);
-        uint256 collateralAmount    = bound(uint256(collateralAmount_),            1e8, 1e12 * 1e18);
+        uint256 collateralAmount    = bound(uint256(collateralAmount_),            1e9, 1e12 * 1e18);
         _collateralPrecision        = uint256(10) ** boundColPrecision;
         _quotePrecision             = uint256(10) ** boundQuotePrecision;
         init(boundColPrecision, boundQuotePrecision);
@@ -622,8 +622,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         emit Transfer(from, address(_pool), amount / ERC20Pool(address(_pool)).collateralScale());
 
         // Add for tearDown
-        bidders.add(from);
-        bidderDepositedIndex[from].add(index);
+        lenders.add(from);
+        lendersDepositedIndex[from].add(index);
         bucketsUsed.add(index); 
 
         return ERC20Pool(address(_pool)).addCollateral(amount, index);

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -401,8 +401,8 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721Pool(address(_pool)).mergeOrRemoveCollateral(removeCollateralAtIndex, noOfNFTsToRemove, toIndex);
 
         // Add for tearDown
-        bidders.add(from);
-        bidderDepositedIndex[from].add(toIndex);
+        lenders.add(from);
+        lendersDepositedIndex[from].add(toIndex);
         bucketsUsed.add(toIndex);
     }
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -30,9 +30,6 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
     mapping(uint256 => uint256) NFTidToIndex;
 
-    mapping(address => EnumerableSet.UintSet) bidderDepositedIndex;
-    EnumerableSet.AddressSet bidders;
-
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
 
     /*****************/
@@ -154,10 +151,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         for (uint i = 0; i < lenders.length(); i++) {
             redeemLenderLps(lenders.at(i), lendersDepositedIndex[lenders.at(i)]);
         }
-
-        for( uint256 i = 0; i < bidders.length(); i++) {
-            redeemLenderLps(bidders.at(i), bidderDepositedIndex[bidders.at(i)]);
-        }
+        
         validateEmpty(bucketsUsed);
     }
 
@@ -187,8 +181,8 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         }
 
         // Add for tearDown
-        bidders.add(from);
-        bidderDepositedIndex[from].add(index);
+        lenders.add(from);
+        lendersDepositedIndex[from].add(index);
         bucketsUsed.add(index); 
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -483,6 +483,30 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         assertEq(availableCollateral, collateral);
         assertEq(curDeposit,          deposit);
         assertEq(rate,                exchangeRate);
+
+        _validateBucketLp(index, lpBalance);
+    }
+
+
+    function _validateBucketLp(
+        uint256 index,
+        uint256 lpBalance
+    ) internal {
+        uint256 lenderLps = 0;
+
+        uint256 curLpBalance;
+        // sum up LP across lenders
+        for(uint i = 0; i < lenders.length(); i++ ){
+            (curLpBalance, ) = _pool.lenderInfo(index, lenders.at(i));
+            lenderLps += curLpBalance;
+        }
+        // handle borrowers awarded LP from liquidation
+        for(uint i = 0; i < borrowers.length(); i++ ){
+            (curLpBalance, ) = _pool.lenderInfo(index, borrowers.at(i));
+            lenderLps += curLpBalance;
+        }
+
+        assertEq(lenderLps, lpBalance);
     }
 
     function _assertBorrower(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -502,8 +502,11 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         }
         // handle borrowers awarded LP from liquidation
         for(uint i = 0; i < borrowers.length(); i++ ){
-            (curLpBalance, ) = _pool.lenderInfo(index, borrowers.at(i));
-            lenderLps += curLpBalance;
+            address borrower = borrowers.at(i);
+            if (!lenders.contains(borrower)) {
+                (curLpBalance, ) = _pool.lenderInfo(index, borrowers.at(i));
+                lenderLps += curLpBalance;
+            }
         }
 
         assertEq(lenderLps, lpBalance);


### PR DESCRIPTION
Integrated this invariant test such that every call to `_assertBucket` implicitly checks it.
Eliminated the `bidders` set to simplify, categorizing these actors as lenders (since they have LPB).
Unrelated, adjusted bounds in `testFuzzedDepositTwoActorSameBucket` for case @grandizzy found.