### PR TITLE
Collateral scaling and dust limits

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -96,7 +96,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             deposits,
             poolState,
             AddQuoteParams({
-                amount: _getTokenScaledAmount(quoteTokenAmountToAdd_, poolState.quoteDustLimit),
+                amount: _roundToScale(quoteTokenAmountToAdd_, poolState.quoteDustLimit),
                 index:  index_
             })
         );

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -243,3 +243,14 @@ import '../libraries/Maths.sol';
     ) pure returns (uint256 scaledAmount_) {
         scaledAmount_ = (amount_ / tokenScale_) * tokenScale_;
     }
+
+    function _getCollateralDustPricePrecisionAdjustment(
+        uint256 bucketIndex_
+    ) pure returns (uint256) {
+        // TODO: explain where this came from and/or find cleaner formula
+        int256 polynomialResult = 
+              (  -2.0844   * 1e11 * int256(bucketIndex_ ** 2)) 
+            + (   0.004553 * 1e18 * int256(bucketIndex_)     ) 
+               - 12.75     * 1e18;
+        return polynomialResult > 0 ? uint256(polynomialResult / 1e18) : 0;
+    }

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -237,6 +237,7 @@ import '../libraries/Maths.sol';
         }
     }
 
+    // TODO: consider renaming _roundToScale
     function _getTokenScaledAmount(
         uint256 amount_,
         uint256 tokenScale_
@@ -247,7 +248,9 @@ import '../libraries/Maths.sol';
     function _getCollateralDustPricePrecisionAdjustment(
         uint256 bucketIndex_
     ) pure returns (uint256) {
-        // TODO: explain where this came from and/or find cleaner formula
+        // conditional is a gas optimization; formula also returns 0 in this case
+        if (bucketIndex_ == 0) return 0;
+        // formula comes from a least squares best fit to a curve constructed using empirically-obtained values
         int256 polynomialResult = 
               (  -2.0844   * 1e11 * int256(bucketIndex_ ** 2)) 
             + (   0.004553 * 1e18 * int256(bucketIndex_)     ) 

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -165,10 +165,10 @@ import '../libraries/Maths.sol';
         uint256 bucketIndex_
     ) pure returns (uint256) {
         // conditional is a gas optimization; formula also returns 0 in this case
-        if (bucketIndex_ == 0) return 0;
-        int256 bucketOffset = Maths.smax(0, int256(bucketIndex_) - int256(3900)) * 1e18;
-        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(PRBMathSD59x18.abs(bucketOffset), int256(36 * 1e18)));
-        return result > 0 ? uint256(result / 1e18) : 0;
+        if (bucketIndex_ <= 3900) return 0;
+        int256 bucketOffset = int256(bucketIndex_ - 3900);
+        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(bucketOffset * 1e18, int256(36 * 1e18)));
+        return uint256(result / 1e18);
     }
 
     /**

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -247,13 +247,10 @@ import '../libraries/Maths.sol';
 
     function _getCollateralDustPricePrecisionAdjustment(
         uint256 bucketIndex_
-    ) pure returns (uint256) {
+    ) view returns (uint256) {
         // conditional is a gas optimization; formula also returns 0 in this case
         if (bucketIndex_ == 0) return 0;
-        // formula comes from a least squares best fit to a curve constructed using empirically-obtained values
-        int256 polynomialResult = 
-              (  -2.0844   * 1e11 * int256(bucketIndex_ ** 2)) 
-            + (   0.004553 * 1e18 * int256(bucketIndex_)     ) 
-               - 12.75     * 1e18;
-        return polynomialResult > 0 ? uint256(polynomialResult / 1e18) : 0;
+        int256 bucketOffset = Maths.smax(0, int256(bucketIndex_) - int256(3900)) * 1e18;
+        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(PRBMathSD59x18.abs(bucketOffset), int256(36 * 1e18)));
+        return result > 0 ? uint256(result / 1e18) : 0;
     }

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -155,6 +155,23 @@ import '../libraries/Maths.sol';
     }
 
     /**
+     *  @notice Price precision adjustment used in calculating collateral dust for a bucket.
+     *          To ensure the accuracy of the exchange rate calculation, buckets with smaller prices require 
+     *          larger minimum amounts of collateral.  This formula imposes a lower bound independent of token scale.
+     *  @param  bucketIndex_ Index of the bucket, or 0 for encumbered collateral with no bucket affinity.
+     *  @return Unscaled integer of the minimum number of decimal places the dust limit requires.
+     */
+    function _getCollateralDustPricePrecisionAdjustment(
+        uint256 bucketIndex_
+    ) pure returns (uint256) {
+        // conditional is a gas optimization; formula also returns 0 in this case
+        if (bucketIndex_ == 0) return 0;
+        int256 bucketOffset = Maths.smax(0, int256(bucketIndex_) - int256(3900)) * 1e18;
+        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(PRBMathSD59x18.abs(bucketOffset), int256(36 * 1e18)));
+        return result > 0 ? uint256(result / 1e18) : 0;
+    }
+
+    /**
      *  @notice Returns the amount of collateral calculated for the given amount of LPs.
      *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  bucketLPs_        Amount of LPs in bucket.
@@ -207,6 +224,19 @@ import '../libraries/Maths.sol';
         if (quoteTokenAmount_ > maxQuoteToken_) quoteTokenAmount_ = maxQuoteToken_;
     }
 
+    /**
+     *  @notice Rounds a token amount down to the minimum amount permissible by the token scale.
+     *  @param  amount_       Value to be rounded.
+     *  @param  tokenScale_   Scale of the token, presented as a power of 10.
+     *  @return scaledAmount_ Rounded value.
+     */
+    function _roundToScale(
+        uint256 amount_,
+        uint256 tokenScale_
+    ) pure returns (uint256 scaledAmount_) {
+        scaledAmount_ = (amount_ / tokenScale_) * tokenScale_;
+    }
+
     /*********************************/
     /*** Reserve Auction Utilities ***/
     /*********************************/
