### PR TITLE
Collateral balance invariant test, eliminate take/repay collateral dust reverts

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -118,13 +118,16 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     ) external override nonReentrant returns (uint256 bucketLPs_) {
         PoolState memory poolState = _accruePoolInterest();
 
+        // round to token precision
+        quoteTokenAmountToAdd_ = _roundToScale(quoteTokenAmountToAdd_, poolState.quoteDustLimit);
+
         uint256 newLup;
         (bucketLPs_, newLup) = LenderActions.addQuoteToken(
             buckets,
             deposits,
             poolState,
             AddQuoteParams({
-                amount: _roundToScale(quoteTokenAmountToAdd_, poolState.quoteDustLimit),
+                amount: quoteTokenAmountToAdd_,
                 index:  index_
             })
         );

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -156,19 +156,20 @@ import { Maths }   from 'src/libraries/Maths.sol';
 
     /**
      *  @notice Price precision adjustment used in calculating collateral dust for a bucket.
-     *          To ensure the accuracy of the exchange rate calculation, buckets with smaller prices require 
+     *          To ensure the accuracy of the exchange rate calculation, buckets with smaller prices require
      *          larger minimum amounts of collateral.  This formula imposes a lower bound independent of token scale.
-     *  @param  bucketIndex_ Index of the bucket, or 0 for encumbered collateral with no bucket affinity.
-     *  @return Unscaled integer of the minimum number of decimal places the dust limit requires.
+     *  @param  bucketIndex_              Index of the bucket, or 0 for encumbered collateral with no bucket affinity.
+     *  @return pricePrecisionAdjustment_ Unscaled integer of the minimum number of decimal places the dust limit requires.
      */
     function _getCollateralDustPricePrecisionAdjustment(
         uint256 bucketIndex_
-    ) pure returns (uint256) {
-        // conditional is a gas optimization; formula also returns 0 in this case
-        if (bucketIndex_ <= 3900) return 0;
-        int256 bucketOffset = int256(bucketIndex_ - 3900);
-        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(bucketOffset * 1e18, int256(36 * 1e18)));
-        return uint256(result / 1e18);
+    ) pure returns (uint256 pricePrecisionAdjustment_) {
+        // conditional is a gas optimization
+        if (bucketIndex_ > 3900) {
+            int256 bucketOffset = int256(bucketIndex_ - 3900);
+            int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(bucketOffset * 1e18, int256(36 * 1e18)));
+            pricePrecisionAdjustment_ = uint256(result / 1e18);
+        }
     }
 
     /**

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -238,6 +238,19 @@ import { Maths }   from 'src/libraries/Maths.sol';
         scaledAmount_ = (amount_ / tokenScale_) * tokenScale_;
     }
 
+    /**
+     *  @notice Rounds a token amount up to the next amount permissible by the token scale.
+     *  @param  amount_       Value to be rounded.
+     *  @param  tokenScale_   Scale of the token, presented as a power of 10.
+     *  @return scaledAmount_ Rounded value.
+     */
+    function _roundUpToScale(
+        uint256 amount_,
+        uint256 tokenScale_
+    ) pure returns (uint256 scaledAmount_) {
+        scaledAmount_ = _roundToScale(amount_, tokenScale_) + tokenScale_;
+    }
+    
     /*********************************/
     /*** Reserve Auction Utilities ***/
     /*********************************/

--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -248,9 +248,12 @@ import { Maths }   from 'src/libraries/Maths.sol';
         uint256 amount_,
         uint256 tokenScale_
     ) pure returns (uint256 scaledAmount_) {
-        scaledAmount_ = _roundToScale(amount_, tokenScale_) + tokenScale_;
+        if (amount_ % tokenScale_ == 0)
+            scaledAmount_ = amount_;
+        else
+            scaledAmount_ = _roundToScale(amount_, tokenScale_) + tokenScale_;
     }
-    
+
     /*********************************/
     /*** Reserve Auction Utilities ***/
     /*********************************/

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -27,9 +27,13 @@ import {
     TakeResult
 } from 'src/base/interfaces/pool/IPoolInternals.sol';
 
