### PR TITLE
Borrower external lib

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,7 @@ linkage=()
 
 echo
 echo Deploying libraries...
-libraries=( Auctions LenderActions PoolCommons PositionNFTSVG )
+libraries=( Auctions LenderActions BorrowerActions PoolCommons PositionNFTSVG )
 for contract in "${libraries[@]}"
 do
     createlib="forge create --rpc-url ${ETH_RPC_URL:?} --keystore ${DEPLOY_KEY:?} --password ${password:?} \

--- a/scripts/ajna_setup.py
+++ b/scripts/ajna_setup.py
@@ -10,6 +10,7 @@ def main():
     Deposits.deploy({"from": accounts[0]})
     PoolCommons.deploy({"from": accounts[0]})
     LenderActions.deploy({"from": accounts[0]})
+    BorrowerActions.deploy({"from": accounts[0]})
     Auctions.deploy({"from": accounts[0]})
     erc20_pool_factory = ERC20PoolFactory.deploy(ajna_address, {"from": accounts[0]})
     erc721_pool_factory = ERC721PoolFactory.deploy(ajna_address, {"from": accounts[0]})

--- a/scripts/erc20pool_test.py
+++ b/scripts/erc20pool_test.py
@@ -8,6 +8,7 @@ def main():
     Deposits.deploy({"from": accounts[0]})
     PoolCommons.deploy({"from": accounts[0]})
     LenderActions.deploy({"from": accounts[0]})
+    BorrowerActions.deploy({"from": accounts[0]})
     Auctions.deploy({"from": accounts[0]})
     erc20_pool_factory = ERC20PoolFactory.deploy({"from": accounts[0]})
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -281,7 +281,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         PoolState memory poolState = _accruePoolInterest();
 
         // kick auctions
-        (KickResult memory result) = Auctions.kickWithDeposit(
+        KickResult memory result = Auctions.kickWithDeposit(
             auctions,
             deposits,
             buckets,

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -338,12 +338,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return IERC20(_getArgAddress(QUOTE_ADDRESS)).balanceOf(address(this));
     }
 
-    function _lupIndex(uint256 debt_) internal view returns (uint256) {
-        return Deposits.findIndexOfSum(deposits, debt_);
-    }
-
     function _lup(uint256 debt_) internal view returns (uint256) {
-        return _priceAt(_lupIndex(debt_));
+        return _priceAt(Deposits.findIndexOfSum(deposits, debt_));
     }
 
     /**************************/

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -341,17 +341,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         } 
     }
 
