### PR TITLE
Max lupColEma to 10 times debt, do not calculate emas if debt is 0

### DIFF
--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -167,7 +167,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 encumberedCollateral: 9.926574536214785829 * 1e18,
                 poolDebt:             995.956730769230769690 * 1e18,
                 actualUtilization:    0.995956730769230770 * 1e18,
-                targetUtilization:    1e18,
+                targetUtilization:    1 * 1e18,
                 minDebtAmount:        99.595673076923076969 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
@@ -196,7 +196,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 encumberedCollateral: 9.927311124438159308 * 1e18,
                 poolDebt:             996.030634410028283604 * 1e18,
                 actualUtilization:    0.995958788335693301 * 1e18,
-                targetUtilization:    0.006618207416292106 * 1e18,
+                targetUtilization:    0.1 * 1e18,
                 minDebtAmount:        99.603063441002828360 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
@@ -351,7 +351,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 encumberedCollateral: 0.000000006658700114 * 1e18,
                 poolDebt:             0.000010023099759839 * 1e18,
                 actualUtilization:    0.000000001002309976 * 1e18,
-                targetUtilization:    0.000665816943976221 * 1e18,
+                targetUtilization:    0.100000000000001021 * 1e18,
                 minDebtAmount:        0.000001002309975984 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
@@ -421,19 +421,19 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // show the rate maxed out at 50000%
         _assertPool(
             PoolParams({
-                htp:                  32229.862501923749497041 * 1e18,
+                htp:                  0.000000001003987504 * 1e18,
                 lup:                  _p1505_26,
-                poolSize:             10_048.284243805461810000 * 1e18,
+                poolSize:             10_000.000000012850420000 * 1e18,
                 pledgedCollateral:    10_000 * 1e18,
-                encumberedCollateral: 0.037733346596011819 * 1e18,
-                poolDebt:             56.798637984728374088 * 1e18,
-                actualUtilization:    0.005652570787867933 * 1e18,
-                targetUtilization:    0.000000466616755449 * 1e18,
-                minDebtAmount:        5.679863798472837409 * 1e18,
+                encumberedCollateral: 0.000000006659785661 * 1e18,
+                poolDebt:             0.000010024733795584 * 1e18,
+                actualUtilization:    0.000000001002473380 * 1e18,
+                targetUtilization:    0.099999999999988029 * 1e18,
+                minDebtAmount:        0.000001002473379558 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                interestRate:         500 * 1e18,
-                interestRateUpdate:   _startTime + (194*12 hours)
+                interestRate:         0.001 * 1e18,
+                interestRateUpdate:   _startTime + (76 * 12 hours)
             })
         );
     }
@@ -665,7 +665,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 encumberedCollateral: 3.094069767562214045 * 1e18,
                 poolDebt:             1012.343273629329809307 * 1e18,
                 actualUtilization:    0.050614203271033305 * 1e18,
-                targetUtilization:    0.030940697675622140 * 1e18,
+                targetUtilization:    0.1 * 1e18,
                 minDebtAmount:        50.617163681466490465 * 1e18,
                 loans:                2,
                 maxBorrower:          address(_borrower),
@@ -676,7 +676,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         _assertEMAs(
             {
                 debtEma:   95.440014344854493304 * 1e18,
-                lupColEma: 3_084.610933645840358918 * 1e18
+                lupColEma: 954.400143448544933043 * 1e18
             }
         );
     }

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -456,7 +456,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 borrower:                  _borrower,
                 borrowerDebt:              debt,
                 borrowerCollateral:        col,
-                borrowert0Np:              3_192.373538835858843381 * 1e18,
+                borrowert0Np:              3_162.114074012770133965 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
         );

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -409,8 +409,8 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         );
         _assertEMAs(
             {
-                debtEma:   128.680263773096486341 * 1e18,
-                lupColEma: 771.284928353319164825 * 1e18
+                debtEma:   142.074529848655991542 * 1e18,
+                lupColEma: 851.567601449557349751 * 1e18
             }
         );
 

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -1156,7 +1156,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    3123578486.616799651636891881 * 1e18,
+                targetUtilization:    3123578486.651416548727612650 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),

