### PR TITLE
Settle gas optimization

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -214,13 +214,9 @@ library Auctions {
         while (params_.bucketDepth != 0 && borrower.t0Debt != 0 && borrower.collateral != 0) {
             SettleLocalVars memory vars;
 
-            {
-                (uint256 sumIndex, , uint256 sumIndexScale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
-                vars.index           = sumIndex;
-                vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
-                vars.scale           = sumIndexScale;
-                vars.price           = _priceAt(vars.index);
-            }
+            (vars.index, , vars.scale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
+            vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
+            vars.price           = _priceAt(vars.index);
 
             if (vars.unscaledDeposit != 0) {
                 vars.debt              = Maths.wmul(borrower.t0Debt, params_.inflator);       // current debt to be settled
@@ -281,14 +277,10 @@ library Auctions {
             while (params_.bucketDepth != 0 && borrower.t0Debt != 0) {
                 SettleLocalVars memory vars;
 
-                {
-                    (uint256 sumIndex, , uint256 sumIndexScale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
-                    vars.index           = sumIndex;
-                    vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
-                    vars.scale           = sumIndexScale;
-                    vars.depositToRemove = Maths.wmul(vars.scale, vars.unscaledDeposit);
-                    vars.debt            = Maths.wmul(borrower.t0Debt, params_.inflator);
-                }
+                (vars.index, , vars.scale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
+                vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
+                vars.depositToRemove = Maths.wmul(vars.scale, vars.unscaledDeposit);
+                vars.debt            = Maths.wmul(borrower.t0Debt, params_.inflator);
 
                 // enough deposit in bucket to settle entire debt
                 if (vars.depositToRemove >= vars.debt) {

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -214,10 +214,13 @@ library Auctions {
         while (params_.bucketDepth != 0 && borrower.t0Debt != 0 && borrower.collateral != 0) {
             SettleLocalVars memory vars;
 
-            vars.index           = Deposits.findIndexOfSum(deposits_, 1);
-            vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
-            vars.scale           = Deposits.scale(deposits_, vars.index);
-            vars.price           = _priceAt(vars.index);
+            {
+                (uint256 sumIndex, , uint256 sumIndexScale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
+                vars.index           = sumIndex;
+                vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
+                vars.scale           = sumIndexScale;
+                vars.price           = _priceAt(vars.index);
+            }
 
             if (vars.unscaledDeposit != 0) {
                 vars.debt              = Maths.wmul(borrower.t0Debt, params_.inflator);       // current debt to be settled
@@ -278,11 +281,14 @@ library Auctions {
             while (params_.bucketDepth != 0 && borrower.t0Debt != 0) {
                 SettleLocalVars memory vars;
 
-                vars.index           = Deposits.findIndexOfSum(deposits_, 1);
-                vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
-                vars.scale           = Deposits.scale(deposits_, vars.index);
-                vars.depositToRemove = Maths.wmul(vars.scale, vars.unscaledDeposit);
-                vars.debt            = Maths.wmul(borrower.t0Debt, params_.inflator);
+                {
+                    (uint256 sumIndex, , uint256 sumIndexScale) = Deposits.findIndexAndSumOfSum(deposits_, 1);
+                    vars.index           = sumIndex;
+                    vars.unscaledDeposit = Deposits.unscaledValueAt(deposits_, vars.index);
+                    vars.scale           = sumIndexScale;
+                    vars.depositToRemove = Maths.wmul(vars.scale, vars.unscaledDeposit);
+                    vars.debt            = Maths.wmul(borrower.t0Debt, params_.inflator);
+                }
 
                 // enough deposit in bucket to settle entire debt
                 if (vars.depositToRemove >= vars.debt) {


### PR DESCRIPTION
Previous implementation was _O(3 log n)_; it hit the Fenwick tree three times:
- `Deposits.findIndexOfSum`
- getting the unscaled vaule at that index
- looking up the scale for the index

I used an existing method to combine the first and third into a single request, reducing this to _O(2 log n)_.


```
develop:
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| settle                               | 9573            | 207371 | 165881 | 418245 | 17      |

settle-gas-opt:
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| settle                               | 9573            | 200005 | 157352 | 408415 | 17      |
```