### PR TITLE
repay all using uint256.max

### DIFF
--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -258,11 +258,14 @@ library BorrowerActions {
         if (vars.repay) {
             if (borrower.t0Debt == 0) revert NoDebt();
 
-            // FIXME: division overflows when passed type(uint256).max
-            result_.t0RepaidDebt = Maths.min(
-                borrower.t0Debt,
-                Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState_.inflator)
-            );
+            if (maxQuoteTokenAmountToRepay_ == type(uint256).max) {
+                result_.t0RepaidDebt = borrower.t0Debt;
+            } else {
+                result_.t0RepaidDebt = Maths.min(
+                    borrower.t0Debt,
+                    Maths.wdiv(maxQuoteTokenAmountToRepay_, poolState_.inflator)
+                );
+            }
 
             result_.quoteTokenToRepay = Maths.wmul(result_.t0RepaidDebt, poolState_.inflator);
 

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1348,7 +1348,7 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         _repayDebt({
             from:             _borrower,
             borrower:         _borrower,
-            amountToRepay:    debt,
+            amountToRepay:    type(uint256).max,
             amountRepaid:     debt,
             collateralToPull: requiredCollateral,
             newLup:           _calculateLup(address(_pool), 0)

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -376,7 +376,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         _repayDebt({
             from:             _borrower,
             borrower:         _borrower,
-            amountToRepay:    1_508.860066921599065131 * 1e18,
+            amountToRepay:    type(uint256).max,
             amountRepaid:     1_508.860066921599065131 * 1e18,
             collateralToPull: 3,
             newLup:           MAX_PRICE


### PR DESCRIPTION
Previous implementation overflowed trying to divide by the inflator.

Resolves #499 .