@@ -235,22 +265,4 @@ import '../libraries/Maths.sol';
 
             _price = Maths.rayToWad(1_000_000_000 * Maths.rmul(hoursComponent, minutesComponent));
         }
-    }
-
-    // TODO: consider renaming _roundToScale
-    function _getTokenScaledAmount(
-        uint256 amount_,
-        uint256 tokenScale_
-    ) pure returns (uint256 scaledAmount_) {
-        scaledAmount_ = (amount_ / tokenScale_) * tokenScale_;
-    }
-
-    function _getCollateralDustPricePrecisionAdjustment(
-        uint256 bucketIndex_
-    ) view returns (uint256) {
-        // conditional is a gas optimization; formula also returns 0 in this case
-        if (bucketIndex_ == 0) return 0;
-        int256 bucketOffset = Maths.smax(0, int256(bucketIndex_) - int256(3900)) * 1e18;
-        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(PRBMathSD59x18.abs(bucketOffset), int256(36 * 1e18)));
-        return result > 0 ? uint256(result / 1e18) : 0;
     }

--- a/src/base/interfaces/pool/IPoolErrors.sol
+++ b/src/base/interfaces/pool/IPoolErrors.sol
@@ -41,7 +41,7 @@ interface IPoolErrors {
     error CannotMergeToHigherPrice();
 
     /**
-     *  @notice User attempted a deposit which does not exceed the dust amount, or a withdrawal which leaves behind less than the dust amount.
+     *  @notice User attempted an operation which does not exceed the dust amount, or leaves behind less than the dust amount.
      */
     error DustAmountNotExceeded();
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -123,7 +123,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             maxQuoteTokenAmountToRepay_,
-            collateralAmountToPull_
+            collateralAmountToPull_,
+            _collateralDust(0)
         );
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, collateralAmountToPull_, result.newLup);
@@ -397,7 +398,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     }
 
     function _collateralDust(uint256 bucketIndex) internal view returns (uint256) {
+        // price precision adjustment will always be 0 for encumbered collateral
         uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
+        // difference between the normalized scale and the collateral token's scale
         uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
         return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
     } 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -50,11 +50,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     }
 
     /// @inheritdoc IERC20PoolImmutables