--- a/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
@@ -138,7 +138,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             }
         );
 
-        expectedDebt = 5_012.354868151222773335 * 1e18;
+        expectedDebt = 5_010.981808341113791532 * 1e18;
         (poolDebt,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -146,11 +146,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        4 * 1e18,
-                borrowert0Np:              1_320.018028846153846762 * 1e18,
-                borrowerCollateralization: 2.402776420583669600 * 1e18
+                borrowert0Np:              1_307.506009615384615987 * 1e18,
+                borrowerCollateralization: 2.403434805679039390 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 6.454207045591150000 * 1e18);  
+        _assertLenderInterest(liquidityAdded, 5.279991354297800000 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed
         skip(10 days);
@@ -163,7 +163,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             collateralToPull: 1
         });
 
-        expectedDebt = 5_020.669907328529218397 * 1e18;
+        expectedDebt = 5_016.545024711958767573 * 1e18;
         (poolDebt,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -171,11 +171,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              1_769.199519230769231585 * 1e18,
-                borrowerCollateralization: 1.799097776455867782 * 1e18
+                borrowert0Np:              1_735.834134615384616185 * 1e18,
+                borrowerCollateralization: 1.800577094812835876 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 13.565138359073600000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 10.037586159478100000 * 1e18);
 
         // borrower borrows some additional quote after some time has passed
         skip(10 days);
@@ -189,7 +189,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             }
         );
 
-        expectedDebt = 6_031.112190940595898550 * 1e18;
+        expectedDebt = 6_022.258161533753529229 * 1e18;
         (poolDebt,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -197,11 +197,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.493158479027971001 * 1e18,
-                borrowerCollateralization: 1.497679993444945851 * 1e18
+                borrowert0Np:              2_073.649973538899174402 * 1e18,
+                borrowerCollateralization: 1.499881908797678561 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 21.400863103971100000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 14.323964694876900000 * 1e18);
 
         // mint additional quote to borrower to enable repayment
         deal(address(_quote), _borrower, 20_000 * 1e18);
@@ -212,8 +212,8 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         _repayDebt({
             from:             _borrower,
             borrower:         _borrower,
-            amountToRepay:    6_043.220426872049838854 * 1e18,
-            amountRepaid:     6_043.220426872049838854 * 1e18,
+            amountToRepay:    6_027.673202243056796795 * 1e18,
+            amountRepaid:     6_027.673202243056796795 * 1e18,
             collateralToPull: 0,
             newLup:           MAX_PRICE
         });
@@ -226,7 +226,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.493158479027971001 * 1e18,
+                borrowert0Np:              2_073.649973538899174402 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
         );
@@ -530,7 +530,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         // time passes and interest accrues
         skip(30 days);
 
-        expectedDebt = 5_027.483380088742884664 * 1e18;
+        expectedDebt = 5_023.352899658361566042 * 1e18;
         (poolDebt, , ) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -539,7 +539,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
                 borrowert0Np:              1_751.682692307692308500 * 1e18,
-                borrowerCollateralization: 1.796659557815227213 * 1e18
+                borrowerCollateralization: 1.798136871333080608 * 1e18
             }
         );
 
@@ -553,7 +553,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             from:             _borrower,
             borrower:         _borrower,
             amountToRepay:    6_000 * 1e18,
-            amountRepaid:     5_035.064750533460450062 * 1e18,
+            amountRepaid:     5_029.549893746063314959 * 1e18,
             collateralToPull: 0,
             newLup:           MAX_PRICE
         });
@@ -570,7 +570,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrowerCollateralization: 1 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 25.875284004017950000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 21.159079125453150000 * 1e18);
 
 
         // borrower borrows again once repayed all debt 
@@ -583,7 +583,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             }
         );
 
-        expectedDebt = 5_005.288461538461540000 * 1e18;
+        expectedDebt = 5_004.326923076923075000 * 1e18;
         (poolDebt, , ) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
