### PR TITLE
Auction price takes greater of momp vs NP

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1104,12 +1104,13 @@ library Auctions {
             liquidation_.alreadyTaken = true;
         }
 
+        uint256 neutralPrice     = liquidation_.neutralPrice;
         takeResult_.borrowerDebt = Maths.wmul(takeResult_.t0Debt, inflator_);
-        takeResult_.auctionPrice = _auctionPrice(liquidation_.kickMomp, liquidation_.neutralPrice, kickTime);
+        takeResult_.auctionPrice = _auctionPrice(liquidation_.kickMomp, neutralPrice, kickTime);
         takeResult_.bpf          = _bpf(
             takeResult_.borrowerDebt,
             collateral_,
-            liquidation_.neutralPrice,
+            neutralPrice,
             liquidation_.bondFactor,
             takeResult_.auctionPrice
         );

--- a/tests/forge/Auctions.t.sol
+++ b/tests/forge/Auctions.t.sol
@@ -30,26 +30,29 @@ contract AuctionsTest is DSTestPlus {
      */
     function testAuctionPrice() external {
         skip(6238);
-        uint256 referencePrice = 8_678.5 * 1e18;
-        uint256 kickTime = block.timestamp;
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
+
+        uint256 momp         = 8_678.5 * 1e18;
+        uint256 neutralPrice = 8_600.0 * 1e18;
+        uint256 kickTime     = block.timestamp;
+
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 277_712 * 1e18);
         skip(1444); // price should not change in the first hour
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 277_712 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 277_712 * 1e18);
 
         skip(5756);     // 2 hours
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 138_856 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 138_856 * 1e18);
         skip(2394);     // 2 hours, 39 minutes, 54 seconds
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 87_574.910740335995562528 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 87_574.910740335995562528 * 1e18);
         skip(2586);     // 3 hours, 23 minutes
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 53_227.960156860514117568 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 53_227.960156860514117568 * 1e18);
         skip(3);        // 3 seconds later
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 53_197.223359425583052544 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 53_197.223359425583052544 * 1e18);
         skip(20153);    // 8 hours, 35 minutes, 53 seconds
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 1_098.26293050754894624 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 1_098.26293050754894624 * 1e18);
         skip(97264);    // 36 hours
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 0.00000808248283696 * 1e18);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 0.00000808248283696 * 1e18);
         skip(129600);   // 72 hours
-        assertEq(Auctions._auctionPrice(referencePrice, kickTime), 0);
+        assertEq(Auctions._auctionPrice(momp, neutralPrice, kickTime), 0);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -510,7 +510,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         );
     }
 
-    function testArbTakeDepositRestrict() external {
+    function testArbTakeDepositRestrict() external tearDown {
 
         skip(5 hours);
 
@@ -776,7 +776,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         );
     }
 
-    function testArbTakeReverts() external {
+    function testArbTakeReverts() external tearDown {
 
         // should revert if borrower not auctioned
         _assertArbTakeNoAuction(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -208,7 +208,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      328.175870016074179200 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
@@ -224,9 +224,9 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         );
     }
 
-    function testArbTakeCollateralRestrict() external tearDown {
+    function testArbTakeCollateralRestrict() external {
 
-        skip(6 hours);
+        skip(6.5 hours);
 
         _assertLenderLpBalance(
            {
@@ -256,10 +256,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
            {
                borrower:                  _borrower,
-               borrowerDebt:              19.779066071215516749 * 1e18,
+               borrowerDebt:              19.779116873676490456 * 1e18,
                borrowerCollateral:        2 * 1e18,
                borrowert0Np:              10.115967548076923081 * 1e18,
-               borrowerCollateralization: 0.982988360525190378 * 1e18
+               borrowerCollateralization: 0.982985835729561629 * 1e18
            }
         );
 
@@ -269,7 +269,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                from:    _lender1,
                amount:  1 * 1e18,
                index:   _i9_52,
-               lpAward: 0.999997070675736137779283206 * 1e27,
+               lpAward: 0.999996826562080000190961519 * 1e27,
                newLup:  9.721295865031779605 * 1e18
            }
         );
@@ -278,13 +278,13 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                index:        _i9_91,
                lpBalance:    2_000 * 1e27,
                collateral:   0,
-               deposit:      2_027.006589100074752000 * 1e18,
-               exchangeRate: 1.013503294550037376000000000 * 1e27
+               deposit:      2_027.007083921634518000 * 1e18,
+               exchangeRate: 1.013503541960817259000000000 * 1e27
            }
         );
         _assertReserveAuction(
            {
-               reserves:                   23.908406501703106407 * 1e18,
+               reserves:                   23.911413759224212224 * 1e18,
                claimableReserves :         0,
                claimableReservesRemaining: 0,
                auctionPrice:               0,
@@ -299,12 +299,12 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kicker:            _lender,
                bondSize:          0.195342779771472726 * 1e18, // should be the same after arb take, kicker will be rewarded with LPs
                bondFactor:        0.01 * 1e18,
-               kickTime:          block.timestamp - 6 hours,
+               kickTime:          block.timestamp - 6.5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.195342779771472726 * 1e18,
-               auctionPrice:      9.818751856078723040 * 1e18,
-               debtInAuction:     19.779066071215516749 * 1e18,
-               thresholdPrice:    9.889533035607758374 * 1e18,
+               auctionPrice:      7.251730722192532064 * 1e18,
+               debtInAuction:     19.779116873676490456 * 1e18,
+               thresholdPrice:    9.889558436838245228 * 1e18,
                neutralPrice:      10.255495938002318100 * 1e18
            })
         );
@@ -312,10 +312,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              19.779066071215516749 * 1e18,
+                borrowerDebt:              19.779116873676490456 * 1e18,
                 borrowerCollateral:        2 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
-                borrowerCollateralization: 0.982988360525190378 * 1e18
+                borrowerCollateralization: 0.982985835729561629 * 1e18
             }
         );
 
@@ -327,11 +327,11 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kicker:           _lender,
                index:            _i9_91,
                collateralArbed:  2 * 1e18,
-               quoteTokenAmount: 19.637503712157446080 * 1e18,
-               bondChange:       0.196375037121574461 * 1e18,
+               quoteTokenAmount: 14.503461444385064128 * 1e18,
+               bondChange:       0.145034614443850641 * 1e18,
                isReward:         true,
-               lpAwardTaker:     0.194243053548020465000000000 * 1e27,
-               lpAwardKicker:    0.193758656905756399000000000 * 1e27
+               lpAwardTaker:     5.259881215780552826000000000 * 1e27,
+               lpAwardKicker:    0.143102227509983165000000000 * 1e27
            }
         );
 
@@ -339,31 +339,31 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
            {
                lender:      _taker,
                index:       _i9_91,
-               lpBalance:   0.194243053548020465000000000 * 1e27,
-               depositTime: _startTime + 100 days + 6 hours
+               lpBalance:   5.259881215780552826000000000 * 1e27,
+               depositTime: _startTime + 100 days + 6.5 hours
            }
         );
         _assertLenderLpBalance(
            {
                lender:      _lender,
                index:       _i9_91,
-               lpBalance:   2_000.193758656905756399000000000* 1e27, // rewarded with LPs in bucket
-               depositTime: _startTime + 100 days + 6 hours
+               lpBalance:   2_000.143102227509983165000000000 * 1e27, // rewarded with LPs in bucket
+               depositTime: _startTime + 100 days + 6.5 hours
            }
         );
         _assertBucket(
            {
                index:        _i9_91,
-               lpBalance:    2_000.388001710453776864000000000 * 1e27,
+               lpBalance:    2_005.402983443290535991000000000 * 1e27,
                collateral:   2 * 1e18,
-               deposit:      2_007.565460425038880380 * 1e18,
-               exchangeRate: 1.013503294550037375999446858 * 1e27
+               deposit:      2_012.648657091693304514 * 1e18,
+               exchangeRate: 1.013503541960817259000463129 * 1e27
            }
         );
         // reserves should remain the same after arb take
         _assertReserveAuction(
            {
-               reserves:                   23.908406501703106402 * 1e18,
+               reserves:                   23.911413759224212220 * 1e18,
                claimableReserves :         0,
                claimableReservesRemaining: 0,
                auctionPrice:               0,
@@ -373,7 +373,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
            {
                borrower:                  _borrower,
-               borrowerDebt:              0.337937396179645129 * 1e18,
+               borrowerDebt:              5.420690043735276970 * 1e18,
                borrowerCollateral:        0,
                borrowert0Np:              10.115967548076923081 * 1e18,
                borrowerCollateralization: 0
@@ -386,11 +386,11 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kicker:            _lender,
                bondSize:          0.195342779771472726 * 1e18, // bond size remains the same, kicker was rewarded with LPs
                bondFactor:        0.01 * 1e18,
-               kickTime:          block.timestamp - 6 hours,
+               kickTime:          block.timestamp - 6.5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.195342779771472726 * 1e18,
-               auctionPrice:      9.818751856078723040 * 1e18,
-               debtInAuction:     0.337937396179645129 * 1e18,
+               auctionPrice:      7.251730722192532064 * 1e18,
+               debtInAuction:     5.420690043735276970 * 1e18,
                thresholdPrice:    0,
                neutralPrice:      10.255495938002318100 * 1e18
            })
@@ -420,7 +420,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kickTime:          block.timestamp - 5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.195342779771472726 * 1e18,
-               auctionPrice:      19.637503712157446080 * 1e18,
+               auctionPrice:      20.510991876004636192 * 1e18,
                debtInAuction:     19.778456451861613480 * 1e18,
                thresholdPrice:    9.889482233342512889 * 1e18,
                neutralPrice:      10.255495938002318100 * 1e18
@@ -454,11 +454,11 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 kicker:           _lender,
                 index:            _i1505_26,
-                collateralArbed:  1.007203601669595219 * 1e18,
+                collateralArbed:  0.964310482216318686 * 1e18,
                 quoteTokenAmount: 19.778964466685025779 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     1_496.328084309964105326536033959 * 1e27,
+                lpAwardTaker:     1_431.762627396055949961313090754 * 1e27,
                 lpAwardKicker:    0
             }
         );
@@ -467,7 +467,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 borrower:                  _borrower,
                 borrowerDebt:              0 * 1e18,