-    function collateralDust(uint256 bucketIndex) external view override returns (uint256) {  // TODO: should be pure
-        uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
-        uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
-        console2.log("collateralDust for bucket %s with prec %s and scale %s", bucketIndex, pricePrecisionAdjustment, scaleExponent);
-        return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
+    function collateralDust(uint256 bucketIndex) external view override returns (uint256) {
+        return _collateralDust(bucketIndex);
     }
 
     /***********************************/
@@ -392,4 +389,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function _transferCollateral(address to_, uint256 amount_) internal {
         IERC20(_getArgAddress(COLLATERAL_ADDRESS)).safeTransfer(to_, amount_ / _getArgUint256(COLLATERAL_SCALE));
     }
+
+    function _collateralDust(uint256 bucketIndex) internal view returns (uint256) {
+        uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
+        uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
+        return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
+    } 
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -67,7 +67,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure the borrower is not credited with a fractional amount of collateral smaller than the token scale
-        collateralToPledge_ = _getTokenScaledAmount(collateralToPledge_, _collateralDust(0));
+        collateralToPledge_ = _roundToScale(collateralToPledge_, _collateralDust(0));
 
         DrawDebtResult memory result = BorrowerActions.drawDebt(
             auctions,
@@ -206,7 +206,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         // revert if the dust amount was not exceeded, but round on the scale amount
         if (amountToAdd_ != 0 && amountToAdd_ < _collateralDust(index_)) revert DustAmountNotExceeded();
-        amountToAdd_ = _getTokenScaledAmount(amountToAdd_, _getArgUint256(COLLATERAL_SCALE));
+        amountToAdd_ = _roundToScale(amountToAdd_, _getArgUint256(COLLATERAL_SCALE));
 
         bucketLPs_ = LenderActions.addCollateral(
             buckets,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -240,12 +240,12 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         PoolState memory poolState = _accruePoolInterest();
 
-        // TODO: Why doesn't this call LenderActions.removeCollateral?
         (collateralAmount_, lpAmount_) = LenderActions.removeMaxCollateral(
             buckets,
             deposits,
             maxAmount_,
-            index_
+            index_,
+            _collateralDust(index_)
         );
 
         emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -232,6 +232,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
         PoolState memory poolState = _accruePoolInterest();
 
+        // TODO: Why doesn't this call LenderActions.removeCollateral?
         (collateralAmount_, lpAmount_) = LenderActions.removeMaxCollateral(
             buckets,
             deposits,
@@ -307,8 +308,11 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             loans,
             poolState,
             borrowerAddress_,
-            collateral_
+            collateral_,
+            _collateralDust(0)
         );
+        // prevent caller from requesting an amount of collateral which costs 0 quote token
+        if (result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE) == 0) revert DustAmountNotExceeded();
 
         // update pool balances state
         uint256 t0PoolDebt      = poolBalances.t0Debt;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -2,6 +2,7 @@
 
 pragma solidity 0.8.14;
 
+import "forge-std/console2.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -46,6 +47,14 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
 
     function collateralScale() external pure override returns (uint256) {
         return _getArgUint256(COLLATERAL_SCALE);
+    }
+
+    /// @inheritdoc IERC20PoolImmutables
+    function collateralDust(uint256 bucketIndex) external view override returns (uint256) {  // TODO: should be pure
+        uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
+        uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
+        console2.log("collateralDust for bucket %s with prec %s and scale %s", bucketIndex, pricePrecisionAdjustment, scaleExponent);
+        return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
     }
 
     /***********************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -2,7 +2,6 @@
 
 pragma solidity 0.8.14;
 
-import "forge-std/console2.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -66,6 +66,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external {
         PoolState memory poolState = _accruePoolInterest();
 
+        // ensure the borrower is not credited with a fractional amount of collateral smaller than the token scale
+        collateralToPledge_ = _getTokenScaledAmount(collateralToPledge_, _collateralDust(0));
+
         DrawDebtResult memory result = BorrowerActions.drawDebt(
             auctions,
             buckets,

--- a/src/erc20/interfaces/pool/IERC20PoolEvents.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolEvents.sol
@@ -24,13 +24,13 @@ interface IERC20PoolEvents {
     /**
      *  @notice Emitted when borrower draws debt from the pool, or adds collateral to the pool.
      *  @param  borrower          The borrower to whom collateral was pledged, and/or debt was drawn for.
-     *  @param  amountBorowed     Amount of quote tokens borrowed from the pool.
+     *  @param  amountBorrowed    Amount of quote tokens borrowed from the pool.
      *  @param  collateralPledged Amount of collateral locked in the pool.
      *  @param  lup               LUP after borrow.
      */
     event DrawDebt(
         address indexed borrower,
-        uint256 amountBorowed,
+        uint256 amountBorrowed,
         uint256 collateralPledged,
         uint256 lup
     );

--- a/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
@@ -15,7 +15,7 @@ interface IERC20PoolImmutables {
 
     /**
      *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
-     *  @param  bucketIndex The bucket index for which the dust limit is desired.
+     *  @param  bucketIndex The bucket index for which the dust limit is desired, or 0 for pledged collateral.
      *  @return The dust limit for `bucketIndex`.
      */
     function collateralDust(uint256 bucketIndex) external view returns (uint256);

--- a/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.14;
 /**
  * @title ERC20 Pool Immutables
  */
-interface IERC20PoolImmutables{
+interface IERC20PoolImmutables {
 
     /**
      *  @notice Returns the `collateralScale` immutable.
@@ -13,4 +13,10 @@ interface IERC20PoolImmutables{
      */
     function collateralScale() external view returns (uint256);
 
+    /**
+     *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
+     *  @param  bucketIndex The bucket index for which the dust limit is desired.
+     *  @return The dust limit for `bucketIndex`.
+     */
+    function collateralDust(uint256 bucketIndex) external view returns (uint256);
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -244,8 +244,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             buckets,
             deposits,
             collateralAmount_,
-            index_,
-            0
+            index_
         );
 
         emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -136,7 +136,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             borrowerAddress_,
             maxQuoteTokenAmountToRepay_,
             Maths.wad(noOfNFTsToPull_),
-            Maths.WAD
+            0
         );
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, noOfNFTsToPull_, result.newLup);
@@ -238,7 +238,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             deposits,
             collateralAmount_,
             index_,
-            Maths.WAD
+            0
         );
 
         emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -313,7 +313,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             loans,
             poolState,
             borrowerAddress_,
-            Maths.wad(collateral_)
+            Maths.wad(collateral_),
+            Maths.WAD
         );
 
         // update pool balances state

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -135,7 +135,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             maxQuoteTokenAmountToRepay_,
-            Maths.wad(noOfNFTsToPull_)
+            Maths.wad(noOfNFTsToPull_),
+            Maths.WAD
         );
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, noOfNFTsToPull_, result.newLup);
@@ -236,7 +237,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             buckets,
             deposits,
             collateralAmount_,
-            index_
+            index_,
+            Maths.WAD
         );
 
         emit RemoveCollateral(msg.sender, index_, noOfNFTsToRemove_, lpAmount_);

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -314,7 +314,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             Maths.wad(collateral_),
-            Maths.WAD
+            0
         );
 
         // update pool balances state

