### PR TITLE
Sherlock 183.md: RewardsManager doesn't delete old bucket snapshot info

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -194,6 +194,17 @@ contract RewardsManager is IRewardsManager {
         // claim rewards, if any
         _claimRewards(tokenId_, IPool(ajnaPool).currentBurnEpoch());
 
+        StakeInfo storage stakeInfo = stakes[tokenId_];
+
+        // remove bucket snapshots recorded at the time of staking
+        uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
+        for (uint256 i = 0; i < positionIndexes.length; ) {
+            delete stakeInfo.snapshot[positionIndexes[i]]; // reset BucketState struct for current position
+
+            unchecked { ++i; }
+        }
+
+        // remove recorded stake info
         delete stakes[tokenId_];
 
         emit Unstake(msg.sender, ajnaPool, tokenId_);
@@ -255,7 +266,19 @@ contract RewardsManager is IRewardsManager {
         return (
             stakes[tokenId_].owner,
             stakes[tokenId_].ajnaPool,
-            stakes[tokenId_].lastInteractionBurnEpoch);
+            stakes[tokenId_].lastInteractionBurnEpoch
+        );
+    }
+
+    /// @inheritdoc IRewardsManagerState
+    function getBucketStateStakeInfo(
+        uint256 tokenId_,
+        uint256 bucketId_
+    ) external view override returns (uint256, uint256) {
+        return (
+            stakes[tokenId_].snapshot[bucketId_].lpsAtStakeTime,
+            stakes[tokenId_].snapshot[bucketId_].rateAtStakeTime
+        );
     }
 
     /**************************/

--- a/src/interfaces/rewards/IRewardsManagerState.sol
+++ b/src/interfaces/rewards/IRewardsManagerState.sol
@@ -47,6 +47,18 @@ interface IRewardsManagerState {
         uint256 tokenId
     ) external view returns (address, address, uint256);
 
+    /**
+     *  @notice Retrieve information about recorded LPs and rate values for a given bucket and a given stake, at stake time.
+     *  @param  tokenId  ID of the NFT staked in the rewards contract to retrieve information about.
+     *  @param  bucketId ID of the bucket to retrieve recorded information at stake time.
+     *  @return [RAY] LP amount the NFT owner is entitled in current bucket at the time of staking.
+     *  @return [RAY] current bucket exchange rate at the time of staking.
+     */
+    function getBucketStateStakeInfo(
+        uint256 tokenId,
+        uint256 bucketId
+    ) external view returns (uint256, uint256);
+
 }
 
 /*********************/
@@ -63,5 +75,5 @@ struct StakeInfo {
 
 struct BucketState {
     uint256 lpsAtStakeTime;  // [RAY] LP amount the NFT owner is entitled in current bucket at the time of staking
-    uint256 rateAtStakeTime; // [RAY] current bucket exchange rate at the time of staking (RAY)
+    uint256 rateAtStakeTime; // [RAY] current bucket exchange rate at the time of staking
 }

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -160,8 +160,15 @@ contract RewardsManagerTest is DSTestPlus {
         _rewardsManager.unstake(tokenId);
         assertEq(_positionManager.ownerOf(tokenId), minter);
 
-        // check token was transferred to rewards contract
+        // check token was transferred from rewards contract to minter
         assertEq(_positionManager.ownerOf(tokenId), address(minter));
+
+        // invariant: all bucket snapshots are removed for the token id that was unstaken
+        for(uint256 bucketIndex = 0; bucketIndex <= 7388; bucketIndex++) {
+            (uint256 lps, uint256 rate) = _rewardsManager.getBucketStateStakeInfo(tokenId, bucketIndex);
+            assertEq(lps, 0);
+            assertEq(rate, 0);
+        }
     }
 
     function _triggerReserveAuctionsNoTake(TriggerReserveAuctionParams memory params_) internal {


### PR DESCRIPTION
# RewardsManager doesn't delete old bucket snapshot info on unstaking

## Summary

RewardsManager's unstake() use `delete stakes[tokenId_]` to clear old stake state, but `snapshot` is the nested mapping in the `StakeInfo` structure and will not be reset this way as delete operation do not traverse through nested mappings as it lacks key set information.

## Vulnerability Detail

`stakes[tokenId_]` gets written on staking and `mapping(uint256 => BucketState) snapshot` is written for the *current* list of buckets. This means if this list persists and there were no bucket changes it's ok as new values will be overwritten on next stake.

But, if Bob the staker has changed his composition of buckets and his second stake takes place over another set, possibly intersecting with the first one, old part will persist. If then Bob's `positionIndexes = positionManager.getPositionIndexes(tokenId_)` changed after the second stake, say as a result of PositionManager's moveLiquidity(), and indices from the first set were added there, their snapshot values from the first stake will be reused.

## Impact

If Bob knows this it will be straightforward for him to exploit the mechanics, obtaining extra rewards (interest earned will be counted from the first stake time for old positions) at the expense of other stakers.

## Recommendation

IRewardsManagerState.BucketState doesn't contain any nested structures, so `delete bucketState` will reset it fully:

https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/interfaces/rewards/IRewardsManagerState.sol#L64-L67

```solidity
struct BucketState {
    uint256 lpsAtStakeTime;  // [RAY] LP amount the NFT owner is entitled in current bucket at the time of staking
    uint256 rateAtStakeTime; // [RAY] current bucket exchange rate at the time of staking (RAY)
}
```

Consider clearing the current stake snapshots on unstaking, for example:

https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/RewardsManager.sol#L187-L203

```solidity
    function unstake(
        uint256 tokenId_
    ) external override {
        if (msg.sender != stakes[tokenId_].owner) revert NotOwnerOfDeposit();

        address ajnaPool = stakes[tokenId_].ajnaPool;

        // claim rewards, if any
        _claimRewards(tokenId_, IPool(ajnaPool).currentBurnEpoch());

+       uint256[] memory positionIndexes = positionManager.getPositionIndexes(tokenId_);
+       for (uint256 i = 0; i < positionIndexes.length; ) {
+           delete stakeInfo.snapshot[positionIndexes[i]]; // BucketState
+           unchecked { ++i; }
+       }
        delete stakes[tokenId_];

        emit Unstake(msg.sender, ajnaPool, tokenId_);

        // transfer LP NFT from contract to sender
        IERC721(address(positionManager)).safeTransferFrom(address(this), msg.sender, tokenId_);
    }
```