-import { FlashloanablePool }                                         from 'src/base/FlashloanablePool.sol';
-import { _getCollateralDustPricePrecisionAdjustment, _roundToScale } from 'src/base/PoolHelper.sol';
-import { _revertIfAuctionClearable }                                 from 'src/base/RevertsHelper.sol';
+import { FlashloanablePool }         from 'src/base/FlashloanablePool.sol';
+import { 
+    _getCollateralDustPricePrecisionAdjustment, 
+    _roundToScale,
+    _roundUpToScale
+} from 'src/base/PoolHelper.sol';
+import { _revertIfAuctionClearable } from 'src/base/RevertsHelper.sol';
 
 import { Loans }    from 'src/libraries/Loans.sol';
 import { Deposits } from 'src/libraries/Deposits.sol';
@@ -360,8 +364,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             collateral_,
             collateralDust
         );
-        // prevent caller from requesting an amount of collateral which costs 0 quote token
-        if (result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE) == 0) revert DustAmountNotExceeded();
+        // round quote token up to cover the cost of purchasing the collateral
+        result.quoteTokenAmount = _roundUpToScale(result.quoteTokenAmount, _getArgUint256(QUOTE_SCALE));
 
         // update pool balances state
         uint256 t0PoolDebt      = poolBalances.t0Debt;

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -148,8 +148,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
-        // ensure collateral accounting is performed using the appropriate token scale
-        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _bucketCollateralDust(0));
+        // ensure accounting is performed using the appropriate token scale
+        maxQuoteTokenAmountToRepay_ = _roundToScale(maxQuoteTokenAmountToRepay_, _getArgUint256(QUOTE_SCALE));
+        collateralAmountToPull_     = _roundToScale(collateralAmountToPull_,     _bucketCollateralDust(0));
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -80,9 +80,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         return _getArgUint256(COLLATERAL_SCALE);
     }
 
-    /// @inheritdoc IERC20PoolImmutables
-    function collateralDust(uint256 bucketIndex) external view override returns (uint256) {
-        return _collateralDust(bucketIndex);
+    /// @inheritdoc IERC20Pool
+    function bucketCollateralDust(uint256 bucketIndex) external pure override returns (uint256) {
+        return _bucketCollateralDust(bucketIndex);
     }
 
     /***********************************/
@@ -99,7 +99,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure the borrower is not credited with a fractional amount of collateral smaller than the token scale
-        collateralToPledge_ = _roundToScale(collateralToPledge_, _collateralDust(0));
+        collateralToPledge_ = _roundToScale(collateralToPledge_, _bucketCollateralDust(0));
 
         DrawDebtResult memory result = BorrowerActions.drawDebt(
             auctions,
@@ -149,7 +149,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure collateral accounting is performed using the appropriate token scale
-        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _collateralDust(0));
+        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _bucketCollateralDust(0));
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,
@@ -244,7 +244,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // revert if the dust amount was not exceeded, but round on the scale amount
-        if (amountToAdd_ != 0 && amountToAdd_ < _collateralDust(index_)) revert DustAmountNotExceeded();
+        if (amountToAdd_ != 0 && amountToAdd_ < _bucketCollateralDust(index_)) revert DustAmountNotExceeded();
+
         amountToAdd_ = _roundToScale(amountToAdd_, _getArgUint256(COLLATERAL_SCALE));
 
         bucketLPs_ = LenderActions.addCollateral(
@@ -277,7 +278,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             deposits,
             maxAmount_,
             index_,
-            _collateralDust(index_)
+            _bucketCollateralDust(index_)
         );
 
         emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);
@@ -343,8 +344,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        uint256 collateralDust = _bucketCollateralDust(0);
+
         // round requested collateral to an amount which can actually be transferred
-        collateral_ = _roundToScale(collateral_, _collateralDust(0));
+        collateral_ = _roundToScale(collateral_, collateralDust);
 
         TakeResult memory result = Auctions.take(
             auctions,
@@ -354,7 +357,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             collateral_,
-            _collateralDust(0)
+            collateralDust
         );
         // prevent caller from requesting an amount of collateral which costs 0 quote token
         if (result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE) == 0) revert DustAmountNotExceeded();
@@ -411,7 +414,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             borrowerAddress_,
             depositTake_,
             index_,