--- a/src/erc721/interfaces/pool/IERC721PoolEvents.sol
+++ b/src/erc721/interfaces/pool/IERC721PoolEvents.sol
@@ -36,13 +36,13 @@ interface IERC721PoolEvents {
     /**
      *  @notice Emitted when borrower draws debt from the pool, or adds collateral to the pool.
      *  @param  borrower          `msg.sender`.
-     *  @param  amountBorowed     Amount of quote tokens borrowed from the pool.
+     *  @param  amountBorrowed    Amount of quote tokens borrowed from the pool.
      *  @param  tokenIdsPledged   Array of tokenIds to be added to the pool.
      *  @param  lup               LUP after borrow.
      */
     event DrawDebtNFT(
         address indexed borrower,
-        uint256   amountBorowed,
+        uint256   amountBorrowed,
         uint256[] tokenIdsPledged,
         uint256   lup
     );

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -19,6 +19,10 @@ library Maths {
         return x >= y ? x : y;
     }
 
+    function smax(int256 x, int256 y) internal pure returns (int256) {
+        return x >= y ? x : y;
+    }
+
     function min(uint256 x, uint256 y) internal pure returns (uint256) {
         return x <= y ? x : y;
     }

--- a/src/libraries/Maths.sol
+++ b/src/libraries/Maths.sol
@@ -19,10 +19,6 @@ library Maths {
         return x >= y ? x : y;
     }
 
-    function smax(int256 x, int256 y) internal pure returns (int256) {
-        return x >= y ? x : y;
-    }
-
     function min(uint256 x, uint256 y) internal pure returns (uint256) {
         return x <= y ? x : y;
     }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -611,7 +611,7 @@ library Auctions {
         PoolState memory poolState_,
         address borrowerAddress_,
         uint256 collateral_,
-        uint256 collateralDustLimit
+        uint256 collateralDustLimit_
     ) external returns (TakeResult memory result_) {
         Borrower memory borrower = loans_.borrowers[borrowerAddress_];
 
@@ -639,7 +639,7 @@ library Auctions {
 
         borrower.collateral -= result_.collateralAmount;
         // revert if the take leaves behind less collateral than the next bidder can take
-        if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit) revert DustAmountNotExceeded();
+        if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit_) revert DustAmountNotExceeded();
 
         if (result_.t0DebtPenalty != 0) {
             poolState_.debt += Maths.wmul(result_.t0DebtPenalty, poolState_.inflator);

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -189,7 +189,7 @@ library BorrowerActions {
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
         uint256 collateralAmountToPull_,
-        uint256 collateralDustLimit
+        uint256 collateralDustLimit_
     ) external returns (
         RepayDebtResult memory result_
     ) {
@@ -273,7 +273,7 @@ library BorrowerActions {
             result_.poolCollateral -= collateralAmountToPull_;
 
             // ensure borrower does not leave behind a collateral balance which cannot be pulled
-            if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit) revert DustAmountNotExceeded();
+            if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit_) revert DustAmountNotExceeded();
         }
 
         // calculate LUP if repay is called with 0 amount

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -50,6 +50,10 @@ library BorrowerActions {
      */
     error BorrowerUnderCollateralized();
     /**
+     *  @notice User attempted a deposit which does not exceed the dust amount, or a withdrawal which leaves behind less than the dust amount.
+     */
+    error DustAmountNotExceeded();
+    /**
      *  @notice User is attempting to move or pull more collateral than is available.
      */
     error InsufficientCollateral();
@@ -184,7 +188,8 @@ library BorrowerActions {
         PoolState calldata poolState_,
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 collateralAmountToPull_
+        uint256 collateralAmountToPull_,
+        uint256 collateralDustLimit
     ) external returns (
         RepayDebtResult memory result_
     ) {
@@ -202,6 +207,7 @@ library BorrowerActions {
         if (vars.repay) {
             if (borrower.t0Debt == 0) revert NoDebt();
 
+            // FIXME: division overflows when passed type(uint256).max
             result_.t0RepaidDebt = Maths.min(
                 borrower.t0Debt,
                 Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState_.inflator)
@@ -265,6 +271,9 @@ library BorrowerActions {
 
             borrower.collateral    -= collateralAmountToPull_;
             result_.poolCollateral -= collateralAmountToPull_;
+
+            // ensure borrower does not leave behind a collateral balance which cannot be pulled
+            if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit) revert DustAmountNotExceeded();
         }
 
         // calculate LUP if repay is called with 0 amount

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -364,7 +364,8 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
         uint256 amount_,
-        uint256 index_
+        uint256 index_,
+        uint256 dustLimit_
     ) external returns (uint256 lpAmount_) {
         Bucket storage bucket = buckets_[index_];
 
@@ -395,6 +396,9 @@ library LenderActions {
         // update bucket LPs and collateral balance
         bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
         bucket.collateral -= Maths.min(bucketCollateral, amount_);
+
+        // ensure a lender does not leave an amount which breaks exchange rate or is below token scale
+        if (bucket.collateral != 0 && bucket.collateral < dustLimit_) revert DustAmountNotExceeded();
     }
 
     function removeMaxCollateral(

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -364,8 +364,7 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
         uint256 amount_,
-        uint256 index_,
-        uint256 dustLimit_
+        uint256 index_
     ) external returns (uint256 lpAmount_) {
         Bucket storage bucket = buckets_[index_];
 
@@ -396,22 +395,21 @@ library LenderActions {
         // update bucket LPs and collateral balance
         bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
         bucket.collateral -= Maths.min(bucketCollateral, amount_);
-
-        // ensure a lender does not leave an amount which breaks exchange rate or is below token scale
-        if (bucket.collateral != 0 && bucket.collateral < dustLimit_) revert DustAmountNotExceeded();
     }
 
     function removeMaxCollateral(
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
         uint256 maxAmount_,
-        uint256 index_
+        uint256 index_,
+        uint256 dustLimit_
     ) external returns (uint256, uint256) {
         return _removeMaxCollateral(
             buckets_,
             deposits_,
             maxAmount_,
-            index_
+            index_,
+            dustLimit_
         );
     }
 
@@ -438,7 +436,8 @@ library LenderActions {
                 buckets_,
                 deposits_,
                 collateralRemaining,
-                fromIndex
+                fromIndex,
+                0
             );
 
             collateralToMerge_ += collateralRemoved;
@@ -525,7 +524,8 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
         uint256 maxAmount_,
-        uint256 index_
+        uint256 index_,
+        uint256 dustLimit_
     ) internal returns (uint256 collateralAmount_, uint256 lpAmount_) {
         Bucket storage bucket = buckets_[index_];
 
@@ -566,6 +566,9 @@ library LenderActions {
         // update bucket LPs and collateral balance
         bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
         bucket.collateral -= Maths.min(bucketCollateral, collateralAmount_);
+
+        // ensure a lender does not leave an amount which breaks exchange rate or is below token scale
+        if (bucket.collateral != 0 && bucket.collateral < dustLimit_) revert DustAmountNotExceeded();
     }
 
 

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -494,6 +494,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).repayDebt(borrower, 0, amount);
     }
 
+    function _assertRepayDustRevert(
+        address from,
+        address borrower,
+        uint256 amount
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
+    }
+
     function _assertRepayMinDebtRevert(
         address from,
         address borrower,

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -130,8 +130,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     /*** Actor actions asserts ***/
     /*****************************/
 
-    // FIXME: poorly named, as it assumes quote token scale
-    function _assertTokenTransferEvent(
+    function _assertQuoteTokenTransferEvent(
         address from,
         address to,
         uint256 amount
@@ -204,7 +203,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit DrawDebt(from, amount, 0, newLup);
-        _assertTokenTransferEvent(address(_pool), from, amount);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
 
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
 
@@ -252,7 +251,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
 
         // borrow quote
         if (amountToBorrow != 0) {
-            _assertTokenTransferEvent(address(_pool), from, amountToBorrow);
+            _assertQuoteTokenTransferEvent(address(_pool), from, amountToBorrow);
         }
 
         ERC20Pool(address(_pool)).drawDebt(borrower, amountToBorrow, limitIndex, collateralToPledge);
@@ -339,7 +338,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         emit AuctionSettle(borrower, collateral);
         vm.expectEmit(true, true, false, true);
         emit RepayDebt(borrower, repaid, 0, newLup);
-        _assertTokenTransferEvent(from, address(_pool), repaid);
+        _assertQuoteTokenTransferEvent(from, address(_pool), repaid);
         ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
     }
 
@@ -360,7 +359,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
 
         // repay checks
         if (amountToRepay != 0) {
-            _assertTokenTransferEvent(from, address(_pool), amountRepaid);
+            _assertQuoteTokenTransferEvent(from, address(_pool), amountRepaid);
         }
 
         // pull checks

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -209,17 +209,18 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         uint256 collateralToPledge,
         uint256 newLup
     ) internal {
+        uint256 collateralScale = ERC20Pool(address(_pool)).collateralScale();
         changePrank(from);
 
         if (newLup != 0) {
             vm.expectEmit(true, true, false, true);
-            emit DrawDebt(from, amountToBorrow, collateralToPledge, newLup);
+            emit DrawDebt(from, amountToBorrow, (collateralToPledge / collateralScale) * collateralScale, newLup);
         }
 
         // pledge collateral
         if (collateralToPledge != 0) {
             vm.expectEmit(true, true, false, true);
-            emit Transfer(from, address(_pool), collateralToPledge / ERC20Pool(address(_pool)).collateralScale());
+            emit Transfer(from, address(_pool), collateralToPledge / collateralScale);
         }
 
         // borrow quote

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -143,7 +143,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         address from,
         address to,
         uint256 amount
-    ) internal {
+    ) internal override {
         vm.expectEmit(true, true, false, true);
         emit Transfer(from, to, amount / ERC20Pool(address(_pool)).collateralScale());
     }
@@ -530,6 +530,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
         ERC20Pool(address(_pool)).removeCollateral(type(uint256).max, index);
+    }
+
+    function _assertRemoveCollateralDustRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
+        ERC20Pool(address(_pool)).removeCollateral(amount, index);
     }
 
     function _assertTransferInvalidIndexRevert(

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -497,11 +497,12 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     function _assertRepayDustRevert(
         address from,
         address borrower,
-        uint256 amount
+        uint256 amountToRepay,
+        uint256 collateralToPull
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
     }
 
     function _assertRepayMinDebtRevert(

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.14;
 
-import "forge-std/console2.sol";
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 
 import { ERC20DSTestPlus }     from './ERC20DSTestPlus.sol';
@@ -179,7 +178,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     {
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 6,    18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      6,    18);
-        uint256 startBucketId       = bound(uint256(startBucketId_),               3000, 4000);//7388 - BUCKETS_WITH_DEPOSIT);
+        uint256 startBucketId       = bound(uint256(startBucketId_),               1000, 6388);
         init(boundColPrecision, boundQuotePrecision);
         addLiquidity(startBucketId);
         uint256 collateralDust = ERC20Pool(address(_pool)).collateralDust(0);

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -18,12 +18,11 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
 
-    uint256 internal constant MAX_DEPOSIT     = 1e22 * 1e18;
-    uint256 internal constant MAX_COLLATERAL  = 1e12 * 1e18;
+    uint256 internal constant MAX_DEPOSIT    = 1e22 * 1e18;
+    uint256 internal constant MAX_COLLATERAL = 1e12 * 1e18;
+    uint256 internal constant POOL_PRECISION = 1e18;
+    uint256 internal constant LP_PRECISION   = 1e27;
 
-    uint256 internal _lpPoolPrecision         = 10**27;
-    uint256 internal _quotePoolPrecision      = 10**18;
-    uint256 internal _collateralPoolPrecision = 10**18;
     uint256 internal _collateralPrecision;
     uint256 internal _quotePrecision;
 
@@ -90,21 +89,21 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2549
             }
         );
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2550
             }
         );
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2551
             }
         );