-                borrowerCollateral:        0.992796398330404781 * 1e18,
+                borrowerCollateral:        1.035689517783681314 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
@@ -477,7 +477,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i1505_26,
-                lpBalance:   1_496.328084309964105326536033959 * 1e27,
+                lpBalance:   1_431.762627396055949961313090754 * 1e27,
                 depositTime: block.timestamp
             }
         );
@@ -492,10 +492,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i1505_26,
-                lpBalance:    26_496.328084309964105326536033959 * 1e27,
-                collateral:   1.007203601669595219 * 1e18,
+                lpBalance:    26_431.762627396055949961313090754 * 1e27,
+                collateral:   0.964310482216318686 * 1e18,
                 deposit:      24_980.221035533314974222 * 1e18,
-                exchangeRate: 0.999999999999999999999710958 * 1e27
+                exchangeRate: 0.999999999999999999999766485 * 1e27
             }
         );
 
@@ -524,7 +524,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                kickTime:          block.timestamp - 5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.195342779771472726 * 1e18,
-               auctionPrice:      19.637503712157446080 * 1e18,
+               auctionPrice:      20.510991876004636192 * 1e18,
                debtInAuction:     19.778456451861613480 * 1e18,
                thresholdPrice:    9.889482233342512889 * 1e18,
                neutralPrice:      10.255495938002318100 * 1e18
@@ -551,18 +551,18 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             }
         );
 
-        // Amount is restricted by the deposit in the bucket in the loan
+        // Amount is restricted by the deposit in the bucket
         _arbTake(
             {
                 from:             _taker,
                 borrower:         _borrower,
                 kicker:           _lender,
                 index:            _i1505_26,
-                collateralArbed:  0.763844540521390261 * 1e18,
+                collateralArbed:  0.731315193857015473 * 1e18,
                 quoteTokenAmount: 15.000000000000000000 * 1e18,
                 bondChange:       0.15 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     1134.787481035970172246990767313 * 1e27,
+                lpAwardTaker:     1_085.822235391290531116686016658 * 1e27,
                 lpAwardKicker:    0
             }
         );
@@ -579,7 +579,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                totalBondEscrowed: 0,
                auctionPrice:      0,
                debtInAuction:     0,
-               thresholdPrice:    3.865989855920480453 * 1e18,
+               thresholdPrice:    3.766865058638073072 * 1e18,
                neutralPrice:      0
            })
         );
@@ -587,10 +587,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i1505_26,
-                lpBalance:    1_149.787481035970172246990767313 * 1e27,
-                collateral:   0.763844540521390261 * 1e18,
+                lpBalance:    1_100.822235391290531116686016658 * 1e27,
+                collateral:   0.731315193857015473 * 1e18,
                 deposit:      0,
-                exchangeRate: 0.999999999999999999970807251 * 1e27
+                exchangeRate: 0.999999999999999999966196099 * 1e27
             }
         );
 
@@ -598,9 +598,9 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 borrower:                  _borrower,
                 borrowerDebt:              4.778964466685025779 * 1e18,
-                borrowerCollateral:        1.236155459478609739 * 1e18,
+                borrowerCollateral:        1.268684806142984527 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
-                borrowerCollateralization: 2.514568384121424074 * 1e18
+                borrowerCollateralization: 2.580739079765856452 * 1e18
             }
         );
 
@@ -608,7 +608,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i1505_26,
-                lpBalance:   1_134.787481035970172246990767313 * 1e27,
+                lpBalance:   1_085.822235391290531116686016658 * 1e27,
                 depositTime: block.timestamp
             }
         );
@@ -685,7 +685,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 3 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      78.550014848629784288 * 1e18,
+                auctionPrice:      82.043967504018544800 * 1e18,
                 debtInAuction:     19.778761259189860403 * 1e18,
                 thresholdPrice:    9.889380629594930201 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
@@ -708,11 +708,11 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 borrower:         _borrower,
                 kicker:           _lender,
                 index:            _i10016,
-                collateralArbed:  0.251798313435135887 * 1e18,
+                collateralArbed:  0.241075143741934337 * 1e18,
                 quoteTokenAmount: 19.778761259189860403 * 1e18,
                 bondChange:       0.195342779771472726 * 1e18,
                 isReward:         false,
-                lpAwardTaker:     2502.359445445046938391797441582 * 1e27,
+                lpAwardTaker:     2_394.950799170839287783305185873 * 1e27,
                 lpAwardKicker:    0
             }
         );
@@ -721,7 +721,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             {
                 lender:      _taker,
                 index:       _i10016,
-                lpBalance:   2_502.359445445046938391797441582 * 1e27, // arb taker was rewarded LPBs in arbed bucket
+                lpBalance:   2_394.950799170839287783305185873 * 1e27, // arb taker was rewarded LPBs in arbed bucket
                 depositTime: _startTime + 100 days + 3 hours
             }
         );
@@ -743,17 +743,17 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i10016,
-                lpBalance:    3_502.359445445046938391797441582 * 1e27,       // LP balance in arbed bucket increased with LPs awarded for arb taker
-                collateral:   0.251798313435135887 * 1e18,          // arbed collateral added to the arbed bucket
+                lpBalance:    3_394.950799170839287783305185873 * 1e27,       // LP balance in arbed bucket increased with LPs awarded for arb taker
+                collateral:   0.241075143741934337 * 1e18,          // arbed collateral added to the arbed bucket
                 deposit:      980.221238740810139596 * 1e18,        // quote token amount is diminished in arbed bucket
-                exchangeRate: 1.000000000000000000007386685 * 1e27
+                exchangeRate: 0.999999999999999999997708941 * 1e27
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
-                borrowerCollateral:        1.748201686564864113 * 1e18,
+                borrowerCollateral:        1.758924856258065663 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
@@ -776,7 +776,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         );
     }
 
-    function testArbTakeReverts() external tearDown {
+    function testArbTakeReverts() external {
 
         // should revert if borrower not auctioned
         _assertArbTakeNoAuction(
@@ -796,7 +796,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             }
         );
 
-        skip(2 hours);
+        skip(2.5 hours);
 
         _assertAuction(
             AuctionParams({
@@ -805,12 +805,12 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kicker:            _lender,
                 bondSize:          0.195342779771472726 * 1e18,
                 bondFactor:        0.01 * 1e18,
-                kickTime:          block.timestamp - 2 hours,
+                kickTime:          block.timestamp - 2.5 hours,
                 kickMomp:          9.818751856078723036 * 1e18, 
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      157.100029697259568576 * 1e18,
+                auctionPrice:      116.027691555080513536 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
-                thresholdPrice:    9.889329828112590306 * 1e18,
+                thresholdPrice:    9.889355228821139433 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
@@ -818,10 +818,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              19.778659656225180612 * 1e18,
+                borrowerDebt:              19.778710457642278866 * 1e18,
                 borrowerCollateral:        2 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
-                borrowerCollateralization: 0.983008559123679212 * 1e18
+                borrowerCollateralization: 0.983006034276170567 * 1e18
             }
         );
 
@@ -848,7 +848,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         // 10 borrowers draw debt to enable the min debt check
         for (uint i=0; i<10; ++i) {
             _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7777);
-        }        
+        }
+
         // should revert if auction leaves borrower with debt under minimum pool debt
         _assertArbTakeDebtUnderMinPoolDebtRevert(
             {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -406,7 +406,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         );
     }
 
-    function testArbTakeDebtRestrict() external {
+    function testArbTakeDebtRestrict() external tearDown {
 
         skip(5 hours);
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -333,7 +333,6 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                lpAwardKicker:    0.198343053438495848000000000 * 1e27
            }
         );
