### PR TITLE
Consistent naming, replace lpTokens with LPs

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -129,7 +129,7 @@
 
 	emit events:
 	- LenderActions.transferLPs():
-		- TransferLPTokens
+		- TransferLPs
 
 ### kick
 	external libraries call:

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -352,13 +352,13 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Calculate the amount of quote tokens in bucket for a given amount of LP Tokens.
-     *  @param  lpTokens_    The number of lpTokens to calculate amounts for.
+     *  @param  lps_         The number of LPs to calculate amounts for.
      *  @param  index_       The price bucket index for which the value should be calculated.
      *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
      */
     function lpsToQuoteTokens(
         address ajnaPool_,
-        uint256 lpTokens_,
+        uint256 lps_,
         uint256 index_
     ) external view returns (uint256 quoteAmount_) {
         IPool pool = IPool(ajnaPool_);
@@ -367,7 +367,7 @@ contract PoolInfoUtils {
             bucketLPs_,
             bucketCollateral,
             bucketDeposit,
-            lpTokens_,
+            lps_,
             bucketDeposit,
             _priceAt(index_)
         );
@@ -375,13 +375,13 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LP Tokens.
-     *  @param  lpTokens_         The number of lpTokens to calculate amounts for.
+     *  @param  lps_              The number of LPs to calculate amounts for.
      *  @param  index_            The price bucket index for which the value should be calculated.
      *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
      */
     function lpsToCollateral(
         address ajnaPool_,
-        uint256 lpTokens_,
+        uint256 lps_,
         uint256 index_
     ) external view returns (uint256 collateralAmount_) {
         IPool pool = IPool(ajnaPool_);
@@ -390,7 +390,7 @@ contract PoolInfoUtils {
             bucketCollateral,
             bucketLPs_,
             bucketDeposit,
-            lpTokens_,
+            lps_,
             _priceAt(index_)
         );
     }

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -165,7 +165,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
 
         emit MemorializePosition(owner, params_.tokenId);
 
-        // update pool lp token accounting and transfer ownership of lp tokens to PositionManager contract
+        // update pool lps accounting and transfer ownership of lps to PositionManager contract
         pool.transferLPs(owner, address(this), params_.indexes);
     }
 
@@ -307,7 +307,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
 
         emit RedeemPosition(owner, params_.tokenId);
 
-        // update pool lp token accounting and transfer ownership of lp tokens from PositionManager contract
+        // update pool lps accounting and transfer ownership of lps from PositionManager contract
         pool.transferLPs(address(this), owner, params_.indexes);
     }
 
@@ -350,7 +350,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     /**********************/
 
     /// @inheritdoc IPositionManagerDerivedState