@@ -131,7 +130,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 maxThresholdPrice: 0
             }
         );
-        assertEq(_pool.depositSize(), 150_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(), 150_000 * POOL_PRECISION);
 
         // check bucket balance
         _assertBucket(
@@ -139,8 +138,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 index:        2549,
                 lpBalance:    50_000 * 1e27,
                 collateral:   0,
-                deposit:      50_000 * _quotePoolPrecision,
-                exchangeRate: 1 * _lpPoolPrecision
+                deposit:      50_000 * POOL_PRECISION,
+                exchangeRate: 1 * LP_PRECISION
             }
         );
         _assertLenderLpBalance(
@@ -157,7 +156,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _removeLiquidity(
             {
                 from:     _lender,
-                amount:   25_000 * _quotePoolPrecision,
+                amount:   25_000 * POOL_PRECISION,
                 index:    2549,
                 newLup:   MAX_PRICE,
                 lpRedeem: 25_000 * 1e27
@@ -186,7 +185,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 maxThresholdPrice: 0
             }
         );
-        assertEq(_pool.depositSize(), 125_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(), 125_000 * POOL_PRECISION);
 
         // check bucket balance
         _assertBucket(
@@ -194,7 +193,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 index:        2549,
                 lpBalance:    25_000 * 1e27,
                 collateral:   0,
-                deposit:      25_000 * _quotePoolPrecision,
+                deposit:      25_000 * POOL_PRECISION,
                 exchangeRate: 1 * 1e27
             }
         );
