### PR TITLE
103.md

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -499,7 +499,8 @@ library Auctions {
         result_.poolDebt   = poolState_.debt;
         (
             result_.newLup,
-            result_.settledAuction
+            result_.settledAuction,
+            result_.remainingCollateral
         ) = _takeLoan(
             auctions_,
             buckets_,
@@ -575,7 +576,8 @@ library Auctions {
         result_.poolDebt   = poolState_.debt;
         (
             result_.newLup,
-            result_.settledAuction
+            result_.settledAuction,
+            result_.remainingCollateral
         ) = _takeLoan(
             auctions_,
             buckets_,
@@ -1000,11 +1002,12 @@ library Auctions {
      *  @notice If borrower becomes recollateralized then auction is settled. Update loan's state.
      *  @dev    reverts on:
      *              - borrower debt less than pool min debt AmountLTMinDebt()
-     *  @param  borrower_        Struct containing pool details.
-     *  @param  borrower_        The borrower details owning loan that is taken.
-     *  @param  borrowerAddress_ The address of the borrower.
-     *  @return newLup_          The new LUP of pool (after debt is repaid).
-     *  @return settledAuction_  True if auction is settled by the take action.
+     *  @param  borrower_            Struct containing pool details.
+     *  @param  borrower_            The borrower details owning loan that is taken.
+     *  @param  borrowerAddress_     The address of the borrower.
+     *  @return newLup_              The new LUP of pool (after debt is repaid).
+     *  @return settledAuction_      True if auction is settled by the take action. (NFT take: rebalance borrower collateral in pool if true)
+     *  @return remainingCollateral_ Borrower collateral remaining after take action. (NFT take: collateral to be rebalanced in case of NFT settlement)
     */
     function _takeLoan(
         AuctionsState storage auctions_,
@@ -1016,7 +1019,8 @@ library Auctions {
         address borrowerAddress_
     ) internal returns (
         uint256 newLup_,
-        bool settledAuction_
+        bool settledAuction_,
+        uint256 remainingCollateral_
     ) {
 
         uint256 borrowerDebt = Maths.wmul(borrower_.t0Debt, poolState_.inflator);
@@ -1036,7 +1040,7 @@ library Auctions {
             settledAuction_ = true;
 
             // settle auction and update borrower's collateral with value after settlement
-            borrower_.collateral = _settleAuction(
+            remainingCollateral_ = _settleAuction(
                 auctions_,
                 buckets_,
                 deposits_,
@@ -1044,6 +1048,8 @@ library Auctions {
                 borrower_.collateral,
                 poolState_.poolType
             );
+
+            borrower_.collateral = remainingCollateral_;
         }
 
         // update loan state, stamp borrower t0Np only when exiting from auction

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import { ERC721HelperContract } from './ERC721DSTestPlus.sol';
+
+import 'src/libraries/helpers/PoolHelper.sol';
+
+contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+    address internal _lender2;
+    address internal _taker;
+
+    function setUp() external {
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender2   = makeAddr("lender2");
+        _taker     = makeAddr("taker");
+
+        // deploy subset pool
+        uint256[] memory subsetTokenIds = new uint256[](6);
+        subsetTokenIds[0] = 1;
+        subsetTokenIds[1] = 3;
+        subsetTokenIds[2] = 5;
+        subsetTokenIds[3] = 51;
+        subsetTokenIds[4] = 53;
+        subsetTokenIds[5] = 73;
+        _pool = _deploySubsetPool(subsetTokenIds);
+
+        _mintAndApproveQuoteTokens(_lender,  120_000 * 1e18);
+        _mintAndApproveQuoteTokens(_lender2, 120_000 * 1e18);
+        _mintAndApproveQuoteTokens(_borrower, 10 * 1e18);
+
+        _mintAndApproveCollateralTokens(_borrower,  6);
+        _mintAndApproveCollateralTokens(_borrower2, 74);
+
+        // Lender adds Quote token accross 5 prices
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 2_000 * 1e18,
+            index:  _i9_91
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 5_000 * 1e18,
+            index:  _i9_81
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 11_000 * 1e18,
+            index:  _i9_72
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 25_000 * 1e18,
+            index:  _i9_62
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 30_000 * 1e18,
+            index:  _i9_52
+        });
+
+        // first borrower adds collateral token and borrows
+        uint256[] memory tokenIdsToAdd = new uint256[](2);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+
+        uint256 expectedNewLup = 9.917184843435912074 * 1e18;
+
+        // borrower deposits two NFTs into the subset pool and borrows
+        _pledgeCollateral({
+            from:     _borrower,
+            borrower: _borrower,
+            tokenIds: tokenIdsToAdd
+        });
+        _borrow({
+            from:       _borrower,
+            amount:     19.8 * 1e18,
+            indexLimit: _i9_91,
+            newLup:     expectedNewLup
+        });
+
+        // second borrower deposits three NFTs into the subset pool and borrows
+        tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 51;
+        tokenIdsToAdd[1] = 53;
+        tokenIdsToAdd[2] = 73;
+        _pledgeCollateral({
+            from:     _borrower2,
+            borrower: _borrower2,
+            tokenIds: tokenIdsToAdd
+        });
+        _borrow({
+            from:       _borrower2,
+            amount:     15 * 1e18,
+            indexLimit: _i9_72,
+            newLup:     expectedNewLup
+        });
+
+        /*****************************/
+        /*** Assert pre-kick state ***/
+        /*****************************/
+
+        _assertPool(
+            PoolParams({
+                htp:                  9.909519230769230774 * 1e18,
+                lup:                  expectedNewLup,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 3.512434434608473285 * 1e18,
+                poolDebt:             34.833461538461538478 * 1e18,
+                actualUtilization:    0.000477170706006322 * 1e18,
+                targetUtilization:    1 * 1e18,
+                minDebtAmount:        1.741673076923076924 * 1e18,
+                loans:                2,
+                maxBorrower:          address(_borrower),
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              19.819038461538461548 * 1e18,
+            borrowerCollateral:        2 * 1e18,
+            borrowert0Np:              10.404995192307692312 * 1e18,
+            borrowerCollateralization: 1.000773560501591181 * 1e18
+        });
+        _assertBorrower({
+            borrower:                  _borrower2,
+            borrowerDebt:              15.014423076923076930 * 1e18,
+            borrowerCollateral:        3 * 1e18,
+            borrowert0Np:              5.255048076923076925 * 1e18,
+            borrowerCollateralization: 1.981531649793150539 * 1e18
+        });
+
+        assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
+
+        // Skip to make borrower undercollateralized
+        skip(1000 days);
+
+        _kick({
+            from:           _lender,
+            borrower:       _borrower,
+            debt:           23.012828827714740289 * 1e18,
+            collateral:     2 * 1e18,
+            bond:           0.227287198298417188 * 1e18,
+            transferAmount: 0.227287198298417188 * 1e18
+        });
+
+        /******************************/
+        /*** Assert Post-kick state ***/
+        /******************************/
+
+        _assertPool(
+            PoolParams({
+                htp:                  6.582216822103492762 * 1e18,
+                lup:                  9.917184843435912074 * 1e18,
+                poolSize:             73_000 * 1e18,
+                pledgedCollateral:    5 * 1e18,
+                encumberedCollateral: 4.056751649452525709 * 1e18,
+                poolDebt:             40.231555971534224231 * 1e18,
+                actualUtilization:    0.000551117205089510 * 1e18,
+                targetUtilization:    0.811350329890505142 * 1e18,
+                minDebtAmount:        4.023155597153422423 * 1e18,
+                loans:                1,
+                maxBorrower:          address(_borrower2),
+                interestRate:         0.045 * 1e18,
+                interestRateUpdate:   block.timestamp
+            })
+        );
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              23.012828827714740289 * 1e18,
+            borrowerCollateral:        2 * 1e18,
+            borrowert0Np:              10.404995192307692312 * 1e18,
+            borrowerCollateralization: 0.861883162446546169 * 1e18
+        });
+        _assertBorrower({
+            borrower:                  _borrower2,
+            borrowerDebt:              17.218727143819483942 * 1e18,
+            borrowerCollateral:        3 * 1e18,
+            borrowert0Np:              5.255048076923076925 * 1e18,
+            borrowerCollateralization: 1.727860269914713433 * 1e18
+        });
+    }
+
+    function testDepositTakeNFTAndSettleAuction() external {
+
+        skip(5 hours);
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            true,
+                kicker:            _lender,
+                bondSize:          0.227287198298417188 * 1e18,
+                bondFactor:        0.01 * 1e18,
+                kickTime:          block.timestamp - 5 hours,
+                kickMomp:          9.917184843435912074 * 1e18,
+                totalBondEscrowed: 0.227287198298417188 * 1e18,
+                auctionPrice:      23.865155821333804736 * 1e18,
+                debtInAuction:     23.012828827714740289 * 1e18,
+                thresholdPrice:    11.506709959118993144 * 1e18,
+                neutralPrice:      11.932577910666902372 * 1e18
+            })
+        );
+
+        _addLiquidity({
+            from:    _lender,
+            amount:  15.0 * 1e18,
+            index:   _i1505_26,
+            lpAward: 15.0 * 1e27,
+            newLup:  9.917184843435912074 * 1e18
+        });
+
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              23.013419918237986289 * 1e18,
+            borrowerCollateral:        2 * 1e18,
+            borrowert0Np:              10.404995192307692312 * 1e18,
+            borrowerCollateralization: 0.861861025320848319 * 1e18
+        });
+
+        // before deposit take: NFTs pledged by auctioned borrower are owned by the pool
+        assertEq(_collateral.ownerOf(3), address(_pool));
+        assertEq(_collateral.ownerOf(1), address(_pool));
+
+        _depositTake({
+            from:             _taker,
+            borrower:         _borrower,
+            kicker:           _lender,
+            index:            _i1505_26,
+            collateralArbed:  0.009965031187761219 * 1e18,
+            quoteTokenAmount: 15.0 * 1e18,
+            bondChange:       0.15 * 1e18,
+            isReward:         false,
+            lpAwardTaker:     0,
+            lpAwardKicker:    0
+        });
+
+        _assertAuction(
+            AuctionParams({
+                borrower:          _borrower,
+                active:            false,
+                kicker:            address(0),
+                bondSize:          0,
+                bondFactor:        0,
+                kickTime:          0,
+                kickMomp:          0,
+                totalBondEscrowed: 0,
+                auctionPrice:      0,
+                debtInAuction:     0,
+                thresholdPrice:    9.624359312514645329 * 1e18,
+                neutralPrice:      0
+            })
+        );
+        // borrower is compensated LPs for fractional collateral
+        _assertLenderLpBalance({
+            lender:      _borrower,
+            index:       3519,
+            lpBalance:   23.737330323739529014630349498 * 1e27,
+            depositTime: block.timestamp
+        });
+        _assertBucket({
+            index:        _i1505_26,
+            lpBalance:    15 * 1e27,
+            collateral:   0.009965031187761219 * 1e18,
+            deposit:      0,
+            exchangeRate: 0.999999999999999999688877723 * 1e27
+        });
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              9.624359312514645329 * 1e18,
+            borrowerCollateral:        1 * 1e18,
+            borrowert0Np:              8.769696613728507377 * 1e18,
+            borrowerCollateralization: 1.030425457052554443 * 1e18
+        });
+        _assertLenderLpBalance({
+            lender:      _taker,
+            index:       _i1505_26,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       _i1505_26,
+            lpBalance:   15.0 * 1e27,
+            depositTime: block.timestamp
+        });
+
+        // borrower should be able to repay and pull collateral from the pool
+        _repayDebtNoLupCheck({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    10 * 1e18,
+            amountRepaid:     10 * 1e18,
+            collateralToPull: 1
+        });
+
+        // after deposit take and pull: NFT taken remains in pool, the pulled one goes to borrower
+        assertEq(_collateral.ownerOf(3), address(_pool));
+        assertEq(_collateral.ownerOf(1), _borrower);
+    }
+}

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -776,6 +776,15 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerCollateralization: 1 * 1e18
         });
 