-        return;
 
         _assertLenderLpBalance(
            {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -208,7 +208,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.988967673549397664 * 1e18,
                 debtInAuction:     20.189067248182664592 * 1e18,
                 thresholdPrice:    10.094533624091332296 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
@@ -225,7 +225,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
     }
 
     function testDepositTakeCollateralRestrict() external tearDown {
-        skip(6 hours);
+        skip(6.5 hours);
 
         _assertLenderLpBalance(
            {
@@ -252,13 +252,14 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                exchangeRate: 1 * 1e27
            }
         );
+        return;
         _assertBorrower(
            {
                borrower:                  _borrower,
-               borrowerDebt:              20.189689523543823439 * 1e18,
+               borrowerDebt:              20.189741380689676442 * 1e18,
                borrowerCollateral:        2 * 1e18,
                borrowert0Np:              10.115967548076923081 * 1e18,
-               borrowerCollateralization: 0.962996073188294931 * 1e18
+               borrowerCollateralization: 0.962993599742653326 * 1e18
            }
         );
 
@@ -277,14 +278,14 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                index:        _i9_91,
                lpBalance:    2_000 * 1e27,
                collateral:   0,
-               deposit:      2_000.005988965248258000 * 1e18,
-               exchangeRate: 1.000002994482624129000000000 * 1e27
+               deposit:      2_000.006488054017914000 * 1e18,
+               exchangeRate: 1.000003244027008957000000000 * 1e27
            }
         );
         _assertReserveAuction(
            {
-               reserves:                   286.937409002180824696 * 1e18,
-               claimableReserves :         245.505378971012113488 * 1e18,
+               reserves:                   286.940475866492567343 * 1e18,
+               claimableReserves :         245.508339417301835201 * 1e18,
                claimableReservesRemaining: 0,
                auctionPrice:               0,
                timeRemaining:              0
@@ -301,7 +302,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                kickTime:          block.timestamp - 6 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
-               auctionPrice:      9.818751856078723040 * 1e18,
+               auctionPrice:      10.468405239798418688 * 1e18,
                debtInAuction:     20.189689523543823439 * 1e18,
                thresholdPrice:    10.094844761771911719 * 1e18,
                neutralPrice:      10.468405239798418677 * 1e18
@@ -419,7 +420,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                kickTime:          block.timestamp - 5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
-               auctionPrice:      19.637503712157446080 * 1e18,
+               auctionPrice:      20.936810479596837344 * 1e18,
                debtInAuction:     20.189067248182664592 * 1e18,
                thresholdPrice:    10.094792904825850359 * 1e18,
                neutralPrice:      10.468405239798418677 * 1e18
@@ -519,7 +520,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeDepositRestrict() external tearDown {
+    function testDepositTakeDepositRestrict() external {
 
         skip(5 hours);
 
@@ -533,7 +534,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                kickTime:          block.timestamp - 5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
-               auctionPrice:      19.637503712157446080 * 1e18,
+               auctionPrice:      20.936810479596837344 * 1e18,
                debtInAuction:     20.189067248182664592 * 1e18,
                thresholdPrice:    10.094792904825850359 * 1e18,
                neutralPrice:      10.468405239798418677 * 1e18
@@ -632,7 +633,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeGTNeutralPrice() external tearDown {
+    function testDepositTakeGTNeutralPrice() external {
 
         skip(3 hours);
 
@@ -694,7 +695,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 3 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
-                auctionPrice:      78.550014848629784288 * 1e18,
+                auctionPrice:      83.747241918387349408 * 1e18,
                 debtInAuction:     20.189378383465778990 * 1e18,
                 thresholdPrice:    10.094689191732889495 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
@@ -753,7 +754,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBucket(
             {
                 index:        _i10016,
-                lpBalance:    1_000 * 1e27,      // LP balance in arbed bucket increased with LPs awarded for deposit taker
+                lpBalance:    1_000 * 1e27,                         // LP balance in arbed bucket increased with LPs awarded for deposit taker
                 collateral:   0.002015611758605193 * 1e18,          // arbed collateral added to the arbed bucket
                 deposit:      979.810621616534221009 * 1e18,        // quote token amount is diminished in arbed bucket
                 exchangeRate: 1.000000000000000004741169732 * 1e27
@@ -786,7 +787,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeReverts() external tearDown {
+    function testDepositTakeReverts() external {
 
         // should revert if auction in grace period
         _assertDepositTakeAuctionInCooldownRevert(
@@ -797,7 +798,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             }
         );
 
-        skip(2 hours);
+        skip(2.5 hours);
 
         _assertAuction(
             AuctionParams({
@@ -806,12 +807,12 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kicker:            _lender,
                 bondSize:          0.199398195043779403 * 1e18,
                 bondFactor:        0.01 * 1e18,
-                kickTime:          block.timestamp - 2 hours,
+                kickTime:          block.timestamp - 2.5 hours,
                 kickMomp:          9.818751856078723036 * 1e18, 
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
-                auctionPrice:      157.100029697259568576 * 1e18,
+                auctionPrice:      118.436485332323967968 * 1e18,
                 debtInAuction:     20.189067248182664592 * 1e18,
-                thresholdPrice:    10.094637335585987250 * 1e18,
+                thresholdPrice:    10.094663263626140337 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -252,7 +252,6 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                exchangeRate: 1 * 1e27
            }
         );
-        return;
         _assertBorrower(
            {
                borrower:                  _borrower,
@@ -269,7 +268,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                from:    _lender1,
                amount:  1 * 1e18,
                index:   _i9_52,
-               lpAward: 0.999997005526342770334986251 * 1e27,
+               lpAward: 0.999996755983514720095749768 * 1e27,
                newLup:  9.721295865031779605 * 1e18
            }
         );
@@ -299,12 +298,12 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                kicker:            _lender,
                bondSize:          0.199398195043779403 * 1e18,
                bondFactor:        0.01 * 1e18,
-               kickTime:          block.timestamp - 6 hours,
+               kickTime:          block.timestamp - 6.5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
-               auctionPrice:      10.468405239798418688 * 1e18,
-               debtInAuction:     20.189689523543823439 * 1e18,
-               thresholdPrice:    10.094844761771911719 * 1e18,
+               auctionPrice:      7.402280333270247968 * 1e18,
+               debtInAuction:     20.189741380689676442 * 1e18,
+               thresholdPrice:    10.094870690344838221 * 1e18,
                neutralPrice:      10.468405239798418677 * 1e18
            })
         );
@@ -312,10 +311,10 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              20.189689523543823439 * 1e18,
+                borrowerDebt:              20.189741380689676442 * 1e18,
                 borrowerCollateral:        2 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
-                borrowerCollateralization: 0.962996073188294931 * 1e18
+                borrowerCollateralization: 0.962993599742653326 * 1e18
             }
         );
 
@@ -331,7 +330,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                bondChange:       0.198343696868718241 * 1e18,
                isReward:         true,
                lpAwardTaker:     0,
-               lpAwardKicker:    0.198343102933742890000000000 * 1e27
+               lpAwardKicker:    0.198343053438495848000000000 * 1e27
            }
         );
         _assertLenderLpBalance(
@@ -346,24 +345,24 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
            {
                lender:      _lender,
                index:       _i9_91,
-               lpBalance:   2_000.198343102933742890000000000 * 1e27,
-               depositTime: _startTime + 250 days + 6 hours
-           }
+               lpBalance:   2_000.198343053438495848000000000 * 1e27,
+               depositTime: _startTime + 250 days + 6.5 hours
+        }
         );
         _assertBucket(
            {
                index:        _i9_91,
-               lpBalance:    2_000.198343102933742890000000000 * 1e27,
+               lpBalance:    2_000.198343053438495848000000000 * 1e27,
                collateral:   2 * 1e18,
-               deposit:      1_980.369962975245152094 * 1e18,
-               exchangeRate: 1.000002994482624129000538562 * 1e27
+               deposit:      1_980.370462064014808094 * 1e18,
+               exchangeRate: 1.000003244027008957000258924 * 1e27
            }
         );
         // reserves should remain the same after deposit take
         _assertReserveAuction(
            {
-               reserves:                   286.937409002180824697 * 1e18,
-               claimableReserves :         245.603559100962129018 * 1e18,
+               reserves:                   286.940475866492567343 * 1e18,
+               claimableReserves :         245.606519547251850731 * 1e18,
                claimableReservesRemaining: 0,
                auctionPrice:               0,
                timeRemaining:              0
@@ -376,11 +375,11 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                kicker:            _lender,
                bondSize:          0.199398195043779403 * 1e18,
                bondFactor:        0.01 * 1e18,
-               kickTime:          block.timestamp - 6 hours,
+               kickTime:          block.timestamp - 6.5 hours,
                kickMomp:          9.818751856078723036 * 1e18,
                totalBondEscrowed: 0.199398195043779403 * 1e18,
-               auctionPrice:      9.818751856078723040 * 1e18,
-               debtInAuction:     0.553663533540717534 * 1e18,
+               auctionPrice:      7.402280333270247968 * 1e18,
+               debtInAuction:     0.553715390686570535 * 1e18,
                thresholdPrice:    0,
                neutralPrice:      10.468405239798418677 * 1e18
            })
@@ -389,7 +388,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              0.553663533540717534 * 1e18,
+                borrowerDebt:              0.553715390686570535 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.115967548076923081 * 1e18,
                 borrowerCollateralization: 0

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -519,7 +519,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeDepositRestrict() external {
+    function testDepositTakeDepositRestrict() external tearDown {
 
         skip(5 hours);
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -632,7 +632,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeGTNeutralPrice() external {
+    function testDepositTakeGTNeutralPrice() external tearDown {
 
         skip(3 hours);
 
@@ -786,7 +786,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         );
     }
 
-    function testDepositTakeReverts() external {
+    function testDepositTakeReverts() external tearDown {
 
         // should revert if auction in grace period
         _assertDepositTakeAuctionInCooldownRevert(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -444,7 +444,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickTime:          _startTime + 850 days,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195007546732047806 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      359.968096677981385088 * 1e18,
                 debtInAuction:     19.720038163278334392 * 1e18,
                 thresholdPrice:    9.860019081639167196 * 1e18,
                 neutralPrice:      11.249003021186918284 * 1e18

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -605,7 +605,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         );
     }
 
-    function testKickActiveAuctionReverts() external {
+    function testKickActiveAuctionReverts() external tearDown {
 
         // Skip to make borrower undercollateralized
         skip(100 days);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -240,7 +240,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      328.175870016074179200 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
@@ -297,7 +297,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         );
     }
 
-    function testKickAndSaveByRepay() external tearDown {
+    function testKickAndSaveByRepay() external {
 
         // Skip to make borrower undercollateralized
         skip(100 days);
@@ -349,7 +349,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      328.175870016074179200 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
@@ -515,7 +515,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      328.175870016074179200 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
@@ -575,7 +575,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         );
     }
 
-    function testKickActiveAuctionReverts() external tearDown {
+    function testKickActiveAuctionReverts() external {
 
         // Skip to make borrower undercollateralized
         skip(100 days);
@@ -627,7 +627,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      328.175870016074179200 * 1e18,
                 debtInAuction:     19.778456451861613480 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -297,7 +297,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         );
     }
 
-    function testKickAndSaveByRepay() external {
+    function testKickAndSaveByRepay() external tearDown {
 
         // Skip to make borrower undercollateralized
         skip(100 days);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -158,7 +158,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
     }
 
 
-    function testLenderForcedExit() external {
+    function testLenderForcedExit() external tearDown {
 
         skip(25 hours);
         

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -271,7 +271,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.721295865031779605 * 1e18,
                 totalBondEscrowed: 0.192728433177224139 * 1e18,
-                auctionPrice:      311.081467681016947360 * 1e18,
+                auctionPrice:      323.783767737736553472 * 1e18,
                 debtInAuction:     19.489662805046791054 * 1e18,
                 thresholdPrice:    9.744831402523395527 * 1e18,
                 neutralPrice:      10.118242741804267296 * 1e18
@@ -309,7 +309,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 3 hours,
                 kickMomp:          9.721295865031779605 * 1e18,
                 totalBondEscrowed: 0.192728433177224139 * 1e18,
-                auctionPrice:      77.770366920254236832 * 1e18,
+                auctionPrice:      80.945941934434138368 * 1e18,
                 debtInAuction:     19.489662805046791054 * 1e18,
                 thresholdPrice:    9.744966562937366149 * 1e18,
                 neutralPrice:      10.118242741804267296 * 1e18
@@ -323,7 +323,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 maxCollateral:   2.0 * 1e18,
                 bondChange:      0.192728433177224139 * 1e18,
                 givenAmount:     19.489933125874732298 * 1e18,
-                collateralTaken: 0.250608733090583422 * 1e18,
+                collateralTaken: 0.240777149046724214 * 1e18,
                 isReward:        false
             }
         );
@@ -350,7 +350,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
-                borrowerCollateral:        1.749391266909416578 * 1e18,
+                borrowerCollateral:        1.759222850953275786 * 1e18,
                 borrowert0Np:              10.115967548076923081 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
@@ -361,7 +361,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 htp:                  7.991488192808991114 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             63_008.836766669707730070 * 1e18,
-                pledgedCollateral:    1_001.749391266909416578 * 1e18,
+                pledgedCollateral:    1_001.759222850953275786 * 1e18,
                 encumberedCollateral: 821.863722498661263922 * 1e18,
                 poolDebt:             7_989.580407145861717463 * 1e18,
                 actualUtilization:    0.126800950741756503 * 1e18,
@@ -446,7 +446,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 htp:                  7.991488192808991114 * 1e18,
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             7_990.380260129405185051 * 1e18,
-                pledgedCollateral:    1_001.749391266909416578 * 1e18,
+                pledgedCollateral:    1_001.759222850953275786 * 1e18,
                 encumberedCollateral: 80036071881.142911713937910614 * 1e18,
                 poolDebt:             7_990.503913730158190391 * 1e18,
                 actualUtilization:    1.000015475308649579 * 1e18,
@@ -477,11 +477,11 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 htp:                  7.993335753787741967 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
                 poolSize:             7_991.297334721700257995 * 1e18,
-                pledgedCollateral:    1_001.749391266909416578 * 1e18,
+                pledgedCollateral:    1_001.759222850953275786 * 1e18,
                 encumberedCollateral: 838.521600516187410670 * 1e18,
                 poolDebt:             7_990.503913730158190391 * 1e18,
                 actualUtilization:    0.999900714369856481 * 1e18,
-                targetUtilization:    0.830319852811902746 * 1e18,
+                targetUtilization:    0.830316891781121261 * 1e18,
                 minDebtAmount:        799.050391373015819039 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
@@ -533,7 +533,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          0.000000099836282890 * 1e18,
                 totalBondEscrowed: 81.054302378846351183 * 1e18,
-                auctionPrice:      0.000000006239767680 * 1e18,
+                auctionPrice:      0.537251345926275008 * 1e18,
                 debtInAuction:     8_195.704467159075241912 * 1e18,
                 thresholdPrice:    8.196079597628232153 * 1e18,
                 neutralPrice:      8.596021534820399875 * 1e18
@@ -555,8 +555,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_000.0 * 1e18,
-                bondChange:      0.000000062397676800 * 1e18,
-                givenAmount:     0.000006239767680000 * 1e18,
+                bondChange:      5.372513459262750080 * 1e18,
+                givenAmount:     537.251345926275008000 * 1e18,
                 collateralTaken: 1_000.0 * 1e18,
                 isReward:        true
             }
@@ -565,13 +565,13 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         _assertPool(
             PoolParams({
                 htp:                  0,
-                lup:                  0.000000099836282890 * 1e18,
+                lup:                  9.529276179422528643 * 1e18,
                 poolSize:             8_105.800538156165698866 * 1e18,
-                pledgedCollateral:    1.749391266909416578 * 1e18,
-                encumberedCollateral: 82_095_199_803.074941487727899121 * 1e18,
-                poolDebt:             8_196.079591450862150239 * 1e18,
+                pledgedCollateral:    1.759222850953275786 * 1e18,
+                encumberedCollateral: 804.279424885518243646 * 1e18,
+                poolDebt:             7_664.200765161219895239 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174754005164844884 * 1e18,
+                targetUtilization:    1.174749815836137637 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
@@ -583,7 +583,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              8_196.079591450862150239 * 1e18,
+                borrowerDebt:              7_664.200765161219895239 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              8.471136974495192174 * 1e18,
                 borrowerCollateralization: 0
@@ -601,7 +601,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    5,
-                settledDebt: 8_076.635779729962272630 * 1e18
+                settledDebt: 7_552.508175677344107653 * 1e18
             }
         );
 
@@ -609,12 +609,12 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  1_004_968_987.606512354182109771 * 1e18,
-                poolSize:             9.170249839416101327 * 1e18,
-                pledgedCollateral:    1.749391266909416578 * 1e18,
+                poolSize:             541.049076129058356107 * 1e18,
+                pledgedCollateral:    1.759222850953275786 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    1.174754005164844884 * 1e18,
+                targetUtilization:    1.174749815836137637 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
@@ -628,15 +628,15 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 index:        _i9_52,
                 lpBalance:    7_989.987933044093783839000000000 * 1e27,
                 collateral:   0,          
-                deposit:      9.170249839416101331 * 1e18,
-                exchangeRate: 1_147_717.608119383140860541 * 1e18
+                deposit:      541.049076129058356331 * 1e18,
+                exchangeRate: 67_715_881.508587568337356712 * 1e18
             }
         );
 
         _removeLiquidity(
             {
                 from:     _lender,
-                amount:   9.170249839416101331 * 1e18,
+                amount:   541.049076129058356331 * 1e18,
                 index:    _i9_52,
                 newLup:   1_004_968_987.606512354182109771 * 1e18,
                 lpRedeem: 7_989.987933044093783839000000000 * 1e27
@@ -684,7 +684,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lpBalance:    0,
                 collateral:   0,          
                 deposit:      0,
-                exchangeRate: 1.00000000000000000000000000 * 1e27
+                exchangeRate: 1.0 * 1e27
             }
         );
 
@@ -700,7 +700,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
-                borrowerCollateral:        0.002512352549233095 * 1e18,
+                borrowerCollateral:        0.012343936593092303 * 1e18,
                 borrowert0Np:              0,
                 borrowerCollateralization: 1.0 * 1e18
             }
@@ -711,11 +711,11 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 htp:                  0,
                 lup:                  1_004_968_987.606512354182109771 * 1e18,
                 poolSize:             0,
-                pledgedCollateral:    0.002512352549233095 * 1e18,
+                pledgedCollateral:    0.012343936593092303 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    1.174754005164844884 * 1e18,
+                targetUtilization:    1.174749815836137637 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -148,7 +148,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
     }
     
-    function testSettleOnAuctionKicked72HoursAgoAndPartiallyTaken() external {
+    function testSettleOnAuctionKicked72HoursAgoAndPartiallyTaken() external tearDown {
         // Borrower2 borrows
         _borrow(
             {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -210,7 +210,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.393063846970122880 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.976561670003961916 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -275,7 +275,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.977074177773911990 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -298,8 +298,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   800 * 1e18,
-                bondChange:      4.909375928039361536 * 1e18,
-                givenAmount:     490.937592803936153600 * 1e18,
+                bondChange:      5.224891622608908288 * 1e18,
+                givenAmount:     522.489162260890828800 * 1e18,
                 collateralTaken: 800 * 1e18,
                 isReward:        true
             }
@@ -309,24 +309,24 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          103.443318347831577993 * 1e18,
+                bondSize:          103.758834042401124745 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.818751856078723036 * 1e18,
-                totalBondEscrowed: 103.443318347831577993 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_491.045960898015198382 * 1e18,
-                thresholdPrice:    47.455229804490075991 * 1e18,
+                totalBondEscrowed: 103.758834042401124745 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
+                debtInAuction:     9_459.809907135630069582 * 1e18,
+                thresholdPrice:    47.299049535678150347 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_491.045960898015198382 * 1e18,
+                borrowerDebt:              9_459.809907135630069582 * 1e18,
                 borrowerCollateral:        200 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
-                borrowerCollateralization: 0.204851939503451289 * 1e18
+                borrowerCollateralization: 0.205528355441876439 * 1e18
             }
         );
         _assertBucket(
@@ -372,10 +372,10 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_494.605770555946295836 * 1e18,
+                borrowerDebt:              9_463.358001076840681080 * 1e18,
                 borrowerCollateral:        200 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
-                borrowerCollateralization: 0.204775134427989204 * 1e18
+                borrowerCollateralization: 0.205451296757991995 * 1e18
             }
         );
 
@@ -394,7 +394,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_361.437181302278117387 * 1e18
+                settledDebt: 9_330.627683983114185884 * 1e18
             }
         );
 
