### PR TITLE
NFT pull fix after take / bucketTake with auction settlement

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -129,7 +129,7 @@
 
 	emit events:
 	- LenderActions.transferLPs():
-		- TransferLPTokens
+		- TransferLPs
 
 ### kick
 	external libraries call:

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -246,9 +246,9 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     /// @inheritdoc FlashloanablePool
     function flashLoan(
         IERC3156FlashBorrower receiver_,
-        address token_,
-        uint256 amount_,
-        bytes calldata data_
+        address               token_,
+        uint256               amount_,
+        bytes calldata        data_
     ) external override(IERC3156FlashLender, FlashloanablePool) nonReentrant returns (bool) {
         if (token_ == _getArgAddress(QUOTE_ADDRESS)) return _flashLoanQuoteToken(receiver_, token_, amount_, data_);
 
@@ -277,7 +277,9 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     /// @inheritdoc FlashloanablePool
     function maxFlashLoan(
         address token_
-    ) external view override(IERC3156FlashLender, FlashloanablePool) returns (uint256 maxLoan_) {
+    ) external view override(IERC3156FlashLender, FlashloanablePool) returns (
+        uint256 maxLoan_
+    ) {
         if (token_ == _getArgAddress(QUOTE_ADDRESS) || token_ == _getArgAddress(COLLATERAL_ADDRESS)) {
             maxLoan_ = IERC20Token(token_).balanceOf(address(this));
         }

--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -48,8 +48,12 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
      *          - PoolCreated
      */
     function deployPool(
-        address collateral_, address quote_, uint256 interestRate_
-    ) external canDeploy(ERC20_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (address pool_) {
+        address collateral_,
+        address quote_,
+        uint256 interestRate_
+    ) external canDeploy(ERC20_NON_SUBSET_HASH, collateral_, quote_, interestRate_) returns (
+        address pool_
+    ) {
         uint256 quoteTokenScale = 10 ** (18 - IERC20Token(quote_).decimals());
         uint256 collateralScale = 10 ** (18 - IERC20Token(collateral_).decimals());
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -96,9 +96,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         if (noOfTokens != 0) {
             // add subset of tokenIds allowed in the pool
             for (uint256 id = 0; id < noOfTokens;) {
-                tokenIdsAllowed[tokenIds_[id]] = true;
-
-                unchecked { ++id; }
+                tokenIdsAllowed[tokenIds_[id++]] = true;
             }
         }
 
@@ -571,10 +569,13 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         uint256 noOfTokensPledged    = borrowerTokens.length;
         uint256 noOfTokensToTransfer = collateral_ != 0 ? noOfTokensPledged - collateral_ / 1e18 : noOfTokensPledged;
 
+        uint256 tokenId;
+
         for (uint256 i = 0; i < noOfTokensToTransfer;) {
-            uint256 tokenId = borrowerTokens[--noOfTokensPledged]; // start with moving the last token pledged by borrower
-            borrowerTokens.pop();                                  // remove token id from borrower
-            bucketTokenIds.push(tokenId);                          // add token id to pool claimable tokens
+            tokenId = borrowerTokens[--noOfTokensPledged]; // start with moving the last token pledged by borrower
+
+            borrowerTokens.pop();          // remove token id from borrower
+            bucketTokenIds.push(tokenId);  // add token id to pool claimable tokens
 
             unchecked { ++i; }
         }
@@ -593,9 +594,14 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         bool subset   = _getArgUint256(SUBSET) != 0;
         uint8 nftType = _getArgUint8(NFT_TYPE);
 
+        uint256 tokenId;
+
         for (uint256 i = 0; i < tokenIds_.length;) {
-            uint256 tokenId = tokenIds_[i];
+            tokenId = tokenIds_[i++];
+
+            // revert if subset and token id not in allowed tokens 
             if (subset && !tokenIdsAllowed[tokenId]) revert OnlySubset();
+
             poolTokens_.push(tokenId);
 
             if (nftType == uint8(NFTTypes.STANDARD_ERC721)) {
@@ -615,8 +621,6 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             else {
                 ICryptoPunks(_getArgAddress(COLLATERAL_ADDRESS)).buyPunk(tokenId);
             }
-
-            unchecked { ++i; }
         }
     }
 
@@ -663,9 +667,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
                 );
             }
 
-            tokensTransferred[i] = tokenId;
-
-            unchecked { ++i; }
+            tokensTransferred[i++] = tokenId;
         }
 
         return tokensTransferred;

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -567,13 +567,21 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             if (subset && !tokenIdsAllowed[tokenId]) revert OnlySubset();
             poolTokens_.push(tokenId);
 
-            if (nftType == uint8(NFTTypes.STANDARD_ERC721)){
-                _transferNFT(msg.sender, address(this), tokenId);
+            if (nftType == uint8(NFTTypes.STANDARD_ERC721)) {
+                IERC721Token(_getArgAddress(COLLATERAL_ADDRESS)).safeTransferFrom(
+                    msg.sender,
+                    address(this),
+                    tokenId
+                );
             }
             else if (nftType == uint8(NFTTypes.CRYPTOKITTIES)) {
-                ICryptoKitties(_getArgAddress(COLLATERAL_ADDRESS)).transferFrom(msg.sender ,address(this), tokenId);
+                ICryptoKitties(_getArgAddress(COLLATERAL_ADDRESS)).transferFrom(
+                    msg.sender,
+                    address(this),
+                    tokenId
+                );
             }
-            else{
+            else {
                 ICryptoPunks(_getArgAddress(COLLATERAL_ADDRESS)).buyPunk(tokenId);
             }
 
@@ -604,14 +612,24 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             uint256 tokenId = poolTokens_[--noOfNFTsInPool]; // start with transferring the last token added in bucket
             poolTokens_.pop();
 
-            if (nftType == uint8(NFTTypes.STANDARD_ERC721)){
-                _transferNFT(address(this), toAddress_, tokenId);
+            if (nftType == uint8(NFTTypes.STANDARD_ERC721)) {
+                IERC721Token(_getArgAddress(COLLATERAL_ADDRESS)).safeTransferFrom(
+                    address(this),
+                    toAddress_,
+                    tokenId
+                );
             }
             else if (nftType == uint8(NFTTypes.CRYPTOKITTIES)) {
-                ICryptoKitties(_getArgAddress(COLLATERAL_ADDRESS)).transfer(toAddress_, tokenId);
+                ICryptoKitties(_getArgAddress(COLLATERAL_ADDRESS)).transfer(
+                    toAddress_,
+                    tokenId
+                );
             }
             else {
-                ICryptoPunks(_getArgAddress(COLLATERAL_ADDRESS)).transferPunk(toAddress_, tokenId);
+                ICryptoPunks(_getArgAddress(COLLATERAL_ADDRESS)).transferPunk(
+                    toAddress_,
+                    tokenId
+                );
             }
 
             tokensTransferred[i] = tokenId;
@@ -620,17 +638,6 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         }
 
         return tokensTransferred;
-    }
-
-    /**
-     *  @dev Helper function to transfer an NFT from owner to target address (reused in code to reduce contract deployment bytecode size).
-     *  @param from_    NFT owner address.
-     *  @param to_      New NFT owner address.
-     *  @param tokenId_ NFT token id to be transferred.
-     */
-    function _transferNFT(address from_, address to_, uint256 tokenId_) internal {
-        // slither-disable-next-line calls-loop
-        IERC721Token(_getArgAddress(COLLATERAL_ADDRESS)).safeTransferFrom(from_, to_, tokenId_);
     }
 
     /************************/

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -52,8 +52,13 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
      *          - PoolCreated
      */
     function deployPool(
-        address collateral_, address quote_, uint256[] memory tokenIds_, uint256 interestRate_
-    ) external canDeploy(getNFTSubsetHash(tokenIds_), collateral_, quote_, interestRate_) returns (address pool_) {
+        address          collateral_,
+        address          quote_,
+        uint256[] memory tokenIds_,
+        uint256          interestRate_
+    ) external canDeploy(getNFTSubsetHash(tokenIds_), collateral_, quote_, interestRate_) returns (
+        address pool_
+    ) {
         uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
 
         NFTTypes nftType;

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -110,7 +110,9 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
     /*** Pool Creation Functions ***/
     /*******************************/
 
-    function getNFTSubsetHash(uint256[] memory tokenIds_) public pure returns (bytes32) {
+    function getNFTSubsetHash(
+        uint256[] memory tokenIds_
+    ) public pure returns (bytes32) {
         if (tokenIds_.length == 0) return ERC721_NON_SUBSET_HASH;
         else return keccak256(abi.encodePacked(tokenIds_));
     }

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -30,104 +30,122 @@ import { PoolCommons } from './libraries/external/PoolCommons.sol';
  */
 contract PoolInfoUtils {
 
-    function borrowerInfo(address ajnaPool_, address borrower_)
-        external
-        view
-        returns (
-            uint256 debt_,             // current debt owed by borrower              (WAD)
-            uint256 collateral_,       // deposited collateral including encumbered  (WAD)
-            uint256 t0Np_              // Np / inflator, used in neutralPrice calc   (WAD)
-        )
-    {
-        IPool pool = IPool(ajnaPool_);
+    /**********************/
+    /*** Borrowers Info ***/
+    /**********************/
 
+    /**
+     *  @notice Get borrower info in a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @param  borrower_ Borrower address.
+     *  @return debt_       Current debt owed by borrower in given pool (WAD).
+     *  @return collateral_ Collateral pledged by borrower in given pool (WAD).
+     *  @return t0Np_       t0 Neutral price of the borrower (WAD).
+     */
+    function borrowerInfo(
+        address ajnaPool_,
+        address borrower_
+    ) external view returns (
+        uint256 debt_,
+        uint256 collateral_,
+        uint256 t0Np_
+    ) {
+        IPool pool = IPool(ajnaPool_);
         (
-            uint256 poolInflatorSnapshot,
-            uint256 lastInflatorSnapshotUpdate
+            uint256 inflator,
+            uint256 inflatorUpdateTime
         ) = pool.inflatorInfo();
 
         (uint256 interestRate,) = pool.interestRateInfo();
 
-        uint256 pendingInflator = PoolCommons.pendingInflator(poolInflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
+        uint256 pendingInflator = PoolCommons.pendingInflator(inflator, inflatorUpdateTime, interestRate);
 
         uint256 t0Debt;
-        (t0Debt, collateral_, t0Np_)  = pool.borrowerInfo(borrower_);
+        (t0Debt, collateral_, t0Np_) = pool.borrowerInfo(borrower_);
 
         debt_ = Maths.wmul(t0Debt, pendingInflator);
     }
 
+    /********************/
+    /*** Buckets Info ***/
+    /********************/
+
     /**
      *  @notice Get a bucket struct for a given index.
-     *  @param  index_             The index of the bucket to retrieve.
-     *  @return price_             Bucket price (WAD)
-     *  @return quoteTokens_       Amount of quote token in bucket, deposit + interest (WAD)
-     *  @return collateral_        Unencumbered collateral in bucket (WAD).
-     *  @return bucketLPs_         Outstanding LP balance in bucket (WAD)
-     *  @return scale_             Lender interest multiplier (WAD).
-     *  @return exchangeRate_      The exchange rate of the bucket, in RAY units.
+     *  @param  ajnaPool_         Address of the pool.
+     *  @param  index_            The index of the bucket to retrieve.
+     *  @return bucketPrice_      Bucket price (WAD)
+     *  @return bucketDeposit_    Unscaled amount of quote token in bucket (WAD).
+     *  @return bucketCollateral_ Unencumbered collateral in bucket (WAD).
+     *  @return bucketLPs_        Outstanding LP balance in bucket (RAY).
+     *  @return bucketScale_      Lender interest multiplier (WAD).
+     *  @return bucketRate_       The exchange rate of the bucket (RAY).
      */
-    function bucketInfo(address ajnaPool_, uint256 index_)
-        external
-        view
-        returns (
-            uint256 price_,
-            uint256 quoteTokens_,
-            uint256 collateral_,
-            uint256 bucketLPs_,
-            uint256 scale_,
-            uint256 exchangeRate_
-        )
-    {
+    function bucketInfo(
+        address ajnaPool_,
+        uint256 index_
+    ) external view returns (
+        uint256 bucketPrice_,
+        uint256 bucketDeposit_,
+        uint256 bucketCollateral_,
+        uint256 bucketLPs_,
+        uint256 bucketScale_,
+        uint256 bucketRate_
+    ) {
         IPool pool = IPool(ajnaPool_);
 
-        price_ = _priceAt(index_);
+        bucketPrice_ = _priceAt(index_);
 
-        (bucketLPs_, collateral_, , quoteTokens_, scale_) = pool.bucketInfo(index_);
+        (bucketLPs_, bucketCollateral_, , bucketDeposit_, bucketScale_) = pool.bucketInfo(index_);
         if (bucketLPs_ == 0) {
-            exchangeRate_ = Maths.RAY;
+            bucketRate_ = Maths.RAY;
         } else {
-            uint256 bucketSize = quoteTokens_ * 1e18 + price_ * collateral_;  // 10^36 + // 10^36
-            exchangeRate_ = bucketSize * 1e18 / bucketLPs_; // 10^27
+            uint256 bucketSize = bucketDeposit_ * 1e18 + bucketPrice_ * bucketCollateral_;  // 10^36 + // 10^36
+            bucketRate_ = bucketSize * 1e18 / bucketLPs_; // 10^27
         }
     }
 
+    /******************/
+    /*** Pools Info ***/
+    /******************/
+
     /**
      *  @notice Returns info related to pool loans.
+     *  @param  ajnaPool_              Address of the pool.
      *  @return poolSize_              The total amount of quote tokens in pool (WAD).
      *  @return loansCount_            The number of loans in pool.
      *  @return maxBorrower_           The address with the highest TP in pool.
-     *  @return pendingInflator_       Pending inflator in pool.
-     *  @return pendingInterestFactor_ Factor used to scale the inflator.
+     *  @return pendingInflator_       Pending inflator in pool (WAD).
+     *  @return pendingInterestFactor_ Factor used to scale the inflator (WAD).
      */
-    function poolLoansInfo(address ajnaPool_)
-        external
-        view
-        returns (
-            uint256 poolSize_,
-            uint256 loansCount_,
-            address maxBorrower_,
-            uint256 pendingInflator_,
-            uint256 pendingInterestFactor_
-        )
-    {
+    function poolLoansInfo(
+        address ajnaPool_
+    ) external view returns (
+        uint256 poolSize_,
+        uint256 loansCount_,
+        address maxBorrower_,
+        uint256 pendingInflator_,
+        uint256 pendingInterestFactor_
+    ) {
         IPool pool = IPool(ajnaPool_);
 
         poolSize_ = pool.depositSize();
         (maxBorrower_, , loansCount_) = pool.loansInfo();
 
         (
-            uint256 inflatorSnapshot,
-            uint256 lastInflatorSnapshotUpdate
+            uint256 inflator,
+            uint256 inflatorUpdate
         ) = pool.inflatorInfo();
 
         (uint256 interestRate, ) = pool.interestRateInfo();
 
-        pendingInflator_       = PoolCommons.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
-        pendingInterestFactor_ = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
+        pendingInflator_       = PoolCommons.pendingInflator(inflator, inflatorUpdate, interestRate);
+        pendingInterestFactor_ = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - inflatorUpdate);
     }
 
     /**
      *  @notice Returns info related to pool prices.
+     *  @param  ajnaPool_ Address of the pool.
      *  @return hpb_      The price value of the current Highest Price Bucket (HPB), in WAD units.
      *  @return hpbIndex_ The index of the current Highest Price Bucket (HPB), in WAD units.
      *  @return htp_      The price value of the current Highest Threshold Price (HTP) bucket, in WAD units.
@@ -135,18 +153,16 @@ contract PoolInfoUtils {
      *  @return lup_      The price value of the current Lowest Utilized Price (LUP) bucket, in WAD units.
      *  @return lupIndex_ The index of the current Lowest Utilized Price (LUP) bucket, in WAD units.
      */
-    function poolPricesInfo(address ajnaPool_)
-        external
-        view
-        returns (
-            uint256 hpb_,
-            uint256 hpbIndex_,
-            uint256 htp_,
-            uint256 htpIndex_,
-            uint256 lup_,
-            uint256 lupIndex_
-        )
-    {
+    function poolPricesInfo(
+        address ajnaPool_
+    ) external view returns (
+        uint256 hpb_,
+        uint256 hpbIndex_,
+        uint256 htp_,
+        uint256 htpIndex_,
+        uint256 lup_,
+        uint256 lupIndex_
+    ) {
         IPool pool = IPool(ajnaPool_);
 
         (uint256 debt,,) = pool.debtInfo();
@@ -165,23 +181,22 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Returns info related to Claimaible Reserve Auction.
+     *  @param  ajnaPool_                   Address of the pool.
      *  @return reserves_                   The amount of excess quote tokens.
      *  @return claimableReserves_          Denominated in quote token, or 0 if no reserves can be auctioned.
      *  @return claimableReservesRemaining_ Amount of claimable reserves which has not yet been taken.
      *  @return auctionPrice_               Current price at which 1 quote token may be purchased, denominated in Ajna.
      *  @return timeRemaining_              Seconds remaining before takes are no longer allowed.
      */
-    function poolReservesInfo(address ajnaPool_)
-        external
-        view
-        returns (
-            uint256 reserves_,
-            uint256 claimableReserves_,
-            uint256 claimableReservesRemaining_,
-            uint256 auctionPrice_,
-            uint256 timeRemaining_
-        )
-    {
+    function poolReservesInfo(
+        address ajnaPool_
+    ) external view returns (
+        uint256 reserves_,
+        uint256 claimableReserves_,
+        uint256 claimableReservesRemaining_,
+        uint256 auctionPrice_,
+        uint256 timeRemaining_
+    ) {
         IPool pool = IPool(ajnaPool_);
 
         (,uint256 poolDebt,) = pool.debtInfo();
@@ -211,21 +226,20 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Returns info related to Claimaible Reserve Auction.
+     *  @param  ajnaPool_              Address of the pool.
      *  @return poolMinDebtAmount_     Minimum debt amount.
      *  @return poolCollateralization_ Current pool collateralization ratio.
      *  @return poolActualUtilization_ The current pool actual utilization, in WAD units.
      *  @return poolTargetUtilization_ The current pool Target utilization, in WAD units.
      */
-    function poolUtilizationInfo(address ajnaPool_)
-        external
-        view
-        returns (
-            uint256 poolMinDebtAmount_,
-            uint256 poolCollateralization_,
-            uint256 poolActualUtilization_,
-            uint256 poolTargetUtilization_
-        )
-    {
+    function poolUtilizationInfo(
+        address ajnaPool_
+    ) external view returns (
+        uint256 poolMinDebtAmount_,
+        uint256 poolCollateralization_,
+        uint256 poolActualUtilization_,
+        uint256 poolTargetUtilization_
+    ) {
         IPool pool = IPool(ajnaPool_);
 
         (uint256 poolDebt,,)    = pool.debtInfo();
@@ -244,100 +258,26 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Returns the proportion of interest rate which is awarded to lenders;
+     *  @notice Returns the proportion of interest rate which is awarded to lenders in a given pool;
      *          the remainder accumulates in reserves.
+     *  @param  ajnaPool_ Address of the pool.
     */
-    function lenderInterestMargin(address ajnaPool_)
-        external
-        view
-        returns (uint256 lenderInterestMargin_)
-    {
+    function lenderInterestMargin(
+        address ajnaPool_
+    ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
 
         (uint256 poolDebt,,)   = pool.debtInfo();
         uint256 poolCollateral = pool.pledgedCollateral();
         uint256 utilization    = pool.depositUtilization(poolDebt, poolCollateral);
 
-        lenderInterestMargin_ = PoolCommons.lenderInterestMargin(utilization);
-    }
-
-    function indexToPrice(
-        uint256 index_
-    ) external pure returns (uint256)
-    {
-        return _priceAt(index_);
-    }
-
-    function priceToIndex(
-        uint256 price_
-    ) external pure returns (uint256)
-    {
-        return _indexOf(price_);
-    }
-
-    function lup(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (uint256 debt,,) = pool.debtInfo();
-        uint256 currentLupIndex = pool.depositIndex(debt);
-
-        return _priceAt(currentLupIndex);
-    }
-
-    function lupIndex(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (uint256 debt,,) = pool.debtInfo();
-
-        return pool.depositIndex(debt);
-    }
-
-    function hpb(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        uint256 hbpIndex = pool.depositIndex(1);
-
-        return _priceAt(hbpIndex);
-    }
-
-    function hpbIndex(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        return pool.depositIndex(1);
-    }
-
-    function htp(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (, uint256 maxThresholdPrice, ) = pool.loansInfo();
-        (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
-
-        return Maths.wmul(maxThresholdPrice, inflatorSnapshot);
-    }
-
-    function momp(
-        address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (uint256 debt, , )       = pool.debtInfo();
-        ( , , uint256 noOfLoans) = pool.loansInfo();
-        return _priceAt(pool.depositIndex(Maths.wdiv(debt, noOfLoans * 1e18)));
+        return  PoolCommons.lenderInterestMargin(utilization);
     }
 
     /**
-     *  @notice Calculates fee rate for a pool.
+     *  @notice Calculates fee rate for a given pool.
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
+     *  @param  ajnaPool_ Address of the pool.
      *  @return Fee rate applied to the given interest rate.
      */
     function feeRate(
@@ -351,19 +291,20 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of quote tokens in bucket for a given pool and given amount of LP Tokens.
+     *  @param  ajnaPool_    Address of the pool.
      *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
      *  @param  index_       The price bucket index for which the value should be calculated.
-     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
      */
     function lpsToQuoteTokens(
         address ajnaPool_,
         uint256 lpTokens_,
         uint256 index_
-    ) external view returns (uint256 quoteAmount_) {
+    ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
-        quoteAmount_ = _lpsToQuoteToken(
+        return _lpsToQuoteToken(
             bucketLPs_,
             bucketCollateral,
             bucketDeposit,
@@ -374,19 +315,20 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of collateral tokens in bucket for a given pool and given amount of LP Tokens.
+     *  @param  ajnaPool_         Address of the pool.
      *  @param  lpTokens_         The number of lpTokens to calculate amounts for.
      *  @param  index_            The price bucket index for which the value should be calculated.
-     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
      */
     function lpsToCollateral(
         address ajnaPool_,
         uint256 lpTokens_,
         uint256 index_
-    ) external view returns (uint256 collateralAmount_) {
+    ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
         (uint256 bucketLPs_, uint256 bucketCollateral , , uint256 bucketDeposit, ) = pool.bucketInfo(index_);
-        collateralAmount_ = _lpsToCollateral(
+        return _lpsToCollateral(
             bucketCollateral,
             bucketLPs_,
             bucketDeposit,
@@ -394,22 +336,138 @@ contract PoolInfoUtils {
             _priceAt(index_)
         );
     }
+
+    /************************/
+    /*** Prices Utilities ***/
+    /************************/
+
+    /**
+     *  @notice Calculates the price for a given index.
+     *  @param  index_ Bucket index.
+     *  @return Bucket price.
+     */
+    function indexToPrice(
+        uint256 index_
+    ) external pure returns (uint256) {
+        return _priceAt(index_);
+    }
+
+    /**
+     *  @notice Calculates the index for a given price.
+     *  @param  price_ Price to retrieve index for.
+     *  @return Bucket index.
+     */
+    function priceToIndex(
+        uint256 price_
+    ) external pure returns (uint256) {
+        return _indexOf(price_);
+    }
+
+    /**
+     *  @notice Returns the LUP of a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return LUP in pool.
+     */
+    function lup(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        (uint256 debt,,) = pool.debtInfo();
+        uint256 currentLupIndex = pool.depositIndex(debt);
+
+        return _priceAt(currentLupIndex);
+    }
+
+    /**
+     *  @notice Returns the LUP index for a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return LUP index of the pool.
+     */
+    function lupIndex(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        (uint256 debt,,) = pool.debtInfo();
+
+        return pool.depositIndex(debt);
+    }
+
+    /**
+     *  @notice Returns the HPB of a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return HPB of the pool.
+     */
+    function hpb(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        uint256 hbpIndex = pool.depositIndex(1);
+
+        return _priceAt(hbpIndex);
+    }
+
+    /**
+     *  @notice Returns the HPB index of a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return HPB index of the pool.
+     */
+    function hpbIndex(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        return pool.depositIndex(1);
+    }
+
+    /**
+     *  @notice Returns the HTP of a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return HTP of the pool.
+     */
+    function htp(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        (, uint256 maxThresholdPrice, ) = pool.loansInfo();
+        (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
+
+        return Maths.wmul(maxThresholdPrice, inflatorSnapshot);
+    }
+
+    /**
+     *  @notice Returns the MOMP of a given pool.
+     *  @param  ajnaPool_ Address of the pool.
+     *  @return MOMP of the pool.
+     */
+    function momp(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        (uint256 debt, , )       = pool.debtInfo();
+        ( , , uint256 noOfLoans) = pool.loansInfo();
+        return _priceAt(pool.depositIndex(Maths.wdiv(debt, noOfLoans * 1e18)));
+    }
 }
 
-    /**********************/
-    /*** Pool Utilities ***/
-    /**********************/
+    /************************/
+    /*** Helper Functions ***/
+    /************************/
 
     /**
      *  @notice Calculates encumberance for a debt amount at a given price.
      *  @param  debt_         The debt amount to calculate encumberance for.
      *  @param  price_        The price to calculate encumberance at.
-     *  @return encumberance_ Encumberance value.
+     *  @return Encumberance value.
      */
     function _encumberance(
         uint256 debt_,
         uint256 price_
-    ) pure returns (uint256 encumberance_) {
+    ) pure returns (uint256) {
         return price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
     }
 

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -180,7 +180,9 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
      */
     function mint(
         MintParams calldata params_
-    ) external override returns (uint256 tokenId_) {
+    ) external override returns (
+        uint256 tokenId_
+    ) {
         tokenId_ = _nextId++;
 
         // revert if the address is not a valid Ajna pool
@@ -280,7 +282,6 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     function reedemPositions(
         RedeemPositionsParams calldata params_
     ) external override mayInteract(params_.pool, params_.tokenId) {
-
         EnumerableSet.UintSet storage positionIndex = positionIndexes[params_.tokenId];
 
         IPool pool = IPool(poolKey[params_.tokenId]);

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -141,7 +141,7 @@ contract RewardsManager is IRewardsManager {
         stakeInfo.stakingEpoch = uint96(curBurnEpoch);
 
         // initialize last time interaction at staking epoch
-        stakeInfo.lastInteractionBurnEpoch = uint96(curBurnEpoch);
+        stakeInfo.lastClaimedEpoch = uint96(curBurnEpoch);
 
         uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
 
@@ -248,7 +248,7 @@ contract RewardsManager is IRewardsManager {
         rewardsEarned += _calculateAndClaimRewards(tokenId_, epochToClaim_);
 
         uint256[] memory burnEpochsClaimed = _getBurnEpochsClaimed(
-            stakeInfo.lastInteractionBurnEpoch,
+            stakeInfo.lastClaimedEpoch,
             epochToClaim_
         );
 
@@ -261,7 +261,7 @@ contract RewardsManager is IRewardsManager {
         );
 
         // update last interaction burn event
-        stakeInfo.lastInteractionBurnEpoch = uint96(epochToClaim_);
+        stakeInfo.lastClaimedEpoch = uint96(epochToClaim_);
 
         uint256 ajnaBalance = IERC20(ajnaToken).balanceOf(address(this));
 
@@ -285,7 +285,7 @@ contract RewardsManager is IRewardsManager {
         uint256 rewards_
     ) {
         address ajnaPool      = stakes[tokenId_].ajnaPool;
-        uint256 lastBurnEpoch = stakes[tokenId_].lastInteractionBurnEpoch;
+        uint256 lastBurnEpoch = stakes[tokenId_].lastClaimedEpoch;
         uint256 stakingEpoch  = stakes[tokenId_].stakingEpoch;
 
         uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
@@ -607,22 +607,22 @@ contract RewardsManager is IRewardsManager {
 
     /**
      *  @notice Retrieve an array of burn epochs from which a depositor has claimed rewards.
-     *  @param  lastInteractionBurnEpoch_ The last burn period in which a depositor interacted with the rewards contract.
-     *  @param  burnEpochToStartClaim_    The most recent burn period from a depostor earned rewards.
-     *  @return burnEpochsClaimed_        Array of burn epochs from which a depositor has claimed rewards.
+     *  @param  lastClaimedEpoch_      The last burn period in which a depositor interacted with the rewards contract.
+     *  @param  burnEpochToStartClaim_ The most recent burn period from a depostor earned rewards.
+     *  @return burnEpochsClaimed_     Array of burn epochs from which a depositor has claimed rewards.
      */
     function _getBurnEpochsClaimed(
-        uint256 lastInteractionBurnEpoch_,
+        uint256 lastClaimedEpoch_,
         uint256 burnEpochToStartClaim_
     ) internal pure returns (
         uint256[] memory burnEpochsClaimed_
     ) {
-        uint256 numEpochsClaimed = burnEpochToStartClaim_ - lastInteractionBurnEpoch_;
+        uint256 numEpochsClaimed = burnEpochToStartClaim_ - lastClaimedEpoch_;
 
         burnEpochsClaimed_ = new uint256[](numEpochsClaimed);
 
         uint256 i;
-        uint256 claimEpoch = lastInteractionBurnEpoch_ + 1;
+        uint256 claimEpoch = lastClaimedEpoch_ + 1;
 
         while (claimEpoch <= burnEpochToStartClaim_) {
             burnEpochsClaimed_[i++] = claimEpoch;
@@ -634,29 +634,29 @@ contract RewardsManager is IRewardsManager {
 
     /**
      *  @notice Retrieve the total ajna tokens burned and total interest earned by a pool since a given block.
-     *  @param  pool_                  Address of the Ajna pool to retrieve accumulators of.
-     *  @param  currentBurnEventEpoch_ The latest burn event.
-     *  @param  lastBurnEventEpoch_    The burn event to use as checkpoint since which values have accumulated.
+     *  @param  pool_             Address of the Ajna pool to retrieve accumulators of.
+     *  @param  currentEpoch_     The latest burn event.
+     *  @param  lastClaimedEpoch_ The burn event to use as checkpoint since which values have accumulated.
      *  @return Timestamp of the latest burn event.
      *  @return Total ajna tokens burned by the pool since the last burn event.
      *  @return Total interest earned by the pool since the last burn event.
      */
     function _getPoolAccumulators(
         address pool_,
-        uint256 currentBurnEventEpoch_,
-        uint256 lastBurnEventEpoch_
+        uint256 currentEpoch_,
+        uint256 lastClaimedEpoch_
     ) internal view returns (uint256, uint256, uint256) {
         (
             uint256 currentBurnTime,
             uint256 totalInterestLatest,
             uint256 totalBurnedLatest
-        ) = IPool(pool_).burnInfo(currentBurnEventEpoch_);
+        ) = IPool(pool_).burnInfo(currentEpoch_);
 
         (
             ,
             uint256 totalInterestAtBlock,
             uint256 totalBurnedAtBlock
-        ) = IPool(pool_).burnInfo(lastBurnEventEpoch_);
+        ) = IPool(pool_).burnInfo(lastClaimedEpoch_);
 
         uint256 totalBurned   = totalBurnedLatest   != 0 ? totalBurnedLatest   - totalBurnedAtBlock   : totalBurnedAtBlock;
         uint256 totalInterest = totalInterestLatest != 0 ? totalInterestLatest - totalInterestAtBlock : totalInterestAtBlock;
@@ -680,14 +680,14 @@ contract RewardsManager is IRewardsManager {
     ) external view override returns (
         uint256 rewards_
     ) {
-        address ajnaPool      = stakes[tokenId_].ajnaPool;
-        uint256 lastBurnEpoch = stakes[tokenId_].lastInteractionBurnEpoch;
-        uint256 stakingEpoch  = stakes[tokenId_].stakingEpoch;
+        address ajnaPool         = stakes[tokenId_].ajnaPool;
+        uint256 lastClaimedEpoch = stakes[tokenId_].lastClaimedEpoch;
+        uint256 stakingEpoch     = stakes[tokenId_].stakingEpoch;
 
         uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
 
         // iterate through all burn periods to calculate and claim rewards
-        for (uint256 epoch = lastBurnEpoch; epoch < epochToClaim_; ) {
+        for (uint256 epoch = lastClaimedEpoch; epoch < epochToClaim_; ) {
 
             rewards_ += _calculateNextEpochRewards(
                 tokenId_,
@@ -708,7 +708,8 @@ contract RewardsManager is IRewardsManager {
         return (
             stakes[tokenId_].owner,
             stakes[tokenId_].ajnaPool,
-            stakes[tokenId_].lastInteractionBurnEpoch);
+            stakes[tokenId_].lastClaimedEpoch
+        );
     }
 
     /************************/

--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -22,9 +22,9 @@ abstract contract FlashloanablePool is Pool {
      */
     function flashLoan(
         IERC3156FlashBorrower receiver_,
-        address token_,
-        uint256 amount_,
-        bytes calldata data_
+        address               token_,
+        uint256               amount_,
+        bytes calldata        data_
     ) external virtual override nonReentrant returns (bool) {
         if (token_ == _getArgAddress(QUOTE_ADDRESS)) return _flashLoanQuoteToken(receiver_, token_, amount_, data_);
         revert FlashloanUnavailableForToken();

--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -62,7 +62,9 @@ abstract contract FlashloanablePool is Pool {
      */
      function maxFlashLoan(
         address token_
-    ) external virtual view override returns (uint256 maxLoan_) {
+    ) external virtual view override returns (
+        uint256 maxLoan_
+    ) {
         if (token_ == _getArgAddress(QUOTE_ADDRESS)) maxLoan_ = _getPoolQuoteTokenBalance();
     }
 }

--- a/src/interfaces/pool/IERC3156FlashLender.sol
+++ b/src/interfaces/pool/IERC3156FlashLender.sol
@@ -8,35 +8,35 @@ interface IERC3156FlashLender {
 
     /**
      * @dev    The amount of currency available to be lent.
-     * @param  token_ The loan currency.
+     * @param  token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
     function maxFlashLoan(
-        address token_
+        address token
     ) external view returns (uint256);
 
     /**
      * @dev    The fee to be charged for a given loan.
-     * @param  token_    The loan currency.
-     * @param  amount_   The amount of tokens lent.
+     * @param  token    The loan currency.
+     * @param  amount   The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function flashFee(
-        address token_,
-        uint256 amount_
+        address token,
+        uint256 amount
     ) external view returns (uint256);
 
     /**
      * @dev    Initiate a flash loan.
-     * @param  receiver_ The receiver of the tokens in the loan, and the receiver of the callback.
-     * @param  token_    The loan currency.
-     * @param  amount_   The amount of tokens lent.
-     * @param  data_     Arbitrary data structure, intended to contain user-defined parameters.
+     * @param  receiver The receiver of the tokens in the loan, and the receiver of the callback.
+     * @param  token    The loan currency.
+     * @param  amount   The amount of tokens lent.
+     * @param  data     Arbitrary data structure, intended to contain user-defined parameters.
      */
     function flashLoan(
-        IERC3156FlashBorrower receiver_,
-        address token_,
-        uint256 amount_,
-        bytes   calldata data_
+        IERC3156FlashBorrower receiver,
+        address token,
+        uint256 amount,
+        bytes   calldata data
     ) external returns (bool);
 }

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -33,7 +33,7 @@ interface IPoolFactory {
 
     /**
      *  @notice Emitted when a new pool is created.
-     *  @param  pool_ The address of the new pool.
+     *  @param  pool The address of the new pool.
      */
-    event PoolCreated(address pool_);
+    event PoolCreated(address pool);
 }

--- a/src/interfaces/pool/commons/IPoolDerivedState.sol
+++ b/src/interfaces/pool/commons/IPoolDerivedState.sol
@@ -7,17 +7,22 @@ pragma solidity 0.8.14;
  */
 interface IPoolDerivedState {
 
+    /**
+     *  @notice Returns the bucket exchange rate.
+     *  @param  index  Bucket index.
+     *  @return Bucket exchange rate.
+     */
     function bucketExchangeRate(
-        uint256 index_
-    ) external view returns (uint256 exchangeRate_);
+        uint256 index
+    ) external view returns (uint256);
 
     /**
      *  @notice Returns the bucket index for a given debt amount.
-     *  @param  debt_  The debt amount to calculate bucket index for.
+     *  @param  debt  The debt amount to calculate bucket index for.
      *  @return Bucket index.
      */
     function depositIndex(
-        uint256 debt_
+        uint256 debt
     ) external view returns (uint256);
 
     /**
@@ -28,13 +33,13 @@ interface IPoolDerivedState {
 
     /**
      *  @notice Returns the deposit utilization for given debt and collateral amounts.
-     *  @param  debt_       The debt amount to calculate utilization for.
-     *  @param  collateral_ The collateral amount to calculate utilization for.
+     *  @param  debt       The debt amount to calculate utilization for.
+     *  @param  collateral The collateral amount to calculate utilization for.
      *  @return Deposit utilization.
      */
     function depositUtilization(
-        uint256 debt_,
-        uint256 collateral_
+        uint256 debt,
+        uint256 collateral
     ) external view returns (uint256);
 
 }

--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -6,9 +6,6 @@ pragma solidity 0.8.14;
  * @title Pool Errors
  */
 interface IPoolErrors {
-    /**************************/
-    /*** Common Pool Errors ***/
-    /**************************/
 
     /**
      *  @notice The action cannot be executed on an active auction.

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -211,13 +211,13 @@ interface IPoolEvents {
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
      *  @param  indexes  Array of price bucket indexes at which LP tokens were transferred.
-     *  @param  lpTokens Amount of LP tokens transferred.
+     *  @param  lps      Amount of LP tokens transferred.
      */
-    event TransferLPTokens(
+    event TransferLPs(
         address owner,
         address newOwner,
         uint256[] indexes,
-        uint256 lpTokens
+        uint256 lps
     );
 
     /**

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -61,7 +61,7 @@ struct AddQuoteParams {
 
 struct MoveQuoteParams {
     uint256 fromIndex;       // the deposit index from where amount is moved
-    uint256 maxAmountToMove; // [WAD] max amount to move between deposits
+    uint256 maxAmount;       // [WAD] max amount to move between deposits
     uint256 toIndex;         // the deposit index where amount is moved to
     uint256 thresholdPrice;  // [WAD] max threshold price in pool
 }
@@ -94,5 +94,5 @@ struct RepayDebtResult {
     bool    settledAuction;        // true if repay debt settles auction
     uint256 t0DebtInAuctionChange; // [WAD] change of t0 pool debt in auction after repay debt
     uint256 t0RepaidDebt;          // [WAD] amount of t0 repaid debt
-    uint256 quoteTokenToRepay;     // [WAD] quote token amount to be transferred from sender to pool
+    uint256 repayAmount;           // [WAD] quote token amount to be transferred from sender to pool
 }

--- a/src/interfaces/pool/commons/IPoolLiquidationActions.sol
+++ b/src/interfaces/pool/commons/IPoolLiquidationActions.sol
@@ -39,10 +39,10 @@ interface IPoolLiquidationActions {
 
     /**
      *  @notice Called by lenders to liquidate the top loan using their deposits.
-     *  @param  index_  The deposit index to use for kicking the top loan.
+     *  @param  index  The deposit index to use for kicking the top loan.
      */
     function kickWithDeposit(
-        uint256 index_
+        uint256 index
     ) external;
 
     /**

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -20,49 +20,49 @@ interface IPoolState {
      *  @return next         Address of the next auction in queue.
      *  @return prev         Address of the prev auction in queue.
      */
-    function auctionInfo(address borrower)
-        external
-        view
-        returns (
-            address kicker,
-            uint256 bondFactor,
-            uint256 bondSize,
-            uint256 kickTime,
-            uint256 kickPrice,
-            uint256 neutralPrice,
-            address head,
-            address next,
-            address prev
-        );
+    function auctionInfo(
+        address borrower
+    ) external view returns (
+        address kicker,
+        uint256 bondFactor,
+        uint256 bondSize,
+        uint256 kickTime,
+        uint256 kickPrice,
+        uint256 neutralPrice,
+        address head,
+        address next,
+        address prev
+    );
 
     /**
      *  @notice Returns pool related debt values.
-     *  @return debt_            Current amount of debt owed by borrowers in pool.
-     *  @return accruedDebt_     Debt owed by borrowers based on last inflator snapshot.
-     *  @return debtInAuction_   Total amount of debt in auction.
+     *  @return debt          Current amount of debt owed by borrowers in pool.
+     *  @return accruedDebt   Debt owed by borrowers based on last inflator snapshot.
+     *  @return debtInAuction Total amount of debt in auction.
      */
-    function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_);
+    function debtInfo() external view returns (
+        uint256 debt,
+        uint256 accruedDebt,
+        uint256 debtInAuction
+    );
 
     /**
      *  @notice Mapping of borrower addresses to {Borrower} structs.
-     *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
      *  @param  borrower   Address of the borrower.
      *  @return t0Debt     Amount of debt borrower would have had if their loan was the first debt drawn from the pool
      *  @return collateral Amount of collateral that the borrower has deposited, in collateral token.
      *  @return t0Np       Np / borrowerInflatorSnapshot
      */
-    function borrowerInfo(address borrower)
-        external
-        view
-        returns (
-            uint256 t0Debt,
-            uint256 collateral,
-            uint256 t0Np
-        );
+    function borrowerInfo(
+        address borrower
+    ) external view returns (
+        uint256 t0Debt,
+        uint256 collateral,
+        uint256 t0Np
+    );
 
     /**
      *  @notice Mapping of buckets indexes to {Bucket} structs.
-     *  @dev    NOTE: Cannot use appended underscore syntax for return params since struct is used.
      *  @param  index               Bucket index.
      *  @return lpAccumulator       Amount of LPs accumulated in current bucket.
      *  @return availableCollateral Amount of collateral available in current bucket.
@@ -70,45 +70,49 @@ interface IPoolState {
      *  @return bucketDeposit       Amount of quote tokens in bucket.
      *  @return bucketScale         Bucket multiplier.
      */
-    function bucketInfo(uint256 index)
-        external
-        view
-        returns (
-            uint256 lpAccumulator,
-            uint256 availableCollateral,
-            uint256 bankruptcyTime,
-            uint256 bucketDeposit,
-            uint256 bucketScale
-        );
+    function bucketInfo(
+        uint256 index
+    ) external view returns (
+        uint256 lpAccumulator,
+        uint256 availableCollateral,
+        uint256 bankruptcyTime,
+        uint256 bucketDeposit,
+        uint256 bucketScale
+    );
 
     /**
      *  @notice Mapping of burnEventEpoch to {BurnEvent} structs.
      *  @dev    Reserve auctions correspond to burn events.
-     *  @param  burnEventEpoch_  Id of the current reserve auction.
-     *  @return burnBlock        Block in which a reserve auction started.
-     *  @return totalInterest    Total interest as of the reserve auction.
-     *  @return totalBurned      Total ajna tokens burned as of the reserve auction.
+     *  @param  burnEventEpoch Id of the current reserve auction.
+     *  @return burnBlock      Block in which a reserve auction started.
+     *  @return totalInterest  Total interest as of the reserve auction.
+     *  @return totalBurned    Total ajna tokens burned as of the reserve auction.
      */
-    function burnInfo(uint256 burnEventEpoch_) external view returns (uint256, uint256, uint256);
+    function burnInfo(
+        uint256 burnEventEpoch
+    ) external view returns (
+        uint256 burnBlock,
+        uint256 totalInterest,
+        uint256 totalBurned
+    );
 
     /**
      *  @notice Returns the latest burnEventEpoch of reserve auctions.
      *  @dev    If a reserve auction is active, it refers to the current reserve auction. If no reserve auction is active, it refers to the last reserve auction.
      *  @return burnEventEpoch Current burnEventEpoch.
      */
-    function currentBurnEpoch() external view returns (uint256);
+    function currentBurnEpoch() external view returns (
+        uint256 burnEventEpoch
+    );
 
     /**
      *  @notice Returns information about the pool EMA (Exponential Moving Average) variables.
      *  @return debtEma   Exponential debt moving average.
      *  @return lupColEma Exponential LUP * pledged collateral moving average.
      */
-    function emasInfo()
-        external
-        view
-        returns (
-            uint256 debtEma,
-            uint256 lupColEma
+    function emasInfo() external view returns (
+        uint256 debtEma,
+        uint256 lupColEma
     );
 
     /**
@@ -116,12 +120,9 @@ interface IPoolState {
      *  @return inflatorSnapshot A snapshot of the last inflator value.
      *  @return lastUpdate       The timestamp of the last `inflatorSnapshot` update.
      */
-    function inflatorInfo()
-        external
-        view
-        returns (
-            uint256 inflatorSnapshot,
-            uint256 lastUpdate
+    function inflatorInfo() external view returns (
+        uint256 inflatorSnapshot,
+        uint256 lastUpdate
     );
 
     /**
@@ -129,13 +130,10 @@ interface IPoolState {
      *  @return interestRate       Current interest rate in pool.
      *  @return interestRateUpdate The timestamp of the last interest rate update.
      */
-    function interestRateInfo()
-        external
-        view
-        returns (
-            uint256 interestRate,
-            uint256 interestRateUpdate
-        );
+    function interestRateInfo() external view returns (
+        uint256 interestRate,
+        uint256 interestRateUpdate
+    );
 
 
     /**
@@ -144,13 +142,12 @@ interface IPoolState {
      *  @return claimable Amount of quote token kicker can claim / withdraw from pool at any time.
      *  @return locked    Amount of quote token kicker locked in auctions (as bonds).
      */
-    function kickerInfo(address kicker)
-        external
-        view
-        returns (
-            uint256 claimable,
-            uint256 locked
-        );
+    function kickerInfo(
+        address kicker
+    ) external view returns (
+        uint256 claimable,
+        uint256 locked
+    );
 
     /**
      *  @notice Mapping of buckets indexes and owner addresses to {Lender} structs.
@@ -162,12 +159,9 @@ interface IPoolState {
     function lenderInfo(
         uint256 index,
         address lp
-    )
-        external
-        view
-        returns (
-            uint256 lpBalance,
-            uint256 lastQuoteDeposit
+    ) external view returns (
+        uint256 lpBalance,
+        uint256 lastQuoteDeposit
     );
 
     /**
@@ -178,12 +172,9 @@ interface IPoolState {
      */
     function loanInfo(
         uint256 loanId
-    )
-        external
-        view
-        returns (
-            address borrower,
-            uint256 thresholdPrice
+    ) external view returns (
+        address borrower,
+        uint256 thresholdPrice
     );
 
     /**
@@ -192,13 +183,10 @@ interface IPoolState {
      *  @return maxThresholdPrice Highest threshold price in pool.
      *  @return noOfLoans         Total number of loans.
      */
-    function loansInfo()
-        external
-        view
-        returns (
-            address maxBorrower,
-            uint256 maxThresholdPrice,
-            uint256 noOfLoans
+    function loansInfo() external view returns (
+        address maxBorrower,
+        uint256 maxThresholdPrice,
+        uint256 noOfLoans
     );
 
     /**
@@ -207,20 +195,19 @@ interface IPoolState {
      *  @return reserveAuctionUnclaimed Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
      *  @return reserveAuctionKicked    Time a Claimable Reserve Auction was last kicked.
      */
-    function reservesInfo()
-        external
-        view
-        returns (
-            uint256 liquidationBondEscrowed,
-            uint256 reserveAuctionUnclaimed,
-            uint256 reserveAuctionKicked
+    function reservesInfo() external view returns (
+        uint256 liquidationBondEscrowed,
+        uint256 reserveAuctionUnclaimed,
+        uint256 reserveAuctionKicked
     );
 
     /**
      *  @notice Returns the `pledgedCollateral` state variable.
-     *  @return The total pledged collateral in the system, in WAD units.
+     *  @return pledgedCollateral The total pledged collateral in the system, in WAD units.
      */
-    function pledgedCollateral() external view returns (uint256);
+    function pledgedCollateral() external view returns (
+        uint256 pledgedCollateral
+    );
 
 }
 

--- a/src/interfaces/pool/erc20/IERC20Pool.sol
+++ b/src/interfaces/pool/erc20/IERC20Pool.sol
@@ -23,7 +23,9 @@ interface IERC20Pool is
      *  @notice Initializes a new pool, setting initial state variables.
      *  @param  rate Initial interest rate of the pool.
      */
-    function initialize(uint256 rate) external;
+    function initialize(
+        uint256 rate
+    ) external;
 
     /**
      *  @notice Returns the minimum amount of collateral an actor may have in a bucket.

--- a/src/interfaces/pool/erc20/IERC20PoolBorrowerActions.sol
+++ b/src/interfaces/pool/erc20/IERC20PoolBorrowerActions.sol
@@ -11,28 +11,28 @@ interface IERC20PoolBorrowerActions {
      *  @notice Called by borrowers to add collateral to the pool and/or borrow quote from the pool.
      *  @dev    Can be called by borrowers with either 0 amountToBorrow_ or 0 collateralToPledge_, if borrower only wants to take a single action. 
      *          Call with 0 amountToBorrow_, and non-0 limitIndex_ to restamp loan's neutral price.
-     *  @param  borrowerAddress_    The borrower to whom collateral was pledged, and/or debt was drawn for.
-     *  @param  amountToBorrow_     The amount of quote tokens to borrow.
-     *  @param  limitIndex_         Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
-     *  @param  collateralToPledge_ The amount of collateral to be added to the pool.
+     *  @param  borrowerAddress    The borrower to whom collateral was pledged, and/or debt was drawn for.
+     *  @param  amountToBorrow     The amount of quote tokens to borrow.
+     *  @param  limitIndex         Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
+     *  @param  collateralToPledge The amount of collateral to be added to the pool.
      */
     function drawDebt(
-        address borrowerAddress_,
-        uint256 amountToBorrow_,
-        uint256 limitIndex_,
-        uint256 collateralToPledge_
+        address borrowerAddress,
+        uint256 amountToBorrow,
+        uint256 limitIndex,
+        uint256 collateralToPledge
     ) external;
 
     /**
      *  @notice Called by borrowers to repay borrowed quote to the pool, and/or pull collateral form the pool.
-     *  @dev    Can be called by borrowers with either 0 maxQuoteTokenAmountToRepay_ or 0 collateralAmountToPull_, if borrower only wants to take a single action. 
-     *  @param  borrowerAddress_            The borrower whose loan is being interacted with.
-     *  @param  maxQuoteTokenAmountToRepay_ The amount of quote tokens to repay.
-     *  @param  collateralAmountToPull_     The amount of collateral to be puled from the pool.
+     *  @dev    Can be called by borrowers with either 0 maxQuoteTokenAmountToRepay or 0 collateralAmountToPull, if borrower only wants to take a single action. 
+     *  @param  borrowerAddress            The borrower whose loan is being interacted with.
+     *  @param  maxQuoteTokenAmountToRepay The amount of quote tokens to repay.
+     *  @param  collateralAmountToPull     The amount of collateral to be puled from the pool.
      */
     function repayDebt(
-        address borrowerAddress_,
-        uint256 maxQuoteTokenAmountToRepay_,
-        uint256 collateralAmountToPull_
+        address borrowerAddress,
+        uint256 maxQuoteTokenAmountToRepay,
+        uint256 collateralAmountToPull
     ) external;
 }

--- a/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
+++ b/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
@@ -9,11 +9,14 @@ interface IERC20PoolLenderActions {
 
     /**
      *  @notice Deposit claimable collateral into a specified bucket.
-     *  @param  amount Amount of collateral to deposit.
-     *  @param  index  The bucket index to which collateral will be deposited.
+     *  @param  amount    Amount of collateral to deposit.
+     *  @param  index     The bucket index to which collateral will be deposited.
+     *  @return lpbChange The amount of LPs for deposited collateral.
      */
     function addCollateral(
         uint256 amount,
         uint256 index
-    ) external returns (uint256 lpbChange);
+    ) external returns (
+        uint256 lpbChange
+    );
 }

--- a/src/interfaces/pool/erc721/IERC721PoolBorrowerActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolBorrowerActions.sol
@@ -9,30 +9,30 @@ interface IERC721PoolBorrowerActions {
 
     /**
      *  @notice Called by borrowers to add collateral to the pool and/or borrow quote from the pool.
-     *  @dev    Can be called by borrowers with either 0 amountToBorrow_ or 0 collateralToPledge_, if borrower only wants to take a single action. 
-     *          Call with 0 amountToBorrow_, and non-0 limitIndex_ to restamp loan's neutral price.
-     *  @param  borrower_         The address of borrower to drawDebt for.
-     *  @param  amountToBorrow_   The amount of quote tokens to borrow.
-     *  @param  limitIndex_       Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
-     *  @param  tokenIdsToPledge_ Array of tokenIds to be pledged to the pool.
+     *  @dev    Can be called by borrowers with either 0 amountToBorrow or 0 collateralToPledge, if borrower only wants to take a single action. 
+     *          Call with 0 amountToBorrow, and non-0 limitIndex to restamp loan's neutral price.
+     *  @param  borrower         The address of borrower to drawDebt for.
+     *  @param  amountToBorrow   The amount of quote tokens to borrow.
+     *  @param  limitIndex       Lower bound of LUP change (if any) that the borrower will tolerate from a creating or modifying position.
+     *  @param  tokenIdsToPledge Array of tokenIds to be pledged to the pool.
      */
     function drawDebt(
-        address borrower_,
-        uint256 amountToBorrow_,
-        uint256 limitIndex_,
-        uint256[] calldata tokenIdsToPledge_
+        address borrower,
+        uint256 amountToBorrow,
+        uint256 limitIndex,
+        uint256[] calldata tokenIdsToPledge
     ) external;
 
     /**
      *  @notice Called by borrowers to repay borrowed quote to the pool, and/or pull collateral form the pool.
-     *  @dev    Can be called by borrowers with either 0 maxQuoteTokenAmountToRepay_ or 0 collateralAmountToPull_, if borrower only wants to take a single action. 
-     *  @param  borrowerAddress_            The borrower whose loan is being interacted with.
-     *  @param  maxQuoteTokenAmountToRepay_ The amount of quote tokens to repay.
-     *  @param  noOfNFTsToPull_             The integer number of NFT collateral to be puled from the pool.
+     *  @dev    Can be called by borrowers with either 0 maxQuoteTokenAmountToRepay or 0 collateralAmountToPull, if borrower only wants to take a single action. 
+     *  @param  borrowerAddress            The borrower whose loan is being interacted with.
+     *  @param  maxQuoteTokenAmountToRepay The amount of quote tokens to repay.
+     *  @param  noOfNFTsToPull             The integer number of NFT collateral to be puled from the pool.
      */
     function repayDebt(
-        address borrowerAddress_,
-        uint256 maxQuoteTokenAmountToRepay_,
-        uint256 noOfNFTsToPull_
+        address borrowerAddress,
+        uint256 maxQuoteTokenAmountToRepay,
+        uint256 noOfNFTsToPull
     ) external;
 }

--- a/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
@@ -26,8 +26,8 @@ interface IERC721PoolLenderActions {
      *  @return bucketLPs_           If non-zero, amount of LPs in toIndex when collateral is merged into bucket. If 0, no collateral is merged.
      */
     function mergeOrRemoveCollateral(
-        uint256[] calldata removeAmountAtIndex_,
         uint256 noOfNFTsToRemove_,
+        uint256[] calldata removeAmountAtIndex_,
         uint256 toIndex_
     ) external returns (uint256 collateralMerged_, uint256 bucketLPs_);
 }

--- a/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
@@ -11,23 +11,29 @@ interface IERC721PoolLenderActions {
      *  @notice Deposit claimable collateral into a specified bucket.
      *  @param  tokenIds Array of collateral to deposit.
      *  @param  index    The bucket index to which collateral will be deposited.
+     *  @return lpbChange The amount of LPs for deposited collateral.
      */
     function addCollateral(
         uint256[] calldata tokenIds,
         uint256 index
-    ) external returns (uint256);
+    ) external returns (
+        uint256 lpbChange
+    );
 
     /**
      *  @notice Merge collateral accross a number of buckets, removeAmountAtIndex_to reconstitute an NFT
-     *  @param  removeAmountAtIndex_ Array of bucket indexes to remove all collateral that the caller has ownership over.
-     *  @param  toIndex_             The bucket index to which merge collateral into.
-     *  @param  noOfNFTsToRemove_    Intergral number of NFTs to remove if collateral amount is met noOfNFTsToRemove_, else merge at bucket index, toIndex_.
-     *  @return collateralMerged_     Amount of collateral merged into toIndex.
-     *  @return bucketLPs_           If non-zero, amount of LPs in toIndex when collateral is merged into bucket. If 0, no collateral is merged.
+     *  @param  removeAmountAtIndex Array of bucket indexes to remove all collateral that the caller has ownership over.
+     *  @param  toIndex           The bucket index to which merge collateral into.
+     *  @param  noOfNFTsToRemove  Intergral number of NFTs to remove if collateral amount is met noOfNFTsToRemove_, else merge at bucket index, toIndex_.
+     *  @return collateralMerged  Amount of collateral merged into toIndex.
+     *  @return bucketLPs         If non-zero, amount of LPs in toIndex when collateral is merged into bucket. If 0, no collateral is merged.
      */
     function mergeOrRemoveCollateral(
-        uint256 noOfNFTsToRemove_,
-        uint256[] calldata removeAmountAtIndex_,
-        uint256 toIndex_
-    ) external returns (uint256 collateralMerged_, uint256 bucketLPs_);
+        uint256 noOfNFTsToRemove,
+        uint256[] calldata removeAmountAtIndex,
+        uint256 toIndex
+    ) external returns (
+        uint256 collateralMerged,
+        uint256 bucketLPs
+    );
 }

--- a/src/interfaces/pool/erc721/IERC721PoolState.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolState.sol
@@ -14,7 +14,9 @@ interface IERC721PoolState {
      */
     function tokenIdsAllowed(
         uint256 tokenId
-    ) external view returns (bool allowed);
+    ) external view returns (
+        bool allowed
+    );
 
     /**
      *  @notice Returns the token id of an NFT pledged by a borrower with a given index.
@@ -25,7 +27,9 @@ interface IERC721PoolState {
     function borrowerTokenIds(
         address borrower,
         uint256 nftIndex
-    ) external view returns (uint256 tokenId);
+    ) external view returns (
+        uint256 tokenId
+    );
 
     /**
      *  @notice Returns the token id of an NFT added in pool bucket.
@@ -34,5 +38,7 @@ interface IERC721PoolState {
      */
     function bucketTokenIds(
         uint256 nftIndex
-    ) external view returns (uint256 tokenId);
+    ) external view returns (
+        uint256 tokenId
+    );
 }

--- a/src/interfaces/position/IPositionManagerDerivedState.sol
+++ b/src/interfaces/position/IPositionManagerDerivedState.sol
@@ -17,16 +17,20 @@ interface IPositionManagerDerivedState {
     function getLPTokens(
         uint256 tokenId,
         uint256 index
-    ) external view returns (uint256 lpTokens);
+    ) external view returns (
+        uint256 lpTokens
+    );
 
     /**
      *  @notice Returns an array of bucket indexes in which an NFT has liquidity.
-     *  @param  tokenId  Unique ID of token.
-     *  @return Array of bucket indexes.
+     *  @param  tokenId Unique ID of token.
+     *  @return indexes Array of bucket indexes.
     */
     function getPositionIndexes(
         uint256 tokenId
-    ) external view returns (uint256[] memory);
+    ) external view returns (
+        uint256[] memory indexes
+    );
 
     /**
      *  @notice Checks if a given tokenId has a given position bucket
@@ -37,5 +41,7 @@ interface IPositionManagerDerivedState {
     function isIndexInPosition(
         uint256 tokenId,
         uint256 index
-    ) external view returns (bool bucketInPosition);
+    ) external view returns (
+        bool bucketInPosition
+    );
 }

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -35,7 +35,9 @@ interface IPositionManagerOwnerActions {
      */
     function mint(
         MintParams calldata params
-    ) external returns (uint256 tokenId);
+    ) external returns (
+        uint256 tokenId
+    );
 
     /**
      *  @notice Called by owners to move liquidity between two buckets.

--- a/src/interfaces/rewards/IRewardsManagerDerivedState.sol
+++ b/src/interfaces/rewards/IRewardsManagerDerivedState.sol
@@ -11,7 +11,7 @@ interface IRewardsManagerDerivedState {
      *  @notice Calculate the amount of rewards that have been accumulated by a staked NFT.
      *  @param  tokenId    ID of the staked LP NFT.
      *  @param  claimEpoch The end burn epoch to calculate rewards for (rewards calculation starts from the last claimed epoch).
-     *  @return rewards_   The amount of rewards earned by the NFT.
+     *  @return The amount of rewards earned by the NFT.
      */
     function calculateRewards(
         uint256 tokenId,

--- a/src/interfaces/rewards/IRewardsManagerState.sol
+++ b/src/interfaces/rewards/IRewardsManagerState.sol
@@ -55,7 +55,7 @@ interface IRewardsManagerState {
 
 struct StakeInfo {
     address ajnaPool;                         // address of the Ajna pool the NFT corresponds to
-    uint96  lastInteractionBurnEpoch;         // last burn event the stake interacted with the rewards contract
+    uint96  lastClaimedEpoch;                 // last epoche stake claimed from rewards contract
     address owner;                            // owner of the LP NFT
     uint96  stakingEpoch;                     // epoch at staking time
     mapping(uint256 => BucketState) snapshot; // the LP NFT's balances and exchange rates in each bucket at the time of staking

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -136,6 +136,13 @@ library Auctions {
         uint256 t0DebtInAuctionChange; // [WAD] t0 change amount of debt after auction is taken
         uint256 t0PoolDebt;            // [WAD] t0 pool debt
     }
+    struct TakeFromLoanResult {
+        uint256 newLup;                // [WAD] LUP after auction is taken and loan info updated
+        uint256 poolDebt;              // [WAD] accrued pool debt after auction is taken
+        uint256 remainingCollateral;   // [WAD] borrower remaining collateral after auction is taken
+        bool    settledAuction;        // true if auction was settled by take auction
+        uint256 t0DebtInAuctionChange; // [WAD] t0 change amount of debt after auction is taken
+    }
 
     /**************/
     /*** Events ***/
@@ -510,12 +517,7 @@ library Auctions {
             poolState_.debt += Maths.wmul(result_.t0DebtPenalty, poolState_.inflator);
         }
 
-        (
-            result_.poolDebt,
-            result_.newLup,
-            result_.t0DebtInAuctionChange,
-            result_.settledAuction
-        ) = _takeLoan(
+        TakeFromLoanResult memory loanTakeResult = _takeLoan(
             auctions_,
             buckets_,
             deposits_,
@@ -525,6 +527,13 @@ library Auctions {
             borrowerAddress_,
             result_.t0RepayAmount
         );
+
+        result_.poolDebt              = loanTakeResult.poolDebt;
+        result_.newLup                = loanTakeResult.newLup;
+        result_.t0DebtInAuctionChange = loanTakeResult.t0DebtInAuctionChange;
+        result_.settledAuction        = loanTakeResult.settledAuction;
+        // set borrower remaining collateral (to be rebalanced in case of NFT settlement)
+        result_.remainingCollateral   = loanTakeResult.remainingCollateral;
     }
 
     /**
@@ -576,12 +585,7 @@ library Auctions {
             poolState_.debt += Maths.wmul(result_.t0DebtPenalty, poolState_.inflator);
         }
 
-        (
-            result_.poolDebt,
-            result_.newLup,
-            result_.t0DebtInAuctionChange,
-            result_.settledAuction
-        ) = _takeLoan(
+        TakeFromLoanResult memory loanTakeResult = _takeLoan(
             auctions_,
             buckets_,
             deposits_,
@@ -591,6 +595,13 @@ library Auctions {
             borrowerAddress_,
             result_.t0RepayAmount
         );
+
+        result_.poolDebt              = loanTakeResult.poolDebt;
+        result_.newLup                = loanTakeResult.newLup;
+        result_.t0DebtInAuctionChange = loanTakeResult.t0DebtInAuctionChange;
+        result_.settledAuction        = loanTakeResult.settledAuction;
+        // set borrower remaining collateral (to be rebalanced in case of NFT settlement)
+        result_.remainingCollateral    = loanTakeResult.remainingCollateral;
     }
 
     /**
@@ -982,13 +993,10 @@ library Auctions {
      *  @notice If borrower becomes recollateralized then auction is settled. Update loan's state.
      *  @dev    reverts on:
      *              - borrower debt less than pool min debt AmountLTMinDebt()
-     *  @param  borrower_               The borrower details owning loan that is taken.
-     *  @param  borrowerAddress_        The address of the borrower.
-     *  @param  t0RepaidDebt_           T0 debt amount repaid by the take action.
-     *  @return poolDebt_               Accrued debt pool after debt is repaid.
-     *  @return newLup_                 The new LUP of pool (after debt is repaid).
-     *  @return t0DebtInAuctionChange_  The overall debt in auction change (remaining borrower debt if auction settled, repaid debt otherwise).
-     *  @return settledAuction_         True if auction is settled by the take action.
+     *  @param  borrower_        The borrower details owning loan that is taken.
+     *  @param  borrowerAddress_ The address of the borrower.
+     *  @param  t0RepaidDebt_    T0 debt amount repaid by the take action.
+     *  @return result_          Result struct of taking from loan.
     */
     function _takeLoan(
         AuctionsState storage auctions_,
@@ -999,12 +1007,7 @@ library Auctions {
         Borrower memory borrower_,
         address borrowerAddress_,
         uint256 t0RepaidDebt_
-    ) internal returns (
-        uint256 poolDebt_,
-        uint256 newLup_,
-        uint256 t0DebtInAuctionChange_,
-        bool settledAuction_
-    ) {
+    ) internal returns (TakeFromLoanResult memory result_) {
 
         TakeLoanLocalVars memory vars;
 
@@ -1012,26 +1015,27 @@ library Auctions {
         vars.borrowerDebt = Maths.wmul(borrower_.t0Debt, poolState_.inflator);
 
         vars.borrowerDebt -= vars.repaidDebt;
-        poolDebt_ = poolState_.debt - vars.repaidDebt;
+        result_.poolDebt  = poolState_.debt - vars.repaidDebt;
 
         // check that taking from loan doesn't leave borrower debt under min debt amount
-        _revertOnMinDebt(loans_, poolDebt_, vars.borrowerDebt, poolState_.quoteDustLimit);
+        _revertOnMinDebt(loans_, result_.poolDebt, vars.borrowerDebt, poolState_.quoteDustLimit);
 
-        newLup_ = _lup(deposits_, poolDebt_);
+        result_.newLup = _lup(deposits_, result_.poolDebt);
 
         vars.inAuction = true;
 
-        if (_isCollateralized(vars.borrowerDebt, borrower_.collateral, newLup_, poolState_.poolType)) {
+        if (_isCollateralized(vars.borrowerDebt, borrower_.collateral, result_.newLup, poolState_.poolType)) {
             // settle auction if borrower becomes re-collateralized
 
             vars.inAuction  = false;
-            settledAuction_ = true;
+
+            result_.settledAuction = true;
 
             // the overall debt in auction change is the total borrower debt exiting auction
-            t0DebtInAuctionChange_ = borrower_.t0Debt;
+            result_.t0DebtInAuctionChange = borrower_.t0Debt;
 
             // settle auction and update borrower's collateral with value after settlement
-            borrower_.collateral = _settleAuction(
+            result_.remainingCollateral = _settleAuction(
                 auctions_,
                 buckets_,
                 deposits_,
@@ -1039,9 +1043,10 @@ library Auctions {
                 borrower_.collateral,
                 poolState_.poolType
             );
+            borrower_.collateral = result_.remainingCollateral;
         } else {
             // the overall debt in auction change is the amount of partially repaid debt
-            t0DebtInAuctionChange_ = t0RepaidDebt_;
+            result_.t0DebtInAuctionChange = t0RepaidDebt_;
         }
 
         borrower_.t0Debt -= t0RepaidDebt_;
@@ -1055,7 +1060,7 @@ library Auctions {
             borrowerAddress_,
             vars.borrowerDebt,
             poolState_.rate,
-            newLup_,
+            result_.newLup,
             vars.inAuction,
             !vars.inAuction // stamp borrower t0Np if exiting from auction
         );

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -495,7 +495,7 @@ library LenderActions {
 
         // Loop over buckets, exit if collateralAmount is reached or max noOfBuckets is reached
         while (amountMerged_ < amount_ && i < noOfBuckets) {
-            fromIndex = indexes_[i];
+            fromIndex = indexes_[i++];
 
             if (fromIndex > toIndex_) revert CannotMergeToHigherPrice();
 
@@ -508,8 +508,6 @@ library LenderActions {
 
             amountMerged_  += amountRemoved;
             amountRemaining -= amountRemoved;
-
-            unchecked { ++i; }
         }
 
         if (amountMerged_ != amount_) {
@@ -551,9 +549,11 @@ library LenderActions {
         uint256 indexesLength = indexes_.length;
 
         uint256 transferredLPs;
+        uint256 index;
 
         for (uint256 i = 0; i < indexesLength; ) {
-            uint256 index = indexes_[i];
+            index = indexes_[i++];
+
             if (index > MAX_FENWICK_INDEX) revert InvalidIndex();
 
             uint256 amount = allowances_[owner_][newOwner_][index];
@@ -581,8 +581,6 @@ library LenderActions {
             delete bucket.lenders[owner_];
 
             transferredLPs += amount;
-
-            unchecked { ++i; }
         }
 
         emit TransferLPs(

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -146,14 +146,16 @@ library PoolCommons {
         uint256 htp = Maths.wmul(thresholdPrice_, newInflator_);
 
         uint256 htpIndex;
-        if (htp > MAX_PRICE)
+
+        if (htp > MAX_PRICE) {
             // if HTP is over the highest price bucket then no buckets earn interest
             htpIndex = 1;
-        else if (htp < MIN_PRICE)
+        }
+        else if (htp < MIN_PRICE) {
             // if HTP is under the lowest price bucket then all buckets earn interest
             htpIndex = MAX_FENWICK_INDEX;
-        else
-            htpIndex = _indexOf(htp);
+        }
+        else htpIndex = _indexOf(htp);
 
         // Scale the fenwick tree to update amount of debt owed to lenders
         uint256 depositAboveHtp = Deposits.prefixSum(deposits_, htpIndex);

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -56,8 +56,8 @@ library PoolCommons {
     function updateInterestRate(
         InterestState storage interestParams_,
         DepositsState storage deposits_,
-        PoolState memory poolState_,
-        uint256 lup_
+        PoolState     memory  poolState_,
+        uint256               lup_
     ) external {
 
         // current values of EMA samples
@@ -133,10 +133,10 @@ library PoolCommons {
      *  @return newInflator_   The new value of pool inflator.
      */
     function accrueInterest(
-        DepositsState storage deposits_,
-        PoolState calldata poolState_,
-        uint256 thresholdPrice_,
-        uint256 elapsed_
+        DepositsState storage  deposits_,
+        PoolState     calldata poolState_,
+        uint256                thresholdPrice_,
+        uint256                elapsed_
     ) external returns (uint256 newInflator_, uint256 newInterest_) {
         // Scale the borrower inflator to update amount of interest owed by borrowers
         uint256 pendingFactor = PRBMathUD60x18.exp((poolState_.rate * elapsed_) / 365 days);
@@ -225,9 +225,11 @@ library PoolCommons {
      */
     function utilization(
         DepositsState storage deposits,
-        uint256 poolDebt_,
-        uint256 collateral_
-    ) external view returns (uint256 utilization_) {
+        uint256               poolDebt_,
+        uint256               collateral_
+    ) external view returns (
+        uint256 utilization_
+    ) {
         return _utilization(deposits, poolDebt_, collateral_);
     }
 
@@ -243,9 +245,11 @@ library PoolCommons {
      */
     function _utilization(
         DepositsState storage deposits,
-        uint256 poolDebt_,
-        uint256 collateral_
-    ) internal view returns (uint256 utilization_) {
+        uint256               poolDebt_,
+        uint256               collateral_
+    ) internal view returns (
+        uint256 utilization_
+    ) {
         if (collateral_ != 0) {
             uint256 ptp = _ptp(poolDebt_, collateral_);
 

--- a/src/libraries/internal/Buckets.sol
+++ b/src/libraries/internal/Buckets.sol
@@ -28,39 +28,42 @@ library Buckets {
      *  @dev    Increment bucket.collateral and bucket.lps accumulator
      *             - addLenderLPs:
      *               - increment lender.lps accumulator and lender.depositTime state
-     *  @param  lender_                Address of the lender.
-     *  @param  deposit_               Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
-     *  @param  collateralAmountToAdd_ Additional collateral amount to add to bucket.
-     *  @param  bucketPrice_           Bucket price.
-     *  @return addedLPs_              Amount of bucket LPs for the collateral amount added.
+     *  @param  lender_      Address of the lender.
+     *  @param  deposit_     Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs
+     *  @param  amount_      Additional collateral amount to add to bucket.
+     *  @param  bucketPrice_ Bucket price.
+     *  @return bucketLPs_   Amount of bucket LPs for the collateral amount added.
      */
     function addCollateral(
         Bucket storage bucket_,
-        address lender_,
-        uint256 deposit_,
-        uint256 collateralAmountToAdd_,
-        uint256 bucketPrice_
-    ) internal returns (uint256 addedLPs_) {
+        address        lender_,
+        uint256        deposit_,
+        uint256        amount_,
+        uint256        bucketPrice_
+    ) internal returns (
+        uint256 bucketLPs_
+    ) {
+        uint256 bucketBankruptcyTime = bucket_.bankruptcyTime;
+
         // cannot deposit in the same block when bucket becomes insolvent
-        uint256 bankruptcyTime = bucket_.bankruptcyTime;
-        if (bankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
+        if (bucketBankruptcyTime == block.timestamp) revert BucketBankruptcyBlock();
 
         // calculate amount of LPs to be added for the amount of collateral added to bucket
-        addedLPs_ = collateralToLPs(
+        bucketLPs_ = collateralToLPs(
             bucket_.collateral,
             bucket_.lps,
             deposit_,
-            collateralAmountToAdd_,
+            amount_,
             bucketPrice_
         );
         // update bucket LPs balance and collateral
 
         // update bucket collateral
-        bucket_.collateral += collateralAmountToAdd_;
+        bucket_.collateral += amount_;
         // update bucket and lender LPs balance and deposit timestamp
-        bucket_.lps += addedLPs_;
+        bucket_.lps += bucketLPs_;
 
-        addLenderLPs(bucket_, bankruptcyTime, lender_, addedLPs_);
+        addLenderLPs(bucket_, bucketBankruptcyTime, lender_, bucketLPs_);
     }
 
     /**
@@ -69,18 +72,18 @@ library Buckets {
      *  @param  bucket_         Bucket to record lender LPs.
      *  @param  bankruptcyTime_ Time when bucket become insolvent.
      *  @param  lender_         Lender address to add LPs for in the given bucket.
-     *  @param  lpsAmount_      Amount of LPs to be recorded for the given lender.
+     *  @param  bucketLPs_      Amount of bucket LPs to be recorded for the given lender.
      */
     function addLenderLPs(
         Bucket storage bucket_,
-        uint256 bankruptcyTime_,
-        address lender_,
-        uint256 lpsAmount_
+        uint256        bankruptcyTime_,
+        address        lender_,
+        uint256        bucketLPs_
     ) internal {
         Lender storage lender = bucket_.lenders[lender_];
 
-        if (bankruptcyTime_ >= lender.depositTime) lender.lps = lpsAmount_;
-        else lender.lps += lpsAmount_;
+        if (bankruptcyTime_ >= lender.depositTime) lender.lps = bucketLPs_;
+        else lender.lps += bucketLPs_;
 
         lender.depositTime = block.timestamp;
     }
@@ -93,42 +96,42 @@ library Buckets {
      *  @notice Returns the amount of bucket LPs calculated for the given amount of collateral.
      *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  deposit_     Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  collateral_  The amount of collateral to calculate bucket LPs for.
-     *  @param  bucketPrice_ Price bucket.
-     *  @return lps_         Amount of LPs calculated for the amount of collateral.
+     *  @param  bucketDeposit_    Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
+     *  @param  amount_           The amount of collateral to calculate bucket LPs for.
+     *  @param  bucketPrice_      Price bucket.
+     *  @return Amount of LPs calculated for the amount of collateral.
      */
     function collateralToLPs(
         uint256 bucketCollateral_,
         uint256 bucketLPs_,
-        uint256 deposit_,
-        uint256 collateral_,
+        uint256 bucketDeposit_,
+        uint256 amount_,
         uint256 bucketPrice_
-    ) internal pure returns (uint256 lps_) {
-        uint256 rate = getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_);
+    ) internal pure returns (uint256) {
+        uint256 bucketRate = getExchangeRate(bucketCollateral_, bucketLPs_, bucketDeposit_, bucketPrice_);
 
-        lps_ = (collateral_ * bucketPrice_ * 1e18 + rate / 2) / rate;
+        return (amount_ * bucketPrice_ * 1e18 + bucketRate / 2) / bucketRate;
     }
 
     /**
      *  @notice Returns the amount of LPs calculated for the given amount of quote tokens.
      *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  bucketLPs_        Amount of LPs in bucket.
-     *  @param  deposit_     Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
-     *  @param  quoteTokens_ The amount of quote tokens to calculate LPs amount for.
-     *  @param  bucketPrice_ Price bucket.
+     *  @param  bucketDeposit_    Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / LPs.
+     *  @param  amount_           The amount of quote tokens to calculate LPs amount for.
+     *  @param  bucketPrice_      Price bucket.
      *  @return The amount of LPs coresponding to the given quote tokens in current bucket.
      */
     function quoteTokensToLPs(
         uint256 bucketCollateral_,
         uint256 bucketLPs_,
-        uint256 deposit_,
-        uint256 quoteTokens_,
+        uint256 bucketDeposit_,
+        uint256 amount_,
         uint256 bucketPrice_
     ) internal pure returns (uint256) {
         return Maths.rdiv(
-            Maths.wadToRay(quoteTokens_),
-            getExchangeRate(bucketCollateral_, bucketLPs_, deposit_, bucketPrice_)
+            Maths.wadToRay(amount_),
+            getExchangeRate(bucketCollateral_, bucketLPs_, bucketDeposit_, bucketPrice_)
         );
     }
 

--- a/src/libraries/internal/Loans.sol
+++ b/src/libraries/internal/Loans.sol
@@ -74,18 +74,17 @@ library Loans {
      *  @param t0NpUpdate_          Whether the neutral price of borrower should be updated or not.
      */
     function update(
-        LoansState storage loans_,
+        LoansState    storage loans_,
         AuctionsState storage auctions_,
         DepositsState storage deposits_,
-        Borrower memory borrower_,
-        address borrowerAddress_,
-        uint256 borrowerAccruedDebt_,
-        uint256 poolRate_,
-        uint256 lup_,
-        bool inAuction_,
-        bool t0NpUpdate_
+        Borrower      memory  borrower_,
+        address               borrowerAddress_,
+        uint256               borrowerAccruedDebt_,
+        uint256               poolRate_,
+        uint256               lup_,
+        bool                  inAuction_,
+        bool                  t0NpUpdate_
     ) internal {
-
         bool activeBorrower = borrower_.t0Debt != 0 && borrower_.collateral != 0;
 
         uint256 t0ThresholdPrice = activeBorrower ? Maths.wdiv(borrower_.t0Debt, borrower_.collateral) : 0;
@@ -129,33 +128,43 @@ library Loans {
 
     /**
      *  @notice Moves a Loan up the heap.
-     *  @param loans_ Holds loan heap data.
-     *  @param loan_ Loan to be moved.
-     *  @param i_    Index for Loan to be moved to.
+     *  @param  loans_  Holds loan heap data.
+     *  @param  loan_   Loan to be moved.
+     *  @param  index_  Index of the Loan to be moved to.
      */
-    function _bubbleUp(LoansState storage loans_, Loan memory loan_, uint i_) private {
+    function _bubbleUp(
+        LoansState storage loans_,
+        Loan       memory  loan_,
+        uint256            index_
+    ) private {
         uint256 count = loans_.loans.length;
-        if (i_ == ROOT_INDEX || loan_.thresholdPrice <= loans_.loans[i_ / 2].thresholdPrice){
-          _insert(loans_, loan_, i_, count);
-        } else {
-          _insert(loans_, loans_.loans[i_ / 2], i_, count);
-          _bubbleUp(loans_, loan_, i_ / 2);
+        if (index_ == ROOT_INDEX || loan_.thresholdPrice <= loans_.loans[index_ / 2].thresholdPrice){
+          _insert(loans_, loan_, index_, count);
+        }
+        else {
+          _insert(loans_, loans_.loans[index_ / 2], index_, count);
+
+          _bubbleUp(loans_, loan_, index_ / 2);
         }
     }
 
     /**
      *  @notice Moves a Loan down the heap.
-     *  @param loans_ Holds Loan heap data.
-     *  @param loan_ Loan to be moved.
-     *  @param i_    Index for Loan to be moved to.
+     *  @param  loans_  Holds Loan heap data.
+     *  @param  loan_   Loan to be moved.
+     *  @param  index_  Index of the Loan to be moved to.
      */
-    function _bubbleDown(LoansState storage loans_, Loan memory loan_, uint i_) private {
+    function _bubbleDown(
+        LoansState storage loans_,
+        Loan       memory  loan_,
+        uint256            index_
+    ) private {
         // Left child index.
-        uint cIndex = i_ * 2;
+        uint cIndex = index_ * 2;
 
         uint256 count = loans_.loans.length;
         if (count <= cIndex) {
-            _insert(loans_, loan_, i_, count);
+            _insert(loans_, loan_, index_, count);
         } else {
             Loan memory largestChild = loans_.loans[cIndex];
 
@@ -164,9 +173,11 @@ library Loans {
             }
 
             if (largestChild.thresholdPrice <= loan_.thresholdPrice) {
-              _insert(loans_, loan_, i_, count);
-            } else {
-              _insert(loans_, largestChild, i_, count);
+              _insert(loans_, loan_, index_, count);
+            }
+            else {
+              _insert(loans_, largestChild, index_, count);
+
               _bubbleDown(loans_, loan_, cIndex);
             }
         }
@@ -174,59 +185,81 @@ library Loans {
 
     /**
      *  @notice Inserts a Loan in the heap.
-     *  @param loans_ Holds loan heap data.
-     *  @param loan_ Loan to be inserted.
-     *  @param i_    index for Loan to be inserted at.
+     *  @param  loans_ Holds loan heap data.
+     *  @param  loan_  Loan to be inserted.
+     *  @param  index_ Index of the Loan to be inserted at.
+     *  @param  count_ Number of loans in heap.
      */
-    function _insert(LoansState storage loans_, Loan memory loan_, uint i_, uint256 count_) private {
-        if (i_ == count_) loans_.loans.push(loan_);
-        else loans_.loans[i_] = loan_;
+    function _insert(
+        LoansState storage loans_,
+        Loan       memory  loan_,
+        uint               index_,
+        uint256            count_
+    ) private {
+        if (index_ == count_) loans_.loans.push(loan_);
+        else loans_.loans[index_] = loan_;
 
-        loans_.indices[loan_.borrower] = i_;
+        loans_.indices[loan_.borrower] = index_;
     }
 
     /**
      *  @notice Removes loan from heap given borrower address.
-     *  @param loans_    Holds loan heap data.
-     *  @param borrower_ Borrower address whose loan is being updated or inserted.
-     *  @param id_       Loan id.
+     *  @param  loans_    Holds loan heap data.
+     *  @param  borrower_ Borrower address whose loan is being updated or inserted.
+     *  @param  index_    Index of the Loan to be removed.
      */
-    function remove(LoansState storage loans_, address borrower_, uint256 id_) internal {
+    function remove(
+        LoansState storage loans_,
+        address            borrower_,
+        uint256            index_
+    ) internal {
         delete loans_.indices[borrower_];
+
         uint256 tailIndex = loans_.loans.length - 1;
-        if (id_ == tailIndex) loans_.loans.pop(); // we're removing the tail, pop without sorting
+
+        if (index_ == tailIndex) loans_.loans.pop(); // we're removing the tail, pop without sorting
         else {
+            // load current tail loan
             Loan memory tail = loans_.loans[tailIndex];
-            loans_.loans.pop();            // remove tail loan
-            _bubbleUp(loans_, tail, id_);
-            _bubbleDown(loans_, loans_.loans[id_], id_);
+
+            // remove current tail loan
+            loans_.loans.pop();
+
+            // sort former tail loan
+            _bubbleUp  (loans_, tail, index_);
+
+            // sort current tail loan
+            _bubbleDown(loans_, loans_.loans[index_], index_);
         }
     }
 
     /**
      *  @notice Performs an insert or an update dependent on borrowers existance.
-     *  @param loans_ Holds loan heap data.
-     *  @param borrower_       Borrower address that is being updated or inserted.
-     *  @param id_             Loan id.
-     *  @param thresholdPrice_ Threshold Price that is updated or inserted.
+     *  @param  loans_ Holds loan heap data.
+     *  @param  borrower_       Borrower address that is being updated or inserted.
+     *  @param  index_          Loan index.
+     *  @param  thresholdPrice_ Threshold Price that is updated or inserted.
      */
     function _upsert(
         LoansState storage loans_,
-        address borrower_,
-        uint256 id_,
-        uint96 thresholdPrice_
+        address            borrower_,
+        uint256            index_,
+        uint96             thresholdPrice_
     ) internal {
         // Loan exists, update in place.
-        if (id_ != 0) {
-            Loan memory currentLoan = loans_.loans[id_];
+        if (index_ != 0) {
+            Loan memory currentLoan = loans_.loans[index_];
+
             if (currentLoan.thresholdPrice > thresholdPrice_) {
                 currentLoan.thresholdPrice = thresholdPrice_;
-                _bubbleDown(loans_, currentLoan, id_);
-            } else {
-                currentLoan.thresholdPrice = thresholdPrice_;
-                _bubbleUp(loans_, currentLoan, id_);
-            }
 
+                _bubbleDown(loans_, currentLoan, index_);
+            }
+            else {
+                currentLoan.thresholdPrice = thresholdPrice_;
+
+                _bubbleUp(loans_, currentLoan, index_);
+            }
         // New loan, insert it
         } else {
             _bubbleUp(loans_, Loan(borrower_, thresholdPrice_), loans_.loans.length);
@@ -240,29 +273,36 @@ library Loans {
 
     /**
      *  @notice Retreives Loan by index, i_.
-     *  @param loans_ Holds loan heap data.
-     *  @param i_    Index to retreive Loan.
+     *  @param  loans_    Holds loan heap data.
+     *  @param  index_    Index of to loan to be retrieved.
      *  @return Loan Loan retrieved by index.
      */
-    function getByIndex(LoansState storage loans_, uint256 i_) internal view returns(Loan memory) {
-        return loans_.loans.length > i_ ? loans_.loans[i_] : Loan(address(0), 0);
+    function getByIndex(
+        LoansState storage loans_,
+        uint256            index_
+    ) internal view returns(Loan memory) {
+        return loans_.loans.length > index_ ? loans_.loans[index_] : Loan(address(0), 0);
     }
 
     /**
      *  @notice Retreives Loan with the highest threshold price value.
-     *  @param loans_ Holds loan heap data.
+     *  @param  loans_ Holds loan heap data.
      *  @return Loan Max Loan in the Heap.
      */
-    function getMax(LoansState storage loans_) internal view returns(Loan memory) {
+    function getMax(
+        LoansState storage loans_
+    ) internal view returns(Loan memory) {
         return getByIndex(loans_, ROOT_INDEX);
     }
 
     /**
      *  @notice Returns number of loans in pool.
-     *  @param loans_ Holds loan heap data.
+     *  @param  loans_ Holds loan heap data.
      *  @return number of loans in pool.
      */
-    function noOfLoans(LoansState storage loans_) internal view returns (uint256) {
+    function noOfLoans(
+        LoansState storage loans_
+    ) internal view returns (uint256) {
         return loans_.loans.length - 1;
     }
 }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -416,7 +416,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(operator);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(from, to, indexes, lpBalance);
+        emit TransferLPs(from, to, indexes, lpBalance);
         _pool.transferLPs(from, to, indexes);
 
         for(uint256 i = 0; i < indexes.length ;i++ ){

--- a/tests/forge/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
+
+import 'src/libraries/helpers/PoolHelper.sol';
+
+contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
+
+    address internal _borrower1;
+    address internal _borrower2;
+    address internal _borrower3;
+    address internal _borrower4;
+    address internal _borrower5;
+    address internal _borrower6;
+    address internal _lender1;
+    address internal _lender2;
+    address internal _lender3;
+    address internal _lender4;
+
+    function setUp() external {
+        _borrower1 = makeAddr("borrower1");
+        _borrower2 = makeAddr("borrower2");
+        _borrower3 = makeAddr("borrower3");
+        _borrower4 = makeAddr("borrower4");
+        _borrower5 = makeAddr("borrower5");
+        _borrower6 = makeAddr("borrower6");
+        _lender1   = makeAddr("lender1");
+        _lender2   = makeAddr("lender2");
+        _lender3   = makeAddr("lender3");
+        _lender4   = makeAddr("lender4");
+
+        _mintQuoteAndApproveTokens(_lender1, 150_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender2, 150_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender3, 150_000 * 1e18);
+        _mintQuoteAndApproveTokens(_lender4, 5_000 * 1e18);
+
+        _mintCollateralAndApproveTokens(_lender1,   1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_lender3,   1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower1, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower3, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower4, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower5, 1_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower6, 1_000 * 1e18);
+
+        // Lender 1 adds Quote token accross 2 buckets
+        _addInitialLiquidity(
+            {
+                from:   _lender1,
+                amount: 50_000 * 1e18,
+                index:  2500
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender1,
+                amount: 50_000 * 1e18,
+                index:  2501
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender1,
+                amount: 1_000 * 1e18,
+                index:  2502
+            }
+        );
+
+    }
+    
+    function testLoanHeapUpdateThresholdPrice() external {
+        // all 6 borrowers draw debt from pool
+        _drawDebt(
+            {
+                from:               _borrower1,
+                borrower:           _borrower1,
+                amountToBorrow:     1_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+        _drawDebt(
+            {
+                from:               _borrower2,
+                borrower:           _borrower2,
+                amountToBorrow:     2_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+        _drawDebt(
+            {
+                from:               _borrower3,
+                borrower:           _borrower3,
+                amountToBorrow:     3_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+        _drawDebt(
+            {
+                from:               _borrower4,
+                borrower:           _borrower4,
+                amountToBorrow:     4_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+        _drawDebt(
+            {
+                from:               _borrower5,
+                borrower:           _borrower5,
+                amountToBorrow:     5_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+        _drawDebt(
+            {
+                from:               _borrower6,
+                borrower:           _borrower6,
+                amountToBorrow:     6_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 1_000 * 1e18,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+
+        _assertLoans(
+            {
+                noOfLoans:         6,
+                maxBorrower:       _borrower6,
+                maxThresholdPrice: 6.005769230769230772 * 1e18
+            }
+        );
+
+        _drawDebt(
+            {
+                from:               _borrower4,
+                borrower:           _borrower4,
+                amountToBorrow:     10_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 0,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+
+        _assertLoans(
+            {
+                noOfLoans:         6,
+                maxBorrower:       _borrower4,
+                maxThresholdPrice: 14.013461538461538468 * 1e18
+            }
+        );
+
+        _repayDebt({
+            from:             _borrower4,
+            borrower:         _borrower4,
+            amountToRepay:    11_000 * 1e18,
+            amountRepaid:     11_000 * 1e18,
+            collateralToPull: 0,
+            newLup:           3_863.654368867279344664 * 1e18
+        });
+
+        _assertLoans(
+            {
+                noOfLoans:         6,
+                maxBorrower:       _borrower6,
+                maxThresholdPrice: 6.005769230769230772 * 1e18
+            }
+        );
+
+        _repayDebt({
+            from:             _borrower6,
+            borrower:         _borrower6,
+            amountToRepay:    5_000 * 1e18,
+            amountRepaid:     5_000 * 1e18,
+            collateralToPull: 0,
+            newLup:           3_863.654368867279344664 * 1e18
+        });
+
+        _assertLoans(
+            {
+                noOfLoans:         6,
+                maxBorrower:       _borrower5,
+                maxThresholdPrice: 5.004807692307692310 * 1e18
+            }
+        );
+
+        _drawDebt(
+            {
+                from:               _borrower6,
+                borrower:           _borrower6,
+                amountToBorrow:     11_000 * 1e18,
+                limitIndex:         5000,
+                collateralToPledge: 0,
+                newLup:             3_863.654368867279344664 * 1e18
+            }
+        );
+
+        _assertLoans(
+            {
+                noOfLoans:         6,
+                maxBorrower:       _borrower6,
+                maxThresholdPrice: 12.016346153846153854 * 1e18
+            }
+        );
+    }
+}

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -913,4 +913,26 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             newLup:           MAX_PRICE
         });
     }
+
+    function testMoveQuoteDustAmountRevert() external virtual tearDown {
+        init(8, 6);
+
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 50_000 * 1e6,
+                index:  2550
+            }
+        );
+        assertEq(_quoteDust, 0.000001 * 1e18);
+        _assertMoveLiquidityDustRevert(
+            {
+                from:      _lender,
+                amount:    0.00000001 * 1e18,
+                fromIndex: 2550,
+                toIndex:   2551
+            }
+        );
+    }
+
 }

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -5,7 +5,7 @@ import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
 import 'src/libraries/helpers/PoolHelper.sol';
 
-contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
+contract ERC20PoolTransferLPsTest is ERC20HelperContract {
 
     address internal _lender;
     address internal _lender1;
@@ -25,7 +25,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
     /*** Transfer LP Tokens Tests ***/
     /********************************/
 
-    function testTransferLPTokensToZeroAddress() external tearDown {
+    function testTransferLPsToZeroAddress() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -55,7 +55,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToUnallowedAddress() external tearDown {
+    function testTransferLPsToUnallowedAddress() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -77,7 +77,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToInvalidIndex() external tearDown {
+    function testTransferLPsToInvalidIndex() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 9999;
         indexes[1] = 2550;
@@ -99,7 +99,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensGreaterThanBalance() external tearDown {
+    function testTransferLPsGreaterThanBalance() external tearDown {
         uint256[] memory indexes = new uint256[](2);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -133,7 +133,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensForAllIndexes() external tearDown {
+    function testTransferLPsForAllIndexes() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -290,7 +290,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensForTwoIndexes() external tearDown {
+    function testTransferLPsForTwoIndexes() external tearDown {
         uint256[] memory depositIndexes = new uint256[](3);
         depositIndexes[0] = 2550;
         depositIndexes[1] = 2551;
@@ -448,7 +448,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToLenderWithLPTokens() external tearDown {
+    function testTransferLPsToLenderWithLPTokens() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -399,7 +399,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
         emit MergeOrRemoveCollateralNFT(from, collateralMerged, toIndexLps);
-        ERC721Pool(address(_pool)).mergeOrRemoveCollateral(removeCollateralAtIndex, noOfNFTsToRemove, toIndex);
+        ERC721Pool(address(_pool)).mergeOrRemoveCollateral(noOfNFTsToRemove, removeCollateralAtIndex, toIndex);
 
         // Add for tearDown
         lenders.add(from);
@@ -517,7 +517,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal virtual {
         changePrank(from);
         vm.expectRevert(IPoolErrors.CannotMergeToHigherPrice.selector);
-        ERC721Pool(address(_pool)).mergeOrRemoveCollateral(removeCollateralAtIndex, noOfNFTsToRemove, toIndex);
+        ERC721Pool(address(_pool)).mergeOrRemoveCollateral(noOfNFTsToRemove, removeCollateralAtIndex, toIndex);
     }
 
     function _assertBorrowBorrowerUnderCollateralizedRevert(

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -13,20 +13,14 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
     address internal _lender;
     address internal _lender2;
 
-    function setUp() external {
+    function setUp() virtual external {
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
         _lender2   = makeAddr("lender2");
 
-        // deploy subset pool
-        uint256[] memory subsetTokenIds = new uint256[](5);
-        subsetTokenIds[0] = 1;
-        subsetTokenIds[1] = 3;
-        subsetTokenIds[2] = 5;
-        subsetTokenIds[3] = 51;
-        subsetTokenIds[4] = 53;
-        _pool = _deploySubsetPool(subsetTokenIds);
+        // deploy collection pool
+        _pool = _deployCollectionPool();
 
         _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
         _mintAndApproveQuoteTokens(_borrower, 100 * 1e18);
@@ -35,15 +29,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         _mintAndApproveCollateralTokens(_borrower2, 53);
     }
 
-    /*******************************/
-    /*** ERC721 Collection Tests ***/
-    /*******************************/
+    /************************************/
+    /*** ERC721 Collection Pool Tests ***/
+    /************************************/
 
-    /***************************/
-    /*** ERC721 Subset Tests ***/
-    /***************************/
-
-    function testPledgeCollateralSubset() external tearDown {
+    function testPledgeCollateral() external tearDown {
         // check initial token balances
         assertEq(_pool.pledgedCollateral(), 0);
 
@@ -55,7 +45,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
-        // borrower deposits three NFTs into the subset pool
+        // borrower deposits three NFTs into the pool
         _pledgeCollateral(
             {
                 from:     _borrower,
@@ -70,22 +60,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(address(_pool)), 3);
     }
 
-    function testPledgeCollateralNotInSubset() external tearDown {
-        uint256[] memory tokenIdsToAdd = new uint256[](3);
-        tokenIdsToAdd[0] = 2;
-        tokenIdsToAdd[1] = 4;
-        tokenIdsToAdd[2] = 6;
-
-        // should revert if borrower attempts to add tokens not in the pool subset
-        _assertPledgeCollateralNotInSubsetRevert(
-            {
-                from:     _borrower,
-                tokenIds: tokenIdsToAdd
-            }
-        );
-    }
-
-    function testPledgeCollateralInSubsetFromDifferentActor() external tearDown {
+    function testPledgeCollateralFromDifferentActor() external tearDown {
         // check initial token balances
         assertEq(_pool.pledgedCollateral(),             0);
 
@@ -115,7 +90,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = 53;
 
-        // borrower deposits three NFTs into the subset pool
+        // borrower deposits three NFTs into the pool
         _pledgeCollateral(
             {
                 from:     _borrower2,
@@ -169,7 +144,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
-        // borrower deposits three NFTs into the subset pool
+        // borrower deposits three NFTs into the pool
         _pledgeCollateral(
             {
                 from:     _borrower,
@@ -352,7 +327,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
-        // borrower deposits three NFTs into the subset pool
+        // borrower deposits three NFTs into the pool
         _pledgeCollateral(
             {
                 from:     _borrower,
@@ -461,7 +436,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
-        // borrower deposits three NFTs into the subset pool
+        // borrower deposits three NFTs into the pool
         _pledgeCollateral(
             {
                 from:     _borrower,
@@ -1168,5 +1143,49 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(_borrower),      50);
         assertEq(_collateral.balanceOf(address(_pool)), 0);
 
+    }
+}
+
+contract ERC721SubsetPoolCollateralTest is ERC721PoolCollateralTest {
+
+    function setUp() override external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender2   = makeAddr("lender2");
+
+        // deploy subset pool
+        uint256[] memory subsetTokenIds = new uint256[](5);
+        subsetTokenIds[0] = 1;
+        subsetTokenIds[1] = 3;
+        subsetTokenIds[2] = 5;
+        subsetTokenIds[3] = 51;
+        subsetTokenIds[4] = 53;
+        _pool = _deploySubsetPool(subsetTokenIds);
+
+        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
+        _mintAndApproveQuoteTokens(_borrower, 100 * 1e18);
+
+        _mintAndApproveCollateralTokens(_borrower,  52);
+        _mintAndApproveCollateralTokens(_borrower2, 53);
+    }
+
+    /********************************/
+    /*** ERC721 Subset Pool Tests ***/
+    /********************************/
+
+    function testPledgeCollateralNotInSubset() external tearDown {
+        uint256[] memory tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 2;
+        tokenIdsToAdd[1] = 4;
+        tokenIdsToAdd[2] = 6;
+
+        // should revert if borrower attempts to add tokens not in the pool subset
+        _assertPledgeCollateralNotInSubsetRevert(
+            {
+                from:     _borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
     }
 }

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import { ERC721HelperContract } from './ERC721DSTestPlus.sol';
+
+import 'src/libraries/helpers/PoolHelper.sol';
+
+contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+    address internal _lender1;
+    address internal _taker;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender1   = makeAddr("lender1");
+        _taker     = makeAddr("taker");
+
+        // deploy subset pool
+        uint256[] memory subsetTokenIds = new uint256[](6);
+        subsetTokenIds[0] = 1;
+        subsetTokenIds[1] = 3;
+        subsetTokenIds[2] = 5;
+        subsetTokenIds[3] = 51;
+        subsetTokenIds[4] = 53;
+        subsetTokenIds[5] = 73;
+        _pool = _deploySubsetPool(subsetTokenIds);
+
+        _mintAndApproveQuoteTokens(_lender,  120_000 * 1e18);
+        _mintAndApproveQuoteTokens(_lender1, 120_000 * 1e18);
+        _mintAndApproveQuoteTokens(_borrower, 10 * 1e18);
+
+        _mintAndApproveCollateralTokens(_borrower,  6);
+        _mintAndApproveCollateralTokens(_borrower2, 74);
+
+        // Lender adds Quote token accross 5 prices
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 2_000 * 1e18,
+                index:  _i9_91
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 5_000 * 1e18,
+                index:  _i9_81
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 11_000 * 1e18,
+                index:  _i9_72
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 25_000 * 1e18,
+                index:  _i9_62
+            }
+        );
+        _addInitialLiquidity(
+            {
+                from:   _lender,
+                amount: 30_000 * 1e18,
+                index:  _i9_52
+            }
+        );
+
+        // first borrower adds collateral token and borrows
+        uint256[] memory tokenIdsToAdd = new uint256[](2);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+
+        // borrower deposits two NFTs into the subset pool and borrows
+        _pledgeCollateral(
+            {
+                from:     _borrower,
+                borrower: _borrower,
+                tokenIds: tokenIdsToAdd
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower,
+                amount:     19.8 * 1e18,
+                indexLimit: _i9_91,
+                newLup:     9.917184843435912074 * 1e18
+            }
+        );
+
+        // second borrower deposits three NFTs into the subset pool and borrows
+        tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 51;
+        tokenIdsToAdd[1] = 53;
+        tokenIdsToAdd[2] = 73;
+        _pledgeCollateral(
+            {
+                from:     _borrower2,
+                borrower: _borrower2,
+                tokenIds: tokenIdsToAdd
+            }
+        );
+        _borrow(
+            {
+                from:       _borrower2,
+                amount:     15 * 1e18,
+                indexLimit: _i9_72,
+                newLup:     9.917184843435912074 * 1e18
+            }
+        );
+
+        /*****************************/
+        /*** Assert pre-kick state ***/
+        /*****************************/
+
+        _assertPool(
+            PoolParams({
+                htp:                  9.909519230769230774 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 3.512434434608473285 * 1e18,
+                poolDebt:             34.833461538461538478 * 1e18,
+                actualUtilization:    0.000477170706006322 * 1e18,
+                targetUtilization:    1 * 1e18,
+                minDebtAmount:        1.741673076923076924 * 1e18,
+                loans:                2,
+                maxBorrower:          address(_borrower),
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              19.819038461538461548 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 1.000773560501591181 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              15.014423076923076930 * 1e18,
+                borrowerCollateral:        3 * 1e18,
+                borrowert0Np:              5.255048076923076925 * 1e18,
+                borrowerCollateralization: 1.981531649793150539 * 1e18
+            }
+        );
+        assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
+
+        // Skip to make borrower undercollateralized
+        skip(1000 days);
+        _kick(
+            {
+                from:           _lender,
+                borrower:       _borrower,
+                debt:           23.012828827714740289 * 1e18,
+                collateral:     2 * 1e18,
+                bond:           0.227287198298417188 * 1e18,
+                transferAmount: 0.227287198298417188 * 1e18
+            }
+        );
+
+        /******************************/
+        /*** Assert Post-kick state ***/
+        /******************************/
+
+        _assertPool(
+            PoolParams({
+                htp:                  6.582216822103492762 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 4.056751649452525709 * 1e18,
+                poolDebt:             40.231555971534224231 * 1e18,
+                actualUtilization:    0.000551117205089510 * 1e18,
+                targetUtilization:    0.811350329890505142 * 1e18,
+                minDebtAmount:        4.023155597153422423 * 1e18,
+                loans:                1,
+                maxBorrower:          address(_borrower2),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   block.timestamp
+            })
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              23.012828827714740289 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 0.861883162446546169 * 1e18
+            }
+        );
+        _assertBorrower(
+            {
+                borrower:                  _borrower2,
+                borrowerDebt:              17.218727143819483942 * 1e18,
+                borrowerCollateral:        3 * 1e18,
+                borrowert0Np:              5.255048076923076925 * 1e18,
+                borrowerCollateralization: 1.727860269914713433 * 1e18
+            }
+        );
+    }
+
+    function testDepositTakeNFTAndSettleAuction() external tearDown {
+
+        skip(5 hours);
+
+        _assertAuction(
+           AuctionParams({
+               borrower:          _borrower,
+               active:            true,
+               kicker:            _lender,
+               bondSize:          0.227287198298417188 * 1e18,
+               bondFactor:        0.01 * 1e18,
+               kickTime:          block.timestamp - 5 hours,
+               kickMomp:          9.917184843435912074 * 1e18,
+               totalBondEscrowed: 0.227287198298417188 * 1e18,
+               auctionPrice:      23.865155821333804736 * 1e18,
+               debtInAuction:     23.012828827714740289 * 1e18,
+               thresholdPrice:    11.506709959118993144 * 1e18,
+               neutralPrice:      11.932577910666902372 * 1e18
+           })
+        );
+
+        _addLiquidity(
+            {
+                from:    _lender,
+                amount:  15.0 * 1e18,
+                index:   _i1505_26,
+                lpAward: 15.0 * 1e27,
+                newLup:  9.917184843435912074 * 1e18
+            }
+        );
+
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              23.013419918237986289 * 1e18,
+                borrowerCollateral:        2 * 1e18,
+                borrowert0Np:              10.404995192307692312 * 1e18,
+                borrowerCollateralization: 0.861861025320848319 * 1e18
+            }
+        );
+
+        _depositTake(
+            {
+                from:             _taker,
+                borrower:         _borrower,
+                kicker:           _lender,
+                index:            _i1505_26,
+                collateralArbed:  0.009965031187761219 * 1e18,
+                quoteTokenAmount: 15.0 * 1e18,
+                bondChange:       0.15 * 1e18,
+                isReward:         false,
+                lpAwardTaker:     0,
+                lpAwardKicker:    0
+            }
+        );
+
+        _assertAuction(
+           AuctionParams({
+               borrower:          _borrower,
+               active:            false,
+               kicker:            address(0),
+               bondSize:          0,
+               bondFactor:        0,
+               kickTime:          0,
+               kickMomp:          0,
+               totalBondEscrowed: 0,
+               auctionPrice:      0,
+               debtInAuction:     0,
+               thresholdPrice:    9.624359312514645329 * 1e18,
+               neutralPrice:      0
+           })
+        );
+        // borrower is compensated LPs for fractional collateral
+        _assertLenderLpBalance(
+            {
+                lender:      _borrower,
+                index:       3519,
+                lpBalance:   23.737330323739529014630349498 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+
+        _assertBucket(
+            {
+                index:        _i1505_26,
+                lpBalance:    15 * 1e27,
+                collateral:   0.009965031187761219 * 1e18,
+                deposit:      0,
+                exchangeRate: 0.999999999999999999688877723 * 1e27
+            }
+        );
+
+        _assertBorrower(
+            {
+                borrower:                  _borrower,
+                borrowerDebt:              9.624359312514645329 * 1e18,
+                borrowerCollateral:        1 * 1e18,
+                borrowert0Np:              8.769696613728507377 * 1e18,
+                borrowerCollateralization: 1.030425457052554443 * 1e18
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _taker,
+                index:       _i1505_26,
+                lpBalance:   0,
+                depositTime: 0
+            }
+        );
+        _assertLenderLpBalance(
+            {
+                lender:      _lender,
+                index:       _i1505_26,
+                lpBalance:   15.0 * 1e27,
+                depositTime: block.timestamp
+            }
+        );
+
+        // borrower should be able to remove collateral in the pool
+        _repayDebtNoLupCheck({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    10 * 1e18,
+            amountRepaid:     10 * 1e18,
+            collateralToPull: 1
+        });
+    }
+
+}

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -212,7 +212,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
         );
     }
 
-    function testDepositTakeNFTAndSettleAuction() external tearDown {
+    function testDepositTakeNFTAndSettleAuction() external {
 
         skip(5 hours);
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -70,7 +70,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             }
         );
 
-       // first borrower adds collateral token and borrows
+        // first borrower adds collateral token and borrows
         uint256[] memory tokenIdsToAdd = new uint256[](2);
         tokenIdsToAdd[0] = 1;
         tokenIdsToAdd[1] = 3;

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -848,6 +848,16 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 borrowerCollateralization: 1 * 1e18
             }
         );
+
+        // borrower should be able to remove collateral in the pool
+        _repayDebtNoLupCheck({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    0,
+            amountRepaid:     0,
+            collateralToPull: 1
+        });
+
         vm.revertTo(snapshot);
 
         // borrower repays part of debt, but not enough to exit from auction

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -170,7 +170,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check memorialization success
@@ -294,7 +294,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance(
@@ -444,7 +444,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 6_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -694,7 +694,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testLender1, tokenId1);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e27);
+        emit TransferLPs(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
@@ -787,7 +787,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testLender2, tokenId2);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testLender2, address(_positionManager), newIndexes, 6_000 * 1e27);
+        emit TransferLPs(testLender2, address(_positionManager), newIndexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // // check lender, position manager,  and pool state
@@ -2089,7 +2089,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit RedeemPosition(testReceiver, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(address(_positionManager), testReceiver, indexes, 15_000 * 1e27);
+        emit TransferLPs(address(_positionManager), testReceiver, indexes, 15_000 * 1e27);
         changePrank(testReceiver);
         _positionManager.reedemPositions(reedemParams);
 
@@ -2610,7 +2610,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress1, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress1, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress1, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance(
@@ -2760,7 +2760,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress1, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress1, address(_positionManager), indexes, 6_000 * 1e27);
+        emit TransferLPs(testAddress1, address(_positionManager), indexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1328,6 +1328,29 @@ contract RewardsManagerTest is DSTestPlus {
         assertGt(_ajnaToken.balanceOf(_updater), 0);
 
         // check owner can withdraw the NFT and rewards will be automatically claimed
+
+        uint256 snapshot = vm.snapshot();
+
+        // claimed rewards amount is greater than available tokens in rewards manager contract
+
+        // burn rewards manager tokens and leave only 5 tokens available
+        changePrank(address(_rewardsManager));
+        IERC20Token(address(_ajnaToken)).burn(99_999_990.978586345404952410 * 1e18);
+        assertEq(_ajnaToken.balanceOf(address(_rewardsManager)), 5 * 1e18); 
+
+        changePrank(_minterOne);
+        vm.expectEmit(true, true, true, true);
+        emit ClaimRewards(_minterOne, address(_poolOne), tokenIdOne, _epochsClaimedArray(1, 0), 40.214136545950568150 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit Unstake(_minterOne, address(_poolOne), tokenIdOne);
+        _rewardsManager.unstake(tokenIdOne);
+        assertEq(_positionManager.ownerOf(tokenIdOne), _minterOne);
+        assertEq(_ajnaToken.balanceOf(_minterOne), 5 * 1e18);
+        assertEq(_ajnaToken.balanceOf(address(_rewardsManager)), 0); 
+
+        vm.revertTo(snapshot);
+
+        // test when enough tokens in rewards manager contracts
         changePrank(_minterOne);
         vm.expectEmit(true, true, true, true);
         emit ClaimRewards(_minterOne, address(_poolOne), tokenIdOne, _epochsClaimedArray(1, 0), 40.214136545950568150 * 1e18);


### PR DESCRIPTION
Fix bug when take / bucketTake settles auction - borrower won't be able to pull his entitled collateral from pool
- because the remaining collateral is always returned as 0 after a take/bucketTake, the entire borrower collateral is rebalanced (all token ids are moved from borrower's array to pool token ids array)
- borrower won't be able to pull because he doesn't have any token entitled
Note: in case of `repayDebt` this scenario is properly handled https://github.com/ajna-finance/contracts/blob/master/src/libraries/external/BorrowerActions.sol#L294