### PR TITLE
Bucket rate for late epoch stakers

### DIFF
--- a/src/AjnaRewards.sol
+++ b/src/AjnaRewards.sol
@@ -259,7 +259,7 @@ contract AjnaRewards is IAjnaRewards {
                     );
                 }
 
-                // calculate change in exchange rates in a stakes buckets
+                // calculate the amount of interest accrued in current epoch
                 vars.interestEarned = _calculateExchangeRateInterestEarned(
                     ajnaPool,
                     vars.nextEpoch,
@@ -315,19 +315,25 @@ contract AjnaRewards is IAjnaRewards {
         uint256 exchangeRate_
     ) internal view returns (uint256 interestEarned_) {
 
-        uint256 nextExchangeRate = poolBucketBurnExchangeRates[pool_][bucketIndex_][nextEventEpoch_];
+        if (exchangeRate_ != 0) {
 
-        if (exchangeRate_ != 0 && nextExchangeRate != 0) {
-            // calculate the equivalent amount of quote tokens given the stakes lp balance,
-            // and the exchange rate at the previous and current burn events
-            uint256 quoteAtCurrentRate = Maths.rayToWad(Maths.rmul(exchangeRate_,  bucketLPs));
-            uint256 quoteAtNextRate    = Maths.rayToWad(Maths.rmul(nextExchangeRate, bucketLPs));
+            uint256 nextExchangeRate = poolBucketBurnExchangeRates[pool_][bucketIndex_][nextEventEpoch_];
 
-            if (quoteAtNextRate > quoteAtCurrentRate) {
-                interestEarned_ = quoteAtNextRate - quoteAtCurrentRate;
-            } else {
-                interestEarned_ = quoteAtCurrentRate - quoteAtNextRate;
+            // calculate interest earned only if current and next exchange rates are not 0
+            if (nextExchangeRate != 0) {
+
+                // calculate the equivalent amount of quote tokens given the stakes lp balance,
+                // and the exchange rate at the previous and current burn events
+                uint256 quoteAtCurrentRate = Maths.rayToWad(Maths.rmul(exchangeRate_,   bucketLPs));
+                uint256 quoteAtNextRate    = Maths.rayToWad(Maths.rmul(nextExchangeRate, bucketLPs));
+
+                if (quoteAtNextRate > quoteAtCurrentRate) {
+                    interestEarned_ = quoteAtNextRate - quoteAtCurrentRate;
+                } else {
+                    interestEarned_ = quoteAtCurrentRate - quoteAtNextRate;
+                }
             }
+
         }
     }
 

--- a/src/AjnaRewards.sol
+++ b/src/AjnaRewards.sol
@@ -136,7 +136,10 @@ contract AjnaRewards is IAjnaRewards {
 
         uint256 curBurnEpoch = IPool(ajnaPool).currentBurnEpoch();
 
-        // record the burnId at which the staking occurs
+        // record the staking epoch
+        stake.stakingEpoch = uint96(curBurnEpoch);
+
+        // initialize last time interaction at staking epoch
         stake.lastInteractionBurnEpoch = uint96(curBurnEpoch);
 
         uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
@@ -230,6 +233,7 @@ contract AjnaRewards is IAjnaRewards {
 
         address ajnaPool      = stakes[tokenId_].ajnaPool;
         uint256 lastBurnEpoch = stakes[tokenId_].lastInteractionBurnEpoch;
+        uint256 stakingEpoch  = stakes[tokenId_].stakingEpoch;
 
         uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
 
@@ -250,7 +254,7 @@ contract AjnaRewards is IAjnaRewards {
 
                 // for the first epoch use the bucket rate at the time of staking
                 // for all the other epochs use saved bucket rates
-                if (vars.epoch != lastBurnEpoch) {
+                if (vars.epoch != stakingEpoch) {
                     vars.bucketRate = poolBucketBurnExchangeRates[ajnaPool][vars.bucketIndex][vars.epoch];
                 }
 

--- a/src/IAjnaRewards.sol
+++ b/src/IAjnaRewards.sol
@@ -71,7 +71,12 @@ interface IAjnaRewards {
         address ajnaPool;                         // address of the Ajna pool the NFT corresponds to
         uint96  lastInteractionBurnEpoch;         // last burn event the stake interacted with the rewards contract
         address owner;                            // owner of the LP NFT
-        mapping(uint256 => uint256) lpsAtDeposit; // the LP NFT's balance in each bucket at the time of staking
+        mapping(uint256 => BucketState) snapshot; // the LP NFT's balances and exchange rates in each bucket at the time of staking
+    }
+
+    struct BucketState {
+        uint256 lpsAtStakeTime;
+        uint256 rateAtStakeTime;
     }
 
 }

--- a/src/IAjnaRewards.sol
+++ b/src/IAjnaRewards.sol
@@ -71,6 +71,7 @@ interface IAjnaRewards {
         address ajnaPool;                         // address of the Ajna pool the NFT corresponds to
         uint96  lastInteractionBurnEpoch;         // last burn event the stake interacted with the rewards contract
         address owner;                            // owner of the LP NFT
+        uint96  stakingEpoch;                     // epoch at staking time
         mapping(uint256 => BucketState) snapshot; // the LP NFT's balances and exchange rates in each bucket at the time of staking
     }
 

--- a/tests/forge/AjnaRewards.t.sol
+++ b/tests/forge/AjnaRewards.t.sol
@@ -889,24 +889,8 @@ contract AjnaRewardsTest is DSTestPlus {
         depositIndexes[3] = 2553;
         depositIndexes[4] = 2555;
 
-        // configure NFT position one and early stake
-        MintAndMemorializeParams memory mintMemorializeParams = MintAndMemorializeParams({
-            indexes:    depositIndexes,
-            minter:     _minterOne,
-            mintAmount: 1000 * 1e18,
-            pool:       _poolOne
-        });
-        uint256 tokenIdOne = _mintAndMemorializePositionNFT(mintMemorializeParams);
-        _stakeToken(address(_poolOne), _minterOne, tokenIdOne);
-
-        assertEq(_poolOne.bucketExchangeRate(2550), 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2551), 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2552), 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2553), 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2555), 1e27);
-
         // configure NFT position two
-        mintMemorializeParams = MintAndMemorializeParams({
+        MintAndMemorializeParams memory mintMemorializeParams = MintAndMemorializeParams({
             indexes:    depositIndexes,
             minter:     _minterTwo,
             mintAmount: 1000 * 1e18,
@@ -938,11 +922,11 @@ contract AjnaRewardsTest is DSTestPlus {
         });
         uint256 tokenIdThree = _mintAndMemorializePositionNFT(mintMemorializeParams);
         // bucket exchange rates are higher at the time minter three stakes
-        assertEq(_poolOne.bucketExchangeRate(2550), 1.000000058280865719999999999 * 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2551), 1.000000058280865719999999999 * 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2552), 1.000000058280865719999999999 * 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2553), 1.000000058280865719999999999 * 1e27);
-        assertEq(_poolOne.bucketExchangeRate(2555), 1.000000058280865719999999999 * 1e27);
+        assertEq(_poolOne.bucketExchangeRate(2550), 1.000000116565164638999999999 * 1e27);
+        assertEq(_poolOne.bucketExchangeRate(2551), 1.000000116565164638999999999 * 1e27);
+        assertEq(_poolOne.bucketExchangeRate(2552), 1.000000116565164638999999999 * 1e27);
+        assertEq(_poolOne.bucketExchangeRate(2553), 1.000000116565164638999999999 * 1e27);
+        assertEq(_poolOne.bucketExchangeRate(2555), 1.000000116565164638999999999 * 1e27);
         _stakeToken(address(_poolOne), _minterThree, tokenIdThree);
 
         skip(1 days);
@@ -961,22 +945,22 @@ contract AjnaRewardsTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdTwo,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            4.921002106887218170 * 1e18,
+            reward:            6.757003114621612065 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterTwoBalance = _ajnaToken.balanceOf(_minterTwo);
-        assertEq(minterTwoBalance, 4.921002106887218170 * 1e18);
+        assertEq(minterTwoBalance, 6.757003114621612065 * 1e18);
 
         _unstakeToken({
             minter:            _minterThree,
             pool:              address(_poolOne),
             tokenId:           tokenIdThree,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            3.784761770897208745 * 1e18,
+            reward:            5.629597976281608765 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterThreeBalance = _ajnaToken.balanceOf(_minterThree);
-        assertEq(minterThreeBalance, 3.784761770897208745 * 1e18);
+        assertEq(minterThreeBalance, 5.629597976281608765 * 1e18);
 
         assertGt(minterTwoBalance, minterThreeBalance);
     }


### PR DESCRIPTION
- record lps, bucket rate and time of staking when stake
- when calculating interest earn in epoch, the bucket exchange rate is calculated as
  - The exchange rate when they staked, if they staked during that epoch
  - The initial exchange rate of that epoch, if they staked during a prior epoch
- simplified logic to calculate interest earned
- test to show rewards for an early and late staker in same epoch 