-            _collateralDust(0)
+            _bucketCollateralDust(0)
         );
 
         // update pool balances state
@@ -448,11 +451,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         IERC20(_getArgAddress(COLLATERAL_ADDRESS)).safeTransfer(to_, amount_ / _getArgUint256(COLLATERAL_SCALE));
     }
 
-    function _collateralDust(uint256 bucketIndex) internal view returns (uint256) {
+    function _bucketCollateralDust(uint256 bucketIndex) internal pure returns (uint256) {
         // price precision adjustment will always be 0 for encumbered collateral
         uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
         // difference between the normalized scale and the collateral token's scale
-        uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
-        return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
+        return Maths.max(_getArgUint256(COLLATERAL_SCALE), 10 ** pricePrecisionAdjustment);
     } 
 }

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -148,6 +148,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        // ensure collateral accounting is performed using the appropriate token scale
+        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _collateralDust(0));
+
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,
             buckets,
@@ -156,8 +159,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             maxQuoteTokenAmountToRepay_,
-            collateralAmountToPull_,
-            _collateralDust(0)
+            collateralAmountToPull_
         );
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, collateralAmountToPull_, result.newLup);
@@ -341,6 +343,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        // round requested collateral to an amount which can actually be transferred
+        collateral_ = _roundToScale(collateral_, _collateralDust(0));
+
         TakeResult memory result = Auctions.take(
             auctions,
             buckets,
@@ -405,7 +410,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             depositTake_,
-            index_
+            index_,
+            _collateralDust(0)
         );
 
         // update pool balances state

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -25,4 +25,13 @@ interface IERC20Pool is
      */
     function initialize(uint256 rate) external;
 
+    /**
+     *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
+     *  @param  bucketIndex The bucket index for which the dust limit is desired, or 0 for pledged collateral.
+     *  @return The dust limit for `bucketIndex`.
+     */
+    function bucketCollateralDust(
+        uint256 bucketIndex
+    ) external pure returns (uint256);
+
 }

--- a/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
@@ -13,10 +13,4 @@ interface IERC20PoolImmutables {
      */
     function collateralScale() external view returns (uint256);
 
-    /**
-     *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
-     *  @param  bucketIndex The bucket index for which the dust limit is desired, or 0 for pledged collateral.
-     *  @return The dust limit for `bucketIndex`.
-     */
-    function collateralDust(uint256 bucketIndex) external view returns (uint256);
 }

--- a/src/erc721/ERC721Pool.sol
+++ b/src/erc721/ERC721Pool.sol
@@ -168,8 +168,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             maxQuoteTokenAmountToRepay_,
-            Maths.wad(noOfNFTsToPull_),
-            0
+            Maths.wad(noOfNFTsToPull_)
         );
 
         emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, noOfNFTsToPull_, result.newLup);
@@ -351,7 +350,7 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             Maths.wad(collateral_),
-            0
+            1
         );
 
         // update pool balances state
@@ -416,7 +415,8 @@ contract ERC721Pool is IERC721Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             depositTake_,
-            index_
+            index_,
+            1
         );
 
         // update pool balances state

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -56,10 +56,6 @@ library BorrowerActions {
      */
     error BorrowerUnderCollateralized();
     /**
-     *  @notice User attempted a deposit which does not exceed the dust amount, or a withdrawal which leaves behind less than the dust amount.
-     */
-    error DustAmountNotExceeded();
-    /**
      *  @notice User is attempting to move or pull more collateral than is available.
      */
     error InsufficientCollateral();
@@ -194,8 +190,7 @@ library BorrowerActions {
         PoolState calldata poolState_,
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 collateralAmountToPull_,
-        uint256 collateralDustLimit_
+        uint256 collateralAmountToPull_
     ) external returns (
         RepayDebtResult memory result_
     ) {
@@ -277,9 +272,6 @@ library BorrowerActions {
 
             borrower.collateral    -= collateralAmountToPull_;
             result_.poolCollateral -= collateralAmountToPull_;
-
-            // ensure borrower does not leave behind a collateral balance which cannot be pulled
-            if (borrower.collateral != 0 && borrower.collateral < collateralDustLimit_) revert DustAmountNotExceeded();
         }
 
         // calculate LUP if repay is called with 0 amount

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -519,17 +519,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).repayDebt(borrower, 0, amount);
     }
 
