### PR TITLE
Sherlock 151.md: Permanent freezing of unclaimed yield

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -449,6 +449,9 @@ contract RewardsManager is IRewardsManager {
 
         address ajnaPool = stakeInfo.ajnaPool;
 
+        // revert if higher epoch to claim than current burn epoch
+        if (epochToClaim_ > IPool(ajnaPool).currentBurnEpoch()) revert EpochNotAvailable();
+
         // update bucket exchange rates and claim associated rewards
         uint256 rewardsEarned = _updateBucketExchangeRates(
             ajnaPool,

--- a/src/interfaces/rewards/IRewardsManagerErrors.sol
+++ b/src/interfaces/rewards/IRewardsManagerErrors.sol
@@ -12,6 +12,11 @@ interface IRewardsManagerErrors {
     error AlreadyClaimed();
 
     /**
+     *  @notice User attempted to claim rewards for an epoch that is not yet available.
+     */
+    error EpochNotAvailable();
+
+    /**
      *  @notice User attempted to record updated exchange rates outside of the allowed period.
      */
     error ExchangeRateUpdateTooLate();

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1625,7 +1625,7 @@ contract RewardsManagerTest is DSTestPlus {
         }
     }
 
-    function testClaimRewardsFroozeUnclaimedYield() external {
+    function testClaimRewardsFreezeUnclaimedYield() external {
         skip(10);
 
         uint256[] memory depositIndexes = new uint256[](5);

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1625,4 +1625,34 @@ contract RewardsManagerTest is DSTestPlus {
         }
     }
 
+    function testClaimRewardsFroozeUnclaimedYield() external {
+        skip(10);
+
+        uint256[] memory depositIndexes = new uint256[](5);
+        depositIndexes[0] = 9;
+        depositIndexes[1] = 1;
+        depositIndexes[2] = 2;
+        depositIndexes[3] = 3;
+        depositIndexes[4] = 4;
+        MintAndMemorializeParams memory mintMemorializeParams = MintAndMemorializeParams({
+            indexes: depositIndexes,
+            minter: _minterOne,
+            mintAmount: 1000 * 1e18,
+            pool: _poolOne
+        });
+
+        uint256 tokenIdOne = _mintAndMemorializePositionNFT(mintMemorializeParams);
+        _stakeToken(address(_poolOne), _minterOne, tokenIdOne);
+
+        uint256 currentBurnEpoch = _poolOne.currentBurnEpoch();
+
+        changePrank(_minterOne);
+        // should revert if the epoch to claim is not available yet
+        vm.expectRevert(IRewardsManagerErrors.EpochNotAvailable.selector);
+        _rewardsManager.claimRewards(tokenIdOne, currentBurnEpoch + 10);
+
+        // user should be able to claim rewards for current epoch
+        _rewardsManager.claimRewards(tokenIdOne, currentBurnEpoch);
+    }
+
 }


### PR DESCRIPTION
# Permanent freezing of unclaimed yield

## Summary
A user can accidentally freeze potential rewards from the `RewardsManager.sol`

## Vulnerability Detail
On `claimRewards` in `RewardsManager` contract the `epochToClaim_` is not limited to the `currentBurnEpoch()`, thus allowing a user to send `epochToClaim_ > currentBurnEpoch`, rendering `isEpochClaimed[tokenId_][epochToClaim_]` true from all epochs from `0 - epochToClaim_` and disallowing the user rewards he may have received in future epochs

[epochToClaim_ no limit check](https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/RewardsManager.sol#L108)


## Impact
By accidentally sending the wrong epoch a user may freeze unclaimed yield with no way of getting it back

## Recommendation

add a require statement when calling `claimRewards`

```js
    function claimRewards(
        uint256 tokenId_,
        uint256 epochToClaim_
    ) external override {
        if (epochToClaim_ > IPool(stakes[tokenId_].ajnaPool).currentBurnEpoch()) revert EpochNotAvailableYet();

        // rest of the function
    }
```

Which is a better solution