### PR TITLE
Sherlock 075.md: If borrower or kicker got blacklisted by asset contr…

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -183,7 +183,8 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 collateralAmountToPull_
+        uint256 collateralAmountToPull_,
+        address collateralReceiver_
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
@@ -223,8 +224,8 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
             // update pool balances state
             poolBalances.pledgedCollateral = result.poolCollateral;
 
-            // move collateral from pool to sender
-            _transferCollateral(msg.sender, collateralAmountToPull_);
+            // move collateral from pool to address specified as collateral receiver
+            _transferCollateral(collateralReceiver_, collateralAmountToPull_);
         }
     }
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -194,7 +194,8 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 noOfNFTsToPull_
+        uint256 noOfNFTsToPull_,
+        address collateralReceiver_
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
@@ -232,8 +233,8 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             _transferQuoteTokenFrom(msg.sender, result.quoteTokenToRepay);
         }
         if (noOfNFTsToPull_ != 0) {
-            // move collateral from pool to sender
-            _transferFromPoolToAddress(msg.sender, borrowerTokenIds[msg.sender], noOfNFTsToPull_);
+            // move collateral from pool to address specified as collateral receiver
+            _transferFromPoolToAddress(collateralReceiver_, borrowerTokenIds[msg.sender], noOfNFTsToPull_);
         }
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -320,10 +320,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev write state:
      *       - reset kicker's claimable accumulator
      */
-    function withdrawBonds() external {
+    function withdrawBonds(address recipient_) external {
         uint256 claimable = auctions.kickers[msg.sender].claimable;
         auctions.kickers[msg.sender].claimable = 0;
-        _transferQuoteToken(msg.sender, claimable);
+        _transferQuoteToken(recipient_, claimable);
     }
 
     /*********************************/

--- a/src/interfaces/pool/commons/IPoolLiquidationActions.sol
+++ b/src/interfaces/pool/commons/IPoolLiquidationActions.sol
@@ -63,6 +63,7 @@ interface IPoolLiquidationActions {
 
     /**
      *  @notice Called by kickers to withdraw their auction bonds (the amount of quote tokens that are not locked in active auctions).
+     *  @param  recipient Address to receive claimed bonds amount.
      */
-    function withdrawBonds() external;
+    function withdrawBonds(address recipient) external;
 }

--- a/src/interfaces/pool/erc20/IERC20PoolBorrowerActions.sol
+++ b/src/interfaces/pool/erc20/IERC20PoolBorrowerActions.sol
@@ -29,10 +29,12 @@ interface IERC20PoolBorrowerActions {
      *  @param  borrowerAddress_            The borrower whose loan is being interacted with.
      *  @param  maxQuoteTokenAmountToRepay_ The amount of quote tokens to repay.
      *  @param  collateralAmountToPull_     The amount of collateral to be puled from the pool.
+     *  @param  recipient_                  The address to receive amount of pulled collateral.
      */
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 collateralAmountToPull_
+        uint256 collateralAmountToPull_,
+        address recipient_
     ) external;
 }

--- a/src/interfaces/pool/erc721/IERC721PoolBorrowerActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolBorrowerActions.sol
@@ -29,10 +29,12 @@ interface IERC721PoolBorrowerActions {
      *  @param  borrowerAddress_            The borrower whose loan is being interacted with.
      *  @param  maxQuoteTokenAmountToRepay_ The amount of quote tokens to repay.
      *  @param  noOfNFTsToPull_             The integer number of NFT collateral to be puled from the pool.
+     *  @param  recipient_                  The address to receive amount of pulled collateral.
      */
     function repayDebt(
         address borrowerAddress_,
         uint256 maxQuoteTokenAmountToRepay_,
-        uint256 noOfNFTsToPull_
+        uint256 noOfNFTsToPull_,
+        address recipient_
     ) external;
 }

