### PR TITLE
Prevent dust amounts of LP when forfeiting deposit

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -625,8 +625,8 @@ library LenderActions {
         // calculate scale amount remaining
         uint256 remaining = Maths.wmul(depositScale, unscaledDepositAvailable - unscaledRemovedAmount);
 
-        // abandon dust amounts
-        if (remaining < params_.dustLimit) {
+        // abandon dust amounts upon last withdrawal
+        if (remaining < params_.dustLimit && redeemedLPs_ == params_.bucketLPs) {
             unscaledRemovedAmount = unscaledDepositAvailable;
         }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -505,8 +505,8 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         assertEq(rate,                exchangeRate);
 
         _validateBucketLp(index, lpBalance);
+        _validateBucketQuantities(index);
     }
-
 
     function _validateBucketLp(
         uint256 index,
@@ -530,6 +530,24 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         }
 
         assertEq(lenderLps, lpBalance);
+    }
+
+    function _validateBucketQuantities(
+        uint256 index
+    ) internal {
+        (
+            ,
+            uint256 curDeposit,
+            uint256 availableCollateral,
+            uint256 lpAccumulator,
+            ,
+        ) = _poolUtils.bucketInfo(address(_pool), index);
+        if (lpAccumulator == 0) {
+            assertEq(curDeposit, 0);
+            assertEq(availableCollateral, 0);
+        } else {
+            assertTrue(curDeposit != 0 || availableCollateral != 0);
+        }
     }
 
     function _assertBorrower(


### PR DESCRIPTION
A concern was raised that a bucket could get into a state where deposit=0, collateral=0, yet LPs != 0.  Two potential countermeasures have been proposed.  In every place where quote or collateral is removed from a bucket, trap the condition and either:
- Induce a bucket bankruptcy
- Revert

I was unable to reproduce this state with a unit test, which prevents me from testing either solution.  As such, my goal in this PR is to make changes such that #466 may be merged without objection.  

I made a small change `_removeMaxDeposit` to ensure removal of deposit dust does not exacerbate the problem.  I also implemented a `_validateBucketQuantities` routine to `DSTest` which implicitly checks for the condition when `_assertBucket` is called.  Note that `tearDown` already checks for 3 zeros.

Recommend we revisit this, if time permits, once dust limits for collateral have been implemented/merged.