### PR TITLE
Code coverage improvements

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -351,9 +351,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             maxAmount_
         );
 
-        IERC20Token ajnaToken = IERC20Token(_getArgAddress(AJNA_ADDRESS));
-        if (!ajnaToken.transferFrom(msg.sender, address(this), ajnaRequired)) revert ERC20TransferFailed();
-        ajnaToken.burn(ajnaRequired);
+        IERC20(_getArgAddress(AJNA_ADDRESS)).safeTransferFrom(msg.sender, address(this), ajnaRequired);
+        IERC20Token(_getArgAddress(AJNA_ADDRESS)).burn(ajnaRequired);
         _transferQuoteToken(msg.sender, amount_);
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -851,8 +851,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function lenderInfo(
         uint256 index_,
         address lender_
-    ) external view override returns (uint256, uint256) {
-        return Buckets.getLenderInfo(buckets, index_, lender_);
+    ) external view override returns (uint256 lpBalance_, uint256 depositTime_) {
+        depositTime_ = buckets[index_].lenders[lender_].depositTime;
+        if (buckets[index_].bankruptcyTime < depositTime_) lpBalance_ = buckets[index_].lenders[lender_].lps;
     }
 
     function loanInfo(

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -189,7 +189,6 @@ import '../libraries/Maths.sol';
      *  @param  maxQuoteToken_    The max quote token amount to calculate LPs for.
      *  @param  bucketPrice_      Bucket price.
      *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given LPs amount.
-     *  @return lps_              Amount of bucket LPs corresponding for calculated quote token amount.
      */
     function _lpsToQuoteToken(
         uint256 bucketLPs_,
@@ -198,12 +197,11 @@ import '../libraries/Maths.sol';
         uint256 lenderLPsBalance_,
         uint256 maxQuoteToken_,
         uint256 bucketPrice_
-    ) pure returns (uint256 quoteTokenAmount_, uint256 lps_) {
+    ) pure returns (uint256 quoteTokenAmount_) {
         uint256 rate = Buckets.getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
         quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
         if (quoteTokenAmount_ > deposit_) quoteTokenAmount_ = deposit_;
         if (quoteTokenAmount_ > maxQuoteToken_) quoteTokenAmount_ = maxQuoteToken_;
-        lps_ = Maths.wrdivr(quoteTokenAmount_, rate);
     }
 
     /*********************************/

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -6,6 +6,7 @@ import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 
 import { PoolType } from './interfaces/IPool.sol';
 
+import '../libraries/Buckets.sol';
 import '../libraries/Maths.sol';
 
     error BucketIndexOutOfBounds();
@@ -151,6 +152,58 @@ import '../libraries/Maths.sol';
             collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
             return Maths.wmul(collateral_, price_) >= debt_;
         }
