### PR TITLE
PoolUtilsInfo scaled to quote token precision

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -13,6 +13,7 @@ import {
     _minDebtAmount,
     _priceAt,
     _reserveAuctionPrice,
+    _roundUpToScale,
     MAX_FENWICK_INDEX,
     MIN_PRICE
 } from './libraries/helpers/PoolHelper.sol';
@@ -53,7 +54,7 @@ contract PoolInfoUtils {
         uint256 t0Debt;
         (t0Debt, collateral_, t0Np_)  = pool.borrowerInfo(borrower_);
 
-        debt_ = Maths.wmul(t0Debt, pendingInflator);
+        debt_ = _roundUpToScale(Maths.wmul(t0Debt, pendingInflator), pool.quoteTokenScale());
     }
 
     /**

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -590,17 +590,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
 
         uint256 lup = _poolUtils.lup(address(_pool));
 
-        assertEq(debt,        borrowerDebt);
-        assertEq(col,         borrowerCollateral);
-        assertEq(t0Np,        borrowert0Np);
-        assertEq(
-            _collateralization(
-                borrowerDebt,
-                borrowerCollateral,
-                lup
-            ),
-            borrowerCollateralization
-        );
+        uint256 collateralization = _collateralization(borrowerDebt, borrowerCollateral, lup);
+
+        assertEq(debt,              _roundUpToScale(borrowerDebt, _pool.quoteTokenScale()));
+        assertEq(col,               borrowerCollateral);
+        assertEq(t0Np,              borrowert0Np);
+        assertEq(collateralization, borrowerCollateralization);
     }
 
     function _assertEMAs(


### PR DESCRIPTION

<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* `PoolUtilsInfo.borrowerInfo` function should return borrower debt scaled to quote token precision
  * Changed `PoolUtilsInfo.borrowerInfo`  to use `_roundUpToScale` when calculating borrower debt, test scenario was added in `testPoolInfoUtilsRepayExactAmount` for WBTC/USDC pool

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* `PoolUtilsInfo` contract should provide debt amounts that can be used (without any modifications) for calling `Pool` functions (like repayDebt). Right now the borrower debt returned is not scaled causing `DustAmount` reverts when debt is repaid in a pool like WBTC/USDC (different precision than WAD)
* `PoolUtilsInfo.borrowerInfo` was changed to use `_roundUpToScale` helper for calculating and returning borrower debt

# Contract size
## Pre Change
N/A
## Post Change
N/A

# Gas usage
## Pre Change
N/A
## Post Change
N/A