+        // borrower should be able to pull collateral from the pool
+        _repayDebtNoLupCheck({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    0,
+            amountRepaid:     0,
+            collateralToPull: 1
+        });
+
         vm.revertTo(snapshot);
 
         // borrower repays part of debt, but not enough to exit from auction


### PR DESCRIPTION
# Remaining collateral used by ERC721Pool is missed in Auctions take and bucketTake return structures

## Summary

ERC721Pool's take() and bucketTake() use remaining collateral variable to adjust borrower's collateral ids array after their debt is settled in an auction. In both cases this variable isn't initialized in Auctions's take() and bucketTake() and all collateral of the borrower ends up being frozen in the pool.

## Vulnerability Detail

Being run with uninitialized zero `result.remainingCollateral`, _rebalanceTokens() will remove all the collateral ids from the borrower and place them into `bucketTokenIds`, i.e. move all borrowers collateral to the LP's cumulative collateral account. Those funds will be permanently frozen as other accounting parts will not have them recorded in any bucket, so no LP be able to withdraw extra funds.

## Impact

Borrower's collateral funds will be permanently frozen in full whenever take() and bucketTake() result in auction settlement.

This takes place as after those ids was removed from `borrowerTokenIds` any operation of the borrower that should result in collateral being returned to them will be reverted instead.

## Recommendation

Consider filling the variable with the resulting collateral of the borrower by placing `result.remainingCollateral = borrower.collateral` in the very end of Auctions's take() and bucketTake().