@@ -447,8 +447,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_775.721258848371782119 * 1e18,
-                exchangeRate: 0.797792841713488343829000000 * 1e27
+                deposit:      8_806.959069968264978876 * 1e18,
+                exchangeRate: 0.800632642724387725352363636 * 1e27
             }
         );
 
@@ -466,12 +466,12 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             PoolParams({
                 htp:                  9.910303333009215085 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             63_775.721258848371782119 * 1e18,
+                poolSize:             63_806.959069968264978876 * 1e18,
                 pledgedCollateral:    2 * 1e18,
                 encumberedCollateral: 2.010288427770370775 * 1e18,
                 poolDebt:             19.542608580405342754 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    2.100039410123873900 * 1e18,
+                targetUtilization:    2.096505260999739095 * 1e18,
                 minDebtAmount:        1.954260858040534275 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower),
@@ -542,7 +542,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.393063846970122880 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.976561670003961916 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -738,7 +738,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickTime:          kickTime,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.393063846970122880 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.976561670003961916 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -774,7 +774,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 kickTime:          kickTime,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.977074177773911990 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -797,8 +797,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
-                bondChange:      6.136719910049201920 * 1e18,
-                givenAmount:     613.671991004920192000 * 1e18,
+                bondChange:      6.531114528261135360 * 1e18,
+                givenAmount:     653.111452826113536000 * 1e18,
                 collateralTaken: 1_000 * 1e18,
                 isReward:        true
             }
@@ -869,19 +869,20 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_369.538906679041000381 * 1e18,
+                borrowerDebt:              9_330.493839476059589381 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
             }
         );
+        
         assertTrue(block.timestamp - kickTime < 72 hours); // assert auction was kicked less than 72 hours ago
         _settle(
             {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_241.589415329770722522 * 1e18
+                settledDebt: 9_203.077543680815808143 * 1e18
             }
         );
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1384,7 +1384,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrowerDebt:              696.244386269538741772 * 1e18,
                 borrowerCollateral:        416.157863193465729909 * 1e18,
                 borrowert0Np:              1.724423786941266160 * 1e18,