-    function _assertRepayDustRevert(
-        address from,
-        address borrower,
-        uint256 amountToRepay,
-        uint256 collateralToPull
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        ERC20Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
-    }
-
     function _assertRepayMinDebtRevert(
         address from,
         address borrower,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -208,13 +208,6 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
                 _assertTakeDustRevert(_bidder, _borrower, takeAmount);
         }
 
-        // test a take which leaves less than a dust amount of collateral
-        (, uint256 collateralAvailable, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
-        if (collateralDust != 1) {
-            takeAmount = collateralAvailable - collateralDust / 2;
-            _assertTakeDustRevert(_bidder, _borrower, takeAmount);
-        }
-
         // settle the auction without any legitimate takes
         (auctionPrice, auctionDebt, auctionCollateral) = _advanceAuction(72 hours);
         assertEq(auctionPrice, 0);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -172,7 +172,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         _settle();
     }
 
-    function testDustyTake(
+    function testSettleAuctionWithoutTakes(
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
         uint16 startBucketId_) external tearDown
@@ -198,15 +198,6 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         assertGt(auctionPrice, 0);
         assertGt(auctionDebt, 0);
         assertGt(auctionCollateral, collateralDust);
-
-        // if collateral precision higher than quote token precision, test a take which costs 0 quote token
-        uint256 takeAmount;
-        if (boundColPrecision > boundQuotePrecision) {
-            takeAmount = collateralDust;
-            uint256 costOfTake = _roundToScale(Maths.wmul(auctionPrice, takeAmount), _pool.quoteTokenScale());
-            if (costOfTake == 0)
-                _assertTakeDustRevert(_bidder, _borrower, takeAmount);
-        }
 
         // settle the auction without any legitimate takes
         (auctionPrice, auctionDebt, auctionCollateral) = _advanceAuction(72 hours);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -182,7 +182,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint256 startBucketId       = bound(uint256(startBucketId_),               1000, 6388);
         init(boundColPrecision, boundQuotePrecision);
         addLiquidity(startBucketId);
-        uint256 collateralDust = ERC20Pool(address(_pool)).collateralDust(0);
+        uint256 collateralDust = ERC20Pool(address(_pool)).bucketCollateralDust(0);
 
         // Borrow everything from the first bucket, with origination fee tapping into the second bucket
         drawDebt(_borrower, 50_000 * 1e18, 1.01 * 1e18);

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -255,7 +255,10 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         }
     }
 
