### PR TITLE
Sherlock 162.md: ERC721Pool taker callback misreports quote funds whe…

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -445,10 +445,12 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             result.collateralAmount / 1e18
         );
 
+        uint256 totalQuoteTokenAmount = result.quoteTokenAmount + result.excessQuoteToken;
+
         if (data_.length != 0) {
             IERC721Taker(callee_).atomicSwapCallback(
                 tokensTaken,
-                result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE), 
+                totalQuoteTokenAmount  / _getArgUint256(QUOTE_SCALE),
                 data_
             );
         }
@@ -456,7 +458,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         if (result.settledAuction) _rebalanceTokens(borrowerAddress_, result.remainingCollateral);
 
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
-        _transferQuoteTokenFrom(callee_, result.quoteTokenAmount + result.excessQuoteToken);
+        _transferQuoteTokenFrom(callee_, totalQuoteTokenAmount);
 
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (result.excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, result.excessQuoteToken);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.14;
 
 import { ERC721HelperContract } from "./ERC721DSTestPlus.sol";
 
+import { NFTNoopTakeExample } from "../interactions/NFTTakeExample.sol";
+
 import 'src/libraries/helpers/PoolHelper.sol';
 
 contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
@@ -830,5 +832,43 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerCollateralization: 1.010408400292926569 * 1e18
         });
 
+    }
+
+    function testTakeCollateralWithAtomicSwapSubsetPool() external tearDown {
+        // Skip to make borrower undercollateralized
+        skip(1000 days);
+
+        _kick({
+            from:           _lender,
+            borrower:       _borrower,
+            debt:           23.012828827714740289 * 1e18,
+            collateral:     2 * 1e18,
+            bond:           0.227287198298417188 * 1e18,
+            transferAmount: 0.227287198298417188 * 1e18
+        });
+
+        skip(5.5 hours);
+
+        uint256 initialBalance = 10_000 * 1e18;
+
+        // instantiate a NOOP taker contract which implements IERC721Taker
+        NFTNoopTakeExample taker = new NFTNoopTakeExample();
+        deal(address(_quote), address(taker), initialBalance);
+        changePrank(address(taker));
+        _quote.approve(address(_pool), type(uint256).max);
+
+        bytes memory data = abi.encode(address(_pool));
+        _pool.take(_borrower, 2, address(taker), data);
+
+        // check that token ids are the same as id pledged by borrower
+        assertEq(taker.tokenIdsReceived(0), 3);
+        assertEq(taker.tokenIdsReceived(1), 1);
+
+        // check that the amount of quote tokens passed to taker contract is the same as the one deducted from taker balance
+        uint256 currentBalance = _quote.balanceOf(address(taker));
+        assertEq(initialBalance - taker.quoteAmountDueReceived(), currentBalance);
+
+        // check address received is the address of current ajna pool
+        assertEq(taker.poolAddressReceived(), address(_pool));
     }
 }

--- a/tests/forge/interactions/NFTTakeExample.sol
+++ b/tests/forge/interactions/NFTTakeExample.sol
@@ -65,3 +65,27 @@ contract NFTMarketPlace is INFTMarketPlace {
         return this.onERC721Received.selector;
     }
 }
+
+contract NFTNoopTakeExample is IERC721Taker {
+    uint256[] public tokenIdsReceived;
+    uint256   public quoteAmountDueReceived;
+    address   public poolAddressReceived;
+
+    function atomicSwapCallback(
+        uint256[] memory tokenIds,
+        uint256          quoteAmountDue,
+        bytes calldata   data
+    ) external {
+        // NOOP, records inputs passed from pool to be checked in tests
+        tokenIdsReceived       = tokenIds;
+        quoteAmountDueReceived = quoteAmountDue;
+        poolAddressReceived    = abi.decode(data, (address));
+    }
+
+    /** @notice Implementing this method allows contracts to receive ERC721 tokens
+     *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828
+     */
+    function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}


### PR DESCRIPTION
# ERC721Pool taker callback misreports quote funds whenever there was collateral amount rounding

## Summary

atomicSwapCallback() now reports `tokensTaken` higher than one corresponding to `quoteTokenAmount` whenever the rounding took place as the `excessQuoteToken` is omitted.

## Vulnerability Detail

ERC721Pool's take() `atomicSwapCallback` needs to have full quote amount, `(result.quoteTokenAmount + result.excessQuoteToken)`, when there is a quote token part added to have the whole integer amount of the collateral asset.

Now the callback quote value, `quoteTokenAmount`, is inconsistent with the collateral amount `tokensTaken` when there was rounding.

## Impact

The impact depends on the logic on `callee_` side, but asset amounts are usually used in the downstream asset management logic, so misreporting such amounts can lead to the asset losses on the taker's side.

As that's the precondition, setting the severity to be medium.

## Code Snippet

ERC721Pool's take() reports `result.quoteTokenAmount` and `tokensTaken` as take result to the `callee_`, ignoring collateral rounding part:

https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/ERC721Pool.sol#L452-L463

```solidity
        if (data_.length != 0) {
            IERC721Taker(callee_).atomicSwapCallback(
                tokensTaken,
                result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE), 
                data_
            );
        }

        if (result.settledAuction) _rebalanceTokens(borrowerAddress_, result.remainingCollateral);

        // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
        _transferQuoteTokenFrom(callee_, result.quoteTokenAmount + result.excessQuoteToken);
```

## Tool used

Manual Review

## Recommendation

Consider adding the `excessQuoteToken` to the reported value:

https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/ERC721Pool.sol#L452-L463

```solidity
        if (data_.length != 0) {
            IERC721Taker(callee_).atomicSwapCallback(
                tokensTaken,
-               result.quoteTokenAmount / _getArgUint256(QUOTE_SCALE), 
+               (result.quoteTokenAmount + result.excessQuoteToken) / _getArgUint256(QUOTE_SCALE), 
                data_
            );
        }

        if (result.settledAuction) _rebalanceTokens(borrowerAddress_, result.remainingCollateral);

        // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
        _transferQuoteTokenFrom(callee_, result.quoteTokenAmount + result.excessQuoteToken);
```