### PR TITLE
NFT atomic swap inputs fix

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -449,10 +449,12 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             result.collateralAmount / 1e18
         );
 
+        uint256 totalQuoteTokenAmount = result.quoteTokenAmount + result.excessQuoteToken;
+
         if (data_.length != 0) {
             IERC721Taker(callee_).atomicSwapCallback(
                 tokensTaken,
-                result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE), 
+                totalQuoteTokenAmount  / _getArgUint256(QUOTE_SCALE),
                 data_
             );
         }
@@ -460,7 +462,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         if (result.settledAuction) _rebalanceTokens(borrowerAddress_, result.remainingCollateral);
 
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
-        _transferQuoteTokenFrom(callee_, result.quoteTokenAmount + result.excessQuoteToken);
+        _transferQuoteTokenFrom(callee_, totalQuoteTokenAmount);
 
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (result.excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, result.excessQuoteToken);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.14;
 
 import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
 
+import { NFTNoopTakeExample } from "../interactions/NFTTakeExample.sol";
+
 import 'src/libraries/helpers/PoolHelper.sol';
 
 contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
@@ -821,5 +823,43 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerCollateralization: 1.010408400292926569 * 1e18
         });
 
+    }
+
+    function testTakeCollateralWithAtomicSwapSubsetPool() external tearDown {
+        // Skip to make borrower undercollateralized
+        skip(1000 days);
+
+        _kick({
+            from:           _lender,
+            borrower:       _borrower,
+            debt:           23.012828827714740289 * 1e18,
+            collateral:     2 * 1e18,
+            bond:           0.227287198298417188 * 1e18,
+            transferAmount: 0.227287198298417188 * 1e18
+        });
+
+        skip(5.5 hours);
+
+        uint256 initialBalance = 10_000 * 1e18;
+
+        // instantiate a NOOP taker contract which implements IERC721Taker
+        NFTNoopTakeExample taker = new NFTNoopTakeExample();
+        deal(address(_quote), address(taker), initialBalance);
+        changePrank(address(taker));
+        _quote.approve(address(_pool), type(uint256).max);
+
+        bytes memory data = abi.encode(address(_pool));
+        _pool.take(_borrower, 2, address(taker), data);
+
+        // check that token ids are the same as id pledged by borrower
+        assertEq(taker.tokenIdsReceived(0), 3);
+        assertEq(taker.tokenIdsReceived(1), 1);
+
+        // check that the amount of quote tokens passed to taker contract is the same as the one deducted from taker balance
+        uint256 currentBalance = _quote.balanceOf(address(taker));
+        assertEq(initialBalance - taker.quoteAmountDueReceived(), currentBalance);
+
+        // check address received is the address of current ajna pool
+        assertEq(taker.poolAddressReceived(), address(_pool));
     }
 }

--- a/tests/forge/interactions/NFTTakeExample.sol
+++ b/tests/forge/interactions/NFTTakeExample.sol
@@ -65,3 +65,27 @@ contract NFTMarketPlace is INFTMarketPlace {
         return this.onERC721Received.selector;
     }
 }
+
+contract NFTNoopTakeExample is IERC721Taker {
+    uint256[] public tokenIdsReceived;
+    uint256   public quoteAmountDueReceived;
+    address   public poolAddressReceived;
+
+    function atomicSwapCallback(
+        uint256[] memory tokenIds,
+        uint256          quoteAmountDue,
+        bytes calldata   data
+    ) external {
+        // NOOP, records inputs passed from pool to be checked in tests
+        tokenIdsReceived       = tokenIds;
+        quoteAmountDueReceived = quoteAmountDue;
+        poolAddressReceived    = abi.decode(data, (address));
+    }
+
+    /** @notice Implementing this method allows contracts to receive ERC721 tokens
+     *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828
+     */
+    function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
*  Pass entire quote token amount (including quote token excess) to contract performing NFT take with atomic swap
  * Add the quote token in excess (that is that will be paid by taker to borrower to compensate fractional of NFT taken outside of debt repayment) to the amount passed to taker contract

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* NFT taker contract could be mislead by the amount to repay to pool if excess quote token is not included
* Sum up amount of quote tokens to repay to cover debt with the excess quote token to compensate fractional of NFT taken outside of debt repayment

# Contract size
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,041B  (89.68%)
```
<PASTE_OUTPUT_HERE>
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,042B  (89.69%)
```

# Gas usage
## Pre Change
N/A
## Post Change
N/A