-    function _revertOnMinDebt(uint256 poolDebt_, uint256 borrowerDebt_) internal view {
-        if (borrowerDebt_ != 0) {
-            uint256 loansCount = Loans.noOfLoans(loans);
-            if (
-                loansCount >= 10
-                &&
-                (borrowerDebt_ < _minDebtAmount(poolDebt_, loansCount))
-            ) revert AmountLTMinDebt();
-        }
-    }
-
     function _transferQuoteTokenFrom(address from_, uint256 amount_) internal {
         IERC20(_getArgAddress(QUOTE_ADDRESS)).safeTransferFrom(from_, address(this), amount_ / _getArgUint256(QUOTE_SCALE));
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -213,45 +213,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*** Liquidation Functions ***/
     /*****************************/
 
-    function bucketTake(
-        address borrowerAddress_,
-        bool    depositTake_,
-        uint256 index_
-    ) external override {
-
-        PoolState memory poolState = _accruePoolInterest();
-
-        BucketTakeResult memory result = Auctions.bucketTake(
-            auctions,
-            buckets,
-            deposits,
-            loans,
-            poolState,
-            borrowerAddress_,
-            depositTake_,
-            index_
-        );
-
-        // update pool balances state
-        uint256 t0PoolDebt      = poolBalances.t0Debt;
-        uint256 t0DebtInAuction = poolBalances.t0DebtInAuction;
-        if (result.t0DebtPenalty != 0) {
-            t0PoolDebt      += result.t0DebtPenalty;
-            t0DebtInAuction += result.t0DebtPenalty;
-        }
-        t0PoolDebt      -= result.t0RepayAmount;
-        t0DebtInAuction -= result.t0DebtInAuctionChange;
-
-        poolBalances.t0Debt            = t0PoolDebt;
-        poolBalances.t0DebtInAuction   = t0DebtInAuction;
-        poolBalances.pledgedCollateral -= result.collateralAmount;
-
-        // update pool interest rate state
-        poolState.debt       = result.poolDebt;
-        poolState.collateral -= result.collateralAmount;
-        _updateInterestState(poolState, result.newLup);
-    }
-
     function kick(address borrowerAddress_) external override {
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/base/RevertsHelper.sol
+++ b/src/base/RevertsHelper.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.14;
+
+import { AuctionsState, LoansState, PoolBalancesState } from './interfaces/pool/IPoolState.sol';
+
+import '../libraries/Loans.sol';
+import '../libraries/Deposits.sol';
+    /**
+     *  @notice Head auction should be cleared prior of executing this action.
+     */
+    error AuctionNotCleared();
+    /**
+     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
+     */
+    error AmountLTMinDebt();
+    /**
+     *  @notice Lender is attempting to remove quote tokens from a bucket that exists above active auction debt from top-of-book downward.
+     */
+    error RemoveDepositLockedByAuctionDebt();
+
+    /**
+     *  @notice Called by LPB removal functions assess whether or not LPB is locked.
+     *  @param  index_    The deposit index from which LPB is attempting to be removed.
+     *  @param  inflator_ The pool inflator used to properly assess t0 debt in auctions.
+     */
+    function _revertIfAuctionDebtLocked(
+        DepositsState storage deposits_,
+        PoolBalancesState storage poolBalances_,
+        uint256 index_,
+        uint256 inflator_
+    ) view {
+        uint256 t0AuctionDebt = poolBalances_.t0DebtInAuction;
+        if (t0AuctionDebt != 0 ) {
+            // deposit in buckets within liquidation debt from the top-of-book down are frozen.
+            if (index_ <= Deposits.findIndexOfSum(deposits_, Maths.wmul(t0AuctionDebt, inflator_))) revert RemoveDepositLockedByAuctionDebt();
+        } 
+    }
+
+    /**
+     *  @notice Check if head auction is clearable (auction is kicked and 72 hours passed since kick time or auction still has debt but no remaining collateral).
+     *  @notice Revert if auction is clearable
+     */
+    function _revertIfAuctionClearable(
+        AuctionsState storage auctions_,
+        LoansState    storage loans_
+    ) view {
+        address head     = auctions_.head;
+        uint256 kickTime = auctions_.liquidations[head].kickTime;
+        if (kickTime != 0) {
+            if (block.timestamp - kickTime > 72 hours) revert AuctionNotCleared();
+
+            Borrower storage borrower = loans_.borrowers[head];
+            if (borrower.t0Debt != 0 && borrower.collateral == 0) revert AuctionNotCleared();
+        }
+    }
+
+    function _revertOnMinDebt(
+        LoansState storage loans_,
+        uint256 poolDebt_,
+        uint256 borrowerDebt_
+    ) view {
+        if (borrowerDebt_ != 0) {
+            uint256 loansCount = Loans.noOfLoans(loans_);
+            if (
+                loansCount >= 10
+                &&
+                (borrowerDebt_ < _minDebtAmount(poolDebt_, loansCount))
+            ) revert AmountLTMinDebt();
+        }
+    }

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -23,6 +23,30 @@ interface IPoolEvents {
     );
 
     /**
+     *  @notice Emitted when auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
+     */
+    event AuctionSettle(
+        address indexed borrower,
+        uint256 collateral
+    );
+
+    /**
+     *  @notice Emitted when NFT auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
+     *  @param  lps        Amount of LPs given to the borrower to compensate fractional collateral (if any).
+     *  @param  index      Index of the bucket with LPs to compensate fractional collateral.
+     */
+    event AuctionNFTSettle(
+        address indexed borrower,
+        uint256 collateral,
+        uint256 lps,
+        uint256 index
+    );
+
+    /**
      *  @notice Emitted when an actor uses quote token to arb higher-priced deposit off the book.
      *  @param  borrower    Identifies the loan being liquidated.
      *  @param  index       The index of the Highest Price Bucket used for this take.
@@ -194,17 +218,5 @@ interface IPoolEvents {
     event UpdateInterestRate(
         uint256 oldRate,
         uint256 newRate
-    );
-
-    event AuctionNFTSettle(
-        address indexed borrower,
-        uint256 collateral,
-        uint256 lps,
-        uint256 index
-    );
-
-    event AuctionSettle(
-        address indexed borrower,
-        uint256 collateral
     );
 }

--- a/src/base/interfaces/pool/IPoolEvents.sol
+++ b/src/base/interfaces/pool/IPoolEvents.sol
@@ -195,4 +195,16 @@ interface IPoolEvents {
         uint256 oldRate,
         uint256 newRate
     );
+
+    event AuctionNFTSettle(
+        address indexed borrower,
+        uint256 collateral,
+        uint256 lps,
+        uint256 index
+    );
+
+    event AuctionSettle(
+        address indexed borrower,
+        uint256 collateral
+    );
 }

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -31,8 +31,6 @@ struct KickResult {
 
 struct SettleParams {
     address borrower;    // borrower address to settle
-    uint256 collateral;  // remaining collateral pledged by borrower that can be used to settle debt
-    uint256 t0Debt;      // borrower t0 debt to settle 
     uint256 reserves;    // current reserves in pool
     uint256 inflator;    // current pool inflator
     uint256 bucketDepth; // number of buckets to use when settle debt

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -29,6 +29,16 @@ struct BucketTakeParams {
     uint256 t0Debt;         // borrower t0 debt  
 }
 
+struct BucketTakeResult {
+    uint256 collateralAmount;
+    uint256 t0RepayAmount;
+    uint256 t0DebtPenalty;
+    uint256 settledCollateral;
+    uint256 poolDebt;
+    uint256 newLup;
+    uint256 t0DebtInAuctionChange;
+}
+
 struct TakeParams {
     address borrower;       // borrower address to take from
     uint256 collateral;     // borrower available collateral to take

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -37,6 +37,7 @@ struct BucketTakeResult {
     uint256 poolDebt;
     uint256 newLup;
     uint256 t0DebtInAuctionChange;
+    bool    settledAuction;
 }
 
 struct TakeParams {
@@ -58,6 +59,7 @@ struct TakeResult {
     uint256 poolDebt;
     uint256 newLup;
     uint256 t0DebtInAuctionChange;
+    bool    settledAuction;
 }
 
 struct KickResult {
@@ -92,6 +94,7 @@ struct DrawDebtResult {
     uint256 t0DebtChange;
     uint256 poolCollateral;
     uint256 poolDebt;
+    bool    settledAuction;
 }
 
 struct RepayDebtResult {
@@ -102,4 +105,5 @@ struct RepayDebtResult {
     uint256 poolCollateral;
     uint256 poolDebt;
     uint256 quoteTokenToRepay;
+    bool    settledAuction;
 }

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -60,3 +60,12 @@ struct RemoveQuoteParams {
     uint256 index;          // the deposit index from where amount is removed
     uint256 thresholdPrice; // max threshold price in pool
 }
+
+struct DrawDebtResult {
+    uint256 newLup;
+    uint256 settledCollateral;
+    uint256 t0DebtInAuctionChange;
+    uint256 t0DebtChange;
+    uint256 poolCollateral;
+    uint256 poolDebt;
+}

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -26,7 +26,7 @@ struct BucketTakeParams {
     bool    depositTake;    // deposit or arb take, used by bucket take
     uint256 index;          // bucket index, used by bucket take
     uint256 inflator;       // current pool inflator
-    uint256 t0Debt;         // borrower t0 debt
+    uint256 t0Debt;         // borrower t0 debt  
 }
 
 struct TakeParams {
@@ -35,6 +35,7 @@ struct TakeParams {
     uint256 t0Debt;         // borrower t0 debt
     uint256 takeCollateral; // desired amount to take
     uint256 inflator;       // current pool inflator
+    uint256 poolType;    // number of buckets to use when settle debt  
 }
 
 struct KickResult {

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -17,6 +17,7 @@ struct SettleParams {
     uint256 reserves;    // current reserves in pool
     uint256 inflator;    // current pool inflator
     uint256 bucketDepth; // number of buckets to use when settle debt
+    uint256 poolType;    // number of buckets to use when settle debt
 }
 
 struct BucketTakeParams {

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -69,3 +69,13 @@ struct DrawDebtResult {
     uint256 poolCollateral;
     uint256 poolDebt;
 }
+
+struct RepayDebtResult {
+    uint256 newLup;
+    uint256 settledCollateral;
+    uint256 t0DebtInAuctionChange;
+    uint256 t0RepaidDebt;
+    uint256 poolCollateral;
+    uint256 poolDebt;
+    uint256 quoteTokenToRepay;
+}

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -48,6 +48,18 @@ struct TakeParams {
     uint256 poolType;    // number of buckets to use when settle debt  
 }
 
+struct TakeResult {
+    uint256 collateralAmount;
+    uint256 quoteTokenAmount;
+    uint256 t0RepayAmount;
+    uint256 t0DebtPenalty;
+    uint256 excessQuoteToken;
+    uint256 settledCollateral;
+    uint256 poolDebt;
+    uint256 newLup;
+    uint256 t0DebtInAuctionChange;
+}
+
 struct KickResult {
     uint256 amountToCoverBond; // amount of bond that needs to be covered
     uint256 kickPenalty;       // kick penalty

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -10,51 +10,10 @@ pragma solidity 0.8.14;
 /*** Auction Param Structs ***/
 /*****************************/
 
-struct SettleParams {
-    address borrower;    // borrower address to settle
-    uint256 collateral;  // remaining collateral pledged by borrower that can be used to settle debt
-    uint256 t0Debt;      // borrower t0 debt to settle 
-    uint256 reserves;    // current reserves in pool
-    uint256 inflator;    // current pool inflator
-    uint256 bucketDepth; // number of buckets to use when settle debt
-    uint256 poolType;    // number of buckets to use when settle debt
-}
-
-struct BucketTakeParams {
-    address borrower;       // borrower address to take from
-    uint256 collateral;     // borrower available collateral to take
-    bool    depositTake;    // deposit or arb take, used by bucket take
-    uint256 index;          // bucket index, used by bucket take
-    uint256 inflator;       // current pool inflator
-    uint256 t0Debt;         // borrower t0 debt  
-}
-
 struct BucketTakeResult {
     uint256 collateralAmount;
     uint256 t0RepayAmount;
     uint256 t0DebtPenalty;
-    uint256 remainingCollateral;
-    uint256 poolDebt;
-    uint256 newLup;
-    uint256 t0DebtInAuctionChange;
-    bool    settledAuction;
-}
-
-struct TakeParams {
-    address borrower;       // borrower address to take from
-    uint256 collateral;     // borrower available collateral to take
-    uint256 t0Debt;         // borrower t0 debt
-    uint256 takeCollateral; // desired amount to take
-    uint256 inflator;       // current pool inflator
-    uint256 poolType;    // number of buckets to use when settle debt  
-}
-
-struct TakeResult {
-    uint256 collateralAmount;
-    uint256 quoteTokenAmount;
-    uint256 t0RepayAmount;
-    uint256 t0DebtPenalty;
-    uint256 excessQuoteToken;
     uint256 remainingCollateral;
     uint256 poolDebt;
     uint256 newLup;
@@ -68,6 +27,29 @@ struct KickResult {
     uint256 t0KickPenalty;     // t0 kick penalty
     uint256 t0KickedDebt;      // new t0 debt after kick
     uint256 lup;               // current lup
+}
+
+struct SettleParams {
+    address borrower;    // borrower address to settle
+    uint256 collateral;  // remaining collateral pledged by borrower that can be used to settle debt
+    uint256 t0Debt;      // borrower t0 debt to settle 
+    uint256 reserves;    // current reserves in pool
+    uint256 inflator;    // current pool inflator
+    uint256 bucketDepth; // number of buckets to use when settle debt
+    uint256 poolType;    // number of buckets to use when settle debt
+}
+
+struct TakeResult {
+    uint256 collateralAmount;
+    uint256 quoteTokenAmount;
+    uint256 t0RepayAmount;
+    uint256 t0DebtPenalty;
+    uint256 excessQuoteToken;
+    uint256 remainingCollateral;
+    uint256 poolDebt;
+    uint256 newLup;
+    uint256 t0DebtInAuctionChange;
+    bool    settledAuction;
 }
 
 /******************************************/
@@ -86,6 +68,10 @@ struct RemoveQuoteParams {
     uint256 index;          // the deposit index from where amount is removed
     uint256 thresholdPrice; // max threshold price in pool
 }
+
+/*************************************/
+/*** Loan Management Param Structs ***/
+/*************************************/
 
 struct DrawDebtResult {
     uint256 newLup;

--- a/src/base/interfaces/pool/IPoolInternals.sol
+++ b/src/base/interfaces/pool/IPoolInternals.sol
@@ -33,7 +33,7 @@ struct BucketTakeResult {
     uint256 collateralAmount;
     uint256 t0RepayAmount;
     uint256 t0DebtPenalty;
-    uint256 settledCollateral;
+    uint256 remainingCollateral;
     uint256 poolDebt;
     uint256 newLup;
     uint256 t0DebtInAuctionChange;
@@ -54,7 +54,7 @@ struct TakeResult {
     uint256 t0RepayAmount;
     uint256 t0DebtPenalty;
     uint256 excessQuoteToken;
-    uint256 settledCollateral;
+    uint256 remainingCollateral;
     uint256 poolDebt;
     uint256 newLup;
     uint256 t0DebtInAuctionChange;
@@ -87,7 +87,7 @@ struct RemoveQuoteParams {
 
 struct DrawDebtResult {
     uint256 newLup;
-    uint256 settledCollateral;
+    uint256 remainingCollateral;
     uint256 t0DebtInAuctionChange;
     uint256 t0DebtChange;
     uint256 poolCollateral;
@@ -96,7 +96,7 @@ struct DrawDebtResult {
 
 struct RepayDebtResult {
     uint256 newLup;
-    uint256 settledCollateral;
+    uint256 remainingCollateral;
     uint256 t0DebtInAuctionChange;
     uint256 t0RepaidDebt;
     uint256 poolCollateral;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -189,10 +189,11 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             index_
         );
 
+        emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);
+
         // update pool interest rate state
         _updateInterestState(poolState, _lup(poolState.debt));
 
-        emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);
         // move collateral from pool to lender
         _transferCollateral(msg.sender, collateralAmount_);
     }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -245,7 +245,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getPoolQuoteTokenBalance();
         uint256 liabilities = Deposits.treeSum(deposits) + auctions.totalBondEscrowed + reserveAuction.unclaimed;
-
         (
             ,
             ,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -274,6 +274,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         poolBalances.pledgedCollateral -= collateralSettled;
 
         // update pool interest rate state
+        poolState.debt       -= Maths.wmul(t0DebtSettled, poolState.inflator);
         poolState.collateral -= collateralSettled;
         _updateInterestState(poolState, _lup(poolState.debt));
     }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -58,7 +58,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 limitIndex_,
         uint256 collateralToPledge_
     ) external {
-        uint256 newLup = _drawDebt(
+        (uint256 newLup, ) = _drawDebt(
             borrowerAddress_,
             amountToBorrow_,
             limitIndex_,
@@ -78,7 +78,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 maxQuoteTokenAmountToRepay_,
         uint256 collateralAmountToPull_
     ) external {
-        (uint256 quoteTokenToRepay, uint256 newLup) = _repayDebt(borrowerAddress_, maxQuoteTokenAmountToRepay_, collateralAmountToPull_);
+        (uint256 quoteTokenToRepay, uint256 newLup, ) = _repayDebt(borrowerAddress_, maxQuoteTokenAmountToRepay_, collateralAmountToPull_);
 
         emit RepayDebt(borrowerAddress_, quoteTokenToRepay, collateralAmountToPull_, newLup);
 
@@ -253,6 +253,12 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         Auctions._removeAuction(auctions, borrowerAddress_);
         emit AuctionSettle(borrowerAddress_, borrowerCollateral_);
         return borrowerCollateral_;
+    }
+
+    function _cleanupAuction(
+        address borrowerAddress_,
+        uint256 borrowerCollateral_
+    ) internal override {
     }
 
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -213,7 +213,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 maxAmount_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        Auctions.revertIfAuctionClearable(auctions, loans);
+        _revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -355,25 +355,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _transferQuoteTokenFrom(callee_, quoteTokenAmount);
     }
 
-    /*******************************/
-    /*** Pool Override Functions ***/
-    /*******************************/
-
-   /**
-     *  @notice Settle an ERC20 pool auction, remove from auction queue and emit event.
-     *  @param borrowerAddress_    Address of the borrower that exits auction.
-     *  @param borrowerCollateral_ Borrower collateral amount before auction exit.
-     *  @return floorCollateral_   Remaining borrower collateral after auction exit.
-     */
-    function _settleAuction(
-        address borrowerAddress_,
-        uint256 borrowerCollateral_
-    ) internal override returns (uint256) {
-        Auctions._removeAuction(auctions, borrowerAddress_);
-        emit AuctionSettle(borrowerAddress_, borrowerCollateral_);
-        return borrowerCollateral_;
-    }
-
     /************************/
     /*** Helper Functions ***/
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -236,7 +236,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     }
 
     /*******************************/
-    /*** Pool External Functions ***/
+    /*** Pool Auctions Functions ***/
     /*******************************/
 
     function settle(
@@ -309,12 +309,12 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         t0PoolDebt      -= result.t0RepayAmount;
         t0DebtInAuction -= result.t0DebtInAuctionChange;
 
-        poolBalances.t0Debt            = t0PoolDebt;
-        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.t0Debt            =  t0PoolDebt;
+        poolBalances.t0DebtInAuction   =  t0DebtInAuction;
         poolBalances.pledgedCollateral -= result.collateralAmount;
 
         // update pool interest rate state
-        poolState.debt       = result.poolDebt;
+        poolState.debt       =  result.poolDebt;
         poolState.collateral -= result.collateralAmount;
         _updateInterestState(poolState, result.newLup);
 
@@ -362,8 +362,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         t0PoolDebt      -= result.t0RepayAmount;
         t0DebtInAuction -= result.t0DebtInAuctionChange;
 
-        poolBalances.t0Debt            = t0PoolDebt;
-        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.t0Debt            =  t0PoolDebt;
+        poolBalances.t0DebtInAuction   =  t0DebtInAuction;
         poolBalances.pledgedCollateral -= result.collateralAmount;
 
         // update pool interest rate state

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -186,6 +186,56 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Pool External Functions ***/
     /*******************************/
 
+    function settle(
+        address borrowerAddress_,
+        uint256 maxDepth_
+    ) external override {
+        PoolState memory poolState = _accruePoolInterest();
+
+        uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getPoolQuoteTokenBalance();
+        uint256 liabilities = Deposits.treeSum(deposits) + auctions.totalBondEscrowed + reserveAuction.unclaimed;
+
+        Borrower storage borrower = loans.borrowers[borrowerAddress_];
+
+        SettleParams memory params = SettleParams(
+            {
+                borrower:    borrowerAddress_,
+                collateral:  borrower.collateral,
+                t0Debt:      borrower.t0Debt,
+                reserves:    (assets > liabilities) ? (assets-liabilities) : 0,
+                inflator:    poolState.inflator,
+                bucketDepth: maxDepth_
+            }
+        );
+        (uint256 remainingCollateral, uint256 t0RemainingDebt) = Auctions.settlePoolDebt(
+            auctions,
+            buckets,
+            deposits,
+            params
+        );
+
+        // slither-disable-next-line incorrect-equality
+        if (t0RemainingDebt == 0) {
+            remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
+        }
+
+        // update borrower state
+        borrower.t0Debt     = t0RemainingDebt;
+        borrower.collateral = remainingCollateral;
+
+        // update pool balances state
+        uint256 t0SettledDebt        = params.t0Debt - t0RemainingDebt;
+        poolBalances.t0Debt          -= t0SettledDebt;
+        poolBalances.t0DebtInAuction -= t0SettledDebt;
+
+        uint256 settledCollateral      = params.collateral - remainingCollateral;
+        poolBalances.pledgedCollateral -= settledCollateral;
+
+        // update pool interest rate state
+        poolState.collateral -= settledCollateral;
+        _updateInterestState(poolState, _lup(poolState.debt));
+    }
+
     function take(
         address        borrowerAddress_,
         uint256        collateral_,
@@ -253,12 +303,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         Auctions._removeAuction(auctions, borrowerAddress_);
         emit AuctionSettle(borrowerAddress_, borrowerCollateral_);
         return borrowerCollateral_;
-    }
-
-    function _cleanupAuction(
-        address borrowerAddress_,
-        uint256 borrowerCollateral_
-    ) internal override {
     }
 
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -59,7 +59,11 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 collateralToPledge_
     ) external {
         PoolState memory poolState = _accruePoolInterest();
-        DrawDebtResult memory result = _drawDebt(
+        DrawDebtResult memory result = BorrowerActions.drawDebt(
+            auctions,
+            buckets,
+            deposits,
+            loans,
             poolState,
             borrowerAddress_,
             amountToBorrow_,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -246,40 +246,34 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getPoolQuoteTokenBalance();
         uint256 liabilities = Deposits.treeSum(deposits) + auctions.totalBondEscrowed + reserveAuction.unclaimed;
 
-        Borrower storage borrower = loans.borrowers[borrowerAddress_];
-
-        SettleParams memory params = SettleParams(
-            {
-                borrower:    borrowerAddress_,
-                collateral:  borrower.collateral,
-                t0Debt:      borrower.t0Debt,
-                reserves:    (assets > liabilities) ? (assets-liabilities) : 0,
-                inflator:    poolState.inflator,
-                bucketDepth: maxDepth_,
-                poolType:    poolState.poolType
-            }
-        );
-        (uint256 remainingCollateral, uint256 t0RemainingDebt) = Auctions.settlePoolDebt(
+        (
+            ,
+            ,
+            uint256 collateralSettled,
+            uint256 t0DebtSettled
+        ) = Auctions.settlePoolDebt(
             auctions,
             buckets,
             deposits,
-            params
+            loans,
+            SettleParams(
+                {
+                    borrower:    borrowerAddress_,
+                    reserves:    (assets > liabilities) ? (assets - liabilities) : 0,
+                    inflator:    poolState.inflator,
+                    bucketDepth: maxDepth_,
+                    poolType:    poolState.poolType
+                }
+            )
         );
 
-        // update borrower state
-        borrower.t0Debt     = t0RemainingDebt;
-        borrower.collateral = remainingCollateral;
-
         // update pool balances state
-        uint256 t0SettledDebt        = params.t0Debt - t0RemainingDebt;
-        poolBalances.t0Debt          -= t0SettledDebt;
-        poolBalances.t0DebtInAuction -= t0SettledDebt;
-
-        uint256 settledCollateral      = params.collateral - remainingCollateral;
-        poolBalances.pledgedCollateral -= settledCollateral;
+        poolBalances.t0Debt            -= t0DebtSettled;
+        poolBalances.t0DebtInAuction   -= t0DebtSettled;
+        poolBalances.pledgedCollateral -= collateralSettled;
 
         // update pool interest rate state
-        poolState.collateral -= settledCollateral;
+        poolState.collateral -= collateralSettled;
         _updateInterestState(poolState, _lup(poolState.debt));
     }
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -255,7 +255,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
                 t0Debt:      borrower.t0Debt,
                 reserves:    (assets > liabilities) ? (assets-liabilities) : 0,
                 inflator:    poolState.inflator,
-                bucketDepth: maxDepth_
+                bucketDepth: maxDepth_,
+                poolType:    poolState.poolType
             }
         );
         (uint256 remainingCollateral, uint256 t0RemainingDebt) = Auctions.settlePoolDebt(
@@ -264,11 +265,6 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             deposits,
             params
         );
-
-        // slither-disable-next-line incorrect-equality
-        if (t0RemainingDebt == 0) {
-            remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
-        }
 
         // update borrower state
         borrower.t0Debt     = t0RemainingDebt;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -355,6 +355,45 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _transferQuoteTokenFrom(callee_, quoteTokenAmount);
     }
 
+    function bucketTake(
+        address borrowerAddress_,
+        bool    depositTake_,
+        uint256 index_
+    ) external override {
+
+        PoolState memory poolState = _accruePoolInterest();
+
+        BucketTakeResult memory result = Auctions.bucketTake(
+            auctions,
+            buckets,
+            deposits,
+            loans,
+            poolState,
+            borrowerAddress_,
+            depositTake_,
+            index_
+        );
+
+        // update pool balances state
+        uint256 t0PoolDebt      = poolBalances.t0Debt;
+        uint256 t0DebtInAuction = poolBalances.t0DebtInAuction;
+        if (result.t0DebtPenalty != 0) {
+            t0PoolDebt      += result.t0DebtPenalty;
+            t0DebtInAuction += result.t0DebtPenalty;
+        }
+        t0PoolDebt      -= result.t0RepayAmount;
+        t0DebtInAuction -= result.t0DebtInAuctionChange;
+
+        poolBalances.t0Debt            = t0PoolDebt;
+        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.pledgedCollateral -= result.collateralAmount;
+
+        // update pool interest rate state
+        poolState.debt       = result.poolDebt;
+        poolState.collateral -= result.collateralAmount;
+        _updateInterestState(poolState, result.newLup);
+    }
+
     /************************/
     /*** Helper Functions ***/
     /************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -319,8 +319,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             params
         );
 
-        borrower.collateral  -= collateralAmount; // collateral is removed from the loan
-        poolState.collateral -= collateralAmount; // collateral is removed from pledged collateral accumulator
+        borrower.collateral -= collateralAmount; // collateral is removed from the loan
 
         TakeFromLoanResult memory result = _takeFromLoan(poolState, borrower, params.borrower, t0RepayAmount, t0DebtPenalty);
 
@@ -336,10 +335,11 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         poolBalances.t0Debt            = t0PoolDebt;
         poolBalances.t0DebtInAuction   = t0DebtInAuction;
-        poolBalances.pledgedCollateral = poolState.collateral;
+        poolBalances.pledgedCollateral -= collateralAmount;
 
         // update pool interest rate state
-        poolState.debt = result.poolDebt;
+        poolState.debt       = result.poolDebt;
+        poolState.collateral -= collateralAmount;
         _updateInterestState(poolState, result.newLup);
 
         _transferCollateral(callee_, collateralAmount);

--- a/src/erc20/interfaces/pool/IERC20PoolEvents.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolEvents.sol
@@ -22,16 +22,6 @@ interface IERC20PoolEvents {
     );
 
     /**
-     *  @notice Emitted when auction is completed.
-     *  @param  borrower   Address of borrower that exits auction.
-     *  @param  collateral Borrower's remaining collateral when auction completed.
-     */
-    event AuctionSettle(
-        address indexed borrower,
-        uint256 collateral
-    );
-
-    /**
      *  @notice Emitted when borrower draws debt from the pool, or adds collateral to the pool.
      *  @param  borrower          The borrower to whom collateral was pledged, and/or debt was drawn for.
      *  @param  amountBorowed     Amount of quote tokens borrowed from the pool.

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -393,32 +393,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         if (vars.excessQuoteToken != 0) _transferQuoteToken(params.borrower, vars.excessQuoteToken);
     }
 
-
-    /*******************************/
-    /*** Pool Override Functions ***/
-    /*******************************/
-
-    /**
-     *  @notice Performs NFT auction settlement by rounding down borrower's collateral amount and by moving borrower's token ids to pool claimable array.
-     *  @param borrowerAddress_    Address of the borrower that exits auction.
-     *  @param borrowerCollateral_ Borrower collateral amount before auction exit (could be fragmented as result of partial takes).
-     *  @return Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
-     */
-    function _settleAuction(
-        address borrowerAddress_,
-        uint256 borrowerCollateral_
-    ) internal override returns (uint256) {
-        (uint256 floorCollateral, uint256 lps, uint256 bucketIndex) = Auctions.settleNFTAuction(
-            auctions,
-            buckets,
-            deposits,
-            borrowerAddress_,
-            borrowerCollateral_
-        );
-        emit AuctionNFTSettle(borrowerAddress_, floorCollateral, lps, bucketIndex);
-        return floorCollateral;
-    }
-
     /**************************/
     /*** Internal Functions ***/
     /**************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -291,6 +291,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         poolBalances.pledgedCollateral -= collateralSettled;
 
         // update pool interest rate state
+        poolState.debt       -= Maths.wmul(t0DebtSettled, poolState.inflator);
         poolState.collateral -= collateralSettled;
         _updateInterestState(poolState, _lup(poolState.debt));
     }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -88,7 +88,11 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256[] calldata tokenIdsToPledge_
     ) external {
         PoolState memory poolState = _accruePoolInterest();
-        DrawDebtResult memory result = _drawDebt(
+        DrawDebtResult memory result = BorrowerActions.drawDebt(
+            auctions,
+            buckets,
+            deposits,
+            loans,
             poolState,
             borrowerAddress_,
             amountToBorrow_,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -393,6 +393,47 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         if (vars.excessQuoteToken != 0) _transferQuoteToken(params.borrower, vars.excessQuoteToken);
     }
 
+    function bucketTake(
+        address borrowerAddress_,
+        bool    depositTake_,
+        uint256 index_
+    ) external override {
+
+        PoolState memory poolState = _accruePoolInterest();
+
+        BucketTakeResult memory result = Auctions.bucketTake(
+            auctions,
+            buckets,
+            deposits,
+            loans,
+            poolState,
+            borrowerAddress_,
+            depositTake_,
+            index_
+        );
+
+        // update pool balances state
+        uint256 t0PoolDebt      = poolBalances.t0Debt;
+        uint256 t0DebtInAuction = poolBalances.t0DebtInAuction;
+        if (result.t0DebtPenalty != 0) {
+            t0PoolDebt      += result.t0DebtPenalty;
+            t0DebtInAuction += result.t0DebtPenalty;
+        }
+        t0PoolDebt      -= result.t0RepayAmount;
+        t0DebtInAuction -= result.t0DebtInAuctionChange;
+
+        poolBalances.t0Debt            = t0PoolDebt;
+        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.pledgedCollateral -= result.collateralAmount;
+
+        // update pool interest rate state
+        poolState.debt       = result.poolDebt;
+        poolState.collateral -= result.collateralAmount;
+        _updateInterestState(poolState, result.newLup);
+
+        if (result.settledCollateral != 0) _cleanupAuction(borrowerAddress_, result.settledCollateral);
+    }
+
     /**************************/
     /*** Internal Functions ***/
     /**************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -107,7 +107,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             _transferFromSenderToPool(borrowerTokenIds[borrowerAddress_], tokenIdsToPledge_);
         }
 
-        if (result.settledCollateral != 0) _settleCollateral(borrowerAddress_, result.settledCollateral);
+        if (result.remainingCollateral != 0) _settleCollateral(borrowerAddress_, result.remainingCollateral);
 
         // move borrowed amount from pool to sender
         if (amountToBorrow_ != 0) {
@@ -138,7 +138,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, noOfNFTsToPull_, result.newLup);
 
-        if (result.settledCollateral != 0) _settleCollateral(borrowerAddress_, result.settledCollateral);
+        if (result.remainingCollateral != 0) _settleCollateral(borrowerAddress_, result.remainingCollateral);
 
         // update pool interest rate state
         poolState.debt       = result.poolDebt;
@@ -352,7 +352,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             );
         }
 
-        if (result.settledCollateral != 0) _settleCollateral(borrowerAddress_, result.settledCollateral);
+        if (result.remainingCollateral != 0) _settleCollateral(borrowerAddress_, result.remainingCollateral);
 
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
         _transferQuoteTokenFrom(callee_, result.quoteTokenAmount + result.excessQuoteToken);
@@ -399,7 +399,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         poolState.collateral -= result.collateralAmount;
         _updateInterestState(poolState, result.newLup);
 
-        if (result.settledCollateral != 0) _settleCollateral(borrowerAddress_, result.settledCollateral);
+        if (result.remainingCollateral != 0) _settleCollateral(borrowerAddress_, result.remainingCollateral);
     }
 
     /**************************/

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -248,7 +248,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     }
 
     /*******************************/
-    /*** Pool External Functions ***/
+    /*** Pool Auctions Functions ***/
     /*******************************/
 
     function settle(
@@ -326,12 +326,12 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         t0PoolDebt      -= result.t0RepayAmount;
         t0DebtInAuction -= result.t0DebtInAuctionChange;
 
-        poolBalances.t0Debt            = t0PoolDebt;
-        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.t0Debt            =  t0PoolDebt;
+        poolBalances.t0DebtInAuction   =  t0DebtInAuction;
         poolBalances.pledgedCollateral -= result.collateralAmount;
 
         // update pool interest rate state
-        poolState.debt       = result.poolDebt;
+        poolState.debt       =  result.poolDebt;
         poolState.collateral -= result.collateralAmount;
         _updateInterestState(poolState, result.newLup);
 
@@ -390,8 +390,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         t0PoolDebt      -= result.t0RepayAmount;
         t0DebtInAuction -= result.t0DebtInAuctionChange;
 
-        poolBalances.t0Debt            = t0PoolDebt;
-        poolBalances.t0DebtInAuction   = t0DebtInAuction;
+        poolBalances.t0Debt            =  t0PoolDebt;
+        poolBalances.t0DebtInAuction   =  t0DebtInAuction;
         poolBalances.pledgedCollateral -= result.collateralAmount;
 
         // update pool interest rate state

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -278,7 +278,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
                 t0Debt:      borrower.t0Debt,
                 reserves:    (assets > liabilities) ? (assets-liabilities) : 0,
                 inflator:    poolState.inflator,
-                bucketDepth: maxDepth_
+                bucketDepth: maxDepth_,
+                poolType:    poolState.poolType
             }
         );
         (uint256 remainingCollateral, uint256 t0RemainingDebt) = Auctions.settlePoolDebt(
@@ -290,7 +291,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
         // slither-disable-next-line incorrect-equality
         if (t0RemainingDebt == 0) {
-            remainingCollateral = _settleAuction(params.borrower, remainingCollateral);
             _cleanupAuction(params.borrower, remainingCollateral);
         }
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -225,7 +225,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 noOfNFTsToRemove_,
         uint256 index_
     ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
-        Auctions.revertIfAuctionClearable(auctions, loans);
+        _revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -95,6 +95,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             Maths.wad(tokenIdsToPledge_.length)
         );
 
+        emit DrawDebtNFT(borrowerAddress_, amountToBorrow_, tokenIdsToPledge_, newLup);
+
         if (tokenIdsToPledge_.length != 0) {
             // update pool balances state
             if (t0DebtInAuctionChange != 0) {
@@ -107,8 +109,6 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         }
 
         if (settledCollateral != 0) _cleanupAuction(borrowerAddress_, settledCollateral);
-
-        emit DrawDebtNFT(borrowerAddress_, amountToBorrow_, tokenIdsToPledge_, newLup);
 
         // move borrowed amount from pool to sender
         if (amountToBorrow_ != 0) {
@@ -214,10 +214,11 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             index_
         );
 
+        emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);
+
         // update pool interest rate state
         _updateInterestState(poolState, _lup(poolState.debt));
 
-        emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);
         _transferFromPoolToAddress(msg.sender, bucketTokenIds, noOfNFTsToRemove_);
     }
 

--- a/src/erc721/interfaces/pool/IERC721PoolEvents.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolEvents.sol
@@ -34,20 +34,6 @@ interface IERC721PoolEvents {
     );
 
     /**
-     *  @notice Emitted when NFT auction is completed.
-     *  @param  borrower   Address of borrower that exits auction.
-     *  @param  collateral Borrower's remaining collateral when auction completed.
-     *  @param  lps        Amount of LPs given to the borrower to compensate fractional collateral (if any).
-     *  @param  index      Index of the bucket with LPs to compensate fractional collateral.
-     */
-    event AuctionNFTSettle(
-        address indexed borrower,
-        uint256 collateral,
-        uint256 lps,
-        uint256 index
-    );
-
-    /**
      *  @notice Emitted when borrower draws debt from the pool, or adds collateral to the pool.
      *  @param  borrower          `msg.sender`.
      *  @param  amountBorowed     Amount of quote tokens borrowed from the pool.

--- a/src/libraries/Deposits.sol
+++ b/src/libraries/Deposits.sol
@@ -13,20 +13,6 @@ library Deposits {
     /**
      *  @notice increase a value in the FenwickTree at an index.
      *  @dev    Starts at leaf/target and moved up towards root
-     *  @param  index_     The deposit index.
-     *  @param  addAmount_ The amount to increase deposit by.
-     */    
-    function add(
-        DepositsState storage deposits_,
-        uint256 index_,
-        uint256 addAmount_
-    ) internal {
-        Deposits.unscaledAdd(deposits_, index_, Maths.wdiv(addAmount_, scale(deposits_, index_)));
-    }
-
-    /**
-     *  @notice increase a value in the FenwickTree at an index.
-     *  @dev    Starts at leaf/target and moved up towards root
      *  @param  index_             The deposit index.
      *  @param  unscaledAddAmount_ The unscaled amount to increase deposit by.
      */    

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -208,19 +208,6 @@ library Loans {
     /**********************/
 
     /**
-     *  @notice Returns borrower struct.
-     *  @param loans_ Holds tree loan data.
-     *  @param borrowerAddress_ Borrower's address.
-     *  @return Borrower struct containing borrower info.
-     */
-    function getBorrowerInfo(
-        LoansState storage loans_,
-        address borrowerAddress_
-    ) internal view returns (Borrower memory) {
-        return loans_.borrowers[borrowerAddress_];
-    }
-
-    /**
      *  @notice Retreives Loan by index, i_.
      *  @param loans_ Holds tree loan data.
      *  @param i_    Index to retreive Loan.

--- a/src/libraries/Loans.sol
+++ b/src/libraries/Loans.sol
@@ -221,16 +221,6 @@ library Loans {
     }
 
     /**
-     *  @notice Retreives Loan by borrower address.
-     *  @param loans_     Holds tree loans data.
-     *  @param borrower_ Borrower address that is being updated or inserted.
-     *  @return Loan     Loan struct containing loans info.
-     */
-    function getById(LoansState storage loans_, address borrower_) internal view returns(Loan memory) {
-        return getByIndex(loans_, loans_.indices[borrower_]);
-    }
-
-    /**
      *  @notice Retreives Loan by index, i_.
      *  @param loans_ Holds tree loan data.
      *  @param i_    Index to retreive Loan.

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -51,15 +51,15 @@ library Auctions {
     }
 
     struct SettleLocalVars {
-        uint256 index;
-        uint256 unscaledDeposit;
-        uint256 scale;
-        uint256 price;
-        uint256 collateralUsed;
-        uint256 debt;
-        uint256 maxSettleableDebt;
-        uint256 scaledDeposit;
-        uint256 depositToRemove;
+        uint256 collateralUsed;    // collateral used to settle debt
+        uint256 debt;              // debt to settle
+        uint256 depositToRemove;   // deposit used by settle auction
+        uint256 index;             // index of settling bucket
+        uint256 maxSettleableDebt; // max amount that can be settled with existing collateral
+        uint256 price;             // price of settling bucket
+        uint256 scaledDeposit;     // scaled amount of quote tokens in bucket
+        uint256 scale;             // scale of settling bucket
+        uint256 unscaledDeposit;   // unscaled amount of quote tokens in bucket
     }
 
     struct TakeLocalVars {
@@ -110,9 +110,9 @@ library Auctions {
     }
 
     /**
-     *  @notice Emitted when an ERC20 auction is settled.
-     *  @param  borrower    Identifies the loan being settled.
-     *  @param  collateral  Amount of remaining borrower collateral after auction is settled.
+     *  @notice Emitted when auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
      */
     event AuctionSettle(
         address indexed borrower,
@@ -120,11 +120,11 @@ library Auctions {
     );
 
     /**
-     *  @notice Emitted when an ERC721 auction is settled.
-     *  @param  borrower   Identifies the loan being settled.
-     *  @param  collateral Amount of remaining borrower collateral after auction is settled (rounded down).
-     *  @param  lps        LPs given to the borrower to compensate fractional collateral (if any).
-     *  @param  index      Index of the bucket with compensated LPs.
+     *  @notice Emitted when NFT auction is completed.
+     *  @param  borrower   Address of borrower that exits auction.
+     *  @param  collateral Borrower's remaining collateral when auction completed.
+     *  @param  lps        Amount of LPs given to the borrower to compensate fractional collateral (if any).
+     *  @param  index      Index of the bucket with LPs to compensate fractional collateral.
      */
     event AuctionNFTSettle(
         address indexed borrower,
@@ -1094,7 +1094,8 @@ library Auctions {
         }
 
         if (vars.isRewarded) {
-            vars.bondChange = Maths.wmul(vars.scaledQuoteTokenAmount, uint256(vars.bpf)); // will be rewarded as LPBs
+            // take is above neutralPrice, Kicker is rewarded
+            vars.bondChange = Maths.wmul(vars.scaledQuoteTokenAmount, uint256(vars.bpf));
         } else {
             // take is above neutralPrice, Kicker is penalized
             vars.bondChange = Maths.wmul(vars.scaledQuoteTokenAmount, uint256(-vars.bpf));

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -528,7 +528,7 @@ library Auctions {
         bool    depositTake_,
         uint256 index_
     ) external returns (BucketTakeResult memory result_) {
-        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+        Borrower memory borrower = loans_.borrowers[borrowerAddress_];
         (
             result_.collateralAmount,
             result_.t0RepayAmount,
@@ -583,7 +583,7 @@ library Auctions {
         address borrowerAddress_,
         uint256 collateral_
     ) external returns (TakeResult memory result_) {
-        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+        Borrower memory borrower = loans_.borrowers[borrowerAddress_];
         // revert if borrower's collateral is 0 or if maxCollateral to be taken is 0
         if (borrower.collateral == 0 || collateral_ == 0) revert InsufficientCollateral();
 

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -66,6 +66,7 @@ library Auctions {
         uint256 poolDebt;
         uint256 newLup;
         uint256 t0DebtInAuctionChange;
+        bool    settledAuction;
     }
 
     struct TakeFromLoanLocalVars {
@@ -513,7 +514,7 @@ library Auctions {
         result_.poolDebt = result.poolDebt;
         result_.newLup = result.newLup;
         result_.t0DebtInAuctionChange = result.t0DebtInAuctionChange;
-
+        result_.settledAuction = result.settledAuction;
     }
 
     // /**
@@ -574,6 +575,7 @@ library Auctions {
         result_.poolDebt = result.poolDebt;
         result_.newLup = result.newLup;
         result_.t0DebtInAuctionChange = result.t0DebtInAuctionChange;
+        result_.settledAuction = result.settledAuction;
     }
 
     /**
@@ -871,6 +873,7 @@ library Auctions {
 
         if (_isCollateralized(vars.borrowerDebt, borrower_.collateral, result_.newLup, poolState_.poolType)) {
             // borrower becomes re-collateralized
+            result_.settledAuction = true;
             // remove entire borrower debt from pool auctions debt accumulator
             result_.t0DebtInAuctionChange = borrower_.t0Debt;
             // settle auction and update borrower's collateral with value after settlement

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1370,19 +1370,6 @@ library Auctions {
     /*** View Functions ***/
     /**********************/
 
-    /**
-     *  @notice Returns true if borrower is in auction.
-     *  @dev    Used to accuratley increment and decrement t0DebtInAuction.
-     *  @param  borrower_ Borrower address to check auction status for.
-     *  @return  active_ Boolean, based on if borrower is in auction.
-     */
-    function isActive(
-        AuctionsState storage auctions_,
-        address borrower_
-    ) internal view returns (bool) {
-        return auctions_.liquidations[borrower_].kickTime != 0;
-    }
-
     function _lup(
         DepositsState storage deposits_,
         uint256 debt_

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -70,7 +70,7 @@ library Auctions {
         uint256 bucketPrice;              // The bucket price.
         uint256 bucketScale;              // The bucket scale.
         uint256 collateralAmount;         // The amount of collateral taken.
-        uint256 excessQuoteToken;         // Difference of quote token that borrower receives after taeke (for fractional NFT only)
+        uint256 excessQuoteToken;         // Difference of quote token that borrower receives after take (for fractional NFT only)
         uint256 factor;                   // The take factor, calculated based on bond penalty factor.
         bool    isRewarded;               // True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
         address kicker;                   // Address of auction kicker.

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -552,8 +552,6 @@ library Auctions {
 
     /**
      *  @notice Performs NFT auction settlement by rounding down borrower's collateral amount and by moving borrower's token ids to pool claimable array.
-     *  @param borrowerTokens_     Array of borrower NFT token ids.
-     *  @param poolTokens_         Array of claimable NFT token ids in pool.
      *  @param borrowerAddress_    Address of the borrower that exits auction.
      *  @param borrowerCollateral_ Borrower collateral amount before auction exit (could be fragmented as result of partial takes).
      *  @return floorCollateral_   Rounded down collateral, the number of NFT tokens borrower can pull after auction exit.
@@ -564,8 +562,6 @@ library Auctions {
         AuctionsState storage auctions_,
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
-        uint256[] storage borrowerTokens_,
-        uint256[] storage poolTokens_,
         address borrowerAddress_,
         uint256 borrowerCollateral_
     ) external returns (uint256 floorCollateral_, uint256 lps_, uint256 bucketIndex_) {
@@ -587,18 +583,6 @@ library Auctions {
                 fractionalCollateral,
                 _priceAt(bucketIndex_)
             );
-        }
-
-        // rebalance borrower's collateral, transfer difference to floor collateral from borrower to pool claimable array
-        uint256 noOfTokensPledged    = borrowerTokens_.length;
-        uint256 noOfTokensToTransfer = noOfTokensPledged - floorCollateral_ / 1e18;
-        for (uint256 i = 0; i < noOfTokensToTransfer;) {
-            uint256 tokenId = borrowerTokens_[--noOfTokensPledged]; // start with moving the last token pledged by borrower
-            borrowerTokens_.pop();                                  // remove token id from borrower
-            poolTokens_.push(tokenId);                              // add token id to pool claimable tokens
-            unchecked {
-                ++i;
-            }
         }
 
         _removeAuction(auctions_, borrowerAddress_);

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -40,7 +40,7 @@ library Auctions {
         uint256 redeemedLPs;
     }
 
-    struct TakeResult {
+    struct TakeLocalVars {
         uint256 auctionPrice;             // The price of auction.
         uint256 bondChange;               // The change made on the bond size (beeing reward or penalty).
         uint256 borrowerDebt;             // The accrued debt of auctioned borrower.
@@ -593,24 +593,24 @@ library Auctions {
         if (params_.collateral == 0) revert InsufficientCollateral(); // revert if borrower's collateral is 0
 
         Liquidation storage liquidation = auctions_.liquidations[params_.borrower];
-        TakeResult memory result = _prepareTake(liquidation, params_.t0Debt, params_.collateral, params_.inflator);
+        TakeLocalVars memory vars = _prepareTake(liquidation, params_.t0Debt, params_.collateral, params_.inflator);
 
-        result.unscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.index);
-        if (result.unscaledDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
+        vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.index);
+        if (vars.unscaledDeposit == 0) revert InsufficientLiquidity(); // revert if no quote tokens in arbed bucket
 
-        result.bucketPrice  = _priceAt(params_.index);
+        vars.bucketPrice  = _priceAt(params_.index);
         // cannot arb with a price lower than the auction price
-        if (result.auctionPrice > result.bucketPrice) revert AuctionPriceGtBucketPrice();
+        if (vars.auctionPrice > vars.bucketPrice) revert AuctionPriceGtBucketPrice();
         
         // if deposit take then price to use when calculating take is bucket price
-        if (params_.depositTake) result.auctionPrice = result.bucketPrice;
+        if (params_.depositTake) vars.auctionPrice = vars.bucketPrice;
 
-        result.bucketScale = Deposits.scale(deposits_, params_.index);
-        result = _calculateTakeFlowsAndBondChange(
+        vars.bucketScale = Deposits.scale(deposits_, params_.index);
+        vars = _calculateTakeFlowsAndBondChange(
             params_.collateral,
             params_.t0Debt,
             params_.inflator,
-            result
+            vars
         );
         _rewardBucketTake(
             auctions_,
@@ -619,23 +619,23 @@ library Auctions {
             liquidation,
             params_.index,
             params_.depositTake,
-            result
+            vars
         );
 
         emit BucketTake(
             params_.borrower,
             params_.index,
-            result.scaledQuoteTokenAmount,
-            result.collateralAmount,
-            result.bondChange,
-            result.isRewarded
+            vars.scaledQuoteTokenAmount,
+            vars.collateralAmount,
+            vars.bondChange,
+            vars.isRewarded
         );
 
         return (
-            result.collateralAmount,
-            result.t0RepayAmount,
-            result.t0Debt,
-            result.t0DebtPenalty
+            vars.collateralAmount,
+            vars.t0RepayAmount,
+            vars.t0Debt,
+            vars.t0DebtPenalty
         );
     }
 
@@ -653,50 +653,50 @@ library Auctions {
         TakeParams calldata params_
     ) external returns (uint256, uint256, uint256, uint256, uint256, uint256) {
         Liquidation storage liquidation = auctions_.liquidations[params_.borrower];
-        TakeResult memory result = _prepareTake(liquidation, params_.t0Debt, params_.collateral, params_.inflator);
+        TakeLocalVars memory vars = _prepareTake(liquidation, params_.t0Debt, params_.collateral, params_.inflator);
         // These are placeholder max values passed to calculateTakeFlows because there is no explicit bound on the
         // quote token amount in take calls (as opposed to bucketTake)
-        result.unscaledDeposit = type(uint256).max;
-        result.bucketScale = Maths.WAD;
+        vars.unscaledDeposit = type(uint256).max;
+        vars.bucketScale = Maths.WAD;
 
         // In the case of take, the taker binds the collateral qty but not the quote token qty
         // ugly to get take work like a bucket take -- this is the max amount of quote token from the take that could go to
         // reduce the debt of the borrower -- analagous to the amount of deposit in the bucket for a bucket take
-        result = _calculateTakeFlowsAndBondChange(
+        vars = _calculateTakeFlowsAndBondChange(
             Maths.min(params_.collateral, params_.takeCollateral),
             params_.t0Debt,
             params_.inflator,
-            result
+            vars
         );
-        _rewardTake(auctions_, liquidation, result);
+        _rewardTake(auctions_, liquidation, vars);
 
         emit Take(
             params_.borrower,
-            result.scaledQuoteTokenAmount,
-            result.collateralAmount,
-            result.bondChange,
-            result.isRewarded
+            vars.scaledQuoteTokenAmount,
+            vars.collateralAmount,
+            vars.bondChange,
+            vars.isRewarded
         );
 
         if (params_.poolType == uint8(PoolType.ERC721)) {
             // slither-disable-next-line divide-before-multiply
-            uint256 collateralTaken = (result.collateralAmount / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
-            if (collateralTaken != result.collateralAmount && params_.collateral >= collateralTaken + 1e18) { // collateral taken not a round number
+            uint256 collateralTaken = (vars.collateralAmount / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
+            if (collateralTaken != vars.collateralAmount && params_.collateral >= collateralTaken + 1e18) { // collateral taken not a round number
                 collateralTaken += 1e18; // round up collateral to take
                 // taker should send additional quote tokens to cover difference between collateral needed to be taken and rounded collateral, at auction price
                 // borrower will get quote tokens for the difference between rounded collateral and collateral taken to cover debt
-                result.excessQuoteToken = Maths.wmul(collateralTaken - result.collateralAmount, result.auctionPrice);
+                vars.excessQuoteToken = Maths.wmul(collateralTaken - vars.collateralAmount, vars.auctionPrice);
             }
-            result.collateralAmount = collateralTaken;
+            vars.collateralAmount = collateralTaken;
         }
 
         return (
-            result.collateralAmount,
-            result.scaledQuoteTokenAmount,
-            result.t0RepayAmount,
-            result.t0Debt,
-            result.t0DebtPenalty,
-            result.excessQuoteToken
+            vars.collateralAmount,
+            vars.scaledQuoteTokenAmount,
+            vars.t0RepayAmount,
+            vars.t0Debt,
+            vars.t0DebtPenalty,
+            vars.excessQuoteToken
         );
     }
 
@@ -915,54 +915,54 @@ library Auctions {
      *  @param  totalCollateral_        Total collateral in loan.
      *  @param  t0Debt_                 t0 equivalent debt in loan.
      *  @param  inflator_               Current pool inflator.
-     *  @param  result_                 TakeParams for the take/buckettake
+     *  @param  vars                    TakeParams for the take/buckettake
      */
     function _calculateTakeFlowsAndBondChange(
-        uint256           totalCollateral_,
-        uint256           t0Debt_,
-        uint256           inflator_,
-        TakeResult memory result_
+        uint256              totalCollateral_,
+        uint256              t0Debt_,
+        uint256              inflator_,
+        TakeLocalVars memory vars
     ) internal pure returns (
-        TakeResult memory
+        TakeLocalVars memory
     ) {
         // price is the current auction price, which is the price paid by the LENDER for collateral
         // from the borrower point of view, the price is actually (1-bpf) * price, as the rewards to the
         // bond holder are effectively paid for by the borrower.
-        uint256 borrowerPayoffFactor = (result_.isRewarded) ? Maths.WAD - uint256(result_.bpf) : Maths.WAD;
-        uint256 borrowerPrice = (result_.isRewarded) ? Maths.wmul(borrowerPayoffFactor, result_.auctionPrice) : result_.auctionPrice;
+        uint256 borrowerPayoffFactor = (vars.isRewarded) ? Maths.WAD - uint256(vars.bpf) : Maths.WAD;
+        uint256 borrowerPrice = (vars.isRewarded) ? Maths.wmul(borrowerPayoffFactor, vars.auctionPrice) : vars.auctionPrice;
 
         // If there is no unscaled quote token bound, then we pass in max, but that cannot be scaled without an overflow.  So we check in the line below.
-        result_.scaledQuoteTokenAmount = (result_.unscaledDeposit != type(uint256).max) ? Maths.wmul(result_.unscaledDeposit, result_.bucketScale) : type(uint256).max;
+        vars.scaledQuoteTokenAmount = (vars.unscaledDeposit != type(uint256).max) ? Maths.wmul(vars.unscaledDeposit, vars.bucketScale) : type(uint256).max;
 
         uint256 borrowerCollateralValue = Maths.wmul(totalCollateral_, borrowerPrice);
         
-        if (result_.scaledQuoteTokenAmount <= result_.borrowerDebt && result_.scaledQuoteTokenAmount <= borrowerCollateralValue) {
+        if (vars.scaledQuoteTokenAmount <= vars.borrowerDebt && vars.scaledQuoteTokenAmount <= borrowerCollateralValue) {
             // quote token used to purchase is constraining factor
-            result_.collateralAmount         = Maths.wdiv(result_.scaledQuoteTokenAmount, borrowerPrice);
-            result_.t0RepayAmount            = Maths.wdiv(result_.scaledQuoteTokenAmount, inflator_);
-            result_.unscaledQuoteTokenAmount = result_.unscaledDeposit;
-        } else if (result_.borrowerDebt <= borrowerCollateralValue) {
+            vars.collateralAmount         = Maths.wdiv(vars.scaledQuoteTokenAmount, borrowerPrice);
+            vars.t0RepayAmount            = Maths.wdiv(vars.scaledQuoteTokenAmount, inflator_);
+            vars.unscaledQuoteTokenAmount = vars.unscaledDeposit;
+        } else if (vars.borrowerDebt <= borrowerCollateralValue) {
             // borrower debt is constraining factor
-            result_.collateralAmount = Maths.wdiv(result_.borrowerDebt, borrowerPrice);
-            result_.t0RepayAmount            = t0Debt_;
-            result_.unscaledQuoteTokenAmount = Maths.wdiv(result_.borrowerDebt, result_.bucketScale);
-            result_.scaledQuoteTokenAmount   = (result_.isRewarded) ? Maths.wdiv(result_.borrowerDebt, borrowerPayoffFactor) : result_.borrowerDebt;
+            vars.collateralAmount = Maths.wdiv(vars.borrowerDebt, borrowerPrice);
+            vars.t0RepayAmount            = t0Debt_;
+            vars.unscaledQuoteTokenAmount = Maths.wdiv(vars.borrowerDebt, vars.bucketScale);
+            vars.scaledQuoteTokenAmount   = (vars.isRewarded) ? Maths.wdiv(vars.borrowerDebt, borrowerPayoffFactor) : vars.borrowerDebt;
         } else {
             // collateral available is constraint
-            result_.collateralAmount         = totalCollateral_;
-            result_.t0RepayAmount            = Maths.wdiv(borrowerCollateralValue, inflator_);
-            result_.unscaledQuoteTokenAmount = Maths.wdiv(borrowerCollateralValue, result_.bucketScale);
-            result_.scaledQuoteTokenAmount   = Maths.wmul(result_.collateralAmount, result_.auctionPrice);
+            vars.collateralAmount         = totalCollateral_;
+            vars.t0RepayAmount            = Maths.wdiv(borrowerCollateralValue, inflator_);
+            vars.unscaledQuoteTokenAmount = Maths.wdiv(borrowerCollateralValue, vars.bucketScale);
+            vars.scaledQuoteTokenAmount   = Maths.wmul(vars.collateralAmount, vars.auctionPrice);
         }
 
-        if (result_.isRewarded) {
-            result_.bondChange = Maths.wmul(result_.scaledQuoteTokenAmount, uint256(result_.bpf)); // will be rewarded as LPBs
+        if (vars.isRewarded) {
+            vars.bondChange = Maths.wmul(vars.scaledQuoteTokenAmount, uint256(vars.bpf)); // will be rewarded as LPBs
         } else {
             // take is above neutralPrice, Kicker is penalized
-            result_.bondChange = Maths.wmul(result_.scaledQuoteTokenAmount, uint256(-result_.bpf));
+            vars.bondChange = Maths.wmul(vars.scaledQuoteTokenAmount, uint256(-vars.bpf));
         }
 
-        return result_;
+        return vars;
     }
 
     /**
@@ -1060,27 +1060,27 @@ library Auctions {
     function _rewardTake(
         AuctionsState storage auctions_,
         Liquidation storage liquidation_,
-        TakeResult memory result_
+        TakeLocalVars memory vars
     ) internal {
-        if (result_.isRewarded) {
+        if (vars.isRewarded) {
             // take is below neutralPrice, Kicker is rewarded
-            liquidation_.bondSize                    += uint160(result_.bondChange);
-            auctions_.kickers[result_.kicker].locked += result_.bondChange;
-            auctions_.totalBondEscrowed              += result_.bondChange;
+            liquidation_.bondSize                 += uint160(vars.bondChange);
+            auctions_.kickers[vars.kicker].locked += vars.bondChange;
+            auctions_.totalBondEscrowed           += vars.bondChange;
         } else {
             // take is above neutralPrice, Kicker is penalized
-            result_.bondChange = Maths.min(liquidation_.bondSize, result_.bondChange);
-            liquidation_.bondSize                    -= uint160(result_.bondChange);
-            auctions_.kickers[result_.kicker].locked -= result_.bondChange;
-            auctions_.totalBondEscrowed              -= result_.bondChange;
+            vars.bondChange = Maths.min(liquidation_.bondSize, vars.bondChange);
+            liquidation_.bondSize                 -= uint160(vars.bondChange);
+            auctions_.kickers[vars.kicker].locked -= vars.bondChange;
+            auctions_.totalBondEscrowed           -= vars.bondChange;
         }
     }
 
     /**
      *  @notice Rewards actors of a bucket take action.
-     *  @param  deposits_      Deposits state
-     *  @param  bucketIndex_   Bucket index.
-     *  @param  result_        Struct containing take action result details.
+     *  @param  deposits_    Deposits state
+     *  @param  bucketIndex_ Bucket index.
+     *  @param  vars         Struct containing take action result details.
      */
     function _rewardBucketTake(
         AuctionsState storage auctions_,
@@ -1089,52 +1089,52 @@ library Auctions {
         Liquidation storage liquidation_,
         uint256 bucketIndex_,
         bool depositTake_,
-        TakeResult memory result_
+        TakeLocalVars memory vars
     ) internal {
         Bucket storage bucket = buckets_[bucketIndex_];
 
         uint256 bucketExchangeRate = Buckets.getUnscaledExchangeRate(
             bucket.collateral,
             bucket.lps,
-            result_.unscaledDeposit,
-            result_.bucketScale,
-            result_.bucketPrice
+            vars.unscaledDeposit,
+            vars.bucketScale,
+            vars.bucketPrice
         );
 
         uint256 bankruptcyTime = bucket.bankruptcyTime;
         uint256 totalLPsReward;
         // if arb take - taker is awarded collateral * (bucket price - auction price) worth (in quote token terms) units of LPB in the bucket
         if (!depositTake_) {
-            uint256 takerReward = Maths.wmul(result_.collateralAmount, result_.bucketPrice - result_.auctionPrice);
-            uint256 takerRewardUnscaledQuoteToken = Maths.wdiv(takerReward, result_.bucketScale);
+            uint256 takerReward = Maths.wmul(vars.collateralAmount, vars.bucketPrice - vars.auctionPrice);
+            uint256 takerRewardUnscaledQuoteToken = Maths.wdiv(takerReward, vars.bucketScale);
             totalLPsReward = Maths.wrdivr(takerRewardUnscaledQuoteToken, bucketExchangeRate);
             Buckets.addLenderLPs(bucket, bankruptcyTime, msg.sender, totalLPsReward);
         }
 
         uint256 kickerLPsReward;
         // the bondholder/kicker is awarded bond change worth of LPB in the bucket
-        if (result_.isRewarded) {
-            kickerLPsReward = Maths.wrdivr(Maths.wdiv(result_.bondChange, result_.bucketScale), bucketExchangeRate);
+        if (vars.isRewarded) {
+            kickerLPsReward = Maths.wrdivr(Maths.wdiv(vars.bondChange, vars.bucketScale), bucketExchangeRate);
             totalLPsReward += kickerLPsReward;
-            Buckets.addLenderLPs(bucket, bankruptcyTime, result_.kicker, kickerLPsReward);
+            Buckets.addLenderLPs(bucket, bankruptcyTime, vars.kicker, kickerLPsReward);
         } else {
             // take is above neutralPrice, Kicker is penalized
-            result_.bondChange = Maths.min(liquidation_.bondSize, result_.bondChange);
-            liquidation_.bondSize                    -= uint160(result_.bondChange);
-            auctions_.kickers[result_.kicker].locked -= result_.bondChange;
-            auctions_.totalBondEscrowed              -= result_.bondChange;
+            vars.bondChange = Maths.min(liquidation_.bondSize, vars.bondChange);
+            liquidation_.bondSize                 -= uint160(vars.bondChange);
+            auctions_.kickers[vars.kicker].locked -= vars.bondChange;
+            auctions_.totalBondEscrowed           -= vars.bondChange;
         }
 
-        Deposits.unscaledRemove(deposits_, bucketIndex_, result_.unscaledQuoteTokenAmount); // remove quote tokens from bucket’s deposit
+        Deposits.unscaledRemove(deposits_, bucketIndex_, vars.unscaledQuoteTokenAmount); // remove quote tokens from bucket’s deposit
 
         // total rewarded LPs are added to the bucket LP balance
         bucket.lps += totalLPsReward;
         // collateral is added to the bucket’s claimable collateral
-        bucket.collateral += result_.collateralAmount;
+        bucket.collateral += vars.collateralAmount;
 
         emit BucketTakeLPAwarded(
             msg.sender,
-            result_.kicker,
+            vars.kicker,
             totalLPsReward - kickerLPsReward,
             kickerLPsReward
         );
@@ -1195,42 +1195,42 @@ library Auctions {
     /**
      *  @notice Utility function to validate take and calculate take's parameters.
      *  @param  liquidation_ Liquidation struct holding auction details.
-     *  @param  t0Debt_       Borrower t0 debt.
+     *  @param  t0Debt_      Borrower t0 debt.
      *  @param  collateral_  Borrower collateral.
      *  @param  inflator_    The pool's inflator, used to calculate borrower debt.
-     *  @return takeResult_  The result of take action.
+     *  @return vars         The prepared vars for take action.
      */
     function _prepareTake(
         Liquidation storage liquidation_,
         uint256 t0Debt_,
         uint256 collateral_,
         uint256 inflator_
-    ) internal returns (TakeResult memory takeResult_) {
+    ) internal returns (TakeLocalVars memory vars) {
 
         uint256 kickTime = liquidation_.kickTime;
         if (kickTime == 0) revert NoAuction();
         if (block.timestamp - kickTime <= 1 hours) revert TakeNotPastCooldown();
 
-        takeResult_.t0Debt = t0Debt_;
+        vars.t0Debt = t0Debt_;
         // if first take borrower debt is increased by 7% penalty
         if (!liquidation_.alreadyTaken) {
-            takeResult_.t0DebtPenalty = Maths.wmul(t0Debt_, 0.07 * 1e18);
-            takeResult_.t0Debt += takeResult_.t0DebtPenalty; 
+            vars.t0DebtPenalty = Maths.wmul(t0Debt_, 0.07 * 1e18);
+            vars.t0Debt += vars.t0DebtPenalty; 
             liquidation_.alreadyTaken = true;
         }
 
-        takeResult_.borrowerDebt = Maths.wmul(takeResult_.t0Debt, inflator_);
-        takeResult_.auctionPrice = _auctionPrice(liquidation_.kickMomp, kickTime);
-        takeResult_.bpf          = _bpf(
-            takeResult_.borrowerDebt,
+        vars.borrowerDebt = Maths.wmul(vars.t0Debt, inflator_);
+        vars.auctionPrice = _auctionPrice(liquidation_.kickMomp, kickTime);
+        vars.bpf          = _bpf(
+            vars.borrowerDebt,
             collateral_,
             liquidation_.neutralPrice,
             liquidation_.bondFactor,
-            takeResult_.auctionPrice
+            vars.auctionPrice
         );
-        takeResult_.factor     = uint256(1e18 - Maths.maxInt(0, takeResult_.bpf));
-        takeResult_.kicker     = liquidation_.kicker;
-        takeResult_.isRewarded = (takeResult_.bpf  >= 0);
+        vars.factor     = uint256(1e18 - Maths.maxInt(0, vars.bpf));
+        vars.kicker     = liquidation_.kicker;
+        vars.isRewarded = (vars.bpf  >= 0);
     }
 
     /**********************/

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -62,7 +62,7 @@ library Auctions {
     }
 
     struct TakeFromLoanResult {
-        uint256 settledCollateral;
+        uint256 remainingCollateral;
         uint256 poolDebt;
         uint256 newLup;
         uint256 t0DebtInAuctionChange;
@@ -877,15 +877,15 @@ library Auctions {
             if (poolState_.poolType == uint8(PoolType.ERC721)) {
                 uint256 lps;
                 uint256 bucketIndex;
-                (result_.settledCollateral, lps, bucketIndex) = settleNFTAuction(
+                (result_.remainingCollateral, lps, bucketIndex) = settleNFTAuction(
                     auctions_,
                     buckets_,
                     deposits_,
                     borrowerAddress_,
                     borrower_.collateral
                 );
-                borrower_.collateral = result_.settledCollateral;
-                emit AuctionNFTSettle(borrowerAddress_, result_.settledCollateral, lps, bucketIndex);
+                borrower_.collateral = result_.remainingCollateral;
+                emit AuctionNFTSettle(borrowerAddress_, result_.remainingCollateral, lps, bucketIndex);
             } else {
                 Auctions._removeAuction(auctions_, borrowerAddress_);
                 emit AuctionSettle(borrowerAddress_, borrower_.collateral);

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -123,15 +123,15 @@ library BorrowerActions {
                 if (poolState_.poolType == uint8(PoolType.ERC721)) {
                     uint256 lps;
                     uint256 bucketIndex;
-                    (result_.settledCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
+                    (result_.remainingCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
                         auctions_,
                         buckets_,
                         deposits_,
                         borrowerAddress_,
                         borrower.collateral
                     );
-                    borrower.collateral = result_.settledCollateral;
-                    emit AuctionNFTSettle(borrowerAddress_, result_.settledCollateral, lps, bucketIndex);
+                    borrower.collateral = result_.remainingCollateral;
+                    emit AuctionNFTSettle(borrowerAddress_, result_.remainingCollateral, lps, bucketIndex);
                 } else {
                     Auctions._removeAuction(auctions_, borrowerAddress_);
                     emit AuctionSettle(borrowerAddress_, borrower.collateral);
@@ -240,15 +240,15 @@ library BorrowerActions {
                     if (poolState_.poolType == uint8(PoolType.ERC721)) {
                         uint256 lps;
                         uint256 bucketIndex;
-                        (result_.settledCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
+                        (result_.remainingCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
                             auctions_,
                             buckets_,
                             deposits_,
                             borrowerAddress_,
                             borrower.collateral
                         );
-                        borrower.collateral = result_.settledCollateral;
-                        emit AuctionNFTSettle(borrowerAddress_, result_.settledCollateral, lps, bucketIndex);
+                        borrower.collateral = result_.remainingCollateral;
+                        emit AuctionNFTSettle(borrowerAddress_, result_.remainingCollateral, lps, bucketIndex);
                     } else {
                         Auctions._removeAuction(auctions_, borrowerAddress_);
                         emit AuctionSettle(borrowerAddress_, borrower.collateral);

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -10,6 +10,8 @@ import {
     RepayDebtResult
 } from '../../base/interfaces/IPool.sol';
 
+import { _revertOnMinDebt } from '../../base/RevertsHelper.sol';
+
 import './Auctions.sol';
 import '../Buckets.sol';
 import '../Deposits.sol';
@@ -37,11 +39,6 @@ library BorrowerActions {
         uint256 t0DebtInAuctionChange; // t0 change amount of debt after repayment
         uint256 t0RepaidDebt;          // t0 debt repaid
     }
-
-    /**
-     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
-     */
-    error AmountLTMinDebt();
 
     /**
      *  @notice Recipient of borrowed quote tokens doesn't match the caller of the drawDebt function.
@@ -312,17 +309,6 @@ library BorrowerActions {
         uint256 debt_
     ) internal view returns (uint256) {
         return _priceAt(_lupIndex(deposits_, debt_));
-    }
-
-    function _revertOnMinDebt(LoansState storage loans_, uint256 poolDebt_, uint256 borrowerDebt_) internal view {
-        if (borrowerDebt_ != 0) {
-            uint256 loansCount = Loans.noOfLoans(loans_);
-            if (
-                loansCount >= 10
-                &&
-                (borrowerDebt_ < _minDebtAmount(poolDebt_, loansCount))
-            ) revert AmountLTMinDebt();
-        }
     }
 
 }

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -192,7 +192,6 @@ library BorrowerActions {
         vars.borrowerDebt = Maths.wmul(borrower.t0Debt, poolState_.inflator);
 
         result_.poolDebt       = poolState_.debt;
-        result_.newLup         = _lup(deposits_, result_.poolDebt);
         result_.poolCollateral = poolState_.collateral;
 
         if (vars.repay) {

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -117,7 +117,9 @@ library BorrowerActions {
                 _isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)
             )
             {
-                // borrower becomes collateralized, remove debt from pool accumulator and settle auction
+                // borrower becomes collateralized
+                result_.settledAuction = true;
+                // remove debt from pool accumulator and settle auction
                 result_.t0DebtInAuctionChange = borrower.t0Debt;
 
                 if (poolState_.poolType == uint8(PoolType.ERC721)) {
@@ -233,6 +235,7 @@ library BorrowerActions {
             if (vars.inAuction) {
                 if (_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) {
                     // borrower becomes re-collateralized
+                    result_.settledAuction = true;
                     // remove entire borrower debt from pool auctions debt accumulator
                     result_.t0DebtInAuctionChange = borrower.t0Debt;
 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -75,7 +75,7 @@ library BorrowerActions {
     ) external returns (
         DrawDebtResult memory result_
     ) {
-        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+        Borrower memory borrower = loans_.borrowers[borrowerAddress_];
 
         result_.poolDebt       = poolState_.debt;
         result_.newLup         = _lup(deposits_, result_.poolDebt);
@@ -176,7 +176,7 @@ library BorrowerActions {
     ) external returns (
         RepayDebtResult memory result_
     ) {
-        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+        Borrower memory borrower = loans_.borrowers[borrowerAddress_];
 
         RepayDebtLocalVars memory vars;
         vars.repay        = maxQuoteTokenAmountToRepay_ != 0;

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.14;
+
+/**
+    @notice External library containing logic for common borrower actions.
+ */
+library BorrowerActions {
+
+}

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -6,7 +6,8 @@ import {
     PoolState,
     DepositsState,
     AuctionsState,
-    DrawDebtResult
+    DrawDebtResult,
+    RepayDebtResult
 } from '../../base/interfaces/IPool.sol';
 
 import './Auctions.sol';
@@ -26,6 +27,17 @@ library BorrowerActions {
         uint256 debtChange;
     }
 
+    struct RepayDebtLocalVars {
+        uint256 borrowerDebt;          // borrower's accrued debt
+        bool    inAuction;             // true if loan still in auction after repay, false otherwise
+        uint256 newLup;                // LUP after auction is taken
+        bool    pull;                  // true if pull action
+        bool    repay;                 // true if repay action
+        bool    stampT0Np;             // true if loan's t0 neutral price should be restamped (when exiting auction)
+        uint256 t0DebtInAuctionChange; // t0 change amount of debt after repayment
+        uint256 t0RepaidDebt;          // t0 debt repaid
+    }
+
     /**
      *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
      */
@@ -42,9 +54,20 @@ library BorrowerActions {
     error BorrowerUnderCollateralized();
 
     /**
+     *  @notice User is attempting to move or pull more collateral than is available.
+     */
+    error InsufficientCollateral();
+
+    /**
      *  @notice Borrower is attempting to borrow more quote token than is available before the supplied limitIndex.
      */
     error LimitIndexReached();
+
+    /**
+     *  @notice Borrower has no debt to liquidate.
+     *  @notice Borrower is attempting to repay when they have no outstanding debt.
+     */
+    error NoDebt();
 
     event AuctionNFTSettle(
         address indexed borrower,
@@ -164,6 +187,113 @@ library BorrowerActions {
             result_.newLup,
             vars.inAuction,
             true
+        );
+    }
+
+    function repayDebt(
+        AuctionsState storage auctions_,
+        mapping(uint256 => Bucket) storage buckets_,
+        DepositsState storage deposits_,
+        LoansState    storage loans_,
+        PoolState calldata poolState_,
+        address borrowerAddress_,
+        uint256 maxQuoteTokenAmountToRepay_,
+        uint256 collateralAmountToPull_
+    ) external returns (
+        RepayDebtResult memory result_
+    ) {
+        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+
+        RepayDebtLocalVars memory vars;
+        vars.repay        = maxQuoteTokenAmountToRepay_ != 0;
+        vars.pull         = collateralAmountToPull_ != 0;
+        vars.borrowerDebt = Maths.wmul(borrower.t0Debt, poolState_.inflator);
+
+        result_.poolDebt       = poolState_.debt;
+        result_.newLup         = _lup(deposits_, result_.poolDebt);
+        result_.poolCollateral = poolState_.collateral;
+
+        if (vars.repay) {
+            if (borrower.t0Debt == 0) revert NoDebt();
+
+            result_.t0RepaidDebt = Maths.min(
+                borrower.t0Debt,
+                Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState_.inflator)
+            );
+            result_.quoteTokenToRepay = Maths.wmul(result_.t0RepaidDebt, poolState_.inflator);
+            result_.poolDebt  -= result_.quoteTokenToRepay;
+            vars.borrowerDebt  -= result_.quoteTokenToRepay;
+
+            // check that paying the loan doesn't leave borrower debt under min debt amount
+            _revertOnMinDebt(loans_, result_.poolDebt, vars.borrowerDebt);
+
+            result_.newLup = _lup(deposits_, result_.poolDebt);
+            vars.inAuction = Auctions.isActive(auctions_, borrowerAddress_);
+
+            if (vars.inAuction) {
+                if (_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) {
+                    // borrower becomes re-collateralized
+                    // remove entire borrower debt from pool auctions debt accumulator
+                    result_.t0DebtInAuctionChange = borrower.t0Debt;
+
+                    // settle auction and update borrower's collateral with value after settlement
+                    if (poolState_.poolType == uint8(PoolType.ERC721)) {
+                        uint256 lps;
+                        uint256 bucketIndex;
+                        (result_.settledCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
+                            auctions_,
+                            buckets_,
+                            deposits_,
+                            borrowerAddress_,
+                            borrower.collateral
+                        );
+                        borrower.collateral = result_.settledCollateral;
+                        emit AuctionNFTSettle(borrowerAddress_, result_.settledCollateral, lps, bucketIndex);
+                    } else {
+                        Auctions._removeAuction(auctions_, borrowerAddress_);
+                        emit AuctionSettle(borrowerAddress_, borrower.collateral);
+                    }
+
+                    vars.inAuction   = false;
+                    vars.stampT0Np = true;  // stamp borrower t0Np when exiting from auction
+                } else {
+                    // partial repay, remove only the paid debt from pool auctions debt accumulator
+                    result_.t0DebtInAuctionChange = result_.t0RepaidDebt;
+                }
+            }
+
+            borrower.t0Debt -= result_.t0RepaidDebt;
+        }
+
+        if (vars.pull) {
+            // only intended recipient can pull collateral
+            if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
+
+            // calculate LUP only if it wasn't calculated by repay action
+            if (!vars.repay) result_.newLup = _lup(deposits_, result_.poolDebt);
+
+            uint256 encumberedCollateral = borrower.t0Debt != 0 ? Maths.wdiv(vars.borrowerDebt, result_.newLup) : 0;
+            if (borrower.collateral - encumberedCollateral < collateralAmountToPull_) revert InsufficientCollateral();
+
+            // stamp borrower t0Np when pull collateral action
+            vars.stampT0Np = true;
+
+            borrower.collateral    -= collateralAmountToPull_;
+            result_.poolCollateral -= collateralAmountToPull_;
+        }
+
+        // update loan state
+        Loans.update(
+            loans_,
+            auctions_,
+            deposits_,
+            borrower,
+            borrowerAddress_,
+            vars.borrowerDebt,
+            poolState_.rate,
+            result_.newLup,
+            vars.inAuction,
+            vars.stampT0Np
         );
     }
 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -2,9 +2,194 @@
 
 pragma solidity 0.8.14;
 
+import {
+    PoolState,
+    DepositsState,
+    AuctionsState,
+    DrawDebtResult
+} from '../../base/interfaces/IPool.sol';
+
+import './Auctions.sol';
+import '../Buckets.sol';
+import '../Deposits.sol';
+import '../Loans.sol';
+
 /**
     @notice External library containing logic for common borrower actions.
  */
 library BorrowerActions {
+
+    struct DrawDebtLocalVars {
+        uint256 borrowerDebt;
+        bool    inAuction;
+        uint256 lupId;
+        uint256 debtChange;
+    }
+
+    /**
+     *  @notice Borrower is attempting to create or modify a loan such that their loan's quote token would be less than the pool's minimum debt amount.
+     */
+    error AmountLTMinDebt();
+
+    /**
+     *  @notice Recipient of borrowed quote tokens doesn't match the caller of the drawDebt function.
+     */
+    error BorrowerNotSender();
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than they have collateral for.
+     */
+    error BorrowerUnderCollateralized();
+
+    /**
+     *  @notice Borrower is attempting to borrow more quote token than is available before the supplied limitIndex.
+     */
+    error LimitIndexReached();
+
+    event AuctionNFTSettle(
+        address indexed borrower,
+        uint256 collateral,
+        uint256 lps,
+        uint256 index
+    );
+
+    event AuctionSettle(
+        address indexed borrower,
+        uint256 collateral
+    );
+
+    function drawDebt(
+        AuctionsState storage auctions_,
+        mapping(uint256 => Bucket) storage buckets_,
+        DepositsState storage deposits_,
+        LoansState    storage loans_,
+        PoolState calldata poolState_,
+        address borrowerAddress_,
+        uint256 amountToBorrow_,
+        uint256 limitIndex_,
+        uint256 collateralToPledge_
+    ) external returns (
+        DrawDebtResult memory result_
+    ) {
+        Borrower memory borrower = Loans.getBorrowerInfo(loans_, borrowerAddress_);
+
+        result_.poolDebt       = poolState_.debt;
+        result_.newLup         = _lup(deposits_, result_.poolDebt);
+        result_.poolCollateral = poolState_.collateral;
+
+        DrawDebtLocalVars memory vars;
+        vars.borrowerDebt = Maths.wmul(borrower.t0Debt, poolState_.inflator);
+
+        // pledge collateral to pool
+        if (collateralToPledge_ != 0) {
+            // add new amount of collateral to pledge to borrower balance
+            borrower.collateral  += collateralToPledge_;
+
+            // load loan's auction state
+            vars.inAuction = Auctions.isActive(auctions_, borrowerAddress_);
+            // if loan is auctioned and becomes collateralized by newly pledged collateral then settle auction
+            if (
+                vars.inAuction
+                &&
+                _isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)
+            )
+            {
+                // borrower becomes collateralized, remove debt from pool accumulator and settle auction
+                result_.t0DebtInAuctionChange = borrower.t0Debt;
+
+                if (poolState_.poolType == uint8(PoolType.ERC721)) {
+                    uint256 lps;
+                    uint256 bucketIndex;
+                    (result_.settledCollateral, lps, bucketIndex) = Auctions.settleNFTAuction(
+                        auctions_,
+                        buckets_,
+                        deposits_,
+                        borrowerAddress_,
+                        borrower.collateral
+                    );
+                    borrower.collateral = result_.settledCollateral;
+                    emit AuctionNFTSettle(borrowerAddress_, result_.settledCollateral, lps, bucketIndex);
+                } else {
+                    Auctions._removeAuction(auctions_, borrowerAddress_);
+                    emit AuctionSettle(borrowerAddress_, borrower.collateral);
+                }
+
+                // auction was settled, reset inAuction flag
+                vars.inAuction = false;
+            }
+
+            // add new amount of collateral to pledge to pool balance
+            result_.poolCollateral += collateralToPledge_;
+        }
+
+        // borrow against pledged collateral
+        // check both values to enable an intentional 0 borrow loan call to update borrower's loan state
+        if (amountToBorrow_ != 0 || limitIndex_ != 0) {
+            // only intended recipient can borrow quote
+            if (borrowerAddress_ != msg.sender) revert BorrowerNotSender();
+
+            // add origination fee to the amount to borrow and add to borrower's debt
+            vars.debtChange   = Maths.wmul(amountToBorrow_, _feeRate(poolState_.rate) + Maths.WAD);
+            vars.borrowerDebt += vars.debtChange;
+
+            // check that drawing debt doesn't leave borrower debt under min debt amount
+            _revertOnMinDebt(loans_, result_.poolDebt, vars.borrowerDebt);
+
+            // add debt change to pool's debt
+            result_.poolDebt += vars.debtChange;
+            // determine new lup index and revert if borrow happens at a price higher than the specified limit (lower index than lup index)
+            vars.lupId = _lupIndex(deposits_, result_.poolDebt);
+            if (vars.lupId > limitIndex_) revert LimitIndexReached();
+
+            // calculate new lup and check borrow action won't push borrower into a state of under-collateralization
+            // this check also covers the scenario when loan is already auctioned
+            result_.newLup = _priceAt(vars.lupId);
+            if (
+                !_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)
+            ) revert BorrowerUnderCollateralized();
+
+            result_.t0DebtChange = Maths.wdiv(vars.debtChange, poolState_.inflator);
+            borrower.t0Debt += result_.t0DebtChange;
+        }
+
+        // update loan state
+        Loans.update(
+            loans_,
+            auctions_,
+            deposits_,
+            borrower,
+            borrowerAddress_,
+            vars.borrowerDebt,
+            poolState_.rate,
+            result_.newLup,
+            vars.inAuction,
+            true
+        );
+    }
+
+    function _lupIndex(
+        DepositsState storage deposits_,
+        uint256 debt_
+    ) internal view returns (uint256) {
+        return Deposits.findIndexOfSum(deposits_, debt_);
+    }
+
+    function _lup(
+        DepositsState storage deposits_,
+        uint256 debt_
+    ) internal view returns (uint256) {
+        return _priceAt(_lupIndex(deposits_, debt_));
+    }
+
+    function _revertOnMinDebt(LoansState storage loans_, uint256 poolDebt_, uint256 borrowerDebt_) internal view {
+        if (borrowerDebt_ != 0) {
+            uint256 loansCount = Loans.noOfLoans(loans_);
+            if (
+                loansCount >= 10
+                &&
+                (borrowerDebt_ < _minDebtAmount(poolDebt_, loansCount))
+            ) revert AmountLTMinDebt();
+        }
+    }
 
 }

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -90,7 +90,7 @@ library BorrowerActions {
             borrower.collateral  += collateralToPledge_;
 
             // load loan's auction state
-            vars.inAuction = Auctions.isActive(auctions_, borrowerAddress_);
+            vars.inAuction = _inAuction(auctions_, borrowerAddress_);
             // if loan is auctioned and becomes collateralized by newly pledged collateral then settle auction
             if (
                 vars.inAuction
@@ -202,7 +202,7 @@ library BorrowerActions {
             _revertOnMinDebt(loans_, result_.poolDebt, vars.borrowerDebt);
 
             result_.newLup = _lup(deposits_, result_.poolDebt);
-            vars.inAuction = Auctions.isActive(auctions_, borrowerAddress_);
+            vars.inAuction = _inAuction(auctions_, borrowerAddress_);
 
             if (vars.inAuction) {
                 if (_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) {
@@ -261,6 +261,19 @@ library BorrowerActions {
             vars.inAuction,
             vars.stampT0Np
         );
+    }
+
+    /**
+     *  @notice Returns true if borrower is in auction.
+     *  @dev    Used to accuratley increment and decrement t0DebtInAuction.
+     *  @param  borrower_ Borrower address to check auction status for.
+     *  @return  active_ Boolean, based on if borrower is in auction.
+     */
+    function _inAuction(
+        AuctionsState storage auctions_,
+        address borrower_
+    ) internal view returns (bool) {
+        return auctions_.liquidations[borrower_].kickTime != 0;
     }
 
     function _lupIndex(

--- a/tests/brownie/sdk/ajna_protocol.py
+++ b/tests/brownie/sdk/ajna_protocol.py
@@ -8,6 +8,7 @@ from brownie import (
     Auctions,
     PoolCommons,
     LenderActions,
+    BorrowerActions,
     Deposits,
     Maths,
     Loans,
@@ -33,6 +34,7 @@ class AjnaProtocol:
         self.deposits = Deposits.deploy({"from": self.deployer})
         self.pool_logic = PoolCommons.deploy({"from": self.deployer})
         self.lender_actions = LenderActions.deploy({"from": self.deployer})
+        self.borrower_actions = BorrowerActions.deploy({"from": self.deployer})
         self.maths = Maths.deploy({"from": self.deployer})
         self.loans = Loans.deploy({"from": self.deployer})
         self.auctions = Auctions.deploy({"from": self.deployer})

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -7,7 +7,7 @@ import 'src/erc20/ERC20Pool.sol';
 import 'src/erc20/ERC20PoolFactory.sol';
 
 contract ERC20PoolFactoryTest is ERC20HelperContract {
-    address immutable poolAddress = 0xC79ea49960D7dEba52eE7Bc9CCe610E977894142;
+    address immutable poolAddress = 0xeCAF6d240E0AdcaD5FfE4306b7D4301Df130bC02;
 
     ERC20PoolFactory internal _poolFactory;
 

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -7,7 +7,7 @@ import 'src/erc20/ERC20Pool.sol';
 import 'src/erc20/ERC20PoolFactory.sol';
 
 contract ERC20PoolFactoryTest is ERC20HelperContract {
-    address immutable poolAddress = 0x918ebA623C6291984Eeea4EE07335c3DDa03c0d3;
+    address immutable poolAddress = 0xC79ea49960D7dEba52eE7Bc9CCe610E977894142;
 
     ERC20PoolFactory internal _poolFactory;
 

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -98,7 +98,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 amountToBorrow:     46_000 * 1e18,
                 limitIndex:         4_300,
                 collateralToPledge: 100 * 1e18,
-                newLup:             2_981.007422784467321543 * 1e18
+                newLup:             0
             }
         );
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -1268,7 +1268,7 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    203333271.751119404110784864 * 1e18,
+                targetUtilization:    162666617.400895523288640654 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -471,7 +471,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 encumberedCollateral: 2.010288427770370775 * 1e18,
                 poolDebt:             19.542608580405342754 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    2.175523973685168466 * 1e18,
+                targetUtilization:    1.026169079990327137 * 1e18,
                 minDebtAmount:        1.954260858040534275 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower),

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -263,14 +263,14 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
 
+        vm.expectEmit(true, true, false, true);
+        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
+
         for (uint256 i = 0; i < tokenIds.length; i++) {
             assertEq(_collateral.ownerOf(tokenIds[i]), from); // token is owned by pledger address
             vm.expectEmit(true, true, false, true);
             emit Transfer(from, address(_pool), tokenIds[i]);
         }
-
-        vm.expectEmit(true, true, false, true);
-        emit DrawDebtNFT(borrower, 0, tokenIds, _poolUtils.lup(address(_pool)));
 
         ERC721Pool(address(_pool)).drawDebt(borrower, 0, 0, tokenIds);
 

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -1130,7 +1130,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         _removeAllLiquidity(
             {
                 from:     _lender,
-                amount:   9.987201910492245717 * 1e18,
+                amount:   9.988365372029241202 * 1e18,
                 index:    7388,
                 newLup:   MAX_PRICE,
                 lpRedeem: 9.999999987399196030933756763 * 1e27
@@ -1156,12 +1156,12 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    4430369124.929039499454123939 * 1e18,
+                targetUtilization:    3123578486.616799651636891881 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.06655 * 1e18,
-                interestRateUpdate:   block.timestamp
+                interestRate:         0.0605 * 1e18,
+                interestRateUpdate:   block.timestamp - 4210 minutes
             })
         );
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -280,12 +280,12 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    33853304875.166890128186624582 * 1e18,
+                targetUtilization:    0.000004568979952926 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.055 * 1e18,
-                interestRateUpdate:   _startTime + 80 hours
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
             })
         );
         _assertBorrower(

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -298,85 +298,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             }
         );
 
-        /**************************************/
-        /*** Take all collateral tokens (2) ***/
-        /**************************************/
         uint256 snapshot = vm.snapshot();
-
-        _take(
-            {
-                from:            _lender,
-                borrower:        _borrower,
-                maxCollateral:   2,
-                bondChange:      0.227287198298417188 * 1e18,
-                givenAmount:     24.624359312514645329 * 1e18,
-                collateralTaken: 1.241499462864870800 * 1e18, // not a rounded collateral, difference of 2 - 1.16 collateral should go to borrower in quote tokens at auction price
-                isReward:        false
-            }
-        );
-
-        _assertPool(
-            PoolParams({
-                htp:                  6.582554958364903034 * 1e18,
-                lup:                  9.917184843435912074 * 1e18,
-                poolSize:             73_000.000878382806067000 * 1e18,
-                pledgedCollateral:    3.0 * 1e18,
-                encumberedCollateral: 1.898735286563375238 * 1e18,
-                poolDebt:             18.830108805603248108 * 1e18,
-                actualUtilization:    0.000257946692863388 * 1e18,
-                targetUtilization:    0.811350329890505142 * 1e18,
-                minDebtAmount:        1.883010880560324811 * 1e18,
-                loans:                1,
-                maxBorrower:          address(_borrower2),
-                interestRate:         0.045 * 1e18,
-                interestRateUpdate:   block.timestamp - 5 hours
-            })
-        );
-
-        _assertBorrower(
-            {
-                borrower:                  _borrower,
-                borrowerDebt:              1.610939394276659040 * 1e18,
-                borrowerCollateral:        0,
-                borrowert0Np:              10.404995192307692312 * 1e18,
-                borrowerCollateralization: 0
-            }
-        );
-
-        _assertAuction(
-            AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          0,
-                bondFactor:        0.01 * 1e18,
-                kickTime:          _startTime + 1000 days,
-                kickMomp:          9.917184843435912074 * 1e18,
-                totalBondEscrowed: 0,
-                auctionPrice:      19.834369686871824160 * 1e18,
-                debtInAuction:     1.610939394276659040 * 1e18,
-                thresholdPrice:    0,
-                neutralPrice:      11.932577910666902372 * 1e18
-            })
-        );
-
-        _assertKicker(
-            {
-                kicker:    address(0),
-                claimable: 0,
-                locked:    0 * 1e18
-            }
-        );
-
-        // after take: NFTs pledged by liquidated borrower are owned by the taker
-        assertEq(_collateral.ownerOf(3), _lender);
-        assertEq(_collateral.ownerOf(1), _lender);
-        // after take: check quote token balances of taker and borrower
-        assertEq(_quote.balanceOf(_lender), 46_960.103973427957934499 * 1e18);
-        assertEq(_quote.balanceOf(_borrower), 134.844380061229002984 * 1e18); // borrower gets quote tokens from the difference of rounded collateral (2) and needed collateral (1.16) at auction price (19.8) = 16.6 additional tokens
-
-        vm.revertTo(snapshot);
-
 
         /****************************************/
         /* Take partial collateral tokens (1) ***/
@@ -453,6 +375,84 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         // after take: check quote token balances of taker and borrower
         assertEq(_quote.balanceOf(_lender), 46_979.938343114829758652 * 1e18);
         assertEq(_quote.balanceOf(_borrower), 119.8 * 1e18); // no additional tokens as there is no rounding of collateral taken (1)
+
+        vm.revertTo(snapshot);
+
+        /**************************************/
+        /*** Take all collateral tokens (2) ***/
+        /**************************************/
+
+        _take(
+            {
+                from:            _lender,
+                borrower:        _borrower,
+                maxCollateral:   2,
+                bondChange:      0.227287198298417188 * 1e18,
+                givenAmount:     24.624359312514645329 * 1e18,
+                collateralTaken: 1.241499462864870800 * 1e18, // not a rounded collateral, difference of 2 - 1.16 collateral should go to borrower in quote tokens at auction price
+                isReward:        false
+            }
+        );
+
+        _assertPool(
+            PoolParams({
+                htp:                  6.582554958364903034 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000.000878382806067000 * 1e18,
+                pledgedCollateral:    3.0 * 1e18,
+                encumberedCollateral: 1.898735286563375238 * 1e18,
+                poolDebt:             18.830108805603248108 * 1e18,
+                actualUtilization:    0.000257946692863388 * 1e18,
+                targetUtilization:    0.811350329890505142 * 1e18,
+                minDebtAmount:        1.883010880560324811 * 1e18,
+                loans:                1,
+                maxBorrower:          address(_borrower2),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   block.timestamp - 5 hours
+            })
+        );
+
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              1.610939394276659040 * 1e18,
+                borrowerCollateral:        0,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 0
+            }
+        );
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            true,
+                kicker:            address(_lender),
+                bondSize:          0,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          _startTime + 1000 days,
+                kickMomp:          9.917184843435912074 * 1e18,
+                totalBondEscrowed: 0,
+                auctionPrice:      19.834369686871824160 * 1e18,
+                debtInAuction:     1.610939394276659040 * 1e18,
+                thresholdPrice:    0,
+                neutralPrice:      11.932577910666902372 * 1e18
+            })
+        );
+
+        _assertKicker(
+            {
+                kicker:    address(0),
+                claimable: 0,
+                locked:    0 * 1e18
+            }
+        );
+
+        // after take: NFTs pledged by liquidated borrower are owned by the taker
+        assertEq(_collateral.ownerOf(3), _lender);
+        assertEq(_collateral.ownerOf(1), _lender);
+        // after take: check quote token balances of taker and borrower
+        assertEq(_quote.balanceOf(_lender), 46_960.103973427957934499 * 1e18);
+        assertEq(_quote.balanceOf(_borrower), 134.844380061229002984 * 1e18); // borrower gets quote tokens from the difference of rounded collateral (2) and needed collateral (1.16) at auction price (19.8) = 16.6 additional tokens
     }
 
     function testTakeCollateralAndSettleSubsetPool() external tearDown {

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -24,7 +24,7 @@ contract FenwickTreeInstance is DSTestPlus {
     }
 
     function add(uint256 i_, uint256 x_) public {
-        deposits.add(i_, x_);
+        deposits.unscaledAdd(i_, Maths.wdiv(x_, deposits.scale(i_)));
     }
 
     function remove(uint256 i_, uint256 x_) public {

--- a/tests/forge/utils/HeapInstance.sol
+++ b/tests/forge/utils/HeapInstance.sol
@@ -40,7 +40,7 @@ contract HeapInstance is DSTestPlus {
     }
 
     function getTp(address borrower_) public view returns (uint256) {
-        return _heap.getById(borrower_).thresholdPrice;
+        return _heap.getByIndex(_heap.indices[borrower_]).thresholdPrice;
     }
 
     function getMaxTp() external view returns (uint256) {


### PR DESCRIPTION
- introduced `BorrowerAction` external library for drawDebt and repayDebt
- externalized all borrower and auctions actions from `Pool` and left only interactions with pool states. Removed settleAuction virtual function, used now only within external borrower and auctions libraries
- added `RevertsHelper` for common reverts used by `BorrowerActions` and `Auctions` libraries
- fixed order of actions in NFT pool, no need to transfer tokens from borrower before drawDebt. Tokens rebalance when auction is settled happens at the end of call
- Auctions lib: renamed `_calculateTakeFlows` to `_calculateTakeFlowsAndBondChange` and keep bond calculation in same place for all takes. Introduced `_rewardTake` and `_rewardBucketTake`  + `_takeLoan` that updates loan / borrower info in auctions take call
- removed unused functions `Deposits.add`, `Loans.getById`, `Auctions.isActive`, `Loans.getBorrowerInfo`
- consistent order of events across all functions: function related first (like `DrawDebt`, `RemoveCollateral`), update interest rate event (when case) then tokens events transfer

TODO: figure out why the gas spike in repayDebt - fixed, was because of doubling LUP calculation

gas after vs before
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101781          | 158492 | 143555 | 629163 | 56004   |
| bucketTake                                 | 291152          | 314963 | 305851 | 357000 | 4       |
| drawDebt                                   | 205378          | 251130 | 226458 | 724086 | 128003  |
| kick                                       | 155180          | 180221 | 179099 | 939194 | 48000   |
| kickWithDeposit                            | 198391          | 233222 | 228111 | 959425 | 8000    |
| moveQuoteToken                             | 285278          | 285278 | 285278 | 285278 | 1       |
| removeQuoteToken                           | 140088          | 161854 | 166456 | 189705 | 4000    |
| repayDebt                                  | 507246          | 539287 | 528692 | 687261 | 16001   |
| settle                                     | 211168          | 211168 | 211168 | 211168 | 1       |
| take                                       | 44917           | 87699  | 87590  | 387526 | 3512    |
```

vs develop
```
| Function Name                              | min             | avg    | median | max    | # calls |
| addQuoteToken                              | 101781          | 158492 | 143555 | 629163 | 56004   |
| bucketTake                                 | 290740          | 314023 | 304910 | 355531 | 4       |
| drawDebt                                   | 202766          | 248340 | 223823 | 718956 | 128003  |
| kick                                       | 155160          | 180205 | 179081 | 939182 | 48000   |
| kickWithDeposit                            | 198416          | 233249 | 228138 | 959452 | 8000    |
| moveQuoteToken                             | 285262          | 285262 | 285262 | 285262 | 1       |
| removeQuoteToken                           | 140072          | 161839 | 166440 | 189689 | 4000    |
| repayDebt                                  | 479348          | 511379 | 500772 | 659344 | 16001   |
| settle                                     | 210388          | 210388 | 210388 | 210388 | 1       |
| take                                       | 43814           | 85301  | 85189  | 385125 | 3512    |
```

sizes after
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  20,901B  (85.04%)
  Auctions                 -  19,880B  (80.89%)
  ERC20Pool                -  18,314B  (74.52%)
```

before
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,127B  (98.17%)
  ERC20Pool                -  22,237B  (90.48%)
  PositionManager          -  17,529B  (71.32%)
  Auctions                 -  17,198B  (69.98%)
```