--- a/tests/brownie/test_scaled_pool.py
+++ b/tests/brownie/test_scaled_pool.py
@@ -85,11 +85,11 @@ def test_borrow_repay_scaled(
                 print(f"Transaction: {i} | {test_utils.get_usage(txes[i].gas_used)}")
 
         repay_txes = []
-        tx = scaled_pool.repayDebt(borrowers[0], 110 * 10**18, 0, {"from": borrowers[0]})
+        tx = scaled_pool.repayDebt(borrowers[0], 110 * 10**18, 0, borrowers[0], {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repayDebt(borrowers[0], 110 * 10**18, 0, {"from": borrowers[0]})
+        tx = scaled_pool.repayDebt(borrowers[0], 110 * 10**18, 0, borrowers[0], {"from": borrowers[0]})
         repay_txes.append(tx)
-        tx = scaled_pool.repayDebt(borrowers[0], 50 * 10**18, 0, {"from": borrowers[0]})
+        tx = scaled_pool.repayDebt(borrowers[0], 50 * 10**18, 0, borrowers[0], {"from": borrowers[0]})
         repay_txes.append(tx)
         with capsys.disabled():
             print("\n==================================")

--- a/tests/brownie/test_stable_volatile.py
+++ b/tests/brownie/test_stable_volatile.py
@@ -364,7 +364,7 @@ def repay_debt(borrower, borrower_index, pool_helper, test_utils):
               f"is withdrawing {collateral_deposited/1e18:.1f} collateral")
         # assert collateral_to_withdraw > 0
         repay_amount = int(repay_amount * 1.01)
-        tx = pool_helper.pool.repayDebt(borrower, repay_amount, collateral_to_withdraw, {"from": borrower})
+        tx = pool_helper.pool.repayDebt(borrower, repay_amount, collateral_to_withdraw, borrower, {"from": borrower})
     elif debt == 0:
         log(f" borrower {borrower_index:>4} has no debt to repay")
     else:

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -366,7 +366,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         vm.expectEmit(true, true, false, true);
         emit RepayDebt(borrower, repaid, 0, newLup);
         _assertQuoteTokenTransferEvent(from, address(_pool), repaid);
-        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0, borrower);
     }
 
     function _repayDebt(
@@ -394,7 +394,23 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             _assertCollateralTokenTransferEvent(address(_pool), from, collateralToPull);
         }
 
-        ERC20Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull, borrower);
+    }
+
+    function _repayDebtAndPullToRecipient(
+        address from,
+        address borrower,
+        address recipient,
+        uint256 amountToRepay,
+        uint256 amountRepaid,
+        uint256 collateralToPull,
+        uint256 newLup
+    ) internal {
+        changePrank(from);
+        vm.expectEmit(true, true, false, true);
+        emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
+        _assertCollateralTokenTransferEvent(address(_pool), recipient, collateralToPull);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull, recipient);
     }
 
     function _repayDebtNoLupCheck(
@@ -497,7 +513,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        ERC20Pool(address(_pool)).repayDebt(from, 0, amount);
+        ERC20Pool(address(_pool)).repayDebt(from, 0, amount, from);
     }
 
     function _assertRepayNoDebtRevert(
@@ -507,7 +523,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.NoDebt.selector);
-        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0, borrower);
     }
 
     function _assertPullBorrowerNotSenderRevert(
@@ -517,7 +533,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.BorrowerNotSender.selector);
-        ERC20Pool(address(_pool)).repayDebt(borrower, 0, amount);
+        ERC20Pool(address(_pool)).repayDebt(borrower, 0, amount, borrower);
     }
 
     function _assertRepayMinDebtRevert(
@@ -527,7 +543,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, amount, 0, borrower);
     }
 
     function _assertRemoveAllCollateralNoClaimRevert(

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -920,7 +920,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
         vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
-        IERC20Pool(address(_pool)).repayDebt(_borrower, 500.480769230769231000 * 1e18 - 1, 0);
+        IERC20Pool(address(_pool)).repayDebt(_borrower, 500.480769230769231000 * 1e18 - 1, 0, _borrower);
 
         // should be able to pay back all pendingDebt
         _repayDebt({

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -29,7 +29,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
     /**
      *  @notice With 1 lender and 1 borrower test pledgeCollateral, borrow, and pullCollateral.
      */
-    function testAddPullCollateral() external tearDown {
+    function testPledgeAndPullCollateral() external tearDown {
         // lender deposits 10000 Quote into 3 buckets
 
         _addInitialLiquidity({
@@ -182,6 +182,122 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         });
 
         assertEq(_collateral.balanceOf(_borrower), 142.938961955526506798 * 1e18);
+    }
+
+    /**
+     *  @notice With 1 lender and 1 borrower test pledgeCollateral, borrow, pull and transfer collateral to a different recipient.
+     */
+    function testPledgeAndPullCollateralToDifferentRecipient() external tearDown {
+        // lender deposits 10000 Quote into 3 buckets
+
+        address collateralReceiver = makeAddr("receiver");
+
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2550
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2551
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2552
+        });
+
+        assertEq(_collateral.balanceOf(collateralReceiver), 0);
+        assertEq(_collateral.balanceOf(_borrower),          150 * 1e18);
+
+        // borrower pledge 100 collateral and get a 21_000 Quote loan
+        _pledgeCollateral({
+            from:     _borrower,
+            borrower: _borrower,
+            amount:   100 * 1e18
+        });
+        _borrow({
+            from:       _borrower,
+            amount:     21_000 * 1e18,
+            indexLimit: 3_000,
+            newLup:     2_981.007422784467321543 * 1e18
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  210.201923076923077020 * 1e18,
+                lup:                  2_981.007422784467321543 * 1e18,
+                poolSize:             30_000 * 1e18,
+                pledgedCollateral:    100 * 1e18,
+                encumberedCollateral: 7.051372011699988577 * 1e18,
+                poolDebt:             21_020.192307692307702000 * 1e18,
+                actualUtilization:    0.700673076923076923 * 1e18,
+                targetUtilization:    1e18,
+                minDebtAmount:        2_102.019230769230770200 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              21_020.192307692307702000 * 1e18,
+            borrowerCollateral:        100 * 1e18,
+            borrowert0Np:              220.712019230769230871 * 1e18,
+            borrowerCollateralization: 14.181637252165253251 * 1e18
+        });
+
+        assertEq(_collateral.balanceOf(collateralReceiver), 0);
+        assertEq(_collateral.balanceOf(_borrower),          50 * 1e18);
+
+        // pass time to allow interest to accrue
+        skip(10 days);
+
+        // remove some of the collateral and transfer to recipient
+        _repayDebtAndPullToRecipient({
+            from:             _borrower,
+            borrower:         _borrower,
+            recipient:        collateralReceiver,
+            amountToRepay:    0,
+            amountRepaid:     0,
+            collateralToPull: 50 * 1e18,
+            newLup:           2_981.007422784467321543 * 1e18
+        });
+
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              21_049.006823139002918431 * 1e18,
+            borrowerCollateral:        50 * 1e18,
+            borrowert0Np:              441.424038461538461742 * 1e18,
+            borrowerCollateralization: 7.081111825921092812 * 1e18
+        });
+
+        assertEq(_collateral.balanceOf(collateralReceiver), 50 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower),          50 * 1e18);
+
+        // remove all of the remaining claimable collateral
+        _repayDebtAndPullToRecipient({
+            from:             _borrower,
+            borrower:         _borrower,
+            recipient:        collateralReceiver,
+            amountToRepay:    0,
+            amountRepaid:     0,
+            collateralToPull: 50 * 1e18 - _encumberance(21_049.006823139002918431 * 1e18, _lup()),
+            newLup:           2_981.007422784467321543 * 1e18
+        });
+
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              21_049.006823139002918431 * 1e18,
+            borrowerCollateral:        7.061038044473493202 * 1e18,
+            borrowert0Np:              3_140.657612229160876676 * 1e18,
+            borrowerCollateralization: 1 * 1e18
+        });
+
+        assertEq(_collateral.balanceOf(collateralReceiver), 92.938961955526506798 * 1e18);
+        assertEq(_collateral.balanceOf(_borrower),          50 * 1e18);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -106,7 +106,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         skip(15 hours);
 
         vm.prank(borrower);
