### PR TITLE
Nonfuzzy fill

### DIFF
--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -185,18 +185,46 @@ contract FenwickTreeTest is DSTestPlus {
         assertLe(subMax - subMin, 2);
     }
 
-    function testLoadFenwickNonFuzzyScalingFind() external {
-        // FIXME: misordered
-        //  uint256 insertions_,  Bound Result: 1145
-        //  uint256 totalAmount_, Bound Result: 549824577419048462197751701941564
-        //  uint256 scaleIndex_,  Bound Result: 1746721984912593317128871914298176971615500961962358
-        //  uint256 factor_,      Bound Result: 7388
-        //  uint256 seed_         Bound Result: 1000000000000000000
-        _tree.nonFuzzyFill(1145, 549824577419048462197751701941564, 1000000000000000000, false);
+    function testLoadFenwickScalingFindFailure1() external {
+        // uint256 insertions_,     Bound Result: 1145
+        // uint256 totalAmount_,    Bound Result: 549824577419048462197751701941564
+        // uint256 seed_,           Bound Result: 1746721984912593317128871914298176971615500961962358
+        // uint256 scaleIndex_,     Bound Result: 7388
+        // uint256 factor_          Bound Result: 1000000000000000000
+        _tree.nonFuzzyFill(1145, 549824577419048462197751701941564, 1746721984912593317128871914298176971615500961962358, false);
 
-        uint256 scaleIndex = bound(1746721984912593317128871914298176971615500961962358, 2, 7388);
-        uint256 subIndex = randomInRange(0, 1746721984912593317128871914298176971615500961962358 - 1);
-        uint256 factor = 7388;
+        uint256 scaleIndex = 7388;
+        uint256 subIndex = randomInRange(0, 7388 - 1);
+        uint256 factor = 1000000000000000000;
+
+        _tree.mult(scaleIndex, factor);
+
+        // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
+        uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
+        uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
+
+        uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
+        uint256 min = Maths.min(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
+
+        uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
+        uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
+
+        // 2 >= scaling discrepency
+        assertLe(max - min, 2);
+        assertLe(subMax - subMin, 2);
+    }
+
+    function testLoadFenwickScalingFindFailure2() external {
+        // uint256 insertions_,      Bound Result: 1000
+        // uint256 totalAmount_,     Bound Result: 7123816489587592052616345476846395
+        // uint256 seed_,            Bound Result: 0
+        // uint256 scaleIndex_,      Bound Result: 7388
+        // uint256 factor_           Bound Result: 1000000000000000000
+        _tree.nonFuzzyFill(1000, 7123816489587592052616345476846395, 0, false);
+
+        uint256 scaleIndex = 7388;
+        uint256 subIndex = randomInRange(0, 7388 - 1);
+        uint256 factor = 1000000000000000000;
 
         _tree.mult(scaleIndex, factor);
 

--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -185,64 +185,6 @@ contract FenwickTreeTest is DSTestPlus {
         assertLe(subMax - subMin, 2);
     }
 
-    function testLoadFenwickScalingFindFailure1() external {
-        // uint256 insertions_,     Bound Result: 1145
-        // uint256 totalAmount_,    Bound Result: 549824577419048462197751701941564
-        // uint256 seed_,           Bound Result: 1746721984912593317128871914298176971615500961962358
-        // uint256 scaleIndex_,     Bound Result: 7388
-        // uint256 factor_          Bound Result: 1000000000000000000
-        _tree.nonFuzzyFill(1145, 549824577419048462197751701941564, 1746721984912593317128871914298176971615500961962358, false);
-
-        uint256 scaleIndex = 7388;
-        uint256 subIndex = randomInRange(0, 7388 - 1);
-        uint256 factor = 1000000000000000000;
-
-        _tree.mult(scaleIndex, factor);
-
-        // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
-        uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
-        uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
-
-        uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
-        uint256 min = Maths.min(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
-
-        uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
-        uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
-
-        // 2 >= scaling discrepency
-        assertLe(max - min, 2);
-        assertLe(subMax - subMin, 2);
-    }
-
-    function testLoadFenwickScalingFindFailure2() external {
-        // uint256 insertions_,      Bound Result: 1000
-        // uint256 totalAmount_,     Bound Result: 7123816489587592052616345476846395
-        // uint256 seed_,            Bound Result: 0
-        // uint256 scaleIndex_,      Bound Result: 7388
-        // uint256 factor_           Bound Result: 1000000000000000000
-        _tree.nonFuzzyFill(1000, 7123816489587592052616345476846395, 0, false);
-
-        uint256 scaleIndex = 7388;
-        uint256 subIndex = randomInRange(0, 7388 - 1);
-        uint256 factor = 1000000000000000000;
-
-        _tree.mult(scaleIndex, factor);
-
-        // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
-        uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
-        uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
-
-        uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
-        uint256 min = Maths.min(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
-
-        uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
-        uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
-
-        // 2 >= scaling discrepency
-        assertLe(max - min, 2);
-        assertLe(subMax - subMin, 2);
-    }
-
     /**
      *  @notice Fuzz tests additions and value removals.
      */

--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -193,14 +193,19 @@ contract FenwickTreeTest is DSTestPlus {
         // uint256 factor_          Bound Result: 1000000000000000000
         _tree.nonFuzzyFill(1145, 549824577419048462197751701941564, 1746721984912593317128871914298176971615500961962358, false);
 
-        uint256 scaleIndex = 7388;
+        uint256 scaleIndex = 7388;  // MAX index of the Fenwick tree
         uint256 subIndex = randomInRange(0, 7388 - 1);
         uint256 factor = 1000000000000000000;
 
         _tree.mult(scaleIndex, factor);
 
         // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
+        // Because scaleIndex == MAX_INDEX, this will end up being scaleIndex - 1
         uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
+        assertEq(scaleIndex, treeDirectedIndex + 1);
+
+        // assuming subIndex < MAX, this should be the largest index >= subIndex with no additional
+        // deposit between it and subindex
         uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
 
         uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
@@ -209,8 +214,8 @@ contract FenwickTreeTest is DSTestPlus {
         uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
         uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
 
+        assertEq(max - min, _tree.valueAt(scaleIndex));
         // 2 >= scaling discrepency
-        assertLe(max - min, 2);
         assertLe(subMax - subMin, 2);
     }
 
@@ -230,6 +235,7 @@ contract FenwickTreeTest is DSTestPlus {
 
         // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
         uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
+        assertEq(scaleIndex, treeDirectedIndex + 1);
         uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
 
         uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
@@ -238,8 +244,8 @@ contract FenwickTreeTest is DSTestPlus {
         uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
         uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
 
+        assertEq(max - min, _tree.valueAt(scaleIndex));
         // 2 >= scaling discrepency
-        assertLe(max - min, 2);
         assertLe(subMax - subMin, 2);
     }
 

--- a/tests/forge/FenwickTree.t.sol
+++ b/tests/forge/FenwickTree.t.sol
@@ -185,6 +185,36 @@ contract FenwickTreeTest is DSTestPlus {
         assertLe(subMax - subMin, 2);
     }
 
+    function testLoadFenwickNonFuzzyScalingFind() external {
+        // FIXME: misordered
+        //  uint256 insertions_,  Bound Result: 1145
+        //  uint256 totalAmount_, Bound Result: 549824577419048462197751701941564
+        //  uint256 scaleIndex_,  Bound Result: 1746721984912593317128871914298176971615500961962358
+        //  uint256 factor_,      Bound Result: 7388
+        //  uint256 seed_         Bound Result: 1000000000000000000
+        _tree.nonFuzzyFill(1145, 549824577419048462197751701941564, 1000000000000000000, false);
+
+        uint256 scaleIndex = bound(1746721984912593317128871914298176971615500961962358, 2, 7388);
+        uint256 subIndex = randomInRange(0, 1746721984912593317128871914298176971615500961962358 - 1);
+        uint256 factor = 7388;
+
+        _tree.mult(scaleIndex, factor);
+
+        // This offset is done because of a rounding issue that occurs when we calculate the prefixSum
+        uint256 treeDirectedIndex = _tree.findIndexOfSum(_tree.prefixSum(scaleIndex) + 1) - 1;
+        uint256 treeDirectedSubIndex = _tree.findIndexOfSum(_tree.prefixSum(subIndex) + 1) - 1;
+
+        uint256 max = Maths.max(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
+        uint256 min = Maths.min(_tree.prefixSum(treeDirectedIndex), _tree.prefixSum(scaleIndex));
+
+        uint256 subMax = Maths.max(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
+        uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
+
+        // 2 >= scaling discrepency
+        assertLe(max - min, 2);
+        assertLe(subMax - subMin, 2);
+    }
+
     /**
      *  @notice Fuzz tests additions and value removals.
      */

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -119,6 +119,7 @@ contract FenwickTreeInstance is DSTestPlus {
     ) external {
         uint256 i;
         uint256 amount;
+        uint256 cumulativeAmount;
 
         // Initialize and print seed for randomness
         setRandomSeed(seed_);
@@ -133,15 +134,16 @@ contract FenwickTreeInstance is DSTestPlus {
 
             // Update values
             add(i, amount);
-            amount_  -=  amount;
-            insertions_      -=  1;
+            amount_          -= amount;
+            insertions_      -= 1;
+            cumulativeAmount += amount;
 
             // Verify tree sum
-            assertEq(deposits.treeSum(), amount_ - amount_);
+            assertEq(deposits.treeSum(), cumulativeAmount);
 
             if (trackInserts)  inserts.push(i);
         }
 
-        assertEq(deposits.treeSum(), amount_);
+        assertEq(deposits.treeSum(), cumulativeAmount);
     }
 }

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -75,37 +75,38 @@ contract FenwickTreeInstance is DSTestPlus {
     ) external {
         uint256 i;
         uint256 amount;
+        uint256 cumulativeAmount;
 
         // Calculate total insertions 
-        uint256 insertsDec= bound(insertions_, 1000, 2000);
+        insertions_ = bound(insertions_, 1000, 2000);
 
         // Calculate total amount to insert
-        uint256 totalAmount = bound(amount_, 1 * 1e18, 9_000_000_000_000_000 * 1e18);
-        uint256 totalAmountDec = totalAmount;
+        amount_ = bound(amount_, 1 * 1e18, 9_000_000_000_000_000 * 1e18);
 
         // Initialize and print seed for randomness
         setRandomSeed(bound(seed_, 0, type(uint256).max - 1));
 
-        while (totalAmountDec > 0 && insertsDec > 0) {
+        while (amount_ > 0 && insertions_ > 0) {
 
             // Insert at random index
             i = randomInRange(1, MAX_FENWICK_INDEX);
 
             // If last iteration, insert remaining
-            amount = insertsDec == 1 ? totalAmountDec : (totalAmountDec % insertsDec) * randomInRange(1_000, 1 * 1e10, true);
+            amount = insertions_ == 1 ? amount_ : (amount_ % insertions_) * randomInRange(1_000, 1 * 1e10, true);
 
             // Update values
             add(i, amount);
-            totalAmountDec  -=  amount;
-            insertsDec      -=  1;
+            amount_          -= amount;
+            insertions_      -= 1;
+            cumulativeAmount += amount;
 
             // Verify tree sum
-            assertEq(deposits.treeSum(), totalAmount - totalAmountDec);
+            assertEq(deposits.treeSum(), cumulativeAmount);
 
             if (trackInserts)  inserts.push(i);
         }
 
-        assertEq(deposits.treeSum(), totalAmount);
+        assertEq(deposits.treeSum(), cumulativeAmount);
     }
 
     /**

--- a/tests/forge/utils/FenwickTreeInstance.sol
+++ b/tests/forge/utils/FenwickTreeInstance.sol
@@ -107,4 +107,41 @@ contract FenwickTreeInstance is DSTestPlus {
 
         assertEq(deposits.treeSum(), totalAmount);
     }
+
+    /**
+     *  @notice fills fenwick tree with deterministic values and tests additions.
+     */
+    function nonFuzzyFill(
+        uint256 insertions_,    // number of insertions to perform
+        uint256 amount_,        // total amount to insert
+        uint256 seed_,          // seed for psuedorandom number generator
+        bool    trackInserts
+    ) external {
+        uint256 i;
+        uint256 amount;
+
+        // Initialize and print seed for randomness
+        setRandomSeed(seed_);
+
+        while (amount_ > 0 && insertions_ > 0) {
+
+            // Insert at random index
+            i = randomInRange(1, MAX_FENWICK_INDEX);
+
+            // If last iteration, insert remaining
+            amount = insertions_ == 1 ? amount_ : (amount_ % insertions_) * randomInRange(1_000, 1 * 1e10, true);
+
+            // Update values
+            add(i, amount);
+            amount_  -=  amount;
+            insertions_      -=  1;
+
+            // Verify tree sum
+            assertEq(deposits.treeSum(), amount_ - amount_);
+
+            if (trackInserts)  inserts.push(i);
+        }
+
+        assertEq(deposits.treeSum(), amount_);
+    }
 }


### PR DESCRIPTION
Reproduced two `testLoadFenwickFuzzyScalingFind` failures using de-fuzzed values.  Failures were caused by an issue with the tests, not the Fenwick tree.

@mattcushman resolved the testing issue in my new `nonFuzzyFill`.  I ported his changes over to the real `fuzzyFill` method used by the tests.