@@ -202,7 +201,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             {
                 lender:      _lender,
                 index:       2549,
-                lpBalance:   25_000 * _lpPoolPrecision,
+                lpBalance:   25_000 * LP_PRECISION,
                 depositTime: start
             }
         );
@@ -219,21 +218,21 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2549
             }
         );
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2550
             }
         );
         _addInitialLiquidity(
             {
                 from:   _lender,
-                amount: 50_000 * _quotePoolPrecision,
+                amount: 50_000 * POOL_PRECISION,
                 index:  2551
             }
         );
@@ -243,7 +242,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             {
                 from:     _borrower,
                 borrower: _borrower,
-                amount:   50 * _collateralPoolPrecision
+                amount:   50 * POOL_PRECISION
             }
         );
 
@@ -271,23 +270,23 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
                 maxThresholdPrice: 0
             }
         );
-        assertEq(_pool.depositSize(), 150_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(), 150_000 * POOL_PRECISION);
 
         // check bucket balance
         _assertBucket(
             {
                 index:        2549,
-                lpBalance:    50_000 * _lpPoolPrecision,
+                lpBalance:    50_000 * LP_PRECISION,
                 collateral:   0,
-                deposit:      50_000 * _quotePoolPrecision,
-                exchangeRate: 1 * _lpPoolPrecision
+                deposit:      50_000 * POOL_PRECISION,
+                exchangeRate: 1 * LP_PRECISION
             }
         );
         _assertLenderLpBalance(
             {
                 lender:      _lender,
                 index:       2549,
-                lpBalance:   50_000 * _lpPoolPrecision,
+                lpBalance:   50_000 * LP_PRECISION,
                 depositTime: start
             }
         );
@@ -298,7 +297,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _borrow(
             {
                 from:       _borrower,
-                amount:     10_000 * _quotePoolPrecision,
+                amount:     10_000 * POOL_PRECISION,
                 indexLimit: 3_000,
                 newLup:     price
             }
@@ -340,24 +339,24 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             }
         );
         (uint256 poolDebt,,) = _pool.debtInfo();
-        assertEq(_pool.depositSize(),       150_000 * _quotePoolPrecision);
+        assertEq(_pool.depositSize(),       150_000 * POOL_PRECISION);
         assertEq(poolDebt,                  debt);
         assertEq(_pool.pledgedCollateral(), col);
 
         _assertBucket(
             {
                 index:        2549,
-                lpBalance:    50_000 * _lpPoolPrecision,
+                lpBalance:    50_000 * LP_PRECISION,
                 collateral:   0,
-                deposit:      50_000 * _quotePoolPrecision,
-                exchangeRate: 1 * _lpPoolPrecision
+                deposit:      50_000 * POOL_PRECISION,
+                exchangeRate: 1 * LP_PRECISION
             }
         );
         _assertLenderLpBalance(
             {
                 lender:      _lender,
                 index:       2549,
-                lpBalance:   50_000 * _lpPoolPrecision,
+                lpBalance:   50_000 * LP_PRECISION,
                 depositTime: start
             }
         );
@@ -366,8 +365,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _repayDebt({
             from:             _borrower,
             borrower:         _borrower,
-            amountToRepay:    5_000 * _quotePoolPrecision,
-            amountRepaid:     5_000 * _quotePoolPrecision,
+            amountToRepay:    5_000 * POOL_PRECISION,
+            amountRepaid:     5_000 * POOL_PRECISION,
             collateralToPull: 0,
             newLup:           3_025.946482308870940904 * 1e18
         });
@@ -416,7 +415,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertBucket(
             {
                 index:        2549,
-                lpBalance:    50_000 * _lpPoolPrecision,
+                lpBalance:    50_000 * LP_PRECISION,
                 collateral:   0,
                 deposit:      50_000 * 1e18,
                 exchangeRate: 1 * 1e27
@@ -426,7 +425,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             {
                 lender:      _lender,
                 index:       2549,
-                lpBalance:   50_000 * _lpPoolPrecision,
+                lpBalance:   50_000 * LP_PRECISION,
                 depositTime: start
             }
         );

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -876,11 +876,10 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         uint256 desiredCollateralizationRatio
     ) internal returns (uint256) {
         assertGt(desiredCollateralizationRatio, 1e18);
-        uint256 colDustAmount = ERC20Pool(address(_pool)).collateralDust(newLupIndex);
         uint256 colScale      = ERC20Pool(address(_pool)).collateralScale();
         uint256 price         = _priceAt(newLupIndex);
         uint256 desiredPledge = Maths.wmul(Maths.wdiv(debtToDraw, price), desiredCollateralizationRatio);
-        uint256 scaledPledge  = Maths.max((desiredPledge / colScale) * colScale, colDustAmount);
+        uint256 scaledPledge  = (desiredPledge / colScale) * colScale;
 
         while (Maths.wdiv(Maths.wmul(scaledPledge, price), debtToDraw) < desiredCollateralizationRatio) {
             scaledPledge += colScale;

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -768,8 +768,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(_getCollateralDustPricePrecisionAdjustment(1),    0);
         assertEq(_getCollateralDustPricePrecisionAdjustment(4156), 2);
         assertEq(_getCollateralDustPricePrecisionAdjustment(4310), 3);
-        assertEq(_getCollateralDustPricePrecisionAdjustment(5260), 5);
-        assertEq(_getCollateralDustPricePrecisionAdjustment(6466), 7);
+        assertEq(_getCollateralDustPricePrecisionAdjustment(5260), 6);
+        assertEq(_getCollateralDustPricePrecisionAdjustment(6466), 8);
         assertEq(_getCollateralDustPricePrecisionAdjustment(6647), 8);
         assertEq(_getCollateralDustPricePrecisionAdjustment(7388), 9);
 
@@ -784,7 +784,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         init(12, 18);
         assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(6466), 10000000);
+        assertEq(IERC20Pool(address(_pool)).collateralDust(6466), 100000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
 
         // check dust limits for 6-decimal collateral

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -43,6 +43,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _collateralPrecision = uint256(10) ** collateralPrecisionDecimals_;
         _quotePrecision = uint256(10) ** quotePrecisionDecimals_;
         _quoteDust      = _pool.quoteTokenDust();
+        assertEq(_quoteDust, _pool.quoteTokenScale());
         assertEq(_quoteDust, 10 ** (18 - quotePrecisionDecimals_));
         
         _borrower  = makeAddr("borrower");

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -755,6 +755,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
     function testCollateralDustPricePrecisionAdjustment() external {
         // test the bucket price adjustment used for determining dust amount
+        assertEq(_getCollateralDustPricePrecisionAdjustment(0), 0);
         assertEq(_getCollateralDustPricePrecisionAdjustment(1), 0);
         assertEq(_getCollateralDustPricePrecisionAdjustment(4156), 2);
         assertEq(_getCollateralDustPricePrecisionAdjustment(4310), 3);
@@ -765,18 +766,21 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // check dust limits for 18-decimal collateral
         init(18, 18);
+        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1);
         assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1);
         assertEq(IERC20Pool(address(_pool)).collateralDust(4166), 100);
         assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
 
         // check dust limits for 12-decimal collateral
         init(12, 18);
+        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(6466), 10000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
 
         // check dust limits for 6-decimal collateral
         init(6, 18);
+        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(4156), 1000000000000);
         assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000000);

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -198,7 +198,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
         vm.expectEmit(true, true, false, true);
         emit DrawDebtNFT(from, amount, emptyArray, newLup);