-        ERC20Pool(address(_pool)).repayDebt(borrower, 100 * 1e18, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, 100 * 1e18, 0, borrower);
 
         assertEq(_noOfLoans(), LOANS_COUNT);
     }
@@ -122,7 +122,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         (uint256 debt, , ) = _poolUtils.borrowerInfo(address(_pool), borrower);
 
         vm.prank(borrower);
-        ERC20Pool(address(_pool)).repayDebt(borrower, debt, 0);
+        ERC20Pool(address(_pool)).repayDebt(borrower, debt, 0, borrower);
 
         assertEq(_noOfLoans(), LOANS_COUNT - 1);
     }
@@ -201,7 +201,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             address borrower = _borrowers[i];
 
             vm.prank(borrower);
-            ERC20Pool(address(_pool)).repayDebt(borrower, 100 * 1e18, 0);
+            ERC20Pool(address(_pool)).repayDebt(borrower, 100 * 1e18, 0, borrower);
 
             assertEq(_noOfLoans(), LOANS_COUNT);
 
@@ -223,7 +223,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             (uint256 debt, , ) = _poolUtils.borrowerInfo(address(_pool), borrower);
 
             vm.prank(borrower);
-            ERC20Pool(address(_pool)).repayDebt(borrower, debt, 0);
+            ERC20Pool(address(_pool)).repayDebt(borrower, debt, 0, borrower);
 
             assertEq(_noOfLoans(), LOANS_COUNT - 1);
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -11,12 +11,14 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
     address internal _borrower2;
     address internal _lender;
     address internal _lender1;