-    function getLPTokens(
+    function getLPs(
         uint256 tokenId_,
         uint256 index_
     ) external override view returns (uint256) {

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -149,8 +149,8 @@ contract RewardsManager is IRewardsManager {
 
             BucketState storage bucketState = stakeInfo.snapshot[bucketId];
 
-            // record the number of lp tokens in bucket at the time of staking
-            bucketState.lpsAtStakeTime = positionManager.getLPTokens(
+            // record the number of lps in bucket at the time of staking
+            bucketState.lpsAtStakeTime = positionManager.getLPs(
                 tokenId_,
                 bucketId
             );

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -93,7 +93,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
     bool internal isPoolInitialized;
 
-    mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpTokenAllowances; // owner address -> new owner address -> deposit index -> allowed amount
+    mapping(address => mapping(address => mapping(uint256 => uint256))) private _lpAllowances; // owner address -> new owner address -> deposit index -> allowed amount
 
     /******************/
     /*** Immutables ***/
@@ -159,14 +159,14 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     /**
      *  @inheritdoc IPoolLenderActions
      *  @dev write state:
-     *          - _lpTokenAllowances mapping
+     *          - _lpAllowances mapping
      */
     function approveLpOwnership(
-        address allowedNewOwner_,
+        address newOwner,
         uint256 index_,
-        uint256 lpsAmountToApprove_
+        uint256 amount_
     ) external nonReentrant {
-        _lpTokenAllowances[msg.sender][allowedNewOwner_][index_] = lpsAmountToApprove_;
+        _lpAllowances[msg.sender][newOwner][index_] = amount_;
     }
 
     /// @inheritdoc IPoolLenderActions
@@ -242,7 +242,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     ) external override nonReentrant {
         LenderActions.transferLPs(
             buckets,
-            _lpTokenAllowances,
+            _lpAllowances,
             owner_,
             newOwner_,
             indexes_

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -211,13 +211,13 @@ interface IPoolEvents {
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
      *  @param  indexes  Array of price bucket indexes at which LP tokens were transferred.
-     *  @param  lpTokens Amount of LP tokens transferred.
+     *  @param  lps      Amount of LPs transferred.
      */
-    event TransferLPTokens(
+    event TransferLPs(
         address owner,
         address newOwner,
         uint256[] indexes,
-        uint256 lpTokens
+        uint256 lps
     );
 
     /**

--- a/src/interfaces/position/IPositionManagerDerivedState.sol
+++ b/src/interfaces/position/IPositionManagerDerivedState.sol
@@ -8,16 +8,16 @@ pragma solidity 0.8.14;
 interface IPositionManagerDerivedState {
 
     /**
-     *  @notice Returns the lpTokens accrued to a given tokenId, bucket pairing.
+     *  @notice Returns the LPs accrued to a given tokenId, bucket pairing.
      *  @dev    Nested mappings aren't returned normally as part of the default getter for a mapping.
-     *  @param  tokenId  Unique ID of token.
-     *  @param  index    Index of bucket to check LP balance of.
-     *  @return lpTokens Balance of lpTokens in the bucket for this position.
+     *  @param  tokenId Unique ID of token.
+     *  @param  index   Index of bucket to check LP balance of.
+     *  @return lps     Balance of lps in the bucket for this position.
     */
-    function getLPTokens(
+    function getLPs(
         uint256 tokenId,
         uint256 index
-    ) external view returns (uint256 lpTokens);
+    ) external view returns (uint256 lps);
 
     /**
      *  @notice Returns an array of bucket indexes in which an NFT has liquidity.

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -9,7 +9,7 @@ interface IPositionManagerOwnerActions {
 
     /**
      *  @notice Called by owners to burn an existing NFT.
-     *  @dev    Requires that all lp tokens have been removed from the NFT prior to calling.
+     *  @dev    Requires that all lps have been removed from the NFT prior to calling.
      *  @param  params Calldata struct supplying inputs required to update the underlying assets owed to an NFT.
      */
     function burn(

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -62,7 +62,7 @@ library LenderActions {
     event BucketBankruptcy(uint256 indexed index, uint256 lpForfeited);
     event MoveQuoteToken(address indexed lender, uint256 indexed from, uint256 indexed to, uint256 amount, uint256 lpRedeemedFrom, uint256 lpAwardedTo, uint256 lup);
     event RemoveQuoteToken(address indexed lender, uint256 indexed price, uint256 amount, uint256 lpRedeemed, uint256 lup);
-    event TransferLPTokens(address owner, address newOwner, uint256[] indexes, uint256 lpTokens);
+    event TransferLPs(address owner, address newOwner, uint256[] indexes, uint256 lps);
 
     /**************/
     /*** Errors ***/
@@ -507,7 +507,7 @@ library LenderActions {
      *          - invalid index InvalidIndex()
      *          - no allowance NoAllowance()
      *  @dev emit events:
-     *          - TransferLPTokens
+     *          - TransferLPs
      */
     function transferLPs(
         mapping(uint256 => Bucket) storage buckets_,
@@ -539,7 +539,7 @@ library LenderActions {
 
             delete allowances_[owner_][newOwner_][index]; // delete allowance
 
-            // move lp tokens to the new owner address
+            // move lps to the new owner address
             Lender storage newLender = bucket.lenders[newOwner_];
 
             newLender.lps += transferAmount;
@@ -554,7 +554,7 @@ library LenderActions {
             unchecked { ++i; }
         }
 
-        emit TransferLPTokens(owner_, newOwner_, indexes_, tokensTransferred);
+        emit TransferLPs(owner_, newOwner_, indexes_, tokensTransferred);
     }
 
     /**************************/

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -416,7 +416,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(operator);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(from, to, indexes, lpBalance);
+        emit TransferLPs(from, to, indexes, lpBalance);
         _pool.transferLPs(from, to, indexes);
 
         for(uint256 i = 0; i < indexes.length ;i++ ){

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -5,7 +5,7 @@ import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
 import 'src/libraries/helpers/PoolHelper.sol';
 
-contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
+contract ERC20PoolTransferLPsTest is ERC20HelperContract {
 
     address internal _lender;
     address internal _lender1;
@@ -21,11 +21,11 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         _mintQuoteAndApproveTokens(_lender2, 200_000 * 1e18);
     }
 
-    /********************************/
-    /*** Transfer LP Tokens Tests ***/
-    /********************************/
+    /**************************/
+    /*** Transfer LPs Tests ***/
+    /**************************/
 
-    function testTransferLPTokensToZeroAddress() external tearDown {
+    function testTransferLPsToZeroAddress() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -55,7 +55,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToUnallowedAddress() external tearDown {
+    function testTransferLPsToUnallowedAddress() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -77,7 +77,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToInvalidIndex() external tearDown {
+    function testTransferLPsToInvalidIndex() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 9999;
         indexes[1] = 2550;
@@ -99,7 +99,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensGreaterThanBalance() external tearDown {
+    function testTransferLPsGreaterThanBalance() external tearDown {
         uint256[] memory indexes = new uint256[](2);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -133,7 +133,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensForAllIndexes() external tearDown {
+    function testTransferLPsForAllIndexes() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -290,7 +290,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensForTwoIndexes() external tearDown {
+    function testTransferLPsForTwoIndexes() external tearDown {
         uint256[] memory depositIndexes = new uint256[](3);
         depositIndexes[0] = 2550;
         depositIndexes[1] = 2551;
@@ -448,7 +448,7 @@ contract ERC20PoolTransferLPTokensTest is ERC20HelperContract {
         );
     }
 
-    function testTransferLPTokensToLenderWithLPTokens() external tearDown {
+    function testTransferLPsToLenderWithLPTokens() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -27,6 +27,7 @@ abstract contract PositionManagerERC20PoolHelperContract is ERC20HelperContract 
 
         vm.prank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
+
         vm.prank(operator_);
         _quote.approve(address(_positionManager), type(uint256).max);
     }
@@ -124,27 +125,21 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         indexes[1] = 2551;
         indexes[2] = 2552;
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
         // mint an NFT to later memorialize existing positions into
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
@@ -198,80 +193,62 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         indexes[1] = 2551;
         indexes[2] = 2552;
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
         // mint an NFT to later memorialize existing positions into
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
 
         // check LPs
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
@@ -297,54 +274,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
@@ -355,77 +320,59 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
 
         // add more liquidity
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 1_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 2_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 1_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 2_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
         // check LP balance
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[0],
-                lpBalance:   1_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[1],
-                lpBalance:   2_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[0],
+            lpBalance:   1_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[1],
+            lpBalance:   2_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
@@ -448,54 +395,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   4_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   5_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   6_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   4_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   5_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   6_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 4_000 * 1e27);
@@ -525,144 +460,110 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         indexes[2] = 2552;
         indexes[3] = 2553;
 
-        _addInitialLiquidity(
-            {
-                from:   testLender1,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testLender1,
-                amount: 3_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testLender1,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testLender1,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testLender1,
+            amount: 3_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testLender1,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
-        _addInitialLiquidity(
-            {
-                from:   testLender2,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testLender2,
-                amount: 3_000 * 1e18,
-                index:  indexes[3]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testLender2,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testLender2,
+            amount: 3_000 * 1e18,
+            index:  indexes[3]
+        });
 
         // mint NFTs to later memorialize existing positions into
         uint256 tokenId1 = _mintNFT(testLender1, testLender1, address(_pool));
         uint256 tokenId2 = _mintNFT(testLender2, testLender2, address(_pool));
 
         // check LPs
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[3],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[3],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[3],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[3],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[3],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[3],
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         assertEq(_positionManager.getLPs(indexes[0], tokenId1), 0);
         assertEq(_positionManager.getLPs(indexes[1], tokenId1), 0);
@@ -698,70 +599,54 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender1,
-                index:       indexes[3],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[3],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender1,
+            index:       indexes[3],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[3],
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         assertEq(_positionManager.getLPs(tokenId1, indexes[0]), 3_000 * 1e27);
         assertEq(_positionManager.getLPs(tokenId1, indexes[1]), 3_000 * 1e27);
@@ -791,70 +676,54 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // // check lender, position manager,  and pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   6_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testLender2,
-                index:       indexes[3],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[3],
-                lpBalance:   3_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   6_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testLender2,
+            index:       indexes[3],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[3],
+            lpBalance:   3_000 * 1e27,
+            depositTime: _startTime
+        });
 
         assertEq(_positionManager.getLPs(tokenId1, indexes[0]), 3_000 * 1e27);
         assertEq(_positionManager.getLPs(tokenId1, indexes[1]), 3_000 * 1e27);
@@ -905,43 +774,36 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // add initial liquidity
         uint256 mintAmount = 50_000 * 1e18;
         _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
-        _addInitialLiquidity(
-            {
-                from:   testMinter,
-                amount: 15_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
+
+        _addInitialLiquidity({
+            from:   testMinter,
+            amount: 15_000 * 1e18,
+            index:  testIndexPrice
+        });
 
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
         // check LPs
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -958,30 +820,24 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
         _positionManager.memorializePositions(memorializeParams);
 
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
@@ -1008,30 +864,24 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -1053,43 +903,36 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // add initial liquidity
         uint256 mintAmount = 50_000 * 1e18;
         _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
-        _addInitialLiquidity(
-            {
-                from:   testMinter,
-                amount: 15_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
+
+        _addInitialLiquidity({
+            from:   testMinter,
+            amount: 15_000 * 1e18,
+            index:  testIndexPrice
+        });
 
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
         // check LPs
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -1107,30 +950,24 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
@@ -1177,30 +1014,24 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -1299,13 +1130,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // add initial liquidity
         uint256 mintAmount = 50_000 * 1e18;
         _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
-        _addInitialLiquidity(
-            {
-                from:   testMinter,
-                amount: 15_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
+
+        _addInitialLiquidity({
+            from:   testMinter,
+            amount: 15_000 * 1e18,
+            index:  testIndexPrice
+        });
 
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
 
@@ -1353,13 +1183,11 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         address notOwner    = makeAddr("notOwner");
         _mintQuoteAndApproveManagerTokens(testAddress, 10_000 * 1e18);
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 10_000 * 1e18,
-                index:  2550
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 10_000 * 1e18,
+            index:  2550
+        });
 
         // mint position NFT
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
@@ -1386,20 +1214,16 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _mintQuoteAndApproveManagerTokens(testAddress2, 10_000 * 1e18);
         _mintCollateralAndApproveTokens(testAddress3, 10_000 * 1e18);
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 2_500 * 1e18,
-                index:  mintIndex
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress2,
-                amount: 5_500 * 1e18,
-                index:  mintIndex
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 2_500 * 1e18,
+            index:  mintIndex
+        });
+        _addInitialLiquidity({
+            from:   testAddress2,
+            amount: 5_500 * 1e18,
+            index:  mintIndex
+        });
 
         uint256 tokenId1 = _mintNFT(testAddress1, testAddress1, address(_pool));
         uint256 tokenId2 = _mintNFT(testAddress2, testAddress2, address(_pool));
@@ -1407,54 +1231,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertEq(_positionManager.ownerOf(tokenId2), testAddress2);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       mintIndex,
-                lpBalance:   2_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       mintIndex,
-                lpBalance:   5_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       moveIndex,
-                lpBalance:   0 * 1e27,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       mintIndex,
+            lpBalance:   2_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       mintIndex,
+            lpBalance:   5_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       moveIndex,
+            lpBalance:   0 * 1e27,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
@@ -1480,54 +1292,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-       _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       mintIndex,
-                lpBalance:   5_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       mintIndex,
-                lpBalance:   2_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       mintIndex,
+            lpBalance:   5_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   2_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId1, mintIndex), 2_500 * 1e27);
@@ -1551,54 +1351,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check pool state
-       _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       mintIndex,
-                lpBalance:   5_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       moveIndex,
-                lpBalance:   2_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       mintIndex,
+            lpBalance:   5_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   2_500 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
@@ -1622,54 +1410,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-       _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       mintIndex,
-                lpBalance:   5_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       moveIndex,
-                lpBalance:   2_500 * 1e27,
-                depositTime: _startTime
-            }
-        );
+       _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   5_500 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   2_500 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
@@ -1686,14 +1462,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId2, address(_pool), mintIndex, moveIndex
         );
 
-        _addCollateral(
-            {
-                from:    testAddress3,
-                amount:  10_000 * 1e18,
-                index:   mintIndex,
-                lpAward: 30_108_920.22197881557845 * 1e27
-            }
-        );
+        _addCollateral({
+            from:    testAddress3,
+            amount:  10_000 * 1e18,
+            index:   mintIndex,
+            lpAward: 30_108_920.22197881557845 * 1e27
+        });
 
         // move liquidity called by testAddress2 owner
         vm.expectEmit(true, true, true, true);
@@ -1702,54 +1476,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check pool state
-       _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       mintIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       mintIndex,
-                lpBalance:   0 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       moveIndex,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       moveIndex,
-                lpBalance:   8_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+       _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   0 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       moveIndex,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   8_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
@@ -1778,35 +1540,30 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // add initial liquidity
         uint256 mintAmount = 50_000 * 1e18;
         _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
-        _addInitialLiquidity(
-            {
-                from:   testMinter,
-                amount: 15_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
+
+        _addInitialLiquidity({
+            from:   testMinter,
+            amount: 15_000 * 1e18,
+            index:  testIndexPrice
+        });
 
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -1824,22 +1581,18 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
@@ -1862,22 +1615,18 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -1916,82 +1665,65 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256 mintAmount = 50_000 * 1e18;
         _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
         _mintQuoteAndApproveManagerTokens(testReceiver, mintAmount);
-        _addInitialLiquidity(
-            {
-                from:   testReceiver,
-                amount: 25_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testReceiver,
-                amount: 15_000 * 1e18,
-                index:  2551
-            }
-        );
 
-        _addInitialLiquidity(
-            {
-                from:   testMinter,
-                amount: 15_000 * 1e18,
-                index:  testIndexPrice
-            }
-        );
+        _addInitialLiquidity({
+            from:   testReceiver,
+            amount: 25_000 * 1e18,
+            index:  testIndexPrice
+        });
+        _addInitialLiquidity({
+            from:   testReceiver,
+            amount: 15_000 * 1e18,
+            index:  2551
+        });
+
+        _addInitialLiquidity({
+            from:   testMinter,
+            amount: 15_000 * 1e18,
+            index:  testIndexPrice
+        });
 
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   25_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       2551,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   25_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       2551,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -2009,54 +1741,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.memorializePositions(memorializeParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   25_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       2551,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   25_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       2551,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
@@ -2094,54 +1814,42 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.reedemPositions(reedemParams);
 
         // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       testIndexPrice,
-                lpBalance:   40_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       testIndexPrice,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testMinter,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testReceiver,
-                index:       2551,
-                lpBalance:   15_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   40_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       2551,
+            lpBalance:   15_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
@@ -2159,37 +1867,30 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = 2550;
 
-        _addInitialLiquidity(
-            {
-                from:   lender,
-                amount: 10_000 * 1e18,
-                index:  2550
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2550,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _addInitialLiquidity({
+            from:   lender,
+            amount: 10_000 * 1e18,
+            index:  2550
+        });
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2550,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+
         // allow position manager to take ownership of the position
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 10_000 * 1e27);
 
@@ -2200,30 +1901,25 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId, indexes
         );
         _positionManager.memorializePositions(memorializeParams);
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2550,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2550,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // minter cannot move liquidity on behalf of lender (is not approved)
         IPositionManagerOwnerActions.MoveLiquidityParams memory moveLiquidityParams = IPositionManagerOwnerActions.MoveLiquidityParams(
@@ -2253,30 +1949,25 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         changePrank(minter);
         // minter can move liquidity on behalf of lender
         _positionManager.moveLiquidity(moveLiquidityParams);
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2551,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2551,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
 
         // minter can redeem liquidity on behalf of lender
         indexes[0] = 2551;
@@ -2284,30 +1975,25 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId, address(_pool), indexes
         );
         _positionManager.reedemPositions(reedemParams);
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2551,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       2551,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2551,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       2551,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // minter can burn NFT on behalf of lender
         _positionManager.burn(burnParams);
@@ -2326,29 +2012,24 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = 2550;
 
-        _addInitialLiquidity(
-            {
-                from:   lender,
-                amount: 10_000 * 1e18,
-                index:  2550
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2550,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _addInitialLiquidity({
+            from:   lender,
+            amount: 10_000 * 1e18,
+            index:  2550
+        });
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2550,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+
         // allow position manager to take ownership of the position
         _pool.approveLpOwnership(address(_positionManager), indexes[0], 10_000 * 1e27);
 
@@ -2372,22 +2053,19 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId, address(_pool), indexes
         );
         _positionManager.reedemPositions(reedemParams);
-        _assertLenderLpBalance(
-            {
-                lender:      lender,
-                index:       2550,
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      minter,
-                index:       2550,
-                lpBalance:   10_000 * 1e27,
-                depositTime: _startTime
-            }
-        );
+
+        _assertLenderLpBalance({
+            lender:      lender,
+            index:       2550,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      minter,
+            index:       2550,
+            lpBalance:   10_000 * 1e27,
+            depositTime: _startTime
+        });
     }
 
     function testMayInteractReverts() external {
@@ -2434,13 +2112,11 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = 2550;
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
 
         // mint NFT
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
@@ -2514,80 +2190,62 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         indexes[1] = 2551;
         indexes[2] = 2552;
 
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 3_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 3_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 3_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 3_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
         // mint an NFT to later memorialize existing positions into
         uint256 tokenId = _mintNFT(testAddress1, testAddress1, address(_pool), keccak256("ERC721_NON_SUBSET_HASH"));
 
         // check LPs
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
@@ -2613,54 +2271,42 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         emit TransferLPs(testAddress1, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
@@ -2671,77 +2317,59 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
 
         // add more liquidity
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 1_000 * 1e18,
-                index:  indexes[0]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 2_000 * 1e18,
-                index:  indexes[1]
-            }
-        );
-        _addInitialLiquidity(
-            {
-                from:   testAddress1,
-                amount: 3_000 * 1e18,
-                index:  indexes[2]
-            }
-        );
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 1_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 2_000 * 1e18,
+            index:  indexes[1]
+        });
+        _addInitialLiquidity({
+            from:   testAddress1,
+            amount: 3_000 * 1e18,
+            index:  indexes[2]
+        });
 
         // check LP balance
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   1_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[1],
-                lpBalance:   2_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   3_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   1_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[1],
+            lpBalance:   2_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   3_000 * 1e27,
+            depositTime: currentTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
@@ -2764,54 +2392,42 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   4_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   5_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   6_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   4_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   5_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   6_000 * 1e27,
+            depositTime: currentTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 4_000 * 1e27);
@@ -2833,54 +2449,42 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         _positionManager.moveLiquidity(moveLiquidityParams);
 
         // check LP balance
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   9_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   6_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   9_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   6_000 * 1e27,
+            depositTime: currentTime
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
@@ -2928,78 +2532,60 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         _positionManager.reedemPositions(reedemParams);
 
          // check pool state
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       indexes[1],
-                lpBalance:   9_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[1],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress1,
-                index:       indexes[0],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      testAddress2,
-                index:       indexes[2],
-                lpBalance:   6_000 * 1e27,
-                depositTime: currentTime
-            }
-        );
-        _assertLenderLpBalance(
-            {
-                lender:      address(_positionManager),
-                index:       indexes[2],
-                lpBalance:   0,
-                depositTime: 0
-            }
-        );
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       indexes[1],
+            lpBalance:   9_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[1],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress1,
+            index:       indexes[0],
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      testAddress2,
+            index:       indexes[2],
+            lpBalance:   6_000 * 1e27,
+            depositTime: currentTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       indexes[2],
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -90,11 +90,11 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         require(tokenId != 0, "tokenId nonce not incremented");
 
         // check position info
-        address owner    = _positionManager.ownerOf(tokenId);
-        uint256 lpTokens = _positionManager.getLPTokens(tokenId, mintPrice);
+        address owner = _positionManager.ownerOf(tokenId);
+        uint256 lps   = _positionManager.getLPs(tokenId, mintPrice);
 
         assertEq(owner, testAddress);
-        assertEq(lpTokens, 0);
+        assertEq(lps,   0);
 
         // deploy a new factory to simulate creating a pool outside of expected factories
         ERC20PoolFactory invalidFactory = new ERC20PoolFactory(_ajna);
@@ -107,10 +107,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
     /**
      *  @notice Tests attachment of a created position to an already existing NFT.
-     *          LP tokens are checked to verify ownership of position.
+     *          LPs are checked to verify ownership of position.
      *          Reverts:
-     *              Attempts to memorialize when lp tokens aren't allowed to be transfered.
-     *              Attempts to set position owner when not owner of the LP tokens.
+     *              Attempts to memorialize when lps aren't allowed to be transfered.
+     *              Attempts to set position owner when not owner of the LPs.
      */
     function testMemorializePositions() external {
         address testAddress = makeAddr("testAddress");
@@ -170,16 +170,16 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check memorialization success
-        uint256 positionAtPriceOneLPTokens = _positionManager.getLPTokens(tokenId, indexes[0]);
-        assertGt(positionAtPriceOneLPTokens, 0);
+        uint256 positionAtPriceOneLPs = _positionManager.getLPs(tokenId, indexes[0]);
+        assertGt(positionAtPriceOneLPs, 0);
 
-        // check lp tokens at non added to price
-        uint256 positionAtWrongPriceLPTokens = _positionManager.getLPTokens(tokenId, 4000000 * 1e18);
-        assertEq(positionAtWrongPriceLPTokens, 0);
+        // check lps at non added to price
+        uint256 positionAtWrongPriceLPs = _positionManager.getLPs(tokenId, 4000000 * 1e18);
+        assertEq(positionAtWrongPriceLPs, 0);
 
         assertTrue(_positionManager.isIndexInPosition(tokenId, 2550));
         assertTrue(_positionManager.isIndexInPosition(tokenId, 2551));
@@ -274,9 +274,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -294,7 +294,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance(
@@ -347,9 +347,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 3_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -428,9 +428,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 3_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -444,7 +444,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress, address(_positionManager), indexes, 6_000 * 1e27);
+        emit TransferLPs(testAddress, address(_positionManager), indexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -498,9 +498,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 4_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 5_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 6_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 4_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 5_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 6_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -664,12 +664,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             }
         );
 
-        assertEq(_positionManager.getLPTokens(indexes[0], tokenId1), 0);
-        assertEq(_positionManager.getLPTokens(indexes[1], tokenId1), 0);
-        assertEq(_positionManager.getLPTokens(indexes[2], tokenId1), 0);
+        assertEq(_positionManager.getLPs(indexes[0], tokenId1), 0);
+        assertEq(_positionManager.getLPs(indexes[1], tokenId1), 0);
+        assertEq(_positionManager.getLPs(indexes[2], tokenId1), 0);
 
-        assertEq(_positionManager.getLPTokens(indexes[0], tokenId2), 0);
-        assertEq(_positionManager.getLPTokens(indexes[3], tokenId2), 0);
+        assertEq(_positionManager.getLPs(indexes[0], tokenId2), 0);
+        assertEq(_positionManager.getLPs(indexes[3], tokenId2), 0);
 
         (uint256 poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
@@ -694,7 +694,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testLender1, tokenId1);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e27);
+        emit TransferLPs(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
@@ -763,9 +763,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             }
         );
 
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[2]), 3_000 * 1e27);
 
         (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
@@ -787,7 +787,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testLender2, tokenId2);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testLender2, address(_positionManager), newIndexes, 6_000 * 1e27);
+        emit TransferLPs(testLender2, address(_positionManager), newIndexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // // check lender, position manager,  and pool state
@@ -856,12 +856,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             }
         );
 
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId1, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[2]), 3_000 * 1e27);
 
-        assertEq(_positionManager.getLPTokens(tokenId2, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId2, indexes[3]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, indexes[3]), 3_000 * 1e27);
 
         (poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);
@@ -944,7 +944,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // memorialize positions
@@ -984,7 +984,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 15_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // approve and transfer NFT to different address
@@ -1034,7 +1034,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
     }
 
@@ -1092,7 +1092,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // memorialize positions
@@ -1133,7 +1133,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 15_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // approve and transfer NFT by permit to different address
@@ -1203,7 +1203,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
     }
 
@@ -1457,10 +1457,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId1, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId1, moveIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, moveIndex), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId1, mintIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId1, moveIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId2, mintIndex));
@@ -1530,10 +1530,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId1, mintIndex), 2_500 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId1, moveIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, mintIndex), 2_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, moveIndex), 0);
         assertTrue(_positionManager.isIndexInPosition(tokenId1, mintIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId1, moveIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId2, mintIndex));
@@ -1601,10 +1601,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId1, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId1, moveIndex), 2_500 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId2, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, moveIndex), 2_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, moveIndex), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId1, mintIndex));
         assertTrue(_positionManager.isIndexInPosition(tokenId1, moveIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId2, mintIndex));
@@ -1672,10 +1672,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId1, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId1, moveIndex), 2_500 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId2, mintIndex), 5_500 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId2, moveIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, moveIndex), 2_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, mintIndex), 5_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, moveIndex), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId1, mintIndex));
         assertTrue(_positionManager.isIndexInPosition(tokenId1, moveIndex));
         assertTrue(_positionManager.isIndexInPosition(tokenId2, mintIndex));
@@ -1752,10 +1752,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId1, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId1, moveIndex), 2_500 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId2, mintIndex), 0);
-        assertEq(_positionManager.getLPTokens(tokenId2, moveIndex), 5_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId1, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId1, moveIndex), 2_500 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId2, mintIndex), 0);
+        assertEq(_positionManager.getLPs(tokenId2, moveIndex), 5_500 * 1e27);
         assertFalse(_positionManager.isIndexInPosition(tokenId1, mintIndex));
         assertTrue(_positionManager.isIndexInPosition(tokenId1, moveIndex));
         assertFalse(_positionManager.isIndexInPosition(tokenId2, mintIndex));
@@ -1809,7 +1809,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // memorialize positions
@@ -1842,7 +1842,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 15_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // redeem positions of testMinter
@@ -1880,7 +1880,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // should fail if trying to redeem one more time
@@ -1994,7 +1994,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // memorialize positions
@@ -2059,7 +2059,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 15_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // approve and transfer NFT to different address
@@ -2089,7 +2089,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         vm.expectEmit(true, true, true, true);
         emit RedeemPosition(testReceiver, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(address(_positionManager), testReceiver, indexes, 15_000 * 1e27);
+        emit TransferLPs(address(_positionManager), testReceiver, indexes, 15_000 * 1e27);
         changePrank(testReceiver);
         _positionManager.reedemPositions(reedemParams);
 
@@ -2144,7 +2144,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, testIndexPrice), 0);
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
     }
 
@@ -2590,9 +2590,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -2610,7 +2610,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress1, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress1, address(_positionManager), indexes, 9_000 * 1e27);
+        emit TransferLPs(testAddress1, address(_positionManager), indexes, 9_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance(
@@ -2663,9 +2663,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 3_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -2744,9 +2744,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 3_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 3_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 3_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -2760,7 +2760,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         vm.expectEmit(true, true, true, true);
         emit MemorializePosition(testAddress1, tokenId);
         vm.expectEmit(true, true, true, true);
-        emit TransferLPTokens(testAddress1, address(_positionManager), indexes, 6_000 * 1e27);
+        emit TransferLPs(testAddress1, address(_positionManager), indexes, 6_000 * 1e27);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -2814,9 +2814,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 4_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 5_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 6_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 4_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 5_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 6_000 * 1e27);
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -2883,9 +2883,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 9_000 * 1e27);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 6_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 9_000 * 1e27);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 6_000 * 1e27);
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertTrue(_positionManager.isIndexInPosition(tokenId, indexes[2]));
@@ -3002,9 +3002,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // check position manager state
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[0]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[1]), 0);
-        assertEq(_positionManager.getLPTokens(tokenId, indexes[2]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[1]), 0);
+        assertEq(_positionManager.getLPs(tokenId, indexes[2]), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[0]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[1]));
         assertFalse(_positionManager.isIndexInPosition(tokenId, indexes[2]));


### PR DESCRIPTION
- rename TransferLPTokens event to TransferLPs
- rename PositionManager.getLPTokens to PositionManager.getLPs
- rename tests, update comments