### PR TITLE
Eliminate the dusty take revert

### DIFF
--- a/src/erc20/ERC20Pool.sol
+++ b/src/erc20/ERC20Pool.sol
@@ -27,9 +27,13 @@ import {
     TakeResult
 } from 'src/base/interfaces/pool/IPoolInternals.sol';
 
-import { FlashloanablePool }                                         from 'src/base/FlashloanablePool.sol';
-import { _getCollateralDustPricePrecisionAdjustment, _roundToScale } from 'src/base/PoolHelper.sol';
-import { _revertIfAuctionClearable }                                 from 'src/base/RevertsHelper.sol';
+import { FlashloanablePool }         from 'src/base/FlashloanablePool.sol';
+import { 
+    _getCollateralDustPricePrecisionAdjustment, 
+    _roundToScale,
+    _roundUpToScale
+} from 'src/base/PoolHelper.sol';
+import { _revertIfAuctionClearable } from 'src/base/RevertsHelper.sol';
 
 import { Loans }    from 'src/libraries/Loans.sol';
 import { Deposits } from 'src/libraries/Deposits.sol';
@@ -360,8 +364,8 @@ contract ERC20Pool is IERC20Pool, FlashloanablePool {
             collateral_,
             collateralDust
         );
-        // prevent caller from requesting an amount of collateral which costs 0 quote token
-        if (result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE) == 0) revert DustAmountNotExceeded();
+        // round quote token up to cover the cost of purchasing the collateral
+        result.quoteTokenAmount = _roundUpToScale(result.quoteTokenAmount, _getArgUint256(QUOTE_SCALE));
 
         // update pool balances state
         uint256 t0PoolDebt      = poolBalances.t0Debt;

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -172,7 +172,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         _settle();
     }
 
-    function testDustyTake(
+    function testSettleAuctionWithoutTakes(
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
         uint16 startBucketId_) external tearDown
@@ -198,15 +198,6 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         assertGt(auctionPrice, 0);
         assertGt(auctionDebt, 0);
         assertGt(auctionCollateral, collateralDust);
-
-        // if collateral precision higher than quote token precision, test a take which costs 0 quote token
-        uint256 takeAmount;
-        if (boundColPrecision > boundQuotePrecision) {
-            takeAmount = collateralDust;
-            uint256 costOfTake = _roundToScale(Maths.wmul(auctionPrice, takeAmount), _pool.quoteTokenScale());
-            if (costOfTake == 0)
-                _assertTakeDustRevert(_bidder, _borrower, takeAmount);
-        }
 
         // settle the auction without any legitimate takes
         (auctionPrice, auctionDebt, auctionCollateral) = _advanceAuction(72 hours);

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -53,7 +53,7 @@ contract BalancerUniswapTaker {
 
         // take auction from Ajna pool, give USDC, receive WETH
         IAjnaPool(decoded.ajnaPool).take(decoded.borrower, decoded.maxAmount, address(this), new bytes(0));
-        uint256 usdcBalanceAfterTake = 85496539;
+        uint256 usdcBalanceAfterTake = 85496538;
         assert(tokens[0].balanceOf(address(this)) == usdcBalanceAfterTake); // USDC balance after Ajna take
         assert(tokens[1].balanceOf(address(this)) == 2000000000000000000);  // WETH balance after Ajna take
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1175,16 +1175,6 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.take(borrower, maxCollateral, from, new bytes(0));
     }
 
-    function _assertTakeDustRevert(
-        address from,
-        address borrower,
-        uint256 maxCollateral
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        _pool.take(borrower, maxCollateral, from, new bytes(0));
-    }
-
     function _assertTakeInsufficentCollateralRevert(
         address from,
         address borrower,


### PR DESCRIPTION
Instead of reverting on a dusty `take`, round up the quote token amount.  Note this doesn't actually credit the borrower with the exact amount of quote token transferred, because doing so would add significant complexity.

Note the supporting logic for this change is in [collateral-balance-test](https://github.com/ajna-finance/contracts/tree/collateral-balance-test) branch.