### PR TITLE
Utilize the upstream clones-with-immutable-args library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/brockelmore/forge-std
-[submodule "lib/clones-with-immutable-args"]
-	path = lib/clones-with-immutable-args
-	url = https://github.com/ZeframLou/clones-with-immutable-args
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/base64"]
 	path = lib/base64
 	url = https://github.com/Brechtpd/base64
+[submodule "lib/clones-with-immutable-args"]
+	path = lib/clones-with-immutable-args
+	url = https://github.com/wighawag/clones-with-immutable-args.git


### PR DESCRIPTION
- Utilizes the upstream `clones-with-immutable-args` library instead of the fork

Will likely require calling `git submodule sync && git submodule update` after pulling.