### PR TITLE
Fix calculate rewards issue

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -322,6 +322,7 @@ contract RewardsManager is IRewardsManager {
     ) internal view returns (uint256 epochRewards_) {
 
         uint256 nextEpoch = epoch_ + 1;
+        uint256 claimedRewardsInNextEpoch = rewardsClaimed[nextEpoch];
 
         // iterate through all buckets and calculate epoch rewards for
         for (uint256 i = 0; i < positionIndexes_.length; ) {
@@ -356,7 +357,7 @@ contract RewardsManager is IRewardsManager {
                     interestEarned,
                     nextEpoch,
                     epoch_,
-                    rewardsClaimed[nextEpoch]
+                    claimedRewardsInNextEpoch
                 );
             }
 

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -82,19 +82,6 @@ contract RewardsManager is IRewardsManager {
     address          public immutable ajnaToken;       // address of the AJNA token
     IPositionManager public immutable positionManager; // The PositionManager contract
 
-    /*************************/
-    /*** Local struct vars ***/
-    /*************************/
-
-    struct RewardsLocalVars {
-        uint256 bucketIndex;    // index of current bucket to calculate rewards for
-        uint256 bucketRate;     // [RAY] recorded exchange rate of current bucket
-        uint256 epoch;          // current epoch to calculate rewards for
-        uint256 nextEpoch;      // next epoch to calculate rewards for
-        uint256 interestEarned; // [WAD] interest earned on current epoch for the current bucket
-        uint256 newRewards;     // [WAD] calculated rewards
-    }
-
     /*******************/
     /*** Constructor ***/
     /*******************/
@@ -440,8 +427,7 @@ contract RewardsManager is IRewardsManager {
             )
         );
 
-        uint256 rewardsCapped         = Maths.wmul(REWARD_CAP, totalBurnedInPeriod);
-        // uint256 rewardsClaimedInEpoch = rewardsClaimed[nextEpoch_];
+        uint256 rewardsCapped = Maths.wmul(REWARD_CAP, totalBurnedInPeriod);
 
         // Check rewards claimed - check that less than 80% of the tokens for a given burn event have been claimed.
         if (rewardsClaimedInEpoch_ + newRewards_ > rewardsCapped) {

--- a/src/interfaces/rewards/IRewardsManagerDerivedState.sol
+++ b/src/interfaces/rewards/IRewardsManagerDerivedState.sol
@@ -16,6 +16,6 @@ interface IRewardsManagerDerivedState {
     function calculateRewards(
         uint256 tokenId,
         uint256 startEpoch
-    ) external returns (uint256);
+    ) external view returns (uint256);
 
 }

--- a/src/interfaces/rewards/IRewardsManagerDerivedState.sol
+++ b/src/interfaces/rewards/IRewardsManagerDerivedState.sol
@@ -10,12 +10,12 @@ interface IRewardsManagerDerivedState {
     /**
      *  @notice Calculate the amount of rewards that have been accumulated by a staked NFT.
      *  @param  tokenId    ID of the staked LP NFT.
-     *  @param  startEpoch The burn epoch from which to start the calculations
+     *  @param  claimEpoch The end burn epoch to calculate rewards for (rewards calculation starts from the last claimed epoch).
      *  @return rewards_   The amount of rewards earned by the NFT.
      */
     function calculateRewards(
         uint256 tokenId,
-        uint256 startEpoch
+        uint256 claimEpoch
     ) external view returns (uint256);
 
 }

--- a/src/interfaces/rewards/IRewardsManagerOwnerActions.sol
+++ b/src/interfaces/rewards/IRewardsManagerOwnerActions.sol
@@ -11,11 +11,11 @@ interface IRewardsManagerOwnerActions {
      *  @notice Claim ajna token rewards that have accrued to a staked LP NFT.
      *  @dev    Underlying NFT LP positions cannot change while staked. Retrieves exchange rates for each bucket the NFT is associated with.
      *  @param  tokenId    ID of the staked LP NFT.
-     *  @param  startEpoch The burn epoch to start claim.
+     *  @param  claimEpoch The burn epoch to claim rewards for.
      */
     function claimRewards(
         uint256 tokenId,
-        uint256 startEpoch
+        uint256 claimEpoch
     ) external;
 
     /**

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -701,7 +701,7 @@ contract RewardsManagerTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdOne,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            0.227347187766462422 * 1e18,
+            reward:            0.298393183929769729 * 1e18,
             updateRatesReward: 0
         });
         // TODO: check reward amount vs expected from burn


### PR DESCRIPTION
- iterate through epoch, then through buckets
- write state only once per epoch instead buckets number times per epoch
- calculateRewards changed to view
- introduced _calculateEpochRewards function that receives epoch and positions to calculate rewards for

gas with fix
```
| Function Name                                  | min             | avg    | median | max     | # calls |
| calculateRewards                               | 4151            | 69132  | 38384  | 183513  | 15      |
| claimRewards                                   | 497             | 97827  | 86049  | 409754  | 11      |
| unstake                                        | 541             | 184737 | 124925 | 428901  | 9       |
```
develop
```
| Function Name                                  | min             | avg    | median | max     | # calls |
| calculateRewards                               | 7875            | 70421  | 41194  | 177619  | 15      |
| claimRewards                                   | 497             | 97850  | 91803  | 371883  | 11      |
| unstake                                        | 541             | 189744 | 129529 | 436791  | 9       |
```