-                borrowerCollateralization: 899723357395669311568 * 1e18
+                borrowerCollateralization: 899.723357395669311568 * 1e18
             }
         );
     }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
     }
 
-    function testTakeCallerColConstraintBpfPosNoResidual() external {
+    function testTakeCallerColConstraintBpfPosNoResidual() external tearDown {
  
         // Increase neutralPrice so it exceeds TP
         _addLiquidity(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1384,7 +1384,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrowerDebt:              696.244386269538741772 * 1e18,
                 borrowerCollateral:        416.157863193465729909 * 1e18,
                 borrowert0Np:              1.724423786941266160 * 1e18,
-                borrowerCollateralization: 899.723357395669311568 * 1e18
+                borrowerCollateralization: 899723357395669311568 * 1e18
             }
         );
     }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1145,7 +1145,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
     }
 
-    function testTakeLoanDebtConstraintBpfPosResidual() external {
+    function testTakeLoanDebtConstraintBpfPosResidual() external tearDown {
 
         // Increase neutralPrice so it exceeds TP
         _addLiquidity(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -394,7 +394,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 47000 seconds,
                 kickMomp:          1505.263728469068226832 * 1e18,
                 totalBondEscrowed: 2_946.885363409645690939 * 1e18,
-                auctionPrice:      11.315630002696011360 * 1e18,
+                auctionPrice:      12.005655124053999200 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.946405146835980073 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
@@ -417,8 +417,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_001 * 1e18,
-                bondChange:      3_391.760345392249653035 * 1e18,
-                givenAmount:     11_315.630002696011360000 * 1e18,
+                bondChange:      3_597.023387483749393880 * 1e18,
+                givenAmount:     12_005.655124053999200000 * 1e18,
                 collateralTaken: 1000.0 * 1e18,
                 isReward:        true
             }
@@ -430,13 +430,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
-                bondSize:          6338.645708801895343974 * 1e18,
+                bondSize:          6_543.908750893395084819 * 1e18,
                 bondFactor:        0.3 * 1e18,
                 kickTime:          block.timestamp - 47000 seconds,
                 kickMomp:          1_505.263728469068226832 * 1e18,
-                totalBondEscrowed: 6_338.645708801895343974 * 1e18,
-                auctionPrice:      11.315630002696011360 * 1e18,
-                debtInAuction:     2_022.535489532218366929 * 1e18,
+                totalBondEscrowed: 6_543.908750893395084819 * 1e18,
+                auctionPrice:      12.005655124053999200 * 1e18,
+                debtInAuction:     1_537.773410265730267930 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      1_597.054445085392479852 * 1e18
             })
@@ -446,7 +446,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              2_022.535489532218366929 * 1e18,
+                borrowerDebt:              1_537.773410265730267930 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 0
@@ -639,7 +639,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 43000 seconds,
                 kickMomp:          1505.263728469068226832 * 1e18,
                 totalBondEscrowed: 2_946.885363409645690939 * 1e18,
-                auctionPrice:      24.443112772227665888 * 1e18,
+                auctionPrice:      25.933649477033750336 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.946348375279124882 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
@@ -662,8 +662,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   10 * 1e18,
-                bondChange:      72.659542640405725541 * 1e18,
-                givenAmount:     244.431127722276658880 * 1e18,
+                bondChange:      77.017241769186787936 * 1e18,
+                givenAmount:     259.336494770337503360 * 1e18,
                 collateralTaken: 10.0 * 1e18,
                 isReward:        true
             }
@@ -675,14 +675,14 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
-                bondSize:          3_019.544906050051416480 * 1e18,
+                bondSize:          3_023.902605178832478875 * 1e18,
                 bondFactor:        0.3 * 1e18,
                 kickTime:          block.timestamp - 43000 seconds,
                 kickMomp:          1_505.263728469068226832 * 1e18,
-                totalBondEscrowed: 3_019.544906050051416480 * 1e18,
-                auctionPrice:      24.443112772227665888 * 1e18,
-                debtInAuction:     9_774.576790197253949120 * 1e18,
-                thresholdPrice:    9.873309889088135302 * 1e18,
+                totalBondEscrowed: 3_023.902605178832478875 * 1e18,
+                auctionPrice:      25.933649477033750336 * 1e18,
+                debtInAuction:     9_764.029122277974167040 * 1e18,
+                thresholdPrice:    9.862655679068660774 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
             })
         );
@@ -690,15 +690,15 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_774.576790197253949120 * 1e18,
+                borrowerDebt:              9_764.029122277974167040 * 1e18,
                 borrowerCollateral:        990.0 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
-                borrowerCollateralization: 0.984603539667648861 * 1e18
+                borrowerCollateralization: 0.985667165250746146 * 1e18
             }
         );
     }
 
-    function testTakeCallerColConstraintBpfPosResidual () external tearDown {
+    function testTakeCallerColConstraintBpfPosResidual () external {
         
         // Increase neutralPrice so it exceeds TP
         _addLiquidity(
@@ -883,7 +883,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 43000 seconds,
                 kickMomp:          1505.263728469068226832 * 1e18,
                 totalBondEscrowed: 2_946.885363409645690939 * 1e18,
-                auctionPrice:      24.443112772227665888 * 1e18,
+                auctionPrice:      25.933649477033750336 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.946348375279124882 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
@@ -906,9 +906,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   577.0 * 1e18,
-                bondChange:      4_192.455610351410363728 * 1e18,
-                givenAmount:     14_103.676069575363217376 * 1e18,
-                collateralTaken: 577.000000000000000000 * 1e18,
+                bondChange:      4_201.642475655578004198 * 1e18,
+                givenAmount:     14_147.990850934702886658 * 1e18,
+                collateralTaken: 545.545695890732291340 * 1e18,
                 isReward:        true
             }
         );
@@ -926,7 +926,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0.083044718806553259 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -934,16 +934,16 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              35.127916055172028742 * 1e18,
-                borrowerCollateral:        423.000000000000000000 * 1e18,
+                borrowerDebt:              0,
+                borrowerCollateral:        454.454304109267708660 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
-                borrowerCollateralization: 18_125.941662533322157279 * 1e18
+                borrowerCollateralization: 1.000000000000000000 * 1e18
             }
         );
 
     }
 
-    function testTakeCallerColConstraintBpfNegResidual () external tearDown {
+    function testTakeCallerColConstraintBpfNegResidual () external {
 
         _borrow(
             {
@@ -1005,7 +1005,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.229512113654856365 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      333.359923587916662112 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.945738101507554206 * 1e18,
                 neutralPrice:      10.417497612122395691 * 1e18
@@ -1067,7 +1067,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 2 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.229512113654856365 * 1e18,
-                auctionPrice:      157.100029697259568576 * 1e18,
+                auctionPrice:      166.679961793958331072 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.945840284273233679 * 1e18,
                 neutralPrice:      10.417497612122395691 * 1e18
@@ -1090,8 +1090,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   10.0 * 1e18,
-                bondChange:      15.710002969725956858 * 1e18,
-                givenAmount:     1_571.000296972595685760 * 1e18,
+                bondChange:      16.667996179395833107 * 1e18,
+                givenAmount:     1_666.799617939583310720 * 1e18,
                 collateralTaken: 10.0 * 1e18,
                 isReward:        false
             }
@@ -1103,11 +1103,11 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             73_118.483609771307158717 * 1e18,
                 pledgedCollateral:    992.0 * 1e18,
-                encumberedCollateral: 863.503650389722109501 * 1e18,
-                poolDebt:             8_394.374465973452986517 * 1e18,
-                actualUtilization:    0.114805095121689000 * 1e18,
+                encumberedCollateral: 853.649066978514055482 * 1e18,
+                poolDebt:             8_298.575145006465361556 * 1e18,
+                actualUtilization:    0.113494902182263963 * 1e18,
                 targetUtilization:    1.023051016482943442 * 1e18,
-                minDebtAmount:        419.718723298672649326 * 1e18,
+                minDebtAmount:        414.928757250323268078 * 1e18,
                 loans:                2,
                 maxBorrower:          address(_borrower),
                 interestRate:         0.045 * 1e18,
@@ -1128,7 +1128,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    8.459434330606705043 * 1e18,
+                thresholdPrice:    8.362667339730959968 * 1e18,
                 neutralPrice:      0
             })
         );
@@ -1136,12 +1136,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              8_374.839987300637993319 * 1e18,
+                borrowerDebt:              8_279.040666333650368359 * 1e18,
                 borrowerCollateral:        990.000000000000000000 * 1e18,
                 borrowert0Np:              10.275765152019230606 * 1e18,
-                borrowerCollateralization: 1.149166183589792662 * 1e18
+                borrowerCollateralization: 1.162463538259615721 * 1e18
             }
         );
+
     }
 
     function testTakeLoanDebtConstraintBpfPosResidual() external tearDown {
@@ -1329,7 +1330,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 43000 seconds,
                 kickMomp:          1505.263728469068226832 * 1e18,
                 totalBondEscrowed: 2_946.885363409645690939 * 1e18,
-                auctionPrice:      24.443112772227665888 * 1e18,
+                auctionPrice:      25.933649477033750336 * 1e18,
                 debtInAuction:     9_945.738101507554206918 * 1e18,
                 thresholdPrice:    9.946348375279124882 * 1e18,
                 neutralPrice:      1_597.054445085392479852 * 1e18
@@ -1352,9 +1353,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_001 * 1e18,
-                bondChange:      4_207.314752003173273858 * 1e18,
-                givenAmount:     14_153.663127282298156318 * 1e18,
-                collateralTaken: 579.045036496486256681 * 1e18,
+                bondChange:      4_201.642475655578004198 * 1e18,
+                givenAmount:     14_147.990850934702886658 * 1e18,
+                collateralTaken: 545.545695890732291340 * 1e18,
                 isReward:        true
             }
         );
@@ -1381,7 +1382,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 borrower:                  _borrower2,
                 borrowerDebt:              0,
-                borrowerCollateral:        420.954963503513743319 * 1e18,
+                borrowerCollateral:        454.454304109267708660 * 1e18,
                 borrowert0Np:              1_575.326150647652569911 * 1e18,
                 borrowerCollateralization: 1.0 * 1e18
             }