+    address internal _withdrawRecipient;
 
     function setUp() external {
-        _borrower  = makeAddr("borrower");
-        _borrower2 = makeAddr("borrower2");
-        _lender    = makeAddr("lender");
-        _lender1   = makeAddr("lender1");
+        _borrower          = makeAddr("borrower");
+        _borrower2         = makeAddr("borrower2");
+        _lender            = makeAddr("lender");
+        _lender1           = makeAddr("lender1");
+        _withdrawRecipient = makeAddr("withdrawRecipient");
 
         _mintQuoteAndApproveTokens(_lender,  120_000 * 1e18);
         _mintQuoteAndApproveTokens(_lender1, 120_000 * 1e18);
@@ -426,10 +428,23 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             })
         );
 
-        // kicker withdraws his auction bonds
-        changePrank(_lender);
+        // kicker balance befor withdraw auction bonds
         assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
-        _pool.withdrawBonds();
+
+        snapshot = vm.snapshot();
+
+        changePrank(_lender);
+
+        // kicker withdraws auction bonds and transfer to a different address
+        _pool.withdrawBonds(_withdrawRecipient);
+
+        assertEq(_quote.balanceOf(_withdrawRecipient), 0.195342779771472726 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
+
+        vm.revertTo(snapshot);
+
+        // kicker withdraws auction bonds
+        _pool.withdrawBonds(_lender);
 
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
 
@@ -533,7 +548,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         changePrank(_lender);
         assertEq(_quote.balanceOf(_lender), 46_999.804657220228527274 * 1e18);
 
-        _pool.withdrawBonds();
+        _pool.withdrawBonds(_lender);
 
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1661,7 +1661,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // kicker withdraws his auction bonds
         assertEq(_quote.balanceOf(_lender), 46_248.354604754094247543 * 1e18);
 
-        _pool.withdrawBonds();
+        _pool.withdrawBonds(_lender);
 
         assertEq(_quote.balanceOf(_lender), 46_353.419661702147599360 * 1e18);
 

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -336,7 +336,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
                 emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
             }
 
-            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
+            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull, borrower);
 
             // post pull checks
             if (collateralToPull != 0) {
@@ -352,7 +352,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
                 emit RepayDebt(borrower, amountRepaid, collateralToPull, newLup);
             }
 
-            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull);
+            ERC721Pool(address(_pool)).repayDebt(borrower, amountToRepay, collateralToPull, borrower);
         }
     }
 
@@ -569,7 +569,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
-        ERC721Pool(address(_pool)).repayDebt(from, 0, amount);
+        ERC721Pool(address(_pool)).repayDebt(from, 0, amount, from);
     }
 
     function _assertRepayNoDebtRevert(
@@ -579,7 +579,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.NoDebt.selector);
-        ERC721Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC721Pool(address(_pool)).repayDebt(borrower, amount, 0, borrower);
     }
 
     function _assertRepayMinDebtRevert(
@@ -589,7 +589,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.AmountLTMinDebt.selector);
-        ERC721Pool(address(_pool)).repayDebt(borrower, amount, 0);
+        ERC721Pool(address(_pool)).repayDebt(borrower, amount, 0, borrower);
     }
 
     function _assertRemoveCollateralNoClaimRevert(

--- a/tests/forge/ERC721Pool/ERC721NonStandardTokenTransfer.sol
+++ b/tests/forge/ERC721Pool/ERC721NonStandardTokenTransfer.sol
@@ -51,7 +51,7 @@ contract ERC721PoolNonStandardNftTest is ERC721HelperContract {
         assertEq(cryptoKittiesContract.ownerOf(1777317), address(_pool));
 
         // Pull collateral
-        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1);
+        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1, _borrower);
 
         // Check Borrower is owner of NFT
         assertEq(cryptoKittiesContract.ownerOf(1777317), _borrower); 
@@ -81,7 +81,7 @@ contract ERC721PoolNonStandardNftTest is ERC721HelperContract {
         assertEq(cryptoFightersContract.ownerOf(1), address(_pool));
 
         // Pull collateral
-        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1);
+        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1, _borrower);
 
         // Check Borrower is owner of NFT
         assertEq(cryptoFightersContract.ownerOf(1), _borrower); 