-        _assertTokenTransferEvent(address(_pool), from, amount);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
 
         ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
 
@@ -232,7 +232,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
         // borrow quote
         if (amountToBorrow != 0) {
-            _assertTokenTransferEvent(address(_pool), from, amountToBorrow);
+            _assertQuoteTokenTransferEvent(address(_pool), from, amountToBorrow);
         }
 
         ERC721Pool(address(_pool)).drawDebt(borrower, amountToBorrow, limitIndex, tokenIds);
@@ -316,7 +316,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
         // repay checks
         if (amountToRepay != 0) {
-            _assertTokenTransferEvent(from, address(_pool), amountRepaid);
+            _assertQuoteTokenTransferEvent(from, address(_pool), amountRepaid);
         }
 
         // pre pull checks

--- a/tests/forge/MathTest.t.sol
+++ b/tests/forge/MathTest.t.sol
@@ -71,4 +71,21 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.rpow(0.5 * 1e27, 60), 0.000000000000000000867361738 * 1e27);
         assertEq(Maths.rpow(0.5 * 1e27, 80), 0.000000000000000000000000827 * 1e27);
     }
+
+    function testMaxMin() external {
+        uint256 smallerWad = 0.002144924036174740 * 1e18;
+        uint256 largerWad  = 0.951347940696070000 * 1e18;
+
+        assertEq(Maths.max(0, 9), 9);
+        assertEq(Maths.max(3, 0), 3);
+        assertEq(Maths.max(smallerWad, largerWad), largerWad);
+
+        assertEq(Maths.smax(-4, 2), 2);
+        assertEq(Maths.smax(-8, 0), 0);
+        assertEq(Maths.smax(-5, 3), 3);
+
+        assertEq(Maths.min(2, 4), 2);
+        assertEq(Maths.min(0, 9), 0);
+        assertEq(Maths.min(smallerWad, largerWad), smallerWad);
+    }
 }

--- a/tests/forge/MathTest.t.sol
+++ b/tests/forge/MathTest.t.sol
@@ -80,10 +80,6 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.max(3, 0), 3);
         assertEq(Maths.max(smallerWad, largerWad), largerWad);
 
-        assertEq(Maths.smax(-4, 2), 2);
-        assertEq(Maths.smax(-8, 0), 0);
-        assertEq(Maths.smax(-5, 3), 3);
-
         assertEq(Maths.min(2, 4), 2);
         assertEq(Maths.min(0, 9), 0);
         assertEq(Maths.min(smallerWad, largerWad), smallerWad);

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -308,9 +308,19 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(from, index, amount, lpRedeem);
-        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
+        _assertCollateralTokenTransferEvent(address(_pool), from, amount);
         (, lpRedeemed_) = _pool.removeCollateral(amount, index);
         assertEq(lpRedeemed_, lpRedeem);