+    }
+
+    /**
+     *  @notice Returns the amount of collateral calculated for the given amount of LPs.
+     *  @param  bucketCollateral_ Amount of collateral in bucket.
+     *  @param  bucketLPs_        Amount of LPs in bucket.
+     *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
+     *  @param  lenderLPsBalance_ The amount of LPs to calculate collateral for.
+     *  @param  bucketPrice_      Bucket price.
+     *  @return collateralAmount_ Amount of collateral calculated for the given LPs amount.
+     */
+    function _lpsToCollateral(
+        uint256 bucketCollateral_,
+        uint256 bucketLPs_,
+        uint256 deposit_,
+        uint256 lenderLPsBalance_,
+        uint256 bucketPrice_
+    ) pure returns (uint256 collateralAmount_) {
+        // max collateral to lps
+        uint256 rate = Buckets.getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
+
+        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), bucketPrice_);
+        if (collateralAmount_ > bucketCollateral_) {
+            // user is owed more collateral than is available in the bucket
+            collateralAmount_ = bucketCollateral_;
+        }
+    }
+
+    /**
+     *  @notice Returns the amount of quote tokens calculated for the given amount of LPs.
+     *  @param  bucketLPs_        Amount of LPs in bucket.
+     *  @param  bucketCollateral_ Amount of collateral in bucket.
+     *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
+     *  @param  lenderLPsBalance_ The amount of LPs to calculate quote token amount for.
+     *  @param  maxQuoteToken_    The max quote token amount to calculate LPs for.
+     *  @param  bucketPrice_      Bucket price.
+     *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given LPs amount.
+     *  @return lps_              Amount of bucket LPs corresponding for calculated quote token amount.
+     */
+    function _lpsToQuoteToken(
+        uint256 bucketLPs_,
+        uint256 bucketCollateral_,
+        uint256 deposit_,
+        uint256 lenderLPsBalance_,
+        uint256 maxQuoteToken_,
+        uint256 bucketPrice_
+    ) pure returns (uint256 quoteTokenAmount_, uint256 lps_) {
+        uint256 rate = Buckets.getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
+        quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
+        if (quoteTokenAmount_ > deposit_) quoteTokenAmount_ = deposit_;
+        if (quoteTokenAmount_ > maxQuoteToken_) quoteTokenAmount_ = maxQuoteToken_;
+        lps_ = Maths.wrdivr(quoteTokenAmount_, rate);
     }
 
     /*********************************/

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -300,7 +300,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256 quoteAmount_) {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
-        (quoteAmount_, ) = _lpsToQuoteToken(
+        quoteAmount_ = _lpsToQuoteToken(
             bucketLPs_,
             bucketCollateral,
             bucketDeposit,

--- a/src/base/PoolInfoUtils.sol
+++ b/src/base/PoolInfoUtils.sol
@@ -300,7 +300,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256 quoteAmount_) {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
-        (quoteAmount_, ) = Buckets.lpsToQuoteToken(
+        (quoteAmount_, ) = _lpsToQuoteToken(
             bucketLPs_,
             bucketCollateral,
             bucketDeposit,
@@ -377,30 +377,4 @@ contract PoolInfoUtils {
         uint256 lupColEma_
     ) pure returns (uint256) {
         return (debtEma_ != 0 && lupColEma_ != 0) ? Maths.wdiv(debtEma_, lupColEma_) : Maths.WAD;
-    }
-
-    /**
-     *  @notice Returns the amount of collateral calculated for the given amount of LPs.
-     *  @param  bucketCollateral_ Amount of collateral in bucket.
-     *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  lenderLPsBalance_ The amount of LPs to calculate collateral for.
-     *  @param  bucketPrice_      Bucket price.
-     *  @return collateralAmount_ Amount of collateral calculated for the given LPs amount.
-     */
-    function _lpsToCollateral(
-        uint256 bucketCollateral_,
-        uint256 bucketLPs_,
-        uint256 deposit_,
-        uint256 lenderLPsBalance_,
-        uint256 bucketPrice_
-    ) pure returns (uint256 collateralAmount_) {
-        // max collateral to lps
-        uint256 rate = Buckets.getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
-
-        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), bucketPrice_);
-        if (collateralAmount_ > bucketCollateral_) {
-            // user is owed more collateral than is available in the bucket
-            collateralAmount_ = bucketCollateral_;
-        }
     }

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -21,8 +21,9 @@ import './PoolHelper.sol';
 
 import '../libraries/Buckets.sol';
 import '../libraries/Maths.sol';
-import '../libraries/SafeTokenNamer.sol';
 import '../libraries/external/PositionNFTSVG.sol';
+
+import { tokenSymbol } from '../libraries/SafeTokenNamer.sol';
 
 contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, ReentrancyGuard {
     using EnumerableSet for EnumerableSet.UintSet;
@@ -193,8 +194,8 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         address quoteTokenAddress = IPool(poolKey[tokenId_]).quoteTokenAddress();
 
         PositionNFTSVG.ConstructTokenURIParams memory params = PositionNFTSVG.ConstructTokenURIParams({
-            collateralTokenSymbol: SafeTokenNamer.tokenSymbol(collateralTokenAddress),
-            quoteTokenSymbol: SafeTokenNamer.tokenSymbol(quoteTokenAddress),
+            collateralTokenSymbol: tokenSymbol(collateralTokenAddress),
+            quoteTokenSymbol: tokenSymbol(quoteTokenAddress),
             tokenId: tokenId_,
             pool: poolKey[tokenId_],
             owner: ownerOf(tokenId_),

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -82,7 +82,8 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         uint256 indexesLength = params_.indexes.length;
         for (uint256 i = 0; i < indexesLength; ) {
             // record price at which a position has added liquidity
-            if (!positionPrice.contains(params_.indexes[i])) if(!positionPrice.add(params_.indexes[i])) revert AddLiquidityFailed();
+            // slither-disable-next-line unused-return
+            positionPrice.add(params_.indexes[i]);
 
             // update PositionManager accounting
             (uint256 lpBalance,) = pool.lenderInfo(params_.indexes[i], owner);
@@ -125,7 +126,8 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         // update prices set at which a position has liquidity
         EnumerableSet.UintSet storage positionPrice = positionPrices[params_.tokenId];
         if (!positionPrice.remove(params_.fromIndex)) revert RemoveLiquidityFailed();
-        if (!positionPrice.contains(params_.toIndex)) if(!positionPrice.add(params_.toIndex)) revert AddLiquidityFailed();
+        // slither-disable-next-line unused-return
+        positionPrice.add(params_.toIndex);
 
         // move quote tokens in pool
         emit MoveLiquidity(owner, params_.tokenId);

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -115,7 +115,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         address owner = ownerOf(params_.tokenId);
 
         (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = IPool(params_.pool).bucketInfo(params_.fromIndex);
-        (uint256 maxQuote, ) = _lpsToQuoteToken(
+        uint256 maxQuote = _lpsToQuoteToken(
             bucketLPs,
             bucketCollateral,
             bucketDeposit,

--- a/src/base/PositionManager.sol
+++ b/src/base/PositionManager.sol
@@ -114,7 +114,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         address owner = ownerOf(params_.tokenId);
 
         (uint256 bucketLPs, uint256 bucketCollateral, , uint256 bucketDeposit, ) = IPool(params_.pool).bucketInfo(params_.fromIndex);
-        (uint256 maxQuote, ) = Buckets.lpsToQuoteToken(
+        (uint256 maxQuote, ) = _lpsToQuoteToken(
             bucketLPs,
             bucketCollateral,
             bucketDeposit,

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -120,11 +120,6 @@ interface IPoolErrors {
     error NoReserves();
 
     /**
-     *  @notice Underlying ERC20 transfer failed.
-     */
-    error ERC20TransferFailed();
-
-    /**
      *  @notice Borrower is attempting to borrow an amount of quote tokens that will push the pool into under-collateralization.
      */
     error PoolUnderCollateralized();

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -136,51 +136,6 @@ library Buckets {
     }
 
     /**
-     *  @notice Returns the lender info for a given bucket.
-     *  @param  index_       Index of the bucket.
-     *  @param  lender_      Lender's address.
-     *  @return lpBalance_   LPs balance of lender in current bucket.
-     *  @return depositTime_ Timestamp of last lender deposit in current bucket.
-     */
-    function getLenderInfo(
-        mapping(uint256 => Bucket) storage self,
-        uint256 index_,
-        address lender_
-    ) internal view returns (uint256 lpBalance_, uint256 depositTime_) {
-        depositTime_ = self[index_].lenders[lender_].depositTime;
-        if (self[index_].bankruptcyTime < depositTime_) lpBalance_ = self[index_].lenders[lender_].lps;
-    }
-
-    /**
-     *  @notice Returns the amount of collateral calculated for the given amount of LPs.
-     *  @param  bucketCollateral_ Amount of collateral in bucket.
-     *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  lenderLPsBalance_ The amount of LPs to calculate collateral for.
-     *  @param  bucketPrice_      Bucket price.
-     *  @return collateralAmount_ Amount of collateral calculated for the given LPs amount.
-     *  @return lenderLPs_        Amount of lender LPs corresponding for calculated collateral amount.
-     */
-    function lpsToCollateral(
-        uint256 bucketCollateral_,
-        uint256 bucketLPs_,
-        uint256 deposit_,
-        uint256 lenderLPsBalance_,
-        uint256 bucketPrice_
-    ) internal pure returns (uint256 collateralAmount_, uint256 lenderLPs_) {
-        // max collateral to lps
-        lenderLPs_  = lenderLPsBalance_;
-        uint256 rate = getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
-
-        collateralAmount_ = Maths.rwdivw(Maths.rmul(lenderLPsBalance_, rate), bucketPrice_);
-        if (collateralAmount_ > bucketCollateral_) {
-            // user is owed more collateral than is available in the bucket
-            collateralAmount_ = bucketCollateral_;
-            lenderLPs_        = Maths.wrdivr(Maths.wmul(collateralAmount_, bucketPrice_), rate);
-        }
-    }
-
-    /**
      *  @notice Returns the amount of quote tokens calculated for the given amount of LPs.
      *  @param  bucketLPs_        Amount of LPs in bucket.
      *  @param  bucketCollateral_ Amount of collateral in bucket.

--- a/src/libraries/Buckets.sol
+++ b/src/libraries/Buckets.sol
@@ -98,6 +98,28 @@ library Buckets {
     }
 
     /**
+     *  @notice Returns the amount of LPs calculated for the given amount of quote tokens.
+     *  @param  bucketCollateral_ Amount of collateral in bucket.
+     *  @param  bucketLPs_        Amount of LPs in bucket.
+     *  @param  deposit_     Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
+     *  @param  quoteTokens_ The amount of quote tokens to calculate LPs amount for.
+     *  @param  bucketPrice_ Price bucket.
+     *  @return The amount of LPs coresponding to the given quote tokens in current bucket.
+     */
+    function quoteTokensToLPs(
+        uint256 bucketCollateral_,
+        uint256 bucketLPs_,
+        uint256 deposit_,
+        uint256 quoteTokens_,
+        uint256 bucketPrice_
+    ) internal pure returns (uint256) {
+        return Maths.rdiv(
+            Maths.wadToRay(quoteTokens_),
+            getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_)
+        );
+    }
+
+    /**
      *  @notice Returns the exchange rate for a given bucket.
      *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  bucketLPs_        Amount of LPs in bucket.
@@ -133,53 +155,5 @@ library Buckets {
         return bucketLPs_ == 0 ? Maths.RAY :
             (bucketUnscaledDeposit_ + bucketPrice_ * bucketCollateral_ / bucketScale_ ) * 10**36 / bucketLPs_;
             // 10^18 * 1e36 / 10^27 = 10^54 / 10^27 = 10^27
-    }
-
-    /**
-     *  @notice Returns the amount of quote tokens calculated for the given amount of LPs.
-     *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  bucketCollateral_ Amount of collateral in bucket.
-     *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  lenderLPsBalance_ The amount of LPs to calculate quote token amount for.
-     *  @param  maxQuoteToken_    The max quote token amount to calculate LPs for.
-     *  @param  bucketPrice_      Bucket price.
-     *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given LPs amount.
-     *  @return lps_              Amount of bucket LPs corresponding for calculated quote token amount.
-     */
-    function lpsToQuoteToken(
-        uint256 bucketLPs_,
-        uint256 bucketCollateral_,
-        uint256 deposit_,
-        uint256 lenderLPsBalance_,
-        uint256 maxQuoteToken_,
-        uint256 bucketPrice_
-    ) internal pure returns (uint256 quoteTokenAmount_, uint256 lps_) {
-        uint256 rate = getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
-        quoteTokenAmount_ = Maths.rayToWad(Maths.rmul(lenderLPsBalance_, rate));
-        if (quoteTokenAmount_ > deposit_) quoteTokenAmount_ = deposit_;
-        if (quoteTokenAmount_ > maxQuoteToken_) quoteTokenAmount_ = maxQuoteToken_;
-        lps_ = Maths.wrdivr(quoteTokenAmount_, rate);
-    }
-
-    /**
-     *  @notice Returns the amount of LPs calculated for the given amount of quote tokens.
-     *  @param  bucketCollateral_ Amount of collateral in bucket.
-     *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  deposit_     Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  quoteTokens_ The amount of quote tokens to calculate LPs amount for.
-     *  @param  bucketPrice_ Price bucket.
-     *  @return The amount of LPs coresponding to the given quote tokens in current bucket.
-     */
-    function quoteTokensToLPs(
-        uint256 bucketCollateral_,
-        uint256 bucketLPs_,
-        uint256 deposit_,
-        uint256 quoteTokens_,
-        uint256 bucketPrice_
-    ) internal pure returns (uint256) {
-        return Maths.rdiv(
-            Maths.wadToRay(quoteTokens_),
-            getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_)
-        );
     }
 }

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -27,10 +27,6 @@ library Maths {
         return x * 10**18;
     }
 
-    function ray(uint256 x) internal pure returns (uint256) {
-        return x * 10**27;
-    }
-
     function rmul(uint256 x, uint256 y) internal pure returns (uint256) {
         return (x * y + 10**27 / 2) / 10**27;
     }
@@ -42,11 +38,6 @@ library Maths {
     /** @notice Divides a WAD by a RAY and returns a RAY */
     function wrdivr(uint256 x, uint256 y) internal pure returns (uint256) {
         return (x * 1e36 + y / 2) / y;
-    }
-
-    /** @notice Divides a WAD by a RAY and returns a WAD */
-    function wrdivw(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * 1e27 + y / 2) / y;
     }
 
     /** @notice Divides a WAD by a WAD and returns a RAY */
@@ -82,32 +73,6 @@ library Maths {
 
     function rayToWad(uint256 x) internal pure returns (uint256) {
         return (x + 10**9 / 2) / 10**9;
-    }
-
-    /**
-     * @notice Round up a fraction to the nearest integer
-     * @dev Doesn't check over or underflows
-     */
-    function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
-        assembly {
-            z := add(div(x, y), gt(mod(x, y), 0))
-        }
-    }
-
-    /**
-     * @notice Round up a fraction to the nearest integer
-     * @dev Based upon OZ Math.ceilDiv()
-     */
-    function divRoundingUpSafe(uint256 a, uint256 b) internal pure returns (uint256) {
-        // (a + b - 1) / b can overflow on addition, so we distribute.
-        return a / b + (a % b == 0 ? 0 : 1);
-    }
-
-    /**
-     * @notice Convert a WAD to an integer, rounding down
-     */
-    function wadToIntRoundingDown(uint256 a) internal pure returns (uint256) {
-        return wdiv(a, 10 ** 18) / 10 ** 18;
     }
 
     /*************************/

--- a/src/libraries/SafeTokenNamer.sol
+++ b/src/libraries/SafeTokenNamer.sol
@@ -4,14 +4,13 @@ pragma solidity 0.8.14;
 
 // produces token descriptors from inconsistent or absent ERC20 symbol implementations that can return string or bytes32
 // this library will always produce a string symbol to represent the token
-library SafeTokenNamer {
 
     /**********************/
     /*** View Functions ***/
     /**********************/
 
     // attempts to extract the token symbol. if it does not implement symbol, returns a symbol derived from the address
-    function tokenSymbol(address token) internal view returns (string memory symbol_) {
+    function tokenSymbol(address token) view returns (string memory symbol_) {
         // 0x95d89b41 = bytes4(keccak256("symbol()"))
         symbol_ = _callAndParseStringReturn(token, 0x95d89b41);
         if (bytes(symbol_).length == 0) {
@@ -21,7 +20,7 @@ library SafeTokenNamer {
     }
 
     // attempts to extract the token name. if it does not implement name, returns a name derived from the address
-    function tokenName(address token) internal view returns (string memory name_) {
+    function tokenName(address token) view returns (string memory name_) {
         // 0x06fdde03 = bytes4(keccak256("name()"))
         name_ = _callAndParseStringReturn(token, 0x06fdde03);
         if (bytes(name_).length == 0) {
@@ -35,7 +34,7 @@ library SafeTokenNamer {
     /*************************/
 
     // calls an external view token contract method that returns a symbol or name, and parses the output into a string
-    function _callAndParseStringReturn(address token, bytes4 selector) private view returns (string memory) {
+    function _callAndParseStringReturn(address token, bytes4 selector) view returns (string memory) {
         (bool success, bytes memory data) = token.staticcall(abi.encodeWithSelector(selector));
         // if not implemented, or returns empty data, return empty string
         if (!success || data.length == 0) {
@@ -55,7 +54,7 @@ library SafeTokenNamer {
     /*** Type Conversion Functions ***/
     /*********************************/
 
-    function _bytes32ToString(bytes32 x) private pure returns (string memory) {
+    function _bytes32ToString(bytes32 x) pure returns (string memory) {
         bytes memory bytesString = new bytes(32);
         uint256 charCount = 0;
         for (uint256 j = 0; j < 32; j++) {
@@ -73,7 +72,7 @@ library SafeTokenNamer {
     }
 
     // converts an address to the uppercase hex string, extracting only len bytes (up to 20, multiple of 2)
-    function _toAsciiString(address addr, uint256 len) private pure returns (string memory) {
+    function _toAsciiString(address addr, uint256 len) pure returns (string memory) {
         require(len % 2 == 0 && len > 0 && len <= 40, 'SafeERC20Namer: INVALID_LEN');
 
         bytes memory s = new bytes(len);
@@ -94,11 +93,10 @@ library SafeTokenNamer {
     // hi and lo are only 4 bits and between 0 and 16
     // this method converts those values to the unicode/ascii code point for the hex representation
     // uses upper case for the characters
-    function _char(uint8 b) private pure returns (bytes1 c) {
+    function _char(uint8 b) pure returns (bytes1 c) {
         if (b < 10) {
             return bytes1(b + 0x30);
         } else {
             return bytes1(b + 0x37);
         }
     }
-}

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -372,6 +372,15 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).addCollateral(amount, index);
     }
 
+    function _assertAddCollateralAtIndex0Revert(
+        address from,
+        uint256 amount
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InvalidIndex.selector);
+        ERC20Pool(address(_pool)).addCollateral(amount, 0);
+    }
+
     function _assertDeployWith0xAddressRevert(
         address poolFactory,
         address collateral,

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -430,6 +430,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
     }
 
+    function _assertPullBorrowerNotSenderRevert(
+        address from,
+        address borrower,
+        uint256 amount
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.BorrowerNotSender.selector);
+        ERC20Pool(address(_pool)).repayDebt(borrower, 0, amount);
+    }
+
     function _assertRepayMinDebtRevert(
         address from,
         address borrower,
@@ -498,6 +508,17 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         changePrank(from);
         vm.expectRevert(IPoolErrors.BorrowerUnderCollateralized.selector);
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
+    }
+
+    function _assertBorrowBorrowerNotSenderRevert(
+        address from,
+        address borrower,
+        uint256 amount,
+        uint256 indexLimit
+    ) internal override {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.BorrowerNotSender.selector);
+        ERC20Pool(address(_pool)).drawDebt(borrower, amount, indexLimit, 0);
     }
 
     function _assertBorrowLimitIndexRevert(

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -575,13 +575,23 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
      *              Attempts to borrow when result would be borrower under collateralization.
      *              Attempts to borrow when result would be pool under collateralization.
      */
-    function testPoolBorrowRequireChecks() external tearDown {
+    function testPoolBorrowReverts() external tearDown {
         // should revert if borrower attempts to borrow with an out of bounds limitIndex
         _assertBorrowLimitIndexRevert(
             {
                 from:       _borrower,
                 amount:     1_000 * 1e18,
                 indexLimit: 1000
+            }
+        );
+
+        // should revert if borrower tries to borrow on behalf of different address
+        _assertBorrowBorrowerNotSenderRevert(
+            {
+                from:       _borrower,
+                borrower:   _borrower2,
+                amount:     1 * 1e18,
+                indexLimit: 7000
             }
         );
 
@@ -681,7 +691,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
      *              Attempts to repay without debt.
      *              Attempts to repay when bucket would be left with amount less than averge debt.
      */
-    function testPoolRepayRequireChecks() external tearDown {
+    function testPoolRepayReverts() external tearDown {
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
 
         // should revert if borrower has no debt
@@ -689,6 +699,14 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             {
                 from:     _borrower,
                 borrower: _borrower,
+                amount:   10_000 * 1e18
+            }
+        );
+
+        _assertPullBorrowerNotSenderRevert(
+            {
+                from:     _borrower,
+                borrower: _borrower2,
                 amount:   10_000 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -235,6 +235,14 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         // test setup
         _mintCollateralAndApproveTokens(_bidder,  100 * 1e18);
 
+        // should revert if adding collateral at index 0
+        _assertAddCollateralAtIndex0Revert(
+            {
+                from:   _bidder,
+                amount: 4 * 1e18
+            }
+        );
+
         // actor deposits collateral into a bucket
         _addCollateral(
             {
@@ -411,7 +419,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(address(_pool)),      0);
     }
 
-    function testRemoveCollateralRequireChecks() external tearDown {
+    function testRemoveCollateralReverts() external tearDown {
         uint256 testIndex = 6348;
 
         // should revert if no collateral in the bucket

--- a/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
+
+import 'src/base/PoolHelper.sol';
+import 'src/erc20/interfaces/IERC20Pool.sol';
+
+import 'src/erc20/ERC20Pool.sol';
+
+contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+    address internal _lender1;
+
+    uint256 highest = 2550;
+    uint256 high    = 2551;
+    uint256 med     = 2552;
+    uint256 low     = 2553;
+    uint256 lowest  = 2554;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender1   = makeAddr("lender1");
+
+        _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  100 * 1e18);
+
+        _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
+
+        // lender deposits 10000 DAI in 5 buckets each
+        _addLiquidity(
+            {
+                from:    _lender,
+                amount:  10_000 * 1e18,
+                index:   highest,
+                lpAward: 10_000 * 1e27,
+                newLup:  MAX_PRICE
+            }
+        );
+        _addLiquidity(
+            {
+                from:    _lender,
+                amount:  10_000 * 1e18,
+                index:   high,
+                lpAward: 10_000 * 1e27,
+                newLup:  MAX_PRICE
+            } 
+        ); 
+        _addLiquidity( 
+            { 
+                from:    _lender,
+                amount:  10_000 * 1e18,
+                index:   med,
+                lpAward: 10_000 * 1e27,
+                newLup:  MAX_PRICE
+            } 
+        ); 
+        _addLiquidity( 
+            { 
+                from:    _lender,
+                amount:  10_000 * 1e18,
+                index:   low,
+                lpAward: 10_000 * 1e27,
+                newLup:  MAX_PRICE
+            } 
+        ); 
+        _addLiquidity( 
+            { 
+                from:    _lender,
+                amount:  10_000 * 1e18,
+                index:   lowest,
+                lpAward: 10_000 * 1e27,
+                newLup:  MAX_PRICE
+            }
+        );
+
+
+        _drawDebt({
+            from: _borrower,
+            borrower: _borrower,
+            amountToBorrow: 21_000 * 1e18,
+            limitIndex: 3_000,
+            collateralToPledge: 100 * 1e18,
+            newLup: 2_981.007422784467321543 * 1e18
+        });
+    }
+
+    function testPoolInfoUtilsInvariantsFuzzed(uint256 depositIndex_, uint256 price_) external {
+        depositIndex_ = bound(depositIndex_, 0, 7388);
+        assertEq(_priceAt(depositIndex_), _poolUtils.indexToPrice(depositIndex_));
+
+        price_ = bound(price_, MIN_PRICE, MAX_PRICE);
+        assertEq(_indexOf(price_), _poolUtils.priceToIndex(price_));
+    }
+
+    function testPoolInfoUtilsBorrowerInfo() external {
+        (uint256 debt, uint256 collateral, uint256 t0Np) = _poolUtils.borrowerInfo(address(_pool), _borrower);
+        assertEq(debt,       21_020.192307692307702000 * 1e18);
+        assertEq(collateral, 100 * 1e18);
+        assertEq(t0Np,       220.712019230769230871 * 1e18);
+    }
+
+    function testPoolInfoUtilsBucketInfo() external {
+        (
+            uint256 price,
+            uint256 quoteTokens,
+            uint256 collateral,
+            uint256 bucketLPs,
+            uint256 scale,
+            uint256 exchangeRate
+        ) = _poolUtils.bucketInfo(address(_pool), 5000);
+        assertEq(price,        0.014854015662334135 * 1e18);
+        assertEq(quoteTokens,  0);
+        assertEq(collateral,   0);
+        assertEq(bucketLPs,    0);
+        assertEq(scale,        1 * 1e18);
+        assertEq(exchangeRate, 1 * 1e27);
+
+        (
+            price,
+            quoteTokens,
+            collateral,
+            bucketLPs,
+            scale,
+            exchangeRate
+        ) = _poolUtils.bucketInfo(address(_pool), high);
+        assertEq(price,        2_995.912459898389633881 * 1e18);
+        assertEq(quoteTokens,  10_000 * 1e18);
+        assertEq(collateral,   0);
+        assertEq(bucketLPs,    10_000 * 1e27);
+        assertEq(scale,        1 * 1e18);
+        assertEq(exchangeRate, 1 * 1e27);
+    }
+
+    function testPoolInfoUtilsLoansInfo() external {
+        (
+            uint256 poolSize,
+            uint256 loansCount,
+            address maxBorrower,
+            uint256 pendingInflator,
+            uint256 pendingInterestFactor
+        ) = _poolUtils.poolLoansInfo(address(_pool));
+        assertEq(poolSize,              50_000 * 1e18);
+        assertEq(loansCount,            1);
+        assertEq(maxBorrower,           _borrower);
+        assertEq(pendingInflator,       1 * 1e18);
+        assertEq(pendingInterestFactor, 1 * 1e18);
+    }
+
+    function testPoolInfoUtilsPricesInfo() external {
+        (
+            uint256 hpb,
+            uint256 hpbIndex,
+            uint256 htp,
+            uint256 htpIndex,
+            uint256 lup,
+            uint256 lupIndex
+        ) = _poolUtils.poolPricesInfo(address(_pool));
+        assertEq(hpb,      3_010.892022197881557845 * 1e18);
+        assertEq(hpbIndex, 2550);
+        assertEq(htp,      210.201923076923077020 * 1e18);
+        assertEq(htpIndex, 3083);
+        assertEq(lup,      2981.007422784467321543 * 1e18);
+        assertEq(lupIndex, 2552);
+
+        assertEq(hpb,      _poolUtils.hpb(address(_pool)));
+        assertEq(hpbIndex, _poolUtils.hpbIndex(address(_pool)));
+        assertEq(htp,      _poolUtils.htp(address(_pool)));
+        assertEq(lup,      _poolUtils.lup(address(_pool)));
+        assertEq(lupIndex, _poolUtils.lupIndex(address(_pool)));
+    }
+
+    function testPoolInfoUtilsReservesInfo() external {
+        (
+            uint256 reserves,
+            uint256 claimableReserves,
+            uint256 claimableReservesRemaining,
+            uint256 auctionPrice,
+            uint256 timeRemaining
+        ) = _poolUtils.poolReservesInfo(address(_pool));
+        assertEq(reserves,                   20.192307692307702000 * 1e18);
+        assertEq(claimableReserves,          0);
+        assertEq(claimableReservesRemaining, 0);
+        assertEq(auctionPrice,               0);
+        assertEq(timeRemaining,              0);
+    }
+
+    function testPoolInfoUtilsUtilizationInfo() external {
+        (
+            uint256 poolMinDebtAmount,
+            uint256 poolCollateralization,
+            uint256 poolActualUtilization,
+            uint256 poolTargetUtilization
+        ) = _poolUtils.poolUtilizationInfo(address(_pool));
+        assertEq(poolMinDebtAmount,     2_102.019230769230770200 * 1e18);
+        assertEq(poolCollateralization, 14.181637252165253251 * 1e18);
+        assertEq(poolActualUtilization, 0.420403846153846154 * 1e18);
+        assertEq(poolTargetUtilization, 1 * 1e18);
+    }
+
+    function testPoolInfoUtilsLenderInterestMargin() external {
+        uint256 lenderInterestMargin = _poolUtils.lenderInterestMargin(address(_pool));
+        assertEq(lenderInterestMargin, 0.874935776592563266 * 1e18);
+    }
+
+    function testPoolInfoUtilsLPsToCollateralAndQuote() external {
+        assertEq(
+            _poolUtils.lpsToCollateral(
+                address(_pool),
+                100 * 1e27,
+                high
+            ), 0
+        );
+        changePrank(_borrower2);
+        ERC20Pool(address(_pool)).addCollateral(10 * 1e18, high);
+
+        assertEq(
+            _poolUtils.lpsToCollateral(
+                address(_pool),
+                5 * 1e27,
+                high
+            ), 1668940620571264
+        );
+        assertEq(
+            _poolUtils.lpsToCollateral(
+                address(_pool),
+                20 * 1e27,
+                high
+            ), 6675762482285055
+        );
+
+        assertEq(
+            _poolUtils.lpsToQuoteTokens(
+                address(_pool),
+                100 * 1e27,
+                high
+            ), 100000000000000000000
+        );
+        assertEq(
+            _poolUtils.lpsToQuoteTokens(
+                address(_pool),
+                5 * 1e27,
+                high
+            ), 5000000000000000000
+        );
+        assertEq(
+            _poolUtils.lpsToQuoteTokens(
+                address(_pool),
+                20 * 1e27,
+                high
+            ), 20000000000000000000
+        );
+    }
+}

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -423,6 +423,36 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             }
         );
 
+        uint256 snapshot = vm.snapshot();
+        // kicker not saved if partial debt paid only
+        _repayDebt({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    0.0001 * 1e18,
+            amountRepaid:     0.0001 * 1e18,
+            collateralToPull: 0,
+            newLup:           9.721295865031779605 * 1e18
+        });
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            true,
+                kicker:            address(_lender),
+                bondSize:          0.195007546732047806 * 1e18,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          _startTime + 850 days,
+                kickMomp:          9.818751856078723036 * 1e18,
+                totalBondEscrowed: 0.195007546732047806 * 1e18,
+                auctionPrice:      314.200059394519137152 * 1e18,
+                debtInAuction:     19.720038163278334392 * 1e18,
+                thresholdPrice:    9.860019081639167196 * 1e18,
+                neutralPrice:      11.249003021186918284 * 1e18
+            })
+        );
+        vm.revertTo(snapshot);
+
+        // kicker saved if enough debt paid
         _repayDebt({
             from:             _borrower,
             borrower:         _borrower,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -278,7 +278,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             })
         );
 
-        // lender cannot withdraw
+        // lender cannot withdraw - deposit in buckets within liquidation debt from the top-of-book down are frozen
         _assertRemoveDepositLockedByAuctionDebtRevert(
             {
                 from:     _lender,
@@ -296,6 +296,11 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 toIndex:   _i9_81 
             }
         );
+
+        // lender can add / remove liquidity in buckets that are not within liquidation debt
+        changePrank(_lender1);
+        _pool.addQuoteToken(2_000 * 1e18, 5000);
+        _pool.removeQuoteToken(2_000 * 1e18, 5000);
 
         skip(3 hours);
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -287,6 +287,16 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             }
         );
 
+        // lender cannot move funds
+        _assertMoveDepositLockedByAuctionDebtRevert(
+            {
+                from:      _lender,
+                amount:    10.0 * 1e18,
+                fromIndex: _i9_72,
+                toIndex:   _i9_81 
+            }
+        );
+
         skip(3 hours);
 
         _assertBorrower(

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -33,6 +33,14 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
     function testPoolDepositQuoteToken() external tearDown {
         assertEq(_hpb(), MIN_PRICE);
 
+        // should revert if trying to deposit at index 0
+        _assertAddLiquidityAtIndex0Revert(
+            {
+                from:   _lender,
+                amount: 10_000 * 1e18
+            }
+        );
+
         // test 10_000 deposit at price of 3_010.892022197881557845
         _addInitialLiquidity(
             {
@@ -538,7 +546,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
      *              Attempts to remove more quote tokens than available from lpBalance.
      *              Attempts to remove quote token when doing so would drive lup below htp.
      */
-    function testPoolRemoveQuoteTokenRequireChecks() external tearDown {
+    function testPoolRemoveQuoteTokenReverts() external tearDown {
         _mintCollateralAndApproveTokens(_borrower, _collateral.balanceOf(_borrower) + 3_500_000 * 1e18);
         _mintCollateralAndApproveTokens(_lender, 1 * 1e18);
         // lender adds initial quote token
@@ -1042,7 +1050,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
      *              Attempts to move quote token from bucket with available collateral.
      *              Attempts to move quote token when doing so would drive lup below htp.
      */
-    function testPoolMoveQuoteTokenRequireChecks() external tearDown {
+    function testPoolMoveQuoteTokenReverts() external tearDown {
         // test setup
         _mintCollateralAndApproveTokens(_lender1, _collateral.balanceOf(_lender1) + 100_000 * 1e18);
         _mintCollateralAndApproveTokens(_borrower, _collateral.balanceOf(_lender1) + 1_500_000 * 1e18);
@@ -1092,6 +1100,15 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 amount:    5_000 * 1e18,
                 fromIndex: 4549,
                 toIndex:   4549
+            }
+        );
+
+        // should revert if moving quote token to index 0
+        _assertMoveLiquidityToIndex0Revert(
+            {
+                from:      _lender,
+                amount:    5_000 * 1e18,
+                fromIndex: 4549
             }
         );
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -87,7 +87,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
             if (bucketCollateral % 1e18 != 0) {
                 revert("Collateral needs to be reconstituted from other buckets");
             }
-            uint256 noOfBucketNftsRedeemable = Maths.wadToIntRoundingDown(bucketCollateral);
+            uint256 noOfBucketNftsRedeemable = _wadToIntRoundingDown(bucketCollateral);
 
             // Calculating redeemable Quote and Collateral Token for Lenders lps
             uint256 lpsAsCollateral = _poolUtils.lpsToCollateral(address(_pool), lenderLpBalance, bucketIndex);
@@ -111,7 +111,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
                 }
 
                 // First redeem LP for collateral
-                uint256 noOfNftsToRemove = Maths.min(Maths.wadToIntRoundingDown(lpsAsCollateral), noOfBucketNftsRedeemable);
+                uint256 noOfNftsToRemove = Maths.min(_wadToIntRoundingDown(lpsAsCollateral), noOfBucketNftsRedeemable);
                 (, lpsRedeemed) = _pool.removeCollateral(noOfNftsToRemove, bucketIndex);
             }
 
@@ -628,3 +628,10 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
         _ajnaToken.approve(address(_pool), type(uint256).max);
     }
 }
+
+    /**
+     * @notice Convert a WAD to an integer, rounding down
+     */
+    function _wadToIntRoundingDown(uint256 a) pure returns (uint256) {
+        return Maths.wdiv(a, 10 ** 18) / 10 ** 18;
+    }

--- a/tests/forge/MathTest.t.sol
+++ b/tests/forge/MathTest.t.sol
@@ -39,8 +39,6 @@ contract MathTest is DSTestPlus {
         assertEq(debt * 1e18 / price,       10.98202093218880245 * 1e18);
         assertEq(Maths.wwdivr(debt, price), 10.982020932188802450191601163 * 1e27);
 
-        assertEq(Maths.wrdivw(20 * 1e18, 10.982020932188802450191601163 * 1e27), 1.821158430082671857 * 1e18);
-
         uint256 exchangeRate = 1.09232010 * 1e27;
         assertEq(Maths.rdiv(Maths.wadToRay(debt), exchangeRate), Maths.wrdivr(debt, exchangeRate));
 
@@ -58,19 +56,8 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.rdiv(1 * 1e27, 3 * 1e27),  0.333333333333333333333333333 * 1e27);
     }
 
-    function testWadToIntRoundingDown() external {
-        uint256 testNum1  = 11_000.143012091382543917 * 1e18;
-        uint256 testNum2  = 1_001.6501589292607751220 * 1e18;
-        uint256 testNum3  = 0.6501589292607751220 * 1e18;
-
-        assertEq(Maths.wadToIntRoundingDown(testNum1), 11_000);
-        assertEq(Maths.wadToIntRoundingDown(testNum2), 1_001);
-        assertEq(Maths.wadToIntRoundingDown(testNum3), 0);
-    }
-
     function testScaleConversions() external {
         assertEq(Maths.wad(153), 153 * 1e18);
-        assertEq(Maths.ray(2009), 2009 * 1e27);
     } 
 
     function testExp() external {

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -2441,10 +2441,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // check retrieval of pool token symbols
         address collateralTokenAddress = IPool(_positionManager.poolKey(tokenId)).collateralAddress();
         address quoteTokenAddress = IPool(_positionManager.poolKey(tokenId)).quoteTokenAddress();
-        assertEq(SafeTokenNamer.tokenSymbol(collateralTokenAddress), "C");
-        assertEq(SafeTokenNamer.tokenSymbol(quoteTokenAddress), "Q");
-        assertEq(SafeTokenNamer.tokenName(collateralTokenAddress), "Collateral");
-        assertEq(SafeTokenNamer.tokenName(quoteTokenAddress), "Quote");
+        assertEq(tokenSymbol(collateralTokenAddress), "C");
+        assertEq(tokenSymbol(quoteTokenAddress), "Q");
+        assertEq(tokenName(collateralTokenAddress), "Collateral");
+        assertEq(tokenName(quoteTokenAddress), "Quote");
 
         // allow position manager to take ownership of the position
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 3_000 * 1e27);

--- a/tests/forge/SafeTokenNamer.t.sol
+++ b/tests/forge/SafeTokenNamer.t.sol
@@ -8,13 +8,13 @@ import 'src/libraries/SafeTokenNamer.sol';
 
 contract SafeTokenNamerTest is DSTestPlus {
 
-    Token           internal _ercCollateralOne;
-    Token           internal _ercQuoteOne;
+    Token internal _ercCollateralOne;
+    Token internal _ercQuoteOne;
 
-    Token           internal _ercCollateralTwo;
-    Token           internal _ercQuoteTwo;
+    Token internal _ercCollateralTwo;
+    Token internal _ercQuoteTwo;
 
-    Token           internal _tokenLong;
+    Token internal _tokenLong;
 
     NFTCollateralToken internal _nftCollateralOne;
 
@@ -33,34 +33,34 @@ contract SafeTokenNamerTest is DSTestPlus {
     }
 
     function testERC20Name() external {
-        assertEq(SafeTokenNamer.tokenName(address(_ercCollateralOne)), "Collateral 1");
-        assertEq(SafeTokenNamer.tokenName(address(_ercCollateralTwo)), "Collateral 2");
+        assertEq(tokenName(address(_ercCollateralOne)), "Collateral 1");
+        assertEq(tokenName(address(_ercCollateralTwo)), "Collateral 2");
 
-        assertEq(SafeTokenNamer.tokenName(address(_tokenLong)), "TOKEN <TESTING LOTS OF CHARACTERS!!> 3");
+        assertEq(tokenName(address(_tokenLong)), "TOKEN <TESTING LOTS OF CHARACTERS!!> 3");
     }
 
     function testERC20Symbol() external {
-        assertEq(SafeTokenNamer.tokenSymbol(address(_ercCollateralOne)), "C1");
-        assertEq(SafeTokenNamer.tokenSymbol(address(_ercCollateralTwo)), "C2");
+        assertEq(tokenSymbol(address(_ercCollateralOne)), "C1");
+        assertEq(tokenSymbol(address(_ercCollateralTwo)), "C2");
         
-        assertEq(SafeTokenNamer.tokenSymbol(address(_tokenLong)), "TESTING_LONG_TOKEN_SYMBOL");
+        assertEq(tokenSymbol(address(_tokenLong)), "TESTING_LONG_TOKEN_SYMBOL");
     }
 
     function testERC721Name() external {
-        assertEq(SafeTokenNamer.tokenName(address(_nftCollateralOne)), "NFTCollateral");
+        assertEq(tokenName(address(_nftCollateralOne)), "NFTCollateral");
     }
 
     function testERC721Symbol() external {
-        assertEq(SafeTokenNamer.tokenSymbol(address(_nftCollateralOne)), "NFTC");
+        assertEq(tokenSymbol(address(_nftCollateralOne)), "NFTC");
     }
 
     function testMoonCatsMetadata() external {
-        assertEq(SafeTokenNamer.tokenName(0x7C40c393DC0f283F318791d746d894DdD3693572), "Wrapped MoonCatsRescue");
-        assertEq(SafeTokenNamer.tokenSymbol(0x7C40c393DC0f283F318791d746d894DdD3693572), "WMCR");
+        assertEq(tokenName(0x7C40c393DC0f283F318791d746d894DdD3693572), "Wrapped MoonCatsRescue");
+        assertEq(tokenSymbol(0x7C40c393DC0f283F318791d746d894DdD3693572), "WMCR");
     }
 
     function testWETHMetadata() external {
-        assertEq(SafeTokenNamer.tokenName(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), "Wrapped Ether");
-        assertEq(SafeTokenNamer.tokenSymbol(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), "WETH");
+        assertEq(tokenName(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), "Wrapped Ether");
+        assertEq(tokenSymbol(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), "WETH");
     }
 }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -810,6 +810,15 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         // to be overidden by ERC20/ERC721DSTestPlus 
     }
 
+    function _assertBorrowBorrowerNotSenderRevert(
+        address from,
+        address borrower,
+        uint256,
+        uint256
+    ) internal virtual {
+        // to be overidden by ERC20/ERC721DSTestPlus 
+    }
+
     function _assertBorrowLimitIndexRevert(
         address from,
         uint256,
@@ -1063,6 +1072,17 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InvalidIndex.selector);
         _pool.moveQuoteToken(amount, fromIndex, 0);
+    }
+
+    function _assertMoveDepositLockedByAuctionDebtRevert(
+        address from,
+        uint256 amount,
+        uint256 fromIndex,
+        uint256 toIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.RemoveDepositLockedByAuctionDebt.selector);
+        _pool.moveQuoteToken(amount, fromIndex, toIndex);
     }
 
     function _assertTakeAuctionInCooldownRevert(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -663,6 +663,15 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.addQuoteToken(amount, index);
     }
 
+    function _assertAddLiquidityAtIndex0Revert(
+        address from,
+        uint256 amount
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InvalidIndex.selector);
+        _pool.addQuoteToken(amount, 0);
+    }
+
     function _assertArbTakeNoAuction(
         address from,
         address borrower,
@@ -1044,6 +1053,16 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectRevert(IPoolErrors.MoveToSamePrice.selector);
         _pool.moveQuoteToken(amount, fromIndex, toIndex);
+    }
+
+    function _assertMoveLiquidityToIndex0Revert(
+        address from,
+        uint256 amount,
+        uint256 fromIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InvalidIndex.selector);
+        _pool.moveQuoteToken(amount, fromIndex, 0);
     }
 
     function _assertTakeAuctionInCooldownRevert(


### PR DESCRIPTION
- LenderAuctions coverage by adding tests for add/remove/move quoteTokens and collateral at index 0
- Pool coverage improvements:
  - use OZ's safe transfer for ajna token reserve auction
  - add negative tests for repay debt and pull, pledge and borrow when sender is not borrower
  - add negative test when trying to move funds but deposit locked by auction; add test when can add / withdraw in buckets that are not locked by debt in auction
  - test of repaying debt partially when loan in auction (hence not removed from auction)
- PositionManager: remove redundant check for adding if positionPrice doesn't contain index (handled by OZ's library, returns true if newly added, false if exists)
- Buckets library:
  - remove Buckets.getLenderInfo, moved logic in Pool.lenderInfo
  - moved lpsToCollateral and lpsToQuoteTokens in PoolHelper
- Maths library: removed unused functions
- SafeTokenNamer library: made free functions insted library, import it in PositionManager
- added unit tests for PoolInfoUtils 

```
Summary coverage rate:
  lines......: 99.7% (1198 of 1202 lines)
  functions..: 99.0% (194 of 196 functions)
  branches...: 94.9% (372 of 392 branches)
```