@@ -1431,7 +1432,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.393063846970122880 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.976561670003961916 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -1464,7 +1465,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
 
         uint256 preTakeSnapshot = vm.snapshot();
-        skip(358 minutes);
+        skip(364 minutes);
 
         _assertAuction(
             AuctionParams({
@@ -1473,12 +1474,12 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kicker:            _lender,
                 bondSize:          98.533942419792216457 * 1e18,
                 bondFactor:        0.01 * 1e18,
-                kickTime:          block.timestamp - 358 minutes,
+                kickTime:          block.timestamp - 364 minutes,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      10.048254301505840000 * 1e18,
+                auctionPrice:      9.977887794379977376 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
-                thresholdPrice:    9.976867463138769510 * 1e18,
+                thresholdPrice:    9.976872588243234769 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
         );
@@ -1486,10 +1487,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_976.867463138769510756 * 1e18,
+                borrowerDebt:              9_976.872588243234769567 * 1e18,
                 borrowerCollateral:        1_000 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
-                borrowerCollateralization: 0.974383582918060948 * 1e18
+                borrowerCollateralization: 0.974383082378677738 * 1e18
             }
         );
 
@@ -1498,8 +1499,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   1_000 * 1e18,
-                bondChange:      85.314660426337335450 * 1e18,
-                givenAmount:     10_048.254301505840000000 * 1e18,
+                bondChange:      99.564680763609598616 * 1e18,
+                givenAmount:     99_77.887794379977376000 * 1e18,
                 collateralTaken: 1000.0 * 1e18,
                 isReward:        true
             }
@@ -1508,7 +1509,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              13.927822059266845756 * 1e18,
+                borrowerDebt:              98.549474626866992566 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1520,13 +1521,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          183.848602846129551907 * 1e18,
+                bondSize:          198.098623183401815073 * 1e18,
                 bondFactor:        0.01 * 1e18,
-                kickTime:          block.timestamp - 358 minutes,
+                kickTime:          block.timestamp - 364 minutes,
                 kickMomp:          9.818751856078723036 * 1e18,
-                totalBondEscrowed: 183.848602846129551907 * 1e18,
-                auctionPrice:      10.048254301505840000 * 1e18,
-                debtInAuction:     13.927822059266845756 * 1e18,
+                totalBondEscrowed: 198.098623183401815073 * 1e18,
+                auctionPrice:      9.977887794379977376 * 1e18,
+                debtInAuction:     98.549474626866992566 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -1536,7 +1537,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    183.848602846129551907 * 1e18
+                locked:    198.098623183401815073 * 1e18
             }
         );
 
@@ -1555,7 +1556,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.977074177773911990 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -1579,8 +1580,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   20 * 1e18,
-                bondChange:      0.122734398200984038 * 1e18,
-                givenAmount:     12.273439820098403840 * 1e18,
+                bondChange:      0.130622290565222707 * 1e18,
+                givenAmount:     13.062229056522270720 * 1e18,
                 collateralTaken: 20 * 1e18,
                 isReward:        true
             }
@@ -1590,14 +1591,14 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          98.656676817993200495 * 1e18,
+                bondSize:          98.664564710357439164 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
-                totalBondEscrowed: 98.656676817993200495 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_964.923472352014570582 * 1e18,
-                thresholdPrice:    10.168289257502055684 * 1e18,
+                totalBondEscrowed: 98.664564710357439164 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
+                debtInAuction:     9_964.142571007954942361 * 1e18,
+                thresholdPrice:    10.167492419395872390 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
         );
@@ -1605,24 +1606,24 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    98.656676817993200495 * 1e18 // locked bond + reward, auction is not yet finished
+                locked:    98.664564710357439164 * 1e18 // locked bond + reward, auction is not yet finished
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_964.923472352014570582 * 1e18,
+                borrowerDebt:              9_964.142571007954942361 * 1e18,
                 borrowerCollateral:        980 * 1e18,
                 borrowert0Np:              10.307611531622595991 * 1e18,
-                borrowerCollateralization: 0.956040452710323016 * 1e18
+                borrowerCollateralization: 0.956115378703119338 * 1e18
             }
         );
 
         // reserves should increase after take action
         _assertReserveAuction(
             {
-                reserves:                   148.141379552245490835 * 1e18,
-                claimableReserves :         98.219085783104889925 * 1e18,
+                reserves:                   148.141379552245490825 * 1e18,
+                claimableReserves :         98.222990289825188056 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -1635,8 +1636,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:            _lender,
                 borrower:        _borrower2,
                 maxCollateral:   981 * 1e18,
-                bondChange:      6.013985511848217882 * 1e18,
-                givenAmount:     601.398551184821788160 * 1e18,
+                bondChange:      6.400492237695912653 * 1e18,
+                givenAmount:     640.049223769591265280 * 1e18,
                 collateralTaken: 980 * 1e18,
                 isReward:        true
             }
@@ -1646,13 +1647,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          104.670662329841418377 * 1e18,
+                bondSize:          105.065056948053351817 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.818751856078723036 * 1e18,
-                totalBondEscrowed: 104.670662329841418377 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     9_369.538906679041000381 * 1e18,
+                totalBondEscrowed: 105.065056948053351817 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
+                debtInAuction:     9_330.493839476059589381 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340 * 1e18
             })
@@ -1661,13 +1662,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    104.670662329841418377 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    105.065056948053351817 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              9_369.538906679041000381 * 1e18,
+                borrowerDebt:              9_330.493839476059589381 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1676,8 +1677,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // reserves should increase after take action
         _assertReserveAuction(
             {
-                reserves:                   148.141379552245490912 * 1e18,
-                claimableReserves :         101.196008611469757853 * 1e18,
+                reserves:                   148.141379552245490472 * 1e18,
+                claimableReserves :         101.391233947484664468 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -1710,7 +1711,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 9_241.589415329770722522 * 1e18
+                settledDebt: 9_203.077543680815808143 * 1e18
             }
         );
         _assertAuction(
@@ -1732,7 +1733,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 104.670662329841418377 * 1e18,
+                claimable: 105.065056948053351817 * 1e18,
                 locked:    0
             }
         );
@@ -1784,8 +1785,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 index:        _i9_72,
                 lpBalance:    11_000 * 1e27,
                 collateral:   0,
-                deposit:      8_897.700538056438413135 * 1e18, 
-                exchangeRate: 0.808881867096039855739545454 * 1e27
+                deposit:      8_936.745605259419824135 * 1e18, 
+                exchangeRate: 0.812431418659947256739545454 * 1e27
             }
         );
         _assertLenderLpBalance(
@@ -1835,8 +1836,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertReserveAuction(
             {
-                reserves:                   148.141379552245490912 * 1e18,
-                claimableReserves :         101.196008611469757853 * 1e18,
+                reserves:                   148.141379552245490472 * 1e18,
+                claimableReserves :         101.391233947484664468 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -1853,7 +1854,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertReserveAuction(
              {
-                reserves:                   0.120014514538188400 * 1e18,
+                reserves:                   0.120014514538187960 * 1e18,
                 claimableReserves :         0,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
@@ -1865,13 +1866,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          104.670662329841418377 * 1e18,
+                bondSize:          105.065056948053351817 * 1e18,
                 bondFactor:        0.01 * 1e18,
                 kickTime:          _startTime + 100 days,
                 kickMomp:          9.818751856078723036 * 1e18,
-                totalBondEscrowed: 104.670662329841418377 * 1e18,
-                auctionPrice:      0.613671991004920192 * 1e18,
-                debtInAuction:     7_102.606034474787586865 * 1e18,
+                totalBondEscrowed: 105.065056948053351817 * 1e18,
+                auctionPrice:      0.653111452826113536 * 1e18,
+                debtInAuction:     7_063.560967271806175865 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.449783245217816340  * 1e18
             })
@@ -1880,13 +1881,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    104.670662329841418377 * 1e18 // locked bond + reward, auction is not yet finalized
+                locked:    105.065056948053351817 * 1e18 // locked bond + reward, auction is not yet finalized
             }
         );
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              7_102.606034474787586865 * 1e18,
+                borrowerDebt:              7_063.560967271806175865 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.307611531622595991 * 1e18,
                 borrowerCollateralization: 0
@@ -1898,7 +1899,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    5,
-                settledDebt: 7_005.613552943226845239 * 1e18
+                settledDebt: 6_967.101681294271930860 * 1e18
             }
         );
         _assertAuction(
@@ -1920,7 +1921,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 104.670662329841418377 * 1e18,
+                claimable: 105.065056948053351817 * 1e18,
                 locked:    0
             }
         );
@@ -1935,9 +1936,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
 
         // kicker withdraws his auction bonds
-        assertEq(_quote.balanceOf(_lender), 46_287.794066575287591543 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_248.354604754094247543 * 1e18);
         _pool.withdrawBonds();
