### PR TITLE
issue #464

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -391,12 +391,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 amountToBorrow_,
         uint256 limitIndex_,
         uint256 collateralToPledge_
-    ) internal returns (bool pledge_, bool borrow_, uint256 newLup_) {
+    ) internal returns (uint256 newLup_) {
         PoolState memory poolState = _accruePoolInterest();
         Borrower  memory borrower = Loans.getBorrowerInfo(loans, borrowerAddress_);
 
-        pledge_ = collateralToPledge_ != 0;
-        borrow_ = amountToBorrow_ != 0 || limitIndex_ != 0;
         newLup_ = _lup(poolState.debt);
 
         uint256 borrowerDebt = Maths.wmul(borrower.t0Debt, poolState.inflator);
@@ -405,7 +403,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         bool inAuction;
 
         // pledge collateral to pool
-        if (pledge_) {
+        if (collateralToPledge_ != 0) {
             // add new amount of collateral to pledge to borrower balance
             borrower.collateral  += collateralToPledge_;
 
@@ -438,7 +436,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         // borrow against pledged collateral
         // check both values to enable an intentional 0 borrow loan call to update borrower's loan state
-        if (borrow_) {
+        if (amountToBorrow_ != 0 || limitIndex_ != 0) {
             // only intended recipient can borrow quote
             if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -58,11 +58,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 limitIndex_,
         uint256 collateralToPledge_
     ) external {
-        (
-            bool pledge,
-            bool borrow,
-            uint256 newLup
-        ) = _drawDebt(
+        uint256 newLup = _drawDebt(
             borrowerAddress_,
             amountToBorrow_,
             limitIndex_,
@@ -72,9 +68,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         emit DrawDebt(borrowerAddress_, amountToBorrow_, collateralToPledge_, newLup);
 
         // move collateral from sender to pool
-        if (pledge) _transferCollateralFrom(msg.sender, collateralToPledge_);
+        if (collateralToPledge_ != 0) _transferCollateralFrom(msg.sender, collateralToPledge_);
         // move borrowed amount from pool to sender
-        if (borrow) _transferQuoteToken(msg.sender, amountToBorrow_);
+        if (amountToBorrow_ != 0) _transferQuoteToken(msg.sender, amountToBorrow_);
     }
 
     function repayDebt(

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -90,11 +90,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         // move collateral from sender to pool to be properly accounted if auction settled
         if (tokenIdsToPledge_.length != 0) _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
 
-        (
-            ,
-            bool borrow,
-            uint256 newLup
-        ) = _drawDebt(
+        uint256 newLup = _drawDebt(
             borrowerAddress_,
             amountToBorrow_,
             limitIndex_,
@@ -104,7 +100,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         emit DrawDebtNFT(borrowerAddress_, amountToBorrow_, tokenIdsToPledge_, newLup);
 
         // move borrowed amount from pool to sender
-        if (borrow) _transferQuoteToken(msg.sender, amountToBorrow_);
+        if (amountToBorrow_ != 0) _transferQuoteToken(msg.sender, amountToBorrow_);
     }
 
     function repayDebt(

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -87,8 +87,11 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 limitIndex_,
         uint256[] calldata tokenIdsToPledge_
     ) external {
+        // move collateral from sender to pool to be properly accounted if auction settled
+        if (tokenIdsToPledge_.length != 0) _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
+
         (
-            bool pledge,
+            ,
             bool borrow,
             uint256 newLup
         ) = _drawDebt(
@@ -100,8 +103,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         emit DrawDebtNFT(borrowerAddress_, amountToBorrow_, tokenIdsToPledge_, newLup);
 
-        // move collateral from sender to pool
-        if (pledge) _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
         // move borrowed amount from pool to sender
         if (borrow) _transferQuoteToken(msg.sender, amountToBorrow_);
     }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -185,6 +185,22 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         borrowers.add(from);
     }
 
+    function _borrowZeroAmount(
+        address from,
+        uint256 amount,
+        uint256 indexLimit,
+        uint256 newLup
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebt(from, amount, 0, newLup);
+
+        ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
+
+        // Add for tearDown
+        borrowers.add(from);
+    }
+
     function _drawDebt(
         address from,
         address borrower,

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -465,7 +465,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         _assertLenderInterest(liquidityAdded, 86.113113158840750000 * 1e18);
 
         skip(10 days);
-        _borrow(
+        _borrowZeroAmount(
             {
                 from:       _borrower,
                 amount:     0,

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -328,7 +328,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         while (i < 77) {
             // trigger an interest accumulation
             skip(12 hours);
-            _borrow(
+            _borrowZeroAmount(
                 {
                     from:       _borrower,
                     amount:     0,
@@ -405,7 +405,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         while (i < 196) {
             // trigger an interest accumulation
             skip(12 hours);
-            _borrow(
+            _borrowZeroAmount(
                 {
                     from:       _borrower,
                     amount:     0,

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -263,14 +263,14 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
 
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
-
         for (uint256 i = 0; i < tokenIds.length; i++) {
             assertEq(_collateral.ownerOf(tokenIds[i]), from); // token is owned by pledger address
             vm.expectEmit(true, true, false, true);
             emit Transfer(from, address(_pool), tokenIds[i]);
         }
+
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
 
         ERC721Pool(address(_pool)).drawDebt(borrower, 0, 0, tokenIds);
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -295,4 +295,147 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
             }
         );
     }
+
+    function testKickSubsetPoolAndSettleByRepayAndPledge() external tearDown {
+        // Skip to make borrower undercollateralized
+        skip(1000 days);
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0,
+                thresholdPrice:    11.364359914920859402 * 1e18,
+                neutralPrice:      0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              22.728719829841718804 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 0.872656701977127996 * 1e18
+            }
+        );
+
+        _kick(
+            {
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           23.012828827714740289 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.227287198298417188 * 1e18,
+                transferAmount: 0.227287198298417188 * 1e18
+            }
+        );
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            true,
+                kicker:            _lender,
+                bondSize:          0.227287198298417188 * 1e18,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          block.timestamp,
+                kickMomp:          9.917184843435912074 * 1e18,
+                totalBondEscrowed: 0.227287198298417188 * 1e18,
+                auctionPrice:      317.349914989949186368 * 1e18,
+                debtInAuction:     23.012828827714740289 * 1e18,
+                thresholdPrice:    11.506414413857370144 * 1e18,
+                neutralPrice:      11.932577910666902372 * 1e18
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              23.012828827714740289 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 0.861883162446546169 * 1e18
+            }
+        );
+
+        uint256 snapshot = vm.snapshot();
+        // borrower repays debt in order to exit from auction
+        _repayDebt({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    25 * 1e18,
+            amountRepaid:     23.012828827714740289 * 1e18,
+            collateralToPull: 0,
+            newLup:           _priceAt(3696)
+        });
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0,
+                thresholdPrice:    0,
+                neutralPrice:      0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              0,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
+            }
+        );
+        vm.revertTo(snapshot);
+
+        // borrower pledge one more NFT to exit from auction
+        uint256[] memory tokenIdsToAdd = new uint256[](1);
+        tokenIdsToAdd[0] = 5;
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0,
+                thresholdPrice:    7.670942942571580096 * 1e18,
+                neutralPrice:      0
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              23.012828827714740289 * 1e18,
+                borrowerCollateral:        3 * 1e18,
+                borrowert0Np:              6.989927127403846156 * 1e18,
+                borrowerCollateralization: 1.292824743669819254 * 1e18
+            }
+        );
+    }
+
 }


### PR DESCRIPTION
- transfer first pledged NFTs from borrower to pool so settle logic can be applied
- added tests for kick and save by repay and pledge more collateral
- added tests for kick, partially take and save by repay and pledge more collateral