### PR TITLE
Inheritdoc

### DIFF
--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -5,6 +5,14 @@ pragma solidity 0.8.14;
 import '../base/Pool.sol';
 
 abstract contract FlashloanablePool is Pool {
+    /**
+     *  @notice Called by flashloan borrowers to borrow liquidity which must be repaid in the same transaction.
+     *  @param  receiver_ Address of the contract which implements the appropriate interface to receive tokens.
+     *  @param  token_    Address of the ERC20 token caller wants to borrow.
+     *  @param  amount_   The amount of tokens to borrow.
+     *  @param  data_     User-defined calldata passed to the receiver.
+     *  @return True if successful.
+     */
     function flashLoan(
         IERC3156FlashBorrower receiver_,
         address token_,
@@ -29,6 +37,9 @@ abstract contract FlashloanablePool is Pool {
         return true;
     }
 
+    /**
+     *  @notice Returns 0, as no fee is charged for flashloans.
+     */
     function flashFee(
         address token_,
         uint256
@@ -37,7 +48,12 @@ abstract contract FlashloanablePool is Pool {
         return 0;
     }
 
-    function maxFlashLoan(
+    /**
+     *  @notice Returns the amount of tokens available to be lent.
+     *  @param  token_   Address of the ERC20 token to be lent.
+     *  @return maxLoan_ The amount of `token_` that can be lent.
+     */
+     function maxFlashLoan(
         address token_
     ) external virtual view override returns (uint256 maxLoan_) {
         if (token_ == _getArgAddress(QUOTE_ADDRESS)) maxLoan_ = _getPoolQuoteTokenBalance();

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -71,18 +71,22 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*** Immutables ***/
     /******************/
 
+    /// @inheritdoc IPoolImmutables
     function poolType() external pure override returns (uint8) {
         return _getArgUint8(POOL_TYPE);
     }
 
+    /// @inheritdoc IPoolImmutables
     function collateralAddress() external pure override returns (address) {
         return _getArgAddress(COLLATERAL_ADDRESS);
     }
 
+    /// @inheritdoc IPoolImmutables
     function quoteTokenAddress() external pure override returns (address) {
         return _getArgAddress(QUOTE_ADDRESS);
     }
 
+    /// @inheritdoc IPoolImmutables
     function quoteTokenScale() external pure override returns (uint256) {
         return _getArgUint256(QUOTE_SCALE);
     }
@@ -91,6 +95,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*** Lender External Functions ***/
     /*********************************/
 
+    /// @inheritdoc IPoolLenderActions
     function addQuoteToken(
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
@@ -113,6 +118,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _transferQuoteTokenFrom(msg.sender, quoteTokenAmountToAdd_);
     }
 
+    /// @inheritdoc IPoolLenderActions
     function approveLpOwnership(
         address allowedNewOwner_,
         uint256 index_,
@@ -121,6 +127,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _lpTokenAllowances[msg.sender][allowedNewOwner_][index_] = lpsAmountToApprove_;
     }
 
+    /// @inheritdoc IPoolLenderActions
     function moveQuoteToken(
         uint256 maxAmountToMove_,
         uint256 fromIndex_,
@@ -151,6 +158,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _updateInterestState(poolState, newLup);
     }
 
+    /// @inheritdoc IPoolLenderActions
     function removeQuoteToken(
         uint256 maxAmount_,
         uint256 index_
@@ -184,6 +192,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _transferQuoteToken(msg.sender, removedAmount_);
     }
 
+    /// @inheritdoc IPoolLenderActions
     function transferLPTokens(
         address owner_,
         address newOwner_,
@@ -198,16 +207,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
-    function withdrawBonds() external {
-        uint256 claimable = auctions.kickers[msg.sender].claimable;
-        auctions.kickers[msg.sender].claimable = 0;
-        _transferQuoteToken(msg.sender, claimable);
-    }
-
     /*****************************/
     /*** Liquidation Functions ***/
     /*****************************/
 
+    /// @inheritdoc IPoolLiquidationActions
     function kick(address borrowerAddress_) external override {
         PoolState memory poolState = _accruePoolInterest();
 
@@ -231,6 +235,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if(result.amountToCoverBond != 0) _transferQuoteTokenFrom(msg.sender, result.amountToCoverBond);
     }
 
+    /// @inheritdoc IPoolLiquidationActions
     function kickWithDeposit(
         uint256 index_
     ) external override {
@@ -258,10 +263,18 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if(result.amountToCoverBond != 0) _transferQuoteTokenFrom(msg.sender, result.amountToCoverBond);
     }
 
+    /// @inheritdoc IPoolLiquidationActions
+    function withdrawBonds() external {
+        uint256 claimable = auctions.kickers[msg.sender].claimable;
+        auctions.kickers[msg.sender].claimable = 0;
+        _transferQuoteToken(msg.sender, claimable);
+    }
+
     /*********************************/
     /*** Reserve Auction Functions ***/
     /*********************************/
 
+    /// @inheritdoc IPoolReserveAuctionActions
     function startClaimableReserveAuction() external override {
         // check that at least two weeks have passed since the last reserve auction completed
         uint256 lastBurnTimestamp = burnEvents[latestBurnEventEpoch].timestamp;
@@ -286,6 +299,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _transferQuoteToken(msg.sender, kickerAward);
     }
 
+    /// @inheritdoc IPoolReserveAuctionActions
     function takeReserves(uint256 maxAmount_) external override returns (uint256 amount_) {
         uint256 ajnaRequired;
         (amount_, ajnaRequired) = Auctions.takeReserves(
@@ -382,6 +396,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*** External Functions ***/
     /**************************/
 
+    /// @inheritdoc IPoolState
     function auctionInfo(
         address borrower_
     ) external
@@ -410,6 +425,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function borrowerInfo(
         address borrower_
     ) external view override returns (uint256, uint256, uint256) {
@@ -420,6 +436,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function bucketInfo(
         uint256 index_
     ) external view override returns (uint256, uint256, uint256, uint256, uint256) {
@@ -432,6 +449,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolDerivedState
     function bucketExchangeRate(
         uint256 index_
     ) external view returns (uint256 exchangeRate_) {
@@ -445,10 +463,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function currentBurnEpoch() external view returns (uint256) {
         return latestBurnEventEpoch;
     }
 
+    /// @inheritdoc IPoolState
     function burnInfo(uint256 burnEventEpoch_) external view returns (uint256, uint256, uint256) {
         BurnEvent memory burnEvent = burnEvents[burnEventEpoch_];
 
@@ -459,6 +479,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function debtInfo() external view returns (uint256, uint256, uint256) {
         uint256 pendingInflator = PoolCommons.pendingInflator(
             inflatorState.inflator,
@@ -472,14 +493,17 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolDerivedState
     function depositIndex(uint256 debt_) external view override returns (uint256) {
         return Deposits.findIndexOfSum(deposits, debt_);
     }
 
+    /// @inheritdoc IPoolDerivedState
     function depositSize() external view override returns (uint256) {
         return Deposits.treeSum(deposits);
     }
 
+    /// @inheritdoc IPoolDerivedState
     function depositUtilization(
         uint256 debt_,
         uint256 collateral_
@@ -487,6 +511,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return PoolCommons.utilization(deposits, debt_, collateral_);
     }
 
+    /// @inheritdoc IPoolState
     function emasInfo() external view override returns (uint256, uint256) {
         return (
             interestState.debtEma,
@@ -494,6 +519,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function inflatorInfo() external view override returns (uint256, uint256) {
         return (
             inflatorState.inflator,
@@ -501,6 +527,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function interestRateInfo() external view returns (uint256, uint256) {
         return (
             interestState.interestRate,
@@ -508,6 +535,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function kickerInfo(
         address kicker_
     ) external view override returns (uint256, uint256) {
@@ -517,6 +545,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function lenderInfo(
         uint256 index_,
         address lender_
@@ -525,6 +554,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         if (buckets[index_].bankruptcyTime < depositTime_) lpBalance_ = buckets[index_].lenders[lender_].lps;
     }
 
+    /// @inheritdoc IPoolState
     function loanInfo(
         uint256 loanId_
     ) external view override returns (address, uint256) {
@@ -534,6 +564,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function loansInfo() external view override returns (address, uint256, uint256) {
         return (
             Loans.getMax(loans).borrower,
@@ -542,10 +573,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         );
     }
 
+    /// @inheritdoc IPoolState
     function pledgedCollateral() external view override returns (uint256) {
         return poolBalances.pledgedCollateral;
     }
 
+    /// @inheritdoc IPoolState
     function reservesInfo() external view override returns (uint256, uint256, uint256) {
         return (
             auctions.totalBondEscrowed,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -23,6 +23,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Initialize Functions ***/
     /****************************/
 
+    /// @inheritdoc IERC20Pool
     function initialize(
         uint256 rate_
     ) external override {
@@ -44,6 +45,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Immutables ***/
     /******************/
 
+    /// @inheritdoc IERC20PoolImmutables
     function collateralScale() external pure override returns (uint256) {
         return _getArgUint256(COLLATERAL_SCALE);
     }
@@ -52,6 +54,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Borrower External Functions ***/
     /***********************************/
 
+    /// @inheritdoc IERC20PoolBorrowerActions
     function drawDebt(
         address borrowerAddress_,
         uint256 amountToBorrow_,
@@ -100,6 +103,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
     }
 
+    /// @inheritdoc IERC20PoolBorrowerActions
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
@@ -148,6 +152,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Flashloan External Functions ***/
     /************************************/
 
+    /// @inheritdoc FlashloanablePool
     function flashLoan(
         IERC3156FlashBorrower receiver_,
         address token_,
@@ -169,6 +174,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         revert FlashloanUnavailableForToken();
     }
 
+    /// @inheritdoc FlashloanablePool
     function flashFee(
         address token_,
         uint256
@@ -177,6 +183,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         revert FlashloanUnavailableForToken();
     }
 
+    /// @inheritdoc FlashloanablePool
     function maxFlashLoan(
         address token_
     ) external view override(IERC3156FlashLender, FlashloanablePool) returns (uint256 maxLoan_) {
@@ -189,6 +196,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Lender External Functions ***/
     /*********************************/
 
+    /// @inheritdoc IERC20PoolLenderActions
     function addCollateral(
         uint256 collateralAmountToAdd_,
         uint256 index_
@@ -211,6 +219,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _transferCollateralFrom(msg.sender, collateralAmountToAdd_);
     }
 
+    /// @inheritdoc IPoolLenderActions
     function removeCollateral(
         uint256 maxAmount_,
         uint256 index_
@@ -239,6 +248,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     /*** Pool Auctions Functions ***/
     /*******************************/
 
+    /// @inheritdoc IPoolLiquidationActions
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
@@ -279,6 +289,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _updateInterestState(poolState, _lup(poolState.debt));
     }
 
+    /// @inheritdoc IPoolLiquidationActions
     function take(
         address        borrowerAddress_,
         uint256        collateral_,
@@ -331,6 +342,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         _transferQuoteTokenFrom(callee_, result.quoteTokenAmount);
     }
 
+    /// @inheritdoc IPoolLiquidationActions
     function bucketTake(
         address borrowerAddress_,
         bool    depositTake_,

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -29,6 +29,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     /*** Initialize Functions ***/
     /****************************/
 
+    /// @inheritdoc IERC721Pool
     function initialize(
         uint256[] memory tokenIds_,
         uint256 rate_
@@ -62,6 +63,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     /*** Immutables ***/
     /******************/
 
+    /// @inheritdoc IERC721PoolImmutables
     function isSubset() external pure override returns (bool) {
         return _getArgUint256(SUBSET) != 0;
     }
@@ -70,6 +72,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     /*** Borrower External Functions ***/
     /***********************************/
 
+    /// @inheritdoc IERC721PoolBorrowerActions
     function drawDebt(
         address borrowerAddress_,
         uint256 amountToBorrow_,
@@ -120,6 +123,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         }
     }
 
+    /// @inheritdoc IERC721PoolBorrowerActions
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
@@ -170,6 +174,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     /*** Lender External Functions ***/
     /*********************************/
 
+    /// @inheritdoc IERC721PoolLenderActions
     function addCollateral(
         uint256[] calldata tokenIdsToAdd_,
         uint256 index_
@@ -192,6 +197,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         _transferFromSenderToPool(bucketTokenIds, tokenIdsToAdd_);
     }
 
+    /// @inheritdoc IERC721PoolLenderActions
     function mergeOrRemoveCollateral(
         uint256[] calldata removalIndexes_,
         uint256 noOfNFTsToRemove_,
@@ -223,6 +229,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
 
     }
 
+    /// @inheritdoc IPoolLenderActions
     function removeCollateral(
         uint256 noOfNFTsToRemove_,
         uint256 index_
@@ -251,6 +258,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     /*** Pool Auctions Functions ***/
     /*******************************/
 
+    /// @inheritdoc IPoolLiquidationActions
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
@@ -296,6 +304,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         _updateInterestState(poolState, _lup(poolState.debt));
     }
 
+    /// @inheritdoc IPoolLiquidationActions
     function take(
         address        borrowerAddress_,
         uint256        collateral_,
@@ -359,6 +368,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         if (result.excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, result.excessQuoteToken);
     }
 
+    /// @inheritdoc IPoolLiquidationActions
     function bucketTake(
         address borrowerAddress_,
         bool    depositTake_,


### PR DESCRIPTION
**Change**
Update core contracts to point to relevant interface documentation.

**Testing**
Compilation fails if I name an "inexistent" interface.

**Out of scope**
Using `forge doc` or some other tool to incorporate autogeneration of HTML/PDF documentation in the CI pipeline.  There's another card for that.