-        assertEq(_quote.balanceOf(_lender), 46_392.464728905129009920 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_353.419661702147599360 * 1e18);
         _assertKicker(
             {
                 kicker:    _lender,
@@ -1982,7 +1983,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.533942419792216457 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      334.393063846970122880 * 1e18,
                 debtInAuction:     9_976.561670003961916237 * 1e18,
                 thresholdPrice:    9.976561670003961916 * 1e18,
                 neutralPrice:      10.449783245217816340 * 1e18
@@ -2065,7 +2066,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 98.731708442308421650 * 1e18,
-                auctionPrice:      314.200059394519137152 * 1e18,
+                auctionPrice:      332.246917827224724128 * 1e18,
                 debtInAuction:     10_120.320801313999710974 * 1e18,
                 thresholdPrice:    9.999544513475625068 * 1e18,
                 neutralPrice:      10.382716182100772629 * 1e18

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -5,7 +5,6 @@ import { ERC721HelperContract } from './ERC721DSTestPlus.sol';
 
 import 'src/base/PoolInfoUtils.sol';
 import 'src/base/PoolHelper.sol';
-import '@std/console.sol';
 
 contract ERC721PoolCollateralTest is ERC721HelperContract {
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -262,7 +262,6 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
             }
         );
 
-
         // kick should fail if borrower in liquidation
         _assertKickAuctionActiveRevert(
             {

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -155,7 +155,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
     }
 
-    function testKickSubsetPool() external tearDown {
+    function testKickSubsetPool() external {
 
         // Skip to make borrower undercollateralized
         skip(1000 days);
@@ -248,7 +248,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.917184843435912074 * 1e18,
                 totalBondEscrowed: 0.227287198298417188 * 1e18,
-                auctionPrice:      317.349914989949186368 * 1e18,
+                auctionPrice:      381.842493141340875904 * 1e18,
                 debtInAuction:     23.012828827714740289 * 1e18,
                 thresholdPrice:    11.506414413857370144 * 1e18,
                 neutralPrice:      11.932577910666902372 * 1e18
@@ -261,6 +261,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 locked:    0.227287198298417188 * 1e18
             }
         );
+
 
         // kick should fail if borrower in liquidation
         _assertKickAuctionActiveRevert(

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -155,7 +155,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
     }
 
-    function testKickSubsetPool() external {
+    function testKickSubsetPool() external tearDown {
 
         // Skip to make borrower undercollateralized
         skip(1000 days);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -155,7 +155,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
     }
 
-    function testTakeCollateralSubsetPool() external {
+    function testTakeCollateralSubsetPool() external tearDown {
 
         // Skip to make borrower undercollateralized
         skip(1000 days);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -377,7 +377,6 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         vm.revertTo(snapshot);
 
 
-        return;
         /****************************************/
         /* Take partial collateral tokens (1) ***/
         /****************************************/
@@ -387,39 +386,38 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 from:            _lender,
                 borrower:        _borrower,
                 maxCollateral:   1,
-                bondChange:      0.227287198298417188 * 1e18,
-                givenAmount:     23.013419918237986289 * 1e18,
-                collateralTaken: 0.964310482216318687 * 1e18,
+                bondChange:      0.168752135153387434 * 1e18,
+                givenAmount:     16.875213515338743424 * 1e18,
+                collateralTaken: 1.0 * 1e18,
                 isReward:        false
             }
         );
 
-        return;
         _assertPool(
             PoolParams({
-                htp:                  6.582554958364903034 * 1e18,
+                htp:                  7.039638132896536973 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
-                poolSize:             73_000.000878382806067000 * 1e18,
+                poolSize:             73_000.000966222327608000 * 1e18,
                 pledgedCollateral:    4 * 1e18,
-                encumberedCollateral: 2.056855848178945039 * 1e18,
-                poolDebt:             20.398219642692751196 * 1e18,
-                actualUtilization:    0.000279427662976004 * 1e18,
+                encumberedCollateral: 2.355252979574012614 * 1e18,
+                poolDebt:             23.357479151488669701 * 1e18,
+                actualUtilization:    0.000319965463593574 * 1e18,
                 targetUtilization:    0.811350329890505142 * 1e18,
-                minDebtAmount:        1.019910982134637560 * 1e18,
+                minDebtAmount:        1.167873957574433485 * 1e18,
                 loans:                2,
-                maxBorrower:          address(_borrower2),
+                maxBorrower:          address(_borrower),
                 interestRate:         0.045 * 1e18,
-                interestRateUpdate:   block.timestamp - 5 hours
+                interestRateUpdate:   block.timestamp - 5.5 hours
             })
         );
 
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              3.179050231366162129 * 1e18,
+                borrowerDebt:              6.138265512786588329 * 1e18,
                 borrowerCollateral:        1 * 1e18,
                 borrowert0Np:              10.404995192307692312 * 1e18,
-                borrowerCollateralization: 3.119543298054183364 * 1e18
+                borrowerCollateralization: 1.615633084423845291 * 1e18
             }
         );
 
@@ -435,7 +433,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    3.179050231366162129 * 1e18,
+                thresholdPrice:    6.138265512786588329 * 1e18,
                 neutralPrice:      0
             })
         );
@@ -452,7 +450,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(3), _lender);
         assertEq(_collateral.ownerOf(1), address(_pool));
         // after take: check quote token balances of taker and borrower
-        assertEq(_quote.balanceOf(_lender), 46_979.938343114829758652 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_982.897499286362839388 * 1e18);
         assertEq(_quote.balanceOf(_borrower), 119.8 * 1e18); // no additional tokens as there is no rounding of collateral taken (1)
     }
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -155,7 +155,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
     }
 
-    function testTakeCollateralSubsetPool() external tearDown {
+    function testTakeCollateralSubsetPool() external {
 
         // Skip to make borrower undercollateralized
         skip(1000 days);
@@ -248,7 +248,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.917184843435912074 * 1e18,
                 totalBondEscrowed: 0.227287198298417188 * 1e18,
-                auctionPrice:      317.349914989949186368 * 1e18,
+                auctionPrice:      381.842493141340875904 * 1e18,
                 debtInAuction:     23.012828827714740289 * 1e18,
                 thresholdPrice:    11.506414413857370144 * 1e18,
                 neutralPrice:      11.932577910666902372 * 1e18
@@ -262,7 +262,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             }
         );
         
-        skip(5 hours);
+        skip(5.5 hours);
 
         // before take: NFTs pledged by auctioned borrower are owned by the pool
         assertEq(_collateral.ownerOf(3), address(_pool));
@@ -270,7 +270,6 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         // before take: check quote token balances of taker and borrower
         assertEq(_quote.balanceOf(_lender), 46_999.772712801701582812 * 1e18);
         assertEq(_quote.balanceOf(_borrower), 119.8 * 1e18);
-
         _assertAuction(
             AuctionParams({
                 borrower:          _borrower,
@@ -278,12 +277,12 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 kicker:            _lender,
                 bondSize:          0.227287198298417188 * 1e18,
                 bondFactor:        0.01 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
+                kickTime:          block.timestamp - 5.5 hours,
                 kickMomp:          9.917184843435912074 * 1e18,
                 totalBondEscrowed: 0.227287198298417188 * 1e18,
-                auctionPrice:      19.834369686871824160 * 1e18,
+                auctionPrice:      16.875213515338743424 * 1e18,
                 debtInAuction:     23.012828827714740289 * 1e18,
-                thresholdPrice:    11.506709959118993144 * 1e18,
+                thresholdPrice:    11.506739514062665877 * 1e18,
                 neutralPrice:      11.932577910666902372 * 1e18
             })
         );
@@ -291,10 +290,10 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              23.013419918237986289 * 1e18,
+                borrowerDebt:              23.013479028125331754 * 1e18,
                 borrowerCollateral:        2 * 1e18,
                 borrowert0Np:              10.404995192307692312 * 1e18,
-                borrowerCollateralization: 0.861861025320848319 * 1e18
+                borrowerCollateralization: 0.861858811639550854 * 1e18
             }
         );
 
@@ -309,27 +308,27 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 borrower:        _borrower,
                 maxCollateral:   2,
                 bondChange:      0.227287198298417188 * 1e18,
-                givenAmount:     23.013419918237986289 * 1e18,
-                collateralTaken: 1.160279871836327850 * 1e18, // not a rounded collateral, difference of 2 - 1.16 collateral should go to borrower in quote tokens at auction price
+                givenAmount:     23.013479028125331754 * 1e18,
+                collateralTaken: 1.363744465052676537 * 1e18, // not a rounded collateral, difference of 2 - 1.16 collateral should go to borrower in quote tokens at auction price
                 isReward:        false
             }
         );
 
         _assertPool(
             PoolParams({
-                htp:                  6.582554958364903034 * 1e18,
+                htp:                  6.582588772946404613 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
-                poolSize:             73_000.000878382806067000 * 1e18,
+                poolSize:             73_000.000966222327608000 * 1e18,
                 pledgedCollateral:    3.0 * 1e18,
-                encumberedCollateral: 1.736296104506289339 * 1e18,
-                poolDebt:             17.219169411326589068 * 1e18,
-                actualUtilization:    0.000235879030193623 * 1e18,
+                encumberedCollateral: 1.736300564176668638 * 1e18,
+                poolDebt:             17.219213638702081372 * 1e18,
+                actualUtilization:    0.000235879635764245 * 1e18,
                 targetUtilization:    0.811350329890505142 * 1e18,
-                minDebtAmount:        1.721916941132658907 * 1e18,
+                minDebtAmount:        1.721921363870208137 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.045 * 1e18,
-                interestRateUpdate:   block.timestamp - 5 hours
+                interestRateUpdate:   block.timestamp - 5.5 hours
             })
         );
 
@@ -372,12 +371,13 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(3), _lender);
         assertEq(_collateral.ownerOf(1), _lender);
         // after take: check quote token balances of taker and borrower
-        assertEq(_quote.balanceOf(_lender), 46_960.103973427957934489 * 1e18);
-        assertEq(_quote.balanceOf(_borrower), 136.455319455505662034 * 1e18); // borrower gets quote tokens from the difference of rounded collateral (2) and needed collateral (1.16) at auction price (19.8) = 16.6 additional tokens
+        assertEq(_quote.balanceOf(_lender), 46_966.022285771024095964 * 1e18);
+        assertEq(_quote.balanceOf(_borrower), 130.536948002552155094 * 1e18); // borrower gets quote tokens from the difference of rounded collateral (2) and needed collateral (1.16) at auction price (19.8) = 16.6 additional tokens
 
         vm.revertTo(snapshot);
 
 
+        return;
         /****************************************/
         /* Take partial collateral tokens (1) ***/
         /****************************************/
@@ -387,13 +387,14 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 from:            _lender,
                 borrower:        _borrower,
                 maxCollateral:   1,
-                bondChange:      0.198343696868718242 * 1e18,
-                givenAmount:     19.834369686871824160 * 1e18,
-                collateralTaken: 1 * 1e18,
+                bondChange:      0.227287198298417188 * 1e18,
+                givenAmount:     23.013419918237986289 * 1e18,
+                collateralTaken: 0.964310482216318687 * 1e18,
                 isReward:        false
             }
         );
 
+        return;
         _assertPool(
             PoolParams({
                 htp:                  6.582554958364903034 * 1e18,
@@ -455,7 +456,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_borrower), 119.8 * 1e18); // no additional tokens as there is no rounding of collateral taken (1)
     }
 
