### PR TITLE
protect pool from being manipulated from take and flashLoan

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Caveats:
 make all
 ```
 
+### Implementation notes
+Pool external calls carry the `nonReentrant` modifier to prevent invocation from `flashLoan` and `take` callbacks.
+
 ## Tests
 ### Forge tests
 - run tests without the gas load tests (good for checking validity)

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -92,7 +92,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function addQuoteToken(
         uint256 quoteTokenAmountToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override nonReentrant returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
         uint256 newLup;
@@ -118,7 +118,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         address allowedNewOwner_,
         uint256 index_,
         uint256 lpsAmountToApprove_
-    ) external {
+    ) external nonReentrant {
         _lpTokenAllowances[msg.sender][allowedNewOwner_][index_] = lpsAmountToApprove_;
     }
 
@@ -127,7 +127,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 maxAmountToMove_,
         uint256 fromIndex_,
         uint256 toIndex_
-    ) external override returns (uint256 fromBucketLPs_, uint256 toBucketLPs_) {
+    ) external override nonReentrant returns (uint256 fromBucketLPs_, uint256 toBucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
         _revertIfAuctionDebtLocked(deposits, poolBalances, fromIndex_, poolState.inflator);
@@ -157,7 +157,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function removeQuoteToken(
         uint256 maxAmount_,
         uint256 index_
-    ) external override returns (uint256 removedAmount_, uint256 redeemedLPs_) {
+    ) external override nonReentrant returns (uint256 removedAmount_, uint256 redeemedLPs_) {
         _revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
@@ -192,7 +192,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         address owner_,
         address newOwner_,
         uint256[] calldata indexes_
-    ) external override {
+    ) external override nonReentrant {
         LenderActions.transferLPTokens(
             buckets,
             _lpTokenAllowances,
@@ -207,7 +207,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*****************************/
 
     /// @inheritdoc IPoolLiquidationActions
-    function kick(address borrowerAddress_) external override {
+    function kick(address borrowerAddress_) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         // kick auction
@@ -233,7 +233,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /// @inheritdoc IPoolLiquidationActions
     function kickWithDeposit(
         uint256 index_
-    ) external override {
+    ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         // kick auctions
@@ -270,7 +270,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /*********************************/
 
     /// @inheritdoc IPoolReserveAuctionActions
-    function startClaimableReserveAuction() external override {
+    function startClaimableReserveAuction() external override nonReentrant {
         // retrieve timestamp of latest burn event and last burn timestamp
         uint256 latestBurnEpoch   = reserveAuction.latestBurnEventEpoch;
         uint256 lastBurnTimestamp = reserveAuction.burnEvents[latestBurnEpoch].timestamp;
@@ -303,7 +303,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     /// @inheritdoc IPoolReserveAuctionActions
-    function takeReserves(uint256 maxAmount_) external override returns (uint256 amount_) {
+    function takeReserves(uint256 maxAmount_) external override nonReentrant returns (uint256 amount_) {
         uint256 ajnaRequired;
         (amount_, ajnaRequired) = Auctions.takeReserves(
             reserveAuction,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -60,7 +60,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         uint256 amountToBorrow_,
         uint256 limitIndex_,
         uint256 collateralToPledge_
-    ) external {
+    ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         DrawDebtResult memory result = BorrowerActions.drawDebt(
@@ -108,7 +108,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
         uint256 collateralAmountToPull_
-    ) external {
+    ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
@@ -200,7 +200,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function addCollateral(
         uint256 collateralAmountToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override nonReentrant returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
         bucketLPs_ = LenderActions.addCollateral(
@@ -223,7 +223,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function removeCollateral(
         uint256 maxAmount_,
         uint256 index_
-    ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
+    ) external override nonReentrant returns (uint256 collateralAmount_, uint256 lpAmount_) {
         _revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
@@ -252,7 +252,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external override {
+    ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getPoolQuoteTokenBalance();
@@ -347,7 +347,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
-    ) external override {
+    ) external override nonReentrant {
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -78,7 +78,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256 amountToBorrow_,
         uint256 limitIndex_,
         uint256[] calldata tokenIdsToPledge_
-    ) external {
+    ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         DrawDebtResult memory result = BorrowerActions.drawDebt(
@@ -128,7 +128,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
         uint256 noOfNFTsToPull_
-    ) external {
+    ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
@@ -178,7 +178,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     function addCollateral(
         uint256[] calldata tokenIdsToAdd_,
         uint256 index_
-    ) external override returns (uint256 bucketLPs_) {
+    ) external override nonReentrant returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
         bucketLPs_ = LenderActions.addCollateral(
@@ -202,7 +202,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         uint256[] calldata removalIndexes_,
         uint256 noOfNFTsToRemove_,
         uint256 toIndex_
-    ) external override returns (uint256 collateralMerged_, uint256 bucketLPs_) {
+    ) external override nonReentrant returns (uint256 collateralMerged_, uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
         uint256 collateralAmount = Maths.wad(noOfNFTsToRemove_);
 
@@ -233,7 +233,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     function removeCollateral(
         uint256 noOfNFTsToRemove_,
         uint256 index_
-    ) external override returns (uint256 collateralAmount_, uint256 lpAmount_) {
+    ) external override nonReentrant returns (uint256 collateralAmount_, uint256 lpAmount_) {
         _revertIfAuctionClearable(auctions, loans);
 
         PoolState memory poolState = _accruePoolInterest();
@@ -262,7 +262,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external override {
+    ) external nonReentrant override {
         PoolState memory poolState = _accruePoolInterest();
 
         uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getPoolQuoteTokenBalance();
@@ -373,7 +373,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
         address borrowerAddress_,
         bool    depositTake_,
         uint256 index_
-    ) external override {
+    ) external override nonReentrant {
 
         PoolState memory poolState = _accruePoolInterest();
 


### PR DESCRIPTION
Evolved out of my task to document why we use it in `take` and `flashLoan`.  We need to protect all external pool calls.