-    function testBorrowRepayPrecision(uint8 collateralPrecisionDecimals_, uint8 quotePrecisionDecimals_) external virtual tearDown {
+    function testBorrowRepayPrecision(
+        uint8 collateralPrecisionDecimals_, 
+        uint8 quotePrecisionDecimals_
+    ) external tearDown {
         // setup fuzzy bounds and initialize the pool
         uint256 boundColPrecision = bound(uint256(collateralPrecisionDecimals_), 1, 18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_), 1, 18);

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -222,7 +222,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         uint256 quoteDecimals      = bound(uint256(quotePrecisionDecimals_),      1, 18);
         uint256 bucketId           = bound(uint256(bucketId_),                    1, 7388);
         init(collateralDecimals, quoteDecimals);
-        uint256 collateralDust = ERC20Pool(address(_pool)).collateralDust(bucketId);
+        uint256 collateralDust = ERC20Pool(address(_pool)).bucketCollateralDust(bucketId);
 
         // put some deposit in the bucket
         _addInitialLiquidity({
@@ -515,7 +515,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         uint256 scaledQuoteAmount = (quoteAmount / 10 ** (18 - boundQuotePrecision)) * 10 ** (18 - boundQuotePrecision);
         uint256 scaledColAmount   = (collateralAmount / 10 ** (18 - boundColPrecision)) * 10 ** (18 - boundColPrecision);
-        uint256 colDustAmount     = ERC20Pool(address(_pool)).collateralDust(bucketId);
+        uint256 colDustAmount     = ERC20Pool(address(_pool)).bucketCollateralDust(bucketId);
 
         assertEq(ERC20Pool(address(_pool)).collateralScale(), 10 ** (18 - boundColPrecision));
         assertEq(_pool.quoteTokenScale(), 10 ** (18 - boundQuotePrecision));
@@ -786,24 +786,24 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // check dust limits for 18-decimal collateral
         init(18, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(4166), 100);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(4166), 100);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
 
         // check dust limits for 12-decimal collateral
         init(12, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(6466), 100000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(6466), 100000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
 
         // check dust limits for 6-decimal collateral
         init(6, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(4156), 1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(4156), 1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000000);
     }
 
     function testDrawDebtPrecision(

--- a/tests/forge/PoolHelperTest.t.sol
+++ b/tests/forge/PoolHelperTest.t.sol
@@ -147,6 +147,10 @@ contract PoolHelperTest is DSTestPlus {
         uint256 nine_and_two_thirds = 9 * 1e18 + Maths.wdiv(2 * 1e18, 3 * 1e18);
         assertEq(_roundToScale(nine_and_two_thirds, tokenScale),   9.666666 * 1e18);
         assertEq(_roundUpToScale(nine_and_two_thirds, tokenScale), 9.666667 * 1e18);
+
+        uint256 five = 5 * 1e18;
+        assertEq(_roundToScale(five, tokenScale),   5 * 1e18);
+        assertEq(_roundUpToScale(five, tokenScale), 5 * 1e18);
     }
 
     function _assertBucketIndexOutOfBoundsRevert(uint256 index) internal {

--- a/tests/forge/PoolHelperTest.t.sol
+++ b/tests/forge/PoolHelperTest.t.sol
@@ -133,6 +133,22 @@ contract PoolHelperTest is DSTestPlus {
         assertEq(_minDebtAmount(0, loansCount),    0);
     }
 
+    /**
+     *  @notice Tests facilities used for rounding token amounts to decimal places supported by the token
+     */
+    function testRounding() external {
+        uint256 decimals   = 6;
+        uint256 tokenScale = 10 ** (18-decimals);
+
+        uint256 one_third = Maths.wdiv(1 * 1e18, 3 * 1e18);
+        assertEq(_roundToScale(one_third, tokenScale),   0.333333 * 1e18);
+        assertEq(_roundUpToScale(one_third, tokenScale), 0.333334 * 1e18);
+
+        uint256 nine_and_two_thirds = 9 * 1e18 + Maths.wdiv(2 * 1e18, 3 * 1e18);
+        assertEq(_roundToScale(nine_and_two_thirds, tokenScale),   9.666666 * 1e18);
+        assertEq(_roundUpToScale(nine_and_two_thirds, tokenScale), 9.666667 * 1e18);
+    }
+
     function _assertBucketIndexOutOfBoundsRevert(uint256 index) internal {
         vm.expectRevert(BucketIndexOutOfBounds.selector);
         _priceAt(index);

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -53,7 +53,7 @@ contract BalancerUniswapTaker {
 
         // take auction from Ajna pool, give USDC, receive WETH
         IAjnaPool(decoded.ajnaPool).take(decoded.borrower, decoded.maxAmount, address(this), new bytes(0));
-        uint256 usdcBalanceAfterTake = 85496539;
+        uint256 usdcBalanceAfterTake = 85496538;
         assert(tokens[0].balanceOf(address(this)) == usdcBalanceAfterTake); // USDC balance after Ajna take
         assert(tokens[1].balanceOf(address(this)) == 2000000000000000000);  // WETH balance after Ajna take
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1175,16 +1175,6 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 
-    function _assertTakeDustRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        _pool.take(borrower, maxCollateral, from, new bytes(0));
-    }
-
     function _assertTakeInsufficentCollateralRevert(
         address from,
         address borrower,


### PR DESCRIPTION
I implemented a facility which ties out collateral amounts in buckets and pledged by borrowers with the pool contract's collateral balance.  In doing so, I found problems handling non-18-decimal collateral types.  I concluded it would be cleaner to ensure pool accounting always deals with values rounded to the collateral scale.  This enabled me to eliminate `take` and `repay` dust reverts.  I also had to meddle with the `bucketTake` accounting to ensure `_calculateTakeFlowsAndBondChange` was rounding collateral amounts appropriately.