### PR TITLE
Sherlock 104.md

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -365,7 +365,6 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
 
         (
             ,
-            ,
             uint256 collateralSettled,
             uint256 t0DebtSettled
         ) = Auctions.settlePoolDebt(

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -370,7 +370,6 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         );
         (
             uint256 collateralRemaining,
-            uint256 t0DebtRemaining,
             uint256 collateralSettled,
             uint256 t0DebtSettled
         ) = Auctions.settlePoolDebt(
@@ -381,8 +380,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             params
         );
 
-        // slither-disable-next-line incorrect-equality
-        if (t0DebtRemaining == 0) _rebalanceTokens(params.borrower, collateralRemaining);
+        if (collateralSettled > 0) _rebalanceTokens(params.borrower, collateralRemaining);
 
         // update pool balances state
         poolBalances.t0Debt            -= t0DebtSettled;

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -174,7 +174,6 @@ library Auctions {
      *              - BucketBankruptcy
      *  @param  params_ Settle params
      *  @return collateralRemaining_ The amount of borrower collateral left after settle.
-     *  @return t0DebtRemaining_     The amount of t0 debt left after settle.
      *  @return collateralSettled_   The amount of collateral settled.
      *  @return t0DebtSettled_       The amount of t0 debt settled.
      */
@@ -186,7 +185,6 @@ library Auctions {
         SettleParams memory params_
     ) external returns (
         uint256 collateralRemaining_,
-        uint256 t0DebtRemaining_,
         uint256 collateralSettled_,
         uint256 t0DebtSettled_
     ) {
@@ -294,8 +292,7 @@ library Auctions {
             }
         }
 
-        t0DebtRemaining_ =  borrower.t0Debt;
-        t0DebtSettled_   -= t0DebtRemaining_;
+        t0DebtSettled_ -= borrower.t0Debt;
 
         emit Settle(params_.borrower, t0DebtSettled_);
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -162,9 +162,9 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertCollateralInvariants();
 
-        // the 2 token ids are still owned by borrower after settle
-        assertEq(ERC721Pool(address(_pool)).borrowerTokenIds(_borrower, 0), 1);
-        assertEq(ERC721Pool(address(_pool)).borrowerTokenIds(_borrower, 1), 3);
+        // the 2 token ids are rebalanced and transferred to pool claimable tokens array after settle
+        assertEq(ERC721Pool(address(_pool)).bucketTokenIds(0), 3);
+        assertEq(ERC721Pool(address(_pool)).bucketTokenIds(1), 1);
 
         // all NFTs are owned by the pool
         assertEq(_collateral.ownerOf(1),  address(_pool));


### PR DESCRIPTION
# Settled collateral of a borrower aren't available for lenders until borrower's debt is fully cleared

## Summary

ERC721Pool's settle() lacks collateral ids array rebalance when the settlement isn't full, i.e. when `t0DebtRemaining > 0`.

## Vulnerability Detail

Auctions's settlePoolDebt() returns current state of the borrower after the settlement. If any of borrower's collateral id were removed from them it needs to be accounted for, but when `t0DebtRemaining > 0` this doesn't happen, i.e. removed borrower's tokens aren't added to the buckets cumulative collateral ids array and so this collateral is still unavailable for lenders.

## Impact

The settled collateral of the borrower will not be available for LP's withdrawal as the corresponding function will revert on an attempt to extract token ids from `bucketTokenIds` array.

The length of such freeze can vary up to be permanent, for example if there is no funds (reserves and deposits) to fully settle the borrower. This is principal fund loss scenario for the lenders, but given the prerequisite of the full default setting the severity to be medium.

## Recommendation

Consider rebalancing each time when there is something to rebalance