### PR TITLE
Fixes

### DIFF
--- a/src/erc721/ERC721PoolFactory.sol
+++ b/src/erc721/ERC721PoolFactory.sol
@@ -45,10 +45,12 @@ contract ERC721PoolFactory is IERC721PoolFactory, PoolDeployer {
         // All other NFTs that support the EIP721 standard
         else {
             // Here 0x80ac58cd is the ERC721 interface Id
-            bool supportsERC721Interface = IERC165(collateral_).supportsInterface(0x80ac58cd);
-
             // Neither a standard NFT nor a non-standard supported NFT(punk, kitty or fighter)
-            if (!supportsERC721Interface) revert NFTNotSupported();
+            try IERC165(collateral_).supportsInterface(0x80ac58cd) returns (bool supportsERC721Interface) {
+                if (!supportsERC721Interface) revert NFTNotSupported();
+            } catch {
+                revert NFTNotSupported();
+            }
 
             nftType = NFTTypes.STANDARD_ERC721;
         }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -888,7 +888,6 @@ library Auctions {
         // reduce the debt of the borrower -- analagous to the amount of deposit in the bucket for a bucket take
         vars = _calculateTakeFlowsAndBondChange(
             Maths.min(params_.collateral, params_.takeCollateral),
-            params_.t0Debt,
             params_.inflator,
             vars
         );
@@ -963,7 +962,6 @@ library Auctions {
 
         vars = _calculateTakeFlowsAndBondChange(
             params_.collateral,
-            params_.t0Debt,
             params_.inflator,
             vars
         );
@@ -1121,13 +1119,11 @@ library Auctions {
     /**
      *  @notice Computes the flows of collateral, quote token between the borrower, lender and kicker.
      *  @param  totalCollateral_        Total collateral in loan.
-     *  @param  t0Debt_                 t0 equivalent debt in loan.
      *  @param  inflator_               Current pool inflator.
      *  @param  vars                    TakeParams for the take/buckettake
      */
     function _calculateTakeFlowsAndBondChange(
         uint256              totalCollateral_,
-        uint256              t0Debt_,
         uint256              inflator_,
         TakeLocalVars memory vars
     ) internal pure returns (
@@ -1153,7 +1149,7 @@ library Auctions {
         } else if (vars.borrowerDebt <= borrowerCollateralValue) {
             // borrower debt is constraining factor
             vars.collateralAmount = Maths.wdiv(vars.borrowerDebt, borrowerPrice);
-            vars.t0RepayAmount            = t0Debt_;
+            vars.t0RepayAmount            = vars.t0Debt;
             vars.unscaledQuoteTokenAmount = Maths.wdiv(vars.borrowerDebt, vars.bucketScale);
 
             vars.scaledQuoteTokenAmount   = (vars.isRewarded) ? Maths.wdiv(vars.borrowerDebt, borrowerPayoffFactor) : vars.borrowerDebt;

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -267,6 +267,11 @@ library BorrowerActions {
             result_.poolCollateral -= collateralAmountToPull_;
         }
 
+        // calculate LUP if repay is called with 0 amount
+        if (!vars.repay && !vars.pull) {
+            result_.newLup = _lup(deposits_, result_.poolDebt);
+        }
+
         // update loan state
         Loans.update(
             loans_,

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -27,6 +27,7 @@ library BorrowerActions {
         uint256 debtChange;   // additional debt resulted from draw debt action
         bool    inAuction;    // true if loan is auctioned
         uint256 lupId;        // id of new LUP
+        bool    stampT0Np;    // true if loan's t0 neutral price should be restamped (when drawing debt or pledge settles auction)
     }
 
     struct RepayDebtLocalVars {
@@ -35,7 +36,7 @@ library BorrowerActions {
         uint256 newLup;                // LUP after repay debt action
         bool    pull;                  // true if pull action
         bool    repay;                 // true if repay action
-        bool    stampT0Np;             // true if loan's t0 neutral price should be restamped (when exiting auction)
+        bool    stampT0Np;             // true if loan's t0 neutral price should be restamped (when repay settles auction or pull collateral)
         uint256 t0DebtInAuctionChange; // t0 change amount of debt after repayment
         uint256 t0RepaidDebt;          // t0 debt repaid
     }
@@ -99,6 +100,7 @@ library BorrowerActions {
             ) {
                 // borrower becomes collateralized
                 vars.inAuction = false;
+                vars.stampT0Np = true;  // stamp borrower t0Np when exiting from auction
 
                 result_.settledAuction = true;
 
@@ -151,6 +153,9 @@ library BorrowerActions {
                 revert BorrowerUnderCollateralized();
             }
 
+            // stamp borrower t0Np when draw debt
+            vars.stampT0Np = true;
+
             result_.t0DebtChange = Maths.wdiv(vars.debtChange, poolState_.inflator);
 
             borrower.t0Debt += result_.t0DebtChange;
@@ -167,7 +172,7 @@ library BorrowerActions {
             poolState_.rate,
             result_.newLup,
             vars.inAuction,
-            true
+            vars.stampT0Np
         );
     }
 

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -420,7 +420,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        60 * 1e18,
-                borrowert0Np:              369.605048076923077093 * 1e18,
+                borrowert0Np:              441.424038461538461742 * 1e18,
                 borrowerCollateralization: 8.483377444958217435 * 1e18
             }
         );
@@ -531,7 +531,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              451.179509711538461746 * 1e18,
+                borrowert0Np:              448.381722115384615591 * 1e18,
                 borrowerCollateralization: 7.030801136225104190 * 1e18
             }
         );
@@ -561,7 +561,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        50 * 1e18,
-                borrowert0Np:              451.179509711538461746 * 1e18,
+                borrowert0Np:              448.381722115384615591 * 1e18,
                 borrowerCollateralization: 7.015307034516347067 * 1e18
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -466,10 +466,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.384527512667951805 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        0.968187784028539006 * 1e18,
-                borrowert0Np:              1.474001371827766616 * 1e18,
-                borrowerCollateralization: 1_052.617546643526281335 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
 
@@ -501,7 +501,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertReserveAuction(
             {
-                reserves:                   26.866789814940436330 * 1e18,
+                reserves:                   25.482262302272484525 * 1e18,
                 claimableReserves :         0,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
@@ -752,10 +752,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.384513288143290228 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        1.742049596196130259 * 1e18,
-                borrowert0Np:              844.090231878632597698 * 1e18,
-                borrowerCollateralization: 12.231720476220547805 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
         _assertAuction(
@@ -770,7 +770,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0.794761119985595130 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -475,10 +475,10 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.413271006675619050 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        1.985648457205370548 * 1e18,
-                borrowert0Np:              0.718712376637648488 * 1e18,
-                borrowerCollateralization: 2114.898406606768008479 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
 
@@ -510,8 +510,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertReserveAuction(
             {
-                reserves:                   289.957215505583880921 * 1e18,
-                claimableReserves :         248.619279883654091927 * 1e18,
+                reserves:                   288.543944498908261870 * 1e18,
+                claimableReserves :         247.213075232011850972 * 1e18,
                 claimableReservesRemaining: 0,
                 auctionPrice:               0,
                 timeRemaining:              0
@@ -762,10 +762,10 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.413256486842604529 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        1.997843295418292444 * 1e18,
-                borrowert0Np:              736.017209642761013404 * 1e18,
-                borrowerCollateralization: 13.742463556719065681 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
         _assertAuction(
@@ -780,7 +780,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0.707391060191589347 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -356,7 +356,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0.783011950431070454 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -364,10 +364,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.364295318811231261 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        1.742368450520005091 * 1e18,
-                borrowert0Np:              0.814529437653465353 * 1e18,
-                borrowerCollateralization: 12.415258617291764765 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
 
@@ -377,12 +377,12 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             63_008.836766669707730070 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,
-                encumberedCollateral: 822.004063389191990638 * 1e18,
-                poolDebt:             7_990.944702464672948723 * 1e18,
-                actualUtilization:    0.126822603185902765 * 1e18,
+                encumberedCollateral: 821.863722498661263922 * 1e18,
+                poolDebt:             7_989.580407145861717463 * 1e18,
+                actualUtilization:    0.126800950741756503 * 1e18,
                 targetUtilization:    0.826474536317057937 * 1e18,
-                minDebtAmount:        399.547235123233647436 * 1e18,
-                loans:                2,
+                minDebtAmount:        798.958040714586171746 * 1e18,
+                loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.0405 * 1e18,
                 interestRateUpdate:   block.timestamp - 3 hours
@@ -462,12 +462,12 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lup:                  9.529276179422528643 * 1e18,
                 poolSize:             8_000.425567917129035051 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,
-                encumberedCollateral: 838.664785894643975534 * 1e18,
-                poolDebt:             7_991.868366746325933658 * 1e18,
-                actualUtilization:    0.998930406751720968 * 1e18,
+                encumberedCollateral: 838.521600516187410670 * 1e18,
+                poolDebt:             7_990.503913730158190391 * 1e18,
+                actualUtilization:    0.998759859197145947 * 1e18,
                 targetUtilization:    0.826474536317057937 * 1e18,
-                minDebtAmount:        399.593418337316296683 * 1e18,
-                loans:                2,
+                minDebtAmount:        799.050391373015819039 * 1e18,
+                loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.0405 * 1e18,
                 interestRateUpdate:   block.timestamp - 28 hours
@@ -491,14 +491,14 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             PoolParams({
                 htp:                  7.993335753787741967 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
-                poolSize:             8_001.334570519785969351 * 1e18,
+                poolSize:             8_001.333743440000452740 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,
-                encumberedCollateral: 838.664785894643975534 * 1e18,
-                poolDebt:             7_991.868366746325933658 * 1e18,
-                actualUtilization:    0.998816921890963361 * 1e18,
-                targetUtilization:    0.830373904741144466 * 1e18,
-                minDebtAmount:        399.593418337316296683 * 1e18,
-                loans:                2,
+                encumberedCollateral: 838.521600516187410670 * 1e18,
+                poolDebt:             7_990.503913730158190391 * 1e18,
+                actualUtilization:    0.998646496939498213 * 1e18,
+                targetUtilization:    0.830321967924028917 * 1e18,
+                minDebtAmount:        799.050391373015819039 * 1e18,
+                loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.04455 * 1e18,
                 interestRateUpdate:   block.timestamp
@@ -572,17 +572,17 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.806166731332729530 * 1e18,
+                htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             6_903.817874766137575452* 1e18,
+                poolSize:             6_903.714005325230313356 * 1e18,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 82_782_420_335.819944460554424794 * 1e18,
-                poolDebt:             8_264.689134965808775268 * 1e18,
+                encumberedCollateral: 82768556085.799578753126793220 * 1e18,
+                poolDebt:             8_263.304979778717856240 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174867102136840281 * 1e18,
-                minDebtAmount:        826.468913496580877527 * 1e18,
-                loans:                1,
-                maxBorrower:          address(_borrower),
+                targetUtilization:    1.174756997670024034 * 1e18,
+                minDebtAmount:        0,
+                loans:                0,
+                maxBorrower:          address(0),
                 interestRate:         0.049005000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
@@ -600,7 +600,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertRemoveLiquidityAuctionNotClearedRevert({
             from:   _lender,
-            amount: 7_990.0 * 1e18,
+            amount: 7_990 * 1e18,
             index:  _i9_52
         });
 
@@ -609,23 +609,23 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 from:        _lender,
                 borrower:    _borrower2,
                 maxDepth:    10,
-                settledDebt: 7_470.137365944503729705 * 1e18
+                settledDebt: 7_468.035011263740962170 * 1e18
             }
         );
 
         _assertPool(
             PoolParams({
-                htp:                  0.806166731332729530 * 1e18,
+                htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             0,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 6851219028.047090376954237584 * 1e18,
-                poolDebt:             684.000241025460159115 * 1e18,
+                encumberedCollateral: 6858724440.814063856459349796 * 1e18,
+                poolDebt:             684.749553537669941064 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174867102136840281 * 1e18,
-                minDebtAmount:        68.400024102546015912 * 1e18,
-                loans:                1,
-                maxBorrower:          address(_borrower),
+                targetUtilization:    1.174756997670024034 * 1e18,
+                minDebtAmount:        0,
+                loans:                0,
+                maxBorrower:          address(0),
                 interestRate:         0.049005000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
@@ -674,16 +674,6 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 collateral:   0,          
                 deposit:      0,
                 exchangeRate: 1 * 1e27
-            }
-        );
-
-        _assertBorrower(
-            {
-                borrower:                  _borrower,
-                borrowerDebt:              1.384155187090919028 * 1e18,
-                borrowerCollateral:        1.742368450520005091 * 1e18,
-                borrowert0Np:              0.814529437653465353 * 1e18,
-                borrowerCollateralization: 0.000000125673472994 * 1e18
             }
         );
     }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1373,7 +1373,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    1.673029510788949976 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -1381,10 +1381,10 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower2,
-                borrowerDebt:              696.244386269538741772 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        416.157863193465729909 * 1e18,
-                borrowert0Np:              1.724423786941266160 * 1e18,
-                borrowerCollateralization: 899.723357395669311568 * 1e18
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
     }

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -455,6 +455,17 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
     }
 
+    function _assertDeployWithNonNFTRevert(
+        address poolFactory,
+        address collateral,
+        address quote,
+        uint256 interestRate
+    ) internal {
+        uint256[] memory tokenIds;
+        vm.expectRevert(abi.encodeWithSignature('NFTNotSupported()'));
+        ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
+    }
+
     function _assertDeployMultipleTimesRevert(
         address poolFactory,
         address collateral,

--- a/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
@@ -126,6 +126,18 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         );
     }
 
+    function testDeployERC721CollectionPoolWithNonNFTAddress() external {
+        // should revert if trying to deploy with non NFT
+        _assertDeployWithNonNFTRevert(
+            {
+                poolFactory:  address(_factory),
+                collateral:   address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2),
+                quote:        address(_quote),
+                interestRate: 0.05 * 10**18
+            }
+        );
+    }
+
     function testDeployERC721PoolMultipleTimes() external {
         // should revert if trying to deploy same pool one more time
         _assertDeployMultipleTimesRevert(

--- a/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
@@ -146,7 +146,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        4 * 1e18,
-                borrowert0Np:              1_320.018028846153846762 * 1e18,
+                borrowert0Np:              1_751.682692307692308500 * 1e18,
                 borrowerCollateralization: 2.402776420583669600 * 1e18
             }
         );
@@ -619,7 +619,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        4 * 1e18,
-                borrowert0Np:              1_319.052640608089425505 * 1e18,
+                borrowert0Np:              1_749.615635192876748587 * 1e18,
                 borrowerCollateralization: 2.402183628347594810 * 1e18
             }
         );

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -399,11 +399,11 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000.000966222327608000 * 1e18,
                 pledgedCollateral:    3.0 * 1e18,
-                encumberedCollateral: 1.898740163458216872 * 1e18,
-                poolDebt:             18.830157170670854594 * 1e18,
-                actualUtilization:    0.000257947355088169 * 1e18,
+                encumberedCollateral: 1.736300564176668638 * 1e18,
+                poolDebt:             17.219213638702081372 * 1e18,
+                actualUtilization:    0.000235879635764245 * 1e18,
                 targetUtilization:    0.811350329890505142 * 1e18,
-                minDebtAmount:        1.883015717067085459 * 1e18,
+                minDebtAmount:        1.721921363870208137 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.045 * 1e18,
@@ -414,27 +414,27 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         _assertBorrower(
             {
                 borrower:                  _borrower,
-                borrowerDebt:              1.610943531968773223 * 1e18,
+                borrowerDebt:              0,
                 borrowerCollateral:        0,
-                borrowert0Np:              10.404995192307692312 * 1e18,
-                borrowerCollateralization: 0
+                borrowert0Np:              0,
+                borrowerCollateralization: 1 * 1e18
             }
         );
 
         _assertAuction(
             AuctionParams({
                 borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
+                active:            false,
+                kicker:            address(0),
                 bondSize:          0,
-                bondFactor:        0.01 * 1e18,
-                kickTime:          _startTime + 1000 days,
-                kickMomp:          9.917184843435912074 * 1e18,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
                 totalBondEscrowed: 0,
-                auctionPrice:      16.875213515338743424 * 1e18,
-                debtInAuction:     1.610943531968773223 * 1e18,
+                auctionPrice:      0,
+                debtInAuction:     0,
                 thresholdPrice:    0,
-                neutralPrice:      11.932577910666902372 * 1e18
+                neutralPrice:      0
             })
         );
 


### PR DESCRIPTION
- Ensure t0Np is not stamped on pledgeCollateral but only if pledge settles auction
- Account take penalty when calculating take flows: do not pass `params.t0Debt` but use `vars.t0Debt` which contains penalty already accumulated (added in prepare take)
- Calculate LUP if repay debt is called with 0 amounts (otherwise is 0 and affects EMAs)
- Increase code coverage by properly handling non NFT tokens as collateral