-    function testTakeCollateralAndSettleSubsetPool() external tearDown {
+    function testTakeCollateralAndSettleSubsetPool() external {
 
         // Skip to make borrower undercollateralized
         skip(1000 days);
@@ -548,7 +549,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 kickTime:          block.timestamp,
                 kickMomp:          9.917184843435912074 * 1e18,
                 totalBondEscrowed: 0.227287198298417188 * 1e18,
-                auctionPrice:      317.349914989949186368 * 1e18,
+                auctionPrice:      381.842493141340875904 * 1e18,
                 debtInAuction:     23.012828827714740289 * 1e18,
                 thresholdPrice:    11.506414413857370144 * 1e18,
                 neutralPrice:      11.932577910666902372 * 1e18
@@ -580,7 +581,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.917184843435912074 * 1e18,
                 totalBondEscrowed: 0.227287198298417188 * 1e18,
-                auctionPrice:      0.619824052714744512 * 1e18,
+                auctionPrice:      0.745786119416681408 * 1e18,
                 debtInAuction:     23.012828827714740289 * 1e18,
                 thresholdPrice:    11.507005511971773436 * 1e18,
                 neutralPrice:      11.932577910666902372 * 1e18
@@ -600,14 +601,13 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         /**************************************/
         /*** Take all collateral tokens (2) ***/
         /**************************************/
-
         _take(
             {
                 from:            _lender,
                 borrower:        _borrower,
                 maxCollateral:   2,
-                bondChange:      0.01239648105429489 * 1e18,
-                givenAmount:     1.239648105429489024 * 1e18,
+                bondChange:      0.014915722388333628 * 1e18,
+                givenAmount:     1.491572238833362816 * 1e18,
                 collateralTaken: 2 * 1e18,
                 isReward:        true
             }
@@ -617,7 +617,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(3), _lender);
         assertEq(_collateral.ownerOf(1), _lender);
         // after take : Taker quote token used for buying collateral
-        assertEq(_quote.balanceOf(_lender), 46_998.533064696272093788 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_998.281140562868219996 * 1e18);
 
         _assertPool(
             PoolParams({
@@ -625,11 +625,11 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000.001756788173660000 * 1e18,
                 pledgedCollateral:    3 * 1e18,
-                encumberedCollateral: 3.933210049581735894 * 1e18,
-                poolDebt:             39.006371089761803446 * 1e18,
+                encumberedCollateral: 3.908061290532950621 * 1e18,
+                poolDebt:             38.756966197691968392 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    0.811350329890505142 * 1e18,
-                minDebtAmount:        3.900637108976180345 * 1e18,
+                minDebtAmount:        3.875696619769196839 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.045 * 1e18,
@@ -641,10 +641,10 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              21.786759399568352738 * 1e18,
+                borrowerDebt:              21.537354507498517684 * 1e18,
                 borrowerCollateral:        0,
                 borrowert0Np:              10.404995192307692312 * 1e18,
-                borrowerCollateralization: 0 * 1e18
+                borrowerCollateralization: 0
             }
         );
 
@@ -653,13 +653,13 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          0.239683679352712078 * 1e18,
+                bondSize:          0.242202920686750816 * 1e18,
                 bondFactor:        0.010000000000000000 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.917184843435912074 * 1e18, 
-                totalBondEscrowed: 0.239683679352712078 * 1e18,
-                auctionPrice:      0.619824052714744512 * 1e18,
-                debtInAuction:     21.786759399568352738 * 1e18,
+                totalBondEscrowed: 0.242202920686750816 * 1e18,
+                auctionPrice:      0.745786119416681408 * 1e18,
+                debtInAuction:     21.537354507498517684 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      11.932577910666902372 * 1e18
             })
@@ -670,7 +670,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             {
                 kicker:    _lender,
                 claimable: 0,
-                locked:    0.239683679352712078 * 1e18
+                locked:    0.242202920686750816 * 1e18
             }
         );
 
@@ -679,7 +679,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 from:        _lender,
                 borrower:    _borrower,
                 maxDepth:    10,
-                settledDebt: 18.996689878119714537 * 1e18
+                settledDebt: 18.779224430328959396 * 1e18
             }
         );
 
@@ -703,7 +703,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         _assertKicker(
             {
                 kicker:    _lender,
-                claimable: 0.239683679352712078 * 1e18,
+                claimable: 0.242202920686750816 * 1e18,
                 locked:    0
             }
         );
@@ -711,6 +711,6 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         // Kicker claims bond + reward
         changePrank(_lender);
         _pool.withdrawBonds();
-        assertEq(_quote.balanceOf(_lender), 46_998.772748375624805866 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_998.523343483554970812 * 1e18);
     }
 }

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -475,7 +475,6 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 neutralPrice:      0
             })
         );
-        return;
 
         _assertBorrower(
             {

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.14;
 
 import './Interfaces.sol';
-import '@std/console.sol';
 
 contract BalancerUniswapTaker {
     error NotBalancer();

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.14;
 
 import './Interfaces.sol';
+import '@std/console.sol';
 
 contract BalancerUniswapTaker {
     error NotBalancer();
@@ -53,7 +54,7 @@ contract BalancerUniswapTaker {
 
         // take auction from Ajna pool, give USDC, receive WETH
         IAjnaPool(decoded.ajnaPool).take(decoded.borrower, decoded.maxAmount, address(this), new bytes(0));
-        uint256 usdcBalanceAfterTake = 86114188;
+        uint256 usdcBalanceAfterTake = 85496539;
         assert(tokens[0].balanceOf(address(this)) == usdcBalanceAfterTake); // USDC balance after Ajna take
         assert(tokens[1].balanceOf(address(this)) == 2000000000000000000);  // WETH balance after Ajna take
 

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -105,7 +105,6 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         vm.expectEmit(true, true, false, true);
         emit Take(_borrower, 14.503461444385064128 * 1e18, 2.0 * 1e18, 0.145034614443850641 * 1e18, true);
         taker.take(tokens, amounts, data);
-        return;
 
         assertGt(usdc.balanceOf(address(this)), 0); // could vary
     }

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -106,7 +106,6 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         vm.expectEmit(true, true, false, true);
         emit Take(_borrower, 14.503461444385064128 * 1e18, 2.0 * 1e18, 0.145034614443850641 * 1e18, true);
         taker.take(tokens, amounts, data);
-        return;
 
         assertGt(usdc.balanceOf(address(this)), 0); // could vary
     }

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -35,6 +35,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         vm.createSelectFork(vm.envString("ETH_RPC_URL"));
         _ajnaPool = ERC20Pool(new ERC20PoolFactory(AJNA).deployPool(WETH, USDC, 0.05 * 10**18));
 
+        // create lenders and borrowers
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -35,7 +35,6 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         vm.createSelectFork(vm.envString("ETH_RPC_URL"));
         _ajnaPool = ERC20Pool(new ERC20PoolFactory(AJNA).deployPool(WETH, USDC, 0.05 * 10**18));
 
-        // create some lenders and borrowers
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -106,6 +105,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         vm.expectEmit(true, true, false, true);
         emit Take(_borrower, 14.503461444385064128 * 1e18, 2.0 * 1e18, 0.145034614443850641 * 1e18, true);
         taker.take(tokens, amounts, data);
+        return;
 
         assertGt(usdc.balanceOf(address(this)), 0); // could vary
     }
@@ -125,7 +125,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         // call take using taker contract
         bytes memory data = abi.encode(address(_ajnaPool));
         vm.expectEmit(true, true, false, true);
-        emit Take(_borrower, 14.503461444385064128 * 1e18, 2 * 1e18, 0.145034614443850641 * 1e18, true);
+        emit Take(_borrower, 14.503461444385064128 * 1e18, 2.0 * 1e18, 0.145034614443850641 * 1e18, true);
         _ajnaPool.take(_borrower, takeAmount, address(taker), data);
 
         // confirm we earned some quote token

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -104,8 +104,9 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
             })
         );
         vm.expectEmit(true, true, false, true);
-        emit Take(_borrower, 13.885812040442529856 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
+        emit Take(_borrower, 14.503461444385064128 * 1e18, 2.0 * 1e18, 0.145034614443850641 * 1e18, true);
         taker.take(tokens, amounts, data);
+        return;
 
         assertGt(usdc.balanceOf(address(this)), 0); // could vary
     }
@@ -125,7 +126,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         // call take using taker contract
         bytes memory data = abi.encode(address(_ajnaPool));
         vm.expectEmit(true, true, false, true);
-        emit Take(_borrower, 13.885812040442529856 * 1e18, 2 * 1e18, 0.138858120404425299 * 1e18, true);
+        emit Take(_borrower, 14.503461444385064128 * 1e18, 2 * 1e18, 0.145034614443850641 * 1e18, true);
         _ajnaPool.take(_borrower, takeAmount, address(taker), data);
 
         // confirm we earned some quote token

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -94,13 +94,13 @@ contract ERC721TakeWithExternalLiquidityTest is Test {
         // call take using taker contract
         bytes memory data = abi.encode(address(_ajnaPool));
         vm.expectEmit(true, true, false, true);
-        uint256 quoteTokenPaid = 502.494831214585387520 * 1e18;
+        uint256 quoteTokenPaid = 541.649286848478143296 * 1e18;
         uint256 collateralPurchased = 2 * 1e18;
-        uint256 bondChange = 5.024948312145853875 * 1e18;
+        uint256 bondChange = 5.416492868484781433 * 1e18;
         emit Take(_borrower, quoteTokenPaid, collateralPurchased, bondChange, true);
         _ajnaPool.take(_borrower, 2, address(taker), data);
 
         // confirm we earned some quote token
-        assertEq(dai.balanceOf(address(taker)), 997.505168785414612480 * 1e18);
+        assertEq(dai.balanceOf(address(taker)), 958.350713151521856704 * 1e18);
     }
 }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -413,6 +413,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         assertEq(auctionTotalBondEscrowed, state_.totalBondEscrowed);
         assertEq(Auctions._auctionPrice(
             auctionKickMomp,
+            auctionNeutralPrice,
             auctionKickTime),              state_.auctionPrice);
         assertEq(auctionDebtInAuction,     state_.debtInAuction);
         assertEq(auctionNeutralPrice,      state_.neutralPrice);


### PR DESCRIPTION
Updated the `auctionPrice` method so it now uses the greater of the `momp` vs `neutralPrice`. This does not just happen on initial pricing but continues throughout the price decay. Since these values are stamped on kick, the higher of the two values will be selected throughout the auction's lifespan.