@@ -592,11 +592,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              1_749.615635192876748587 * 1e18,
-                borrowerCollateralization: 1.804626473779154828 * 1e18
+                borrowert0Np:              1_734.598566269106425655 * 1e18,
+                borrowerCollateralization: 1.804973217265326249 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 25.875284004017950000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 21.159079125453150000 * 1e18);
 
 
         // borrower pledge additional collateral after some time has passed
@@ -611,7 +611,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             }
         );
 
-        expectedDebt = 5_013.591778192248902657 * 1e18;
+        expectedDebt = 5_009.882751161786609875 * 1e18;
         (poolDebt, , ) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -619,11 +619,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        4 * 1e18,
-                borrowert0Np:              1_319.052640608089425505 * 1e18,
-                borrowerCollateralization: 2.402183628347594810 * 1e18
+                borrowert0Np:              1_295.346752298807585570 * 1e18,
+                borrowerCollateralization: 2.403962065978217811 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 32.976110091508700000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 25.910306427042600000 * 1e18);
 
         // borrower pulls some of their collateral after some time has passed
         skip(10 days);
@@ -636,7 +636,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             collateralToPull: 1
         });
 
-        expectedDebt = 5_022.741336874076464394 * 1e18;
+        expectedDebt = 5_014.888269974849063159 * 1e18;
         (poolDebt, , ) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -644,11 +644,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              1_768.770194990485967968 * 1e18,
-                borrowerCollateralization: 1.798355810258620132 * 1e18
+                borrowert0Np:              1_720.406396181450100354 * 1e18,
+                borrowerCollateralization: 1.801171946476675110 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 40.800699487970150000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 30.190948084888350000 * 1e18);
 
         // borrower borrows some additional quote after some time has passed
         skip(10 days);
@@ -662,7 +662,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             }
         );
 
-        expectedDebt = 6_034.232926665142656779 * 1e18;
+        expectedDebt = 6_020.028378139519091440 * 1e18;
         (poolDebt, , ) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
         _assertBorrower(
@@ -670,11 +670,11 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              expectedDebt,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.944439289318232279 * 1e18,
-                borrowerCollateralization: 1.496905435432969068 * 1e18
+                borrowert0Np:              2_056.117700366713112261 * 1e18,
+                borrowerCollateralization: 1.500437456307337195 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 49.424332079106750000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 34.047204345325150000 * 1e18);
 
         // mint additional quote to borrower to enable repayment
         deal(address(_quote), _borrower, 20_000 * 1e18);
@@ -686,7 +686,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             from:             _borrower,
             borrower:         _borrower,
             amountToRepay:    7_000 * 1e18,
-            amountRepaid:     6_047.560214870786628632 * 1e18,
+            amountRepaid:     6_024.899891362842471130 * 1e18,
             collateralToPull: 0,
             newLup:           MAX_PRICE
         });
@@ -699,10 +699,10 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
                 borrower:                  _borrower,
                 borrowerDebt:              0,
                 borrowerCollateral:        3 * 1e18,
-                borrowert0Np:              2_133.944439289318232279 * 1e18,
+                borrowert0Np:              2_056.117700366713112261 * 1e18,
                 borrowerCollateralization: 1 * 1e18
             }
         );
-        _assertLenderInterest(liquidityAdded, 60.836331709962400000 * 1e18);
+        _assertLenderInterest(liquidityAdded, 38.218558139693000000 * 1e18);
     }
 }

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -280,7 +280,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    0.000004568979952926 * 1e18,
+                targetUtilization:    0.437382306954677563 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),


### PR DESCRIPTION
According with whitespec

Target utilization
The ratio of the 3.5 day EMA of system debt to 3.5 day EMA of LUP*totalCollateral (maxed with 10*debt.  So it’s really an EMA of Min{LUP*totalCollatreral, 10.0*systemDebt}).  These EMAs are not updated when systemDebt==0.  

TODO: interest rate should be calculated even if debt is 0