### PR TITLE
Liquidation fuzz test fix

### DIFF
--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -65,7 +65,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     function addLiquidity(uint256 startBucketId) internal {
         // ensure start bucket is in appropriate range
         assertGt(startBucketId, 0);
-        assertLt(startBucketId, 7388 - BUCKETS_WITH_DEPOSIT);
+        assertLt(startBucketId, 7385);
         _startBucketId = startBucketId;
 
         // deposit 200k quote token across 4 buckets
@@ -114,8 +114,9 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     function testLiquidationSingleBorrower(
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
-        uint16 startBucketId_) external tearDown
-    {
+        uint16 startBucketId_
+    ) external tearDown {
+
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 18, 18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1,  18);
         uint256 startBucketId       = bound(uint256(startBucketId_),               1,  7388 - BUCKETS_WITH_DEPOSIT);
@@ -163,8 +164,9 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
      function testLiquidationKickWithDeposit(
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
-        uint16 startBucketId_) external tearDown
-    {
+        uint16 startBucketId_
+    ) external tearDown {
+
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 18, 18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1,  18);
         uint256 startBucketId       = bound(uint256(startBucketId_),               1,  7388 - BUCKETS_WITH_DEPOSIT);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -65,7 +65,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     function addLiquidity(uint256 startBucketId) internal {
         // ensure start bucket is in appropriate range
         assertGt(startBucketId, 0);
-        assertLt(startBucketId, 7385);
+        assertLt(startBucketId, 7388 - BUCKETS_WITH_DEPOSIT + 1);
         _startBucketId = startBucketId;
 
         // deposit 200k quote token across 4 buckets


### PR DESCRIPTION
Check that start bucket is lower than index 7388 - BUCKETS_WITH_DEPOSIT + 1 = 7385, providing at least 4 buckets to add liquidity to
(this fix scenario where provided bucket index is 7383 but when bounded is 7384)