### PR TITLE
Staking bug cleanup and test utility methods

### DIFF
--- a/src/AjnaRewards.sol
+++ b/src/AjnaRewards.sol
@@ -363,11 +363,17 @@ contract AjnaRewards is IAjnaRewards {
         uint256 tokenId_,
         uint256 burnEpochToStartClaim_
     ) internal {
-        uint256 rewardsEarned = _calculateRewards(tokenId_, burnEpochToStartClaim_, true);
 
         Stake storage stake = stakes[tokenId_];
-
         address ajnaPool = stake.ajnaPool;
+
+        // update bucket exchange rates and claim associated rewards
+        uint256 rewardsEarned = _updateBucketExchangeRates(
+            ajnaPool,
+            positionManager.getPositionIndexes(tokenId_)
+        );
+
+        rewardsEarned += _calculateRewards(tokenId_, burnEpochToStartClaim_, true); 
 
         uint256[] memory burnEpochsClaimed = _getBurnEpochsClaimed(
             stake.lastInteractionBurnEpoch,
@@ -385,11 +391,6 @@ contract AjnaRewards is IAjnaRewards {
         // update last interaction burn event
         stake.lastInteractionBurnEpoch = uint96(burnEpochToStartClaim_);
 
-        // update bucket exchange rates and claim associated rewards
-        rewardsEarned += _updateBucketExchangeRates(
-            ajnaPool,
-            positionManager.getPositionIndexes(tokenId_)
-        );
 
         uint256 ajnaBalance = IERC20(ajnaToken).balanceOf(address(this));
 

--- a/src/AjnaRewards.sol
+++ b/src/AjnaRewards.sol
@@ -453,11 +453,15 @@ contract AjnaRewards is IAjnaRewards {
             uint256 totalBurnedAtBlock
         ) = IPool(pool_).burnInfo(lastBurnEventEpoch_);
 
+        uint256 totalBurned   = totalBurnedLatest   != 0 ? totalBurnedLatest   - totalBurnedAtBlock   : totalBurnedAtBlock;
+        uint256 totalInterest = totalInterestLatest != 0 ? totalInterestLatest - totalInterestAtBlock : totalInterestAtBlock;
+
         return (
             currentBurnTime,
-            totalBurnedLatest - totalBurnedAtBlock,
-            totalInterestLatest - totalInterestAtBlock
+            totalBurned,
+            totalInterest
         );
+
     }
 
     /**

--- a/src/AjnaRewards.sol
+++ b/src/AjnaRewards.sol
@@ -391,7 +391,6 @@ contract AjnaRewards is IAjnaRewards {
         // update last interaction burn event
         stake.lastInteractionBurnEpoch = uint96(burnEpochToStartClaim_);
 
-
         uint256 ajnaBalance = IERC20(ajnaToken).balanceOf(address(this));
 
         if (rewardsEarned > ajnaBalance) rewardsEarned = ajnaBalance;

--- a/tests/forge/AjnaRewards.t.sol
+++ b/tests/forge/AjnaRewards.t.sol
@@ -527,11 +527,6 @@ contract AjnaRewardsTest is DSTestPlus {
             interest:  6.466873982955353003 * 1e18
         });
 
-        (uint256 e2Timestamp, uint256 e2Interest, uint256 e2Burned) = IPool(_poolOne).burnInfo(2);
-        assertGt(e2Timestamp, 0); // GT assert -> non-zero value
-        assertEq(e2Interest, 0);  // not stamped because this happens in takeReserves
-        assertEq(e2Burned, 0);    // not stamped because this happens in takeReserves
-        
         _assertBurn({
             pool:      address(_poolOne),
             epoch:     2,


### PR DESCRIPTION
* Added an underflow fix that protects stakers from getting funds locked in the contract if take is not called on a reserve auction.
*  changed so `updateBucketExchangeRates` happens before `_calculateRewards` in `claimRewards`
* staking test cleanup and added utility methods