### PR TITLE
Sherlock 105.md

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -282,6 +282,8 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         uint256 noOfNFTsToRemove_,
         uint256 toIndex_
     ) external override nonReentrant returns (uint256 collateralMerged_, uint256 bucketLPs_) {
+        _revertIfAuctionClearable(auctions, loans);
+
         PoolState memory poolState = _accruePoolInterest();
         uint256 collateralAmount = Maths.wad(noOfNFTsToRemove_);
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -530,6 +530,17 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
     }
 
+    function _assertMergeRemoveCollateralAuctionNotClearedRevert(
+        address from,
+        uint256 toIndex,
+        uint256 noOfNFTsToRemove,
+        uint256[] memory removeCollateralAtIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
+        ERC721Pool(address(_pool)).mergeOrRemoveCollateral(removeCollateralAtIndex, noOfNFTsToRemove, toIndex);
+    }
+
     function _assertCannotMergeToHigherPriceRevert(
         address from,
         uint256 toIndex,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -203,6 +203,14 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             })
         );
 
+        // revert if auction is not settled
+        _assertMergeRemoveCollateralAuctionNotClearedRevert({
+            from:                    _lender,
+            toIndex:                 MAX_FENWICK_INDEX,
+            noOfNFTsToRemove:        2,
+            removeCollateralAtIndex: new uint256[](0)
+        });
+
         _settle({
             from:        _lender,
             borrower:    _borrower2,
@@ -226,6 +234,14 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 neutralPrice:      0
             })
         );
+
+        // revert if auction is not settled
+        _assertMergeRemoveCollateralAuctionNotClearedRevert({
+            from:                    _lender,
+            toIndex:                 MAX_FENWICK_INDEX,
+            noOfNFTsToRemove:        2,
+            removeCollateralAtIndex: new uint256[](0)
+        });
 
         // settle borrower
         _settle({


### PR DESCRIPTION
## Summary

User facing mergeOrRemoveCollateral() can effectively remove collateral, but lacks _revertIfAuctionClearable() check, i.e. allows to remove it while auction wasn't cleared.

## Vulnerability Detail

mergeOrRemoveCollateral() can remove collateral funds from the pool with _transferFromPoolToAddress() when the amount requested has been merged. As settling the auction can alter the collateral in some buckets its removal is generally restricted in the protocol when auction wasn't yet cleared.

## Impact

Collateral can be removed while auction result can change the allocation of the collateral in the buckets, i.e. can alter collateral amount per LP shares. This way mergeOrRemoveCollateral() result will not correspond to the current state of the pool and will lead to either a lender who initiated the call benefiting at the expense of other bucket LPs or vice versa, caller will have less collateral for the LP shares spent as some will be added to the bucket as a result of auction settlement.

Either way it is a gain for some LP at the expense of the others and a distribution based on a stale pool state (i.e. without auction result). As mergeOrRemoveCollateral() can be called by a lender at will an attacker will use it exactly when it is beneficial, at the expense of other participants.

Due to that setting the severity to be high as auctions are regular and so there is no low probability prerequisites.

## Code Snippet

mergeOrRemoveCollateral() allows for removing a collateral when the auction is clearable

## Recommendation

Consider adding the `_revertIfAuctionClearable(auctions, loans);` check