@@ -112,7 +112,7 @@ contract ERC721PoolNonStandardNftTest is ERC721HelperContract {
         assertEq(cryptoPunksContract.punkIndexToAddress(1), address(_pool));
 
         // Pull collateral
-        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1);
+        ERC721Pool(address(_pool)).repayDebt(_borrower, 0, 1, _borrower);
 
         // Check Borrower is owner of NFT
         assertEq(cryptoPunksContract.punkIndexToAddress(1), _borrower);

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -12,11 +12,13 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
+    address internal _withdrawRecipient;
 
     function setUp() external {
-        _borrower  = makeAddr("borrower");
-        _borrower2 = makeAddr("borrower2");
-        _lender    = makeAddr("lender");
+        _borrower          = makeAddr("borrower");
+        _borrower2         = makeAddr("borrower2");
+        _lender            = makeAddr("lender");
+        _withdrawRecipient = makeAddr("withdrawRecipient");
 
         // deploy subset pool
         uint256[] memory subsetTokenIds = new uint256[](6);
@@ -646,9 +648,18 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             locked:    0
         });
 
-        // Kicker claims bond + reward
+        uint256 snapshot = vm.snapshot();
+
         changePrank(_lender);
-        _pool.withdrawBonds();
+
+        // Kicker claims bond + reward and transfer to a different address
+        _pool.withdrawBonds(_withdrawRecipient);
+        assertEq(_quote.balanceOf(_withdrawRecipient), 0.242202920686750816 * 1e18);
+
+        vm.revertTo(snapshot);
+
+        // Kicker claims bond + reward
+        _pool.withdrawBonds(_lender);
         assertEq(_quote.balanceOf(_lender), 46_998.523343483554970812 * 1e18);
     }
 

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -179,7 +179,7 @@ contract RewardsManagerTest is DSTestPlus {
 
         // borrower repays some of their debt, providing reserves to be claimed
         // don't pull any collateral, as such functionality is unrelated to reserve auctions
-        params_.pool.repayDebt(borrower, Maths.wdiv(params_.borrowAmount, Maths.wad(2)), 0);
+        params_.pool.repayDebt(borrower, Maths.wdiv(params_.borrowAmount, Maths.wad(2)), 0, borrower);
 
         // start reserve auction
         changePrank(_bidder);
@@ -279,7 +279,7 @@ contract RewardsManagerTest is DSTestPlus {
 
         // borrower repays some of their debt, providing reserves to be claimed
         // don't pull any collateral, as such functionality is unrelated to reserve auctions
-        params_.pool.repayDebt(borrower, params_.borrowAmount, 0);
+        params_.pool.repayDebt(borrower, params_.borrowAmount, 0, borrower);
 
         // start reserve auction
         changePrank(_bidder);
@@ -623,7 +623,7 @@ contract RewardsManagerTest is DSTestPlus {
 
         // borrower1 repays their loan
         (uint256 debt, , ) = _poolOne.borrowerInfo(borrower1);
-        _poolOne.repayDebt(borrower1, debt, 0);
+        _poolOne.repayDebt(borrower1, debt, 0, borrower1);
 
         /*****************************/
         /*** First Reserve Auction ***/
@@ -683,7 +683,7 @@ contract RewardsManagerTest is DSTestPlus {
         // borrower1 repays their loan again
         changePrank(borrower1);
         (debt, , ) = _poolOne.borrowerInfo(borrower1);
-        _poolOne.repayDebt(borrower1, debt, 0);
+        _poolOne.repayDebt(borrower1, debt, 0, borrower1);
 
         // recorder updates the change in exchange rates in the second index
         _updateExchangeRates({


### PR DESCRIPTION
…act their collateral or bond funds can be permanently frozen with the pool

# If borrower or kicker got blacklisted by asset contract their collateral or bond funds can be permanently frozen with the pool
TBD: should we revert on `0x` passed as recipient?

## Summary

It's impossible for borrower or kicker to transfer their otherwise withdraw-able funds to another address. If for some reason borrower or kicker got blacklisted by collateral or quote token contract (correspondingly), these funds will be permanently frozen as now there is no mechanics to move them to another address or specify the recipient for the transfer.

## Vulnerability Detail

If during the duration of a loan the borrower got blacklisted by collateral asset contract, let's say it is USDC, there is no way to retrieve the collateral. These collateral funds will be permanently locked at the Pool contract balance.

Similar, although less dangerous as both duration and exposure is less, situation takes place with kicker's balance, that is referenced by `msg.sender` only and so bonds due will be frozen with the pool if that address be blacklisted.

For lender's case there is a position managing possibility via Pool's transferLPs() and PositionManager's memorializePositions() and reedemPositions(), but for a borrower and a kicker there is no way to transfer funds due ownership or even specify transfer recipient, so the corresponding collateral and bond funds will be frozen with the pool if current beneficiary be blacklisted.

## Impact

Principal funds of borrower or kicker being permanently frozen in full, but backlisting is a low probability event, so setting the severity to be medium.
