### PR TITLE
Sherlock 101.md: Flashloan end result isn't controlled

### DIFF
--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -35,6 +35,8 @@ abstract contract FlashloanablePool is Pool {
 
         IERC20 tokenContract = IERC20(token_);
 
+        uint256 initialBalance = tokenContract.balanceOf(address(this));
+
         tokenContract.safeTransfer(
             address(receiver_),
             amount_
@@ -48,6 +50,8 @@ abstract contract FlashloanablePool is Pool {
             address(this),
             amount_
         );
+
+        if (tokenContract.balanceOf(address(this)) != initialBalance) revert FlashloanIncorrectBalance();
 
         success_ = true;
     }

--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -76,6 +76,11 @@ interface IPoolErrors {
     error FlashloanCallbackFailed();
 
     /**
+     *  @notice Balance of pool contract before flash loan is different than the balance after flash loan.
+     */
+    error FlashloanIncorrectBalance();
+
+    /**
      *  @notice Pool cannot facilitate a flashloan for the specified token address.
      */
     error FlashloanUnavailableForToken();

--- a/tests/forge/utils/FlashloanBorrower.sol
+++ b/tests/forge/utils/FlashloanBorrower.sol
@@ -5,6 +5,7 @@ import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 import { Token } from '../utils/Tokens.sol';
 
+import 'src/ERC20Pool.sol';
 import 'src/interfaces/pool/IERC3156FlashBorrower.sol';
 import 'src/libraries/internal/Maths.sol';
 
@@ -47,5 +48,28 @@ contract SomeDefiStrategy {
         uint256 reward = Maths.wmul(0.035 * 1e18, amount_);
         // step 3: profit
         token.transfer(msg.sender, amount_ + reward);
+    }
+}
+
+// Example of some defi strategy which repays to pool
+contract SomeDefiStrategyWithRepayment {
+    ERC20 public token;
+    address public pool;
+
+    constructor(ERC20 token_, address pool_) {
+        token = token_;
+        pool  = pool_;
+    }
+
+    function makeMoney(uint256 amount_) external {
+        // step 1: take deposit from caller
+        token.transferFrom(msg.sender, address(this), amount_);
+        // step 2: earn 3.5% reward
+        uint256 reward = Maths.wmul(0.035 * 1e18, amount_);
+        // step 3: profit
+        token.transfer(msg.sender, amount_ + reward);
+
+        // repay amount to pool
+        token.transfer(pool, 1 * 1e18);
     }
 }


### PR DESCRIPTION
## Summary

FlashLoan logic do not control the end result of transferring tokens out and back in. Given that protocol aims to support arbitrary non-rebasing / without fee on transfer / decimals in `[1, 18]` fungible tokens to be quote and collateral of a pool, this includes any exotic types of behavior, for example, reporting a successful transfer, but not performing internal accounting update for any reason.

As an example, this can be a kind of wide blacklisting mechanics introduction (i.e. allow this white list of accounts, freeze everyone else type of logic).

## Vulnerability Detail

Now there is no control of the resulting balance, and any token that successfully performs safeTransfer, but for any reason withholds an update of token internal accounting, can successfully steal the whole pool's balance of any Ajna pool. This can be initiated by an attacker unrelated to token itself as griefing.

As many core token contracts are upgradable (USDC, USDT and so forth), such behaviour can be not in place right now, but can be introduced in the future.

## Impact

Some fungible tokens that qualify for Ajna pools (including not imposing any fee on transfers) may not return the whole amount back, but will report successful safeTransfer(), i.e. up to the whole balance of Ajna pool for such ERC20 token can be stolen.

This can take place in a situation when a popular token was upgraded and the consequences of the internal logic change weren't fully understood by wide market initially and most depositors remained in the corresponding Ajna pool, then someone calls a flash loan as a griefing attack that will result in the token freezing the balancer of the pool. Or it was understood, but the griefer was quicker.

As the probability of such internal mechanics introduction is low, but the impact is up to full loss of user's funds, setting the severity to be medium.

## Recommendation

Consider adding a balance control check to ensure that flash loan invariant remains: record contract balance before `receiver_.onFlashLoan(...)` callback and record it after `_transferQuoteTokenFrom(address(receiver_), amount_)`, require that resulting token balance ends up being not less than initial.