+    }
+
+    function _removeCollateralWithoutLPCheck(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal virtual returns (uint256 lpRedeemed_) {
+        changePrank(from);
+        _assertCollateralTokenTransferEvent(address(_pool), from, amount);
+        (, lpRedeemed_) = _pool.removeCollateral(amount, index);
     }
 
     function _removeLiquidity(
@@ -380,6 +390,14 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     }
 
     function _assertQuoteTokenTransferEvent(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {
+        // to be overidden by ERC20 helper 
+    }
+
+    function _assertCollateralTokenTransferEvent(
         address from,
         address to,
         uint256 amount

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1156,6 +1156,16 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 
+    function _assertTakeDustRevert(
+        address from,
+        address borrower,
+        uint256 maxCollateral
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
+        _pool.take(borrower, maxCollateral, from, new bytes(0));
+    }
+
     function _assertTakeInsufficentCollateralRevert(
         address from,
         address borrower,

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -132,7 +132,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
 
         vm.expectEmit(true, true, false, true);
         emit AddQuoteToken(from, index, (amount / quoteTokenScale) * quoteTokenScale, lpAward, newLup);
-        _assertTokenTransferEvent(from, address(_pool), amount);
+        _assertQuoteTokenTransferEvent(from, address(_pool), amount);
         _pool.addQuoteToken(amount, index);
 
         // Add for tearDown
@@ -224,7 +224,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit Kick(borrower, debt, collateral, bond);
-        if(transferAmount != 0) _assertTokenTransferEvent(from, address(_pool), transferAmount);
+        if(transferAmount != 0) _assertQuoteTokenTransferEvent(from, address(_pool), transferAmount);
         _pool.kick(borrower);
     }
 
@@ -244,7 +244,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         emit Kick(borrower, debt, collateral, bond);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, removedFromDeposit, removedFromDeposit * 1e9, lup);
-        if(transferAmount != 0) _assertTokenTransferEvent(from, address(_pool), transferAmount);
+        if(transferAmount != 0) _assertQuoteTokenTransferEvent(from, address(_pool), transferAmount);
         _pool.kickWithDeposit(index);
     }
 
@@ -293,7 +293,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amount, lpRedeem, newLup);
-        _assertTokenTransferEvent(address(_pool), from, amount);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
         (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, index);
         assertEq(removedAmount, amount);
         assertEq(lpRedeemed,    lpRedeem);
@@ -308,7 +308,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
         emit RemoveCollateral(from, index, amount, lpRedeem);
-        _assertTokenTransferEvent(address(_pool), from, amount);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
         (, lpRedeemed_) = _pool.removeCollateral(amount, index);
         assertEq(lpRedeemed_, lpRedeem);
     }
@@ -334,7 +334,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, amountRemoved, lpRedeem, newLup);
-        _assertTokenTransferEvent(address(_pool), from, amountRemoved);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amountRemoved);
         (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
         assertEq(removedAmount, amountRemoved);
         assertEq(lpRedeemed,    lpRedeem);
@@ -363,7 +363,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit Take(borrower, givenAmount, collateralTaken, bondChange, isReward);
-        _assertTokenTransferEvent(from, address(_pool), givenAmount);
+        _assertQuoteTokenTransferEvent(from, address(_pool), givenAmount);
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 
@@ -379,7 +379,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.takeReserves(amount);
     }
 
-    function _assertTokenTransferEvent(
+    function _assertQuoteTokenTransferEvent(
         address from,
         address to,
         uint256 amount

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -100,7 +100,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 amount,
         uint256 index
     ) internal {
-        _addLiquidity(from, amount, index, amount * 1e9, MAX_PRICE);
+        uint256 quoteTokenScale = IPool(address(_pool)).quoteTokenScale();
+        uint256 lpAmount        = (amount / quoteTokenScale) * quoteTokenScale * 1e9;
+        _addLiquidity(from, amount, index, lpAmount, MAX_PRICE);
     }
 
     // Adds liquidity with interest rate update
@@ -125,9 +127,11 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 lpAward,
         uint256 newLup
     ) internal {
+        uint256 quoteTokenScale = IPool(address(_pool)).quoteTokenScale();
         changePrank(from);
+
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(from, index, amount, lpAward, newLup);
+        emit AddQuoteToken(from, index, (amount / quoteTokenScale) * quoteTokenScale, lpAward, newLup);
         _assertTokenTransferEvent(from, address(_pool), amount);
         _pool.addQuoteToken(amount, index);
 


### PR DESCRIPTION
**Problem**
Because Ajna supports ERC20 collateral with less than 18 decimals, the user may deposit less than the token precision and wind up with an LP balance with 0 tokens in the bucket.  They could repeat this process to earn LP without transferring any tokens.  Similarly, borrowers can pledge a larger amount of collateral than allowed by the token scale, and their collateralization will be examined against the normalized amount entered by the borrower, rather than the actual collateral balance.  Similar issues with taking liquidations.

**Solution**
To resolve this, we shall establish dust limits and round inputs to the scaled value as appropriate.  For deposited collateral, the dust limit is a function of collateral scale and bucket price (where applicable).  For pledged collateral and liquidations, the dust limit is simply the scale.

**Performance**
Noticeable increase in size of ERC20Pool, bringing it closer to ERC721 pool size.  I do not understand why ERC721Pool got smaller.  Reference commit hash was fcb216717901722bc06a2983a7dbb25554d51caf, where I branched from.

```
============ develop Bytecode Sizes ============
  ERC721Pool               -  21,835B  (88.84%)
  Auctions                 -  19,918B  (81.04%)
  ERC20Pool                -  19,180B  (78.04%)


============ collateral-dust-limit Bytecode Sizes ============
  ERC721Pool               -  21,773B  (88.59%)
  ERC20Pool                -  21,073B  (85.74%)
  Auctions                 -  19,981B  (81.30%)
```

**Out of scope**
- I've considered restructuring token transfers such that we calculate the denormalized amount and rounded normalized amount ahead of time using a `prepareTransfer` function.  This would save an operation when we transfer at the end of the function, but it means adding a variable to the stack, which is undesirable.  Would also make sense to update a lot of implementation outside the scope of this PR.
- Another solution to dust reverts would be to round values up in situations where scaling down would produce a 0 value (or cause some other dust-related problem).  This seems undesirable because:
  - It could cause a dramatic difference in quantity (consider a value like 10^-18 being rounded up on a token with 4 decimal places.
  - When a user defines a quantity in normalized terms, rounding should never result in a transfer of more assets than they have explicitly requested.
  - Such a solution should be implemented consistently throughout the entire codebase, not just in a change which targets collateral precision.
- `make test-load` was broken in `develop` branch already; this does not fix it.
- Found and documented #499 while testing this change.