### PR TITLE
Proposed changes:

### DIFF
--- a/src/base/PoolHelper.sol
+++ b/src/base/PoolHelper.sol
@@ -156,19 +156,20 @@ import { Maths }   from 'src/libraries/Maths.sol';
 
     /**
      *  @notice Price precision adjustment used in calculating collateral dust for a bucket.
-     *          To ensure the accuracy of the exchange rate calculation, buckets with smaller prices require 
+     *          To ensure the accuracy of the exchange rate calculation, buckets with smaller prices require
      *          larger minimum amounts of collateral.  This formula imposes a lower bound independent of token scale.
-     *  @param  bucketIndex_ Index of the bucket, or 0 for encumbered collateral with no bucket affinity.
-     *  @return Unscaled integer of the minimum number of decimal places the dust limit requires.
+     *  @param  bucketIndex_              Index of the bucket, or 0 for encumbered collateral with no bucket affinity.
+     *  @return pricePrecisionAdjustment_ Unscaled integer of the minimum number of decimal places the dust limit requires.
      */
     function _getCollateralDustPricePrecisionAdjustment(
         uint256 bucketIndex_
-    ) pure returns (uint256) {
-        // conditional is a gas optimization; formula also returns 0 in this case
-        if (bucketIndex_ <= 3900) return 0;
-        int256 bucketOffset = int256(bucketIndex_ - 3900);
-        int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(bucketOffset * 1e18, int256(36 * 1e18)));
-        return uint256(result / 1e18);
+    ) pure returns (uint256 pricePrecisionAdjustment_) {
+        // conditional is a gas optimization
+        if (bucketIndex_ > 3900) {
+            int256 bucketOffset = int256(bucketIndex_ - 3900);
+            int256 result = PRBMathSD59x18.sqrt(PRBMathSD59x18.div(bucketOffset * 1e18, int256(36 * 1e18)));
+            pricePrecisionAdjustment_ = uint256(result / 1e18);
+        }
     }
 
     /**

--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -80,9 +80,9 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         return _getArgUint256(COLLATERAL_SCALE);
     }
 
-    /// @inheritdoc IERC20PoolImmutables
-    function collateralDust(uint256 bucketIndex) external view override returns (uint256) {
-        return _collateralDust(bucketIndex);
+    /// @inheritdoc IERC20Pool
+    function bucketCollateralDust(uint256 bucketIndex) external pure override returns (uint256) {
+        return _bucketCollateralDust(bucketIndex);
     }
 
     /***********************************/
@@ -99,7 +99,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure the borrower is not credited with a fractional amount of collateral smaller than the token scale
-        collateralToPledge_ = _roundToScale(collateralToPledge_, _collateralDust(0));
+        collateralToPledge_ = _roundToScale(collateralToPledge_, _bucketCollateralDust(0));
 
         DrawDebtResult memory result = BorrowerActions.drawDebt(
             auctions,
@@ -149,7 +149,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure collateral accounting is performed using the appropriate token scale
-        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _collateralDust(0));
+        collateralAmountToPull_ = _roundToScale(collateralAmountToPull_, _bucketCollateralDust(0));
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,
@@ -244,7 +244,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         PoolState memory poolState = _accruePoolInterest();
 
         // revert if the dust amount was not exceeded, but round on the scale amount
-        if (amountToAdd_ != 0 && amountToAdd_ < _collateralDust(index_)) revert DustAmountNotExceeded();
+        if (amountToAdd_ != 0 && amountToAdd_ < _bucketCollateralDust(index_)) revert DustAmountNotExceeded();
+
         amountToAdd_ = _roundToScale(amountToAdd_, _getArgUint256(COLLATERAL_SCALE));
 
         bucketLPs_ = LenderActions.addCollateral(
@@ -277,7 +278,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             deposits,
             maxAmount_,
             index_,
-            _collateralDust(index_)
+            _bucketCollateralDust(index_)
         );
 
         emit RemoveCollateral(msg.sender, index_, collateralAmount_, lpAmount_);
@@ -343,8 +344,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        uint256 collateralDust = _bucketCollateralDust(0);
+
         // round requested collateral to an amount which can actually be transferred
-        collateral_ = _roundToScale(collateral_, _collateralDust(0));
+        collateral_ = _roundToScale(collateral_, collateralDust);
 
         TakeResult memory result = Auctions.take(
             auctions,
@@ -354,7 +357,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             poolState,
             borrowerAddress_,
             collateral_,
-            _collateralDust(0)
+            collateralDust
         );
         // prevent caller from requesting an amount of collateral which costs 0 quote token
         if (result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE) == 0) revert DustAmountNotExceeded();
@@ -411,7 +414,7 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             borrowerAddress_,
             depositTake_,
             index_,
-            _collateralDust(0)
+            _bucketCollateralDust(0)
         );
 
         // update pool balances state
@@ -448,11 +451,10 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
         IERC20(_getArgAddress(COLLATERAL_ADDRESS)).safeTransfer(to_, amount_ / _getArgUint256(COLLATERAL_SCALE));
     }
 
-    function _collateralDust(uint256 bucketIndex) internal view returns (uint256) {
+    function _bucketCollateralDust(uint256 bucketIndex) internal pure returns (uint256) {
         // price precision adjustment will always be 0 for encumbered collateral
         uint256 pricePrecisionAdjustment = _getCollateralDustPricePrecisionAdjustment(bucketIndex);
         // difference between the normalized scale and the collateral token's scale
-        uint256 scaleExponent            = 18 - IERC20Token(_getArgAddress(COLLATERAL_ADDRESS)).decimals();
-        return 10 ** Maths.max(scaleExponent, pricePrecisionAdjustment);
+        return Maths.max(_getArgUint256(COLLATERAL_SCALE), 10 ** pricePrecisionAdjustment);
     } 
 }

--- a/src/erc20/interfaces/IERC20Pool.sol
+++ b/src/erc20/interfaces/IERC20Pool.sol
@@ -25,4 +25,13 @@ interface IERC20Pool is
      */
     function initialize(uint256 rate) external;
 
+    /**
+     *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
+     *  @param  bucketIndex The bucket index for which the dust limit is desired, or 0 for pledged collateral.
+     *  @return The dust limit for `bucketIndex`.
+     */
+    function bucketCollateralDust(
+        uint256 bucketIndex
+    ) external pure returns (uint256);
+
 }

--- a/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
+++ b/src/erc20/interfaces/pool/IERC20PoolImmutables.sol
@@ -13,10 +13,4 @@ interface IERC20PoolImmutables {
      */
     function collateralScale() external view returns (uint256);
 
-    /**
-     *  @notice Returns the minimum amount of collateral an actor may have in a bucket.
-     *  @param  bucketIndex The bucket index for which the dust limit is desired, or 0 for pledged collateral.
-     *  @return The dust limit for `bucketIndex`.
-     */
-    function collateralDust(uint256 bucketIndex) external view returns (uint256);
 }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -182,7 +182,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint256 startBucketId       = bound(uint256(startBucketId_),               1000, 6388);
         init(boundColPrecision, boundQuotePrecision);
         addLiquidity(startBucketId);
-        uint256 collateralDust = ERC20Pool(address(_pool)).collateralDust(0);
+        uint256 collateralDust = ERC20Pool(address(_pool)).bucketCollateralDust(0);
 
         // Borrow everything from the first bucket, with origination fee tapping into the second bucket
         drawDebt(_borrower, 50_000 * 1e18, 1.01 * 1e18);

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -222,7 +222,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         uint256 quoteDecimals      = bound(uint256(quotePrecisionDecimals_),      1, 18);
         uint256 bucketId           = bound(uint256(bucketId_),                    1, 7388);
         init(collateralDecimals, quoteDecimals);
-        uint256 collateralDust = ERC20Pool(address(_pool)).collateralDust(bucketId);
+        uint256 collateralDust = ERC20Pool(address(_pool)).bucketCollateralDust(bucketId);
 
         // put some deposit in the bucket
         _addInitialLiquidity({
@@ -515,7 +515,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         uint256 scaledQuoteAmount = (quoteAmount / 10 ** (18 - boundQuotePrecision)) * 10 ** (18 - boundQuotePrecision);
         uint256 scaledColAmount   = (collateralAmount / 10 ** (18 - boundColPrecision)) * 10 ** (18 - boundColPrecision);
-        uint256 colDustAmount     = ERC20Pool(address(_pool)).collateralDust(bucketId);
+        uint256 colDustAmount     = ERC20Pool(address(_pool)).bucketCollateralDust(bucketId);
 
         assertEq(ERC20Pool(address(_pool)).collateralScale(), 10 ** (18 - boundColPrecision));
         assertEq(_pool.quoteTokenScale(), 10 ** (18 - boundQuotePrecision));
@@ -786,24 +786,24 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // check dust limits for 18-decimal collateral
         init(18, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(4166), 100);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(4166), 100);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
 
         // check dust limits for 12-decimal collateral
         init(12, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(6466), 100000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(6466), 100000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
 
         // check dust limits for 6-decimal collateral
         init(6, 18);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(0),    1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(1),    1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(4156), 1000000000000);
-        assertEq(IERC20Pool(address(_pool)).collateralDust(7388), 1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(0),    1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(4156), 1000000000000);
+        assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000000);
     }
 
     function testDrawDebtPrecision(


### PR DESCRIPTION
- rename _collateralDust to _bucketCollateralDust for clarity
- slightly change of _getCollateralDustPricePrecisionAdjustment conditional
- use immutable COLLATERAL_SCALE instead recalculating scale exponent
- move bucketCollateralDust function from immutables interface to IERC20Pool interface
- calculate bucket collateral dust only once in take function