### PR TITLE
gas improvements

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -291,15 +291,13 @@ contract RewardsManager is IRewardsManager {
                 positionIndexes
             );
 
-            uint256 nextEpoch = epoch + 1;
-
-            // update epoch token claim trackers
-            rewardsClaimed[nextEpoch]           += nextEpochRewards;
-            isEpochClaimed[tokenId_][nextEpoch] = true;
-
             rewards_ += nextEpochRewards;
 
             unchecked { ++epoch; }
+
+            // update epoch token claim trackers
+            rewardsClaimed[epoch]           += nextEpochRewards;
+            isEpochClaimed[tokenId_][epoch] = true;
         }
     }
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -248,7 +248,7 @@ library LenderActions {
         uint256 unscaledToBucketDeposit = Deposits.unscaledValueAt(deposits_, params_.toIndex);
         uint256 toBucketScale           = Deposits.scale(deposits_, params_.toIndex);
         uint256 toBucketDeposit         = Maths.wmul(toBucketScale, unscaledToBucketDeposit);
-        vars.toBucketPrice              = _priceAt(params_.toIndex);
+
         toBucketLPs_ = Buckets.quoteTokensToLPs(
             toBucket.collateral,
             toBucket.lps,

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -320,7 +320,7 @@ library LenderActions {
 
         RemoveDepositParams memory removeParams;
 
-        if (bucket.bankruptcyTime < lender.depositTime) removeParams.lpConstraint = lender.lps;
+        if (bucket.bankruptcyTime < depositTime) removeParams.lpConstraint = lender.lps;
 
         if (removeParams.lpConstraint == 0) revert NoClaim(); // revert if no LP to claim
 


### PR DESCRIPTION
- LenderActions.removeQuoteToken: reuse depositTime instead loading again from storage
- LenderActions.moveQuoteToken: remove duped calculation of to price
- RewardsManager: calculateAndClaimRewards, increment and then use next epoch
```
| calculateRewards                               | 4151            | 33039  | 24009  | 183513  | 285     |
| claimRewards                                   | 497             | 106796 | 91023  | 409342  | 282     |
| stake                                          | 2386            | 368950 | 224503 | 1060019 | 44      |
| unstake                                        | 541             | 184632 | 124852 | 428729  | 9       |
| updateBucketExchangeRatesAndClaim              | 14784           | 259140 | 185527 | 526260  | 38      |

vs master

| calculateRewards                               | 4151            | 37495  | 24009  | 183513  | 129     |
| claimRewards                                   | 497             | 122316 | 114899 | 409742  | 126     |
| stake                                          | 2386            | 396268 | 306608 | 1060019 | 38      |
| unstake                                        | 541             | 184728 | 124916 | 428889  | 9       |
| updateBucketExchangeRatesAndClaim              | 14784           | 274226 | 195565 | 526260  | 32      |
```