### PR TITLE
Sherlock 139.md

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1137,6 +1137,8 @@ library Auctions {
             vars.t0RepayAmount            = Maths.wdiv(vars.scaledQuoteTokenAmount, inflator_);
             vars.unscaledQuoteTokenAmount = vars.unscaledDeposit;
 
+            vars.scaledQuoteTokenAmount   = Maths.wmul(vars.collateralAmount, vars.auctionPrice);
+
         } else if (vars.borrowerDebt <= borrowerCollateralValue) {
             // borrower debt is constraining factor
             vars.collateralAmount         = _roundToScale(Maths.wdiv(vars.borrowerDebt, borrowerPrice), collateralScale_);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -474,7 +474,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i1505_26,
             collateralArbed:  0.731315193857015473 * 1e18,
-            quoteTokenAmount: 15.000000000000000000 * 1e18,
+            quoteTokenAmount: 14.99999999999999999 * 1e18,
             bondChange:       0.15 * 1e18,
             isReward:         false,
             lpAwardTaker:     1_085.822235391290531116686016658 * 1e27,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -479,7 +479,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i1505_26,
             collateralArbed:  0.009965031187761219 * 1e18,
-            quoteTokenAmount: 15.0 * 1e18,
+            quoteTokenAmount: 14.999999999999999995 * 1e18,
             bondChange:       0.15 * 1e18,
             isReward:         false,
             lpAwardTaker:     0,

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -529,7 +529,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
     }
 
-    function testMergeOrRemoveCollateral() external  {
+    function testMergeOrRemoveCollateral() external tearDown {
         for (uint256 i = 3060; i < (3060 + 10); i++) {
             _addLiquidity({
                 from:   _lender,
@@ -627,7 +627,6 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             newLup: 99836282890,
             lpAward: 0 * 1e27
         });
-        return;
         _assertBucket({
             index:        3060,
             lpBalance:    20.000000000000000000 * 1e27,

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -529,7 +529,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
     }
 
-    function testMergeOrRemoveCollateral() external tearDown {
+    function testMergeOrRemoveCollateral() external  {
         for (uint256 i = 3060; i < (3060 + 10); i++) {
             _addLiquidity({
                 from:   _lender,
@@ -619,6 +619,23 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             })
         );
 
+        // force an interest accumulation to assert bucket with interest
+        _addLiquidity({
+            from:   _lender,
+            amount: 0 * 1e18,
+            index:  7000,
+            newLup: 99836282890,
+            lpAward: 0 * 1e27
+        });
+        return;
+        _assertBucket({
+            index:        3060,
+            lpBalance:    20.000000000000000000 * 1e27,
+            collateral:   0.0000000000000000000 * 1e18,
+            deposit:      20.010216420146293860 * 1e18,
+            exchangeRate: 1.000510821007314693000000000 * 1e27
+        });
+
         // Before depositTake: NFTs pledged by liquidated borrower are owned by the borrower in the pool
         assertEq(_collateral.ownerOf(1), address(_pool));
         assertEq(_collateral.ownerOf(3), address(_pool));
@@ -682,7 +699,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 encumberedCollateral: 4407944209.541175956055268556 * 1e18,
                 poolDebt:             440.072765067090279852 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    3_123_578_486.651416548727612650 * 1e18,
+                targetUtilization:    2_996_091_127.870826153174895975 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
@@ -989,7 +1006,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 encumberedCollateral: 0,
                 poolDebt:             0,
                 actualUtilization:    0,
-                targetUtilization:    3123578486.651416548727612650 * 1e18,
+                targetUtilization:    2_996_091_127.870826153174895975 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -634,18 +634,18 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        3060,
-            lpBalance:    20.2 * 1e27,
+            lpBalance:    20.202020202020202022 * 1e27,
             collateral:   0.085430491711717314 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000610882095524250072170475 * 1e27
+            exchangeRate: 1.000510821007314697558117795 * 1e27
         });
 
         _assertBucket({
             index:        3061,
-            lpBalance:    20.2 * 1e27,
+            lpBalance:    20.202020202020202019 * 1e27,
             collateral:   0.085857644170275899 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000610882095524239992886155 * 1e27
+            exchangeRate: 1.000510821007314687628417260 * 1e27
         });
 
         _assertBucket({
@@ -793,22 +793,22 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        3060,
-            lpBalance:    20.2 * 1e27,
+            lpBalance:    20.202020202020202022 * 1e27,
             collateral:   0.085430491711717314 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000610882095524250072170475 * 1e27
+            exchangeRate: 1.000510821007314697558117795 * 1e27
         });
         _assertBucket({
             index:        3069,
-            lpBalance:    20.2 * 1e27,
+            lpBalance:    20.20202020202020202 * 1e27,
             collateral:   0.089352655062849951 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000610882095524241676916623 * 1e27
+            exchangeRate: 1.000510821007314689262754039 * 1e27
         });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       3069,
-            lpBalance:   20.2 * 1e27,
+            lpBalance:   20.20202020202020202 * 1e27,
             depositTime: _startTime + 10000 days + 32 hours
         });
         _assertBucket({

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -235,7 +235,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             kicker:           _lender,
             index:            _i1505_26,
             collateralArbed:  0.009965031187761219 * 1e18,
-            quoteTokenAmount: 15.0 * 1e18,
+            quoteTokenAmount: 14.999999999999999995 * 1e18,
             bondChange:       0.15 * 1e18,
             isReward:         false,
             lpAwardTaker:     0,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -364,10 +364,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -399,10 +399,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBucket({
             index:        2501,
@@ -490,19 +490,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             kicker:           _lender,
             index:            2500,
             collateralArbed:  1.848006454703595366 * 1e18,
-            quoteTokenAmount: 4_998.040748687334744778 * 1e18,
-            bondChange:       1_499.412224606200423433 * 1e18,
+            quoteTokenAmount: 7_140.058212410478208121 * 1e18,
+            bondChange:       2_142.017463723143462436 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    1_499.134615384615384200000000000 * 1e27
+            lpAwardKicker:    2_141.620879120879120674 * 1e27
         });
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -573,10 +573,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBucket({
             index:        6113,
@@ -664,19 +664,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             kicker:           _lender,
             index:            2500,
             collateralArbed:  1.848006454703595366 * 1e18,
-            quoteTokenAmount: 4_998.040748687334744778 * 1e18,
-            bondChange:       1_499.412224606200423433 * 1e18,
+            quoteTokenAmount: 7_140.058212410478208121 * 1e18,
+            bondChange:       2_142.017463723143462436 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    1_499.134615384615384200000000000 * 1e27
+            lpAwardKicker:    2_141.620879120879120674 * 1e27
         });
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -739,10 +739,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    6_496.2499999999999982 * 1e27,
+            lpBalance:    7_138.736263736263734674 * 1e27,
             collateral:   1.848006454703595366 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414485129597 * 1e27
+            exchangeRate: 1.000185179648802797127066481 * 1e27
         });
         _assertBucket({
             index:        6113,
@@ -826,8 +826,8 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             kicker:           _lender,
             index:            2000,
             collateralArbed:  0.021378186081598093 * 1e18,
-            quoteTokenAmount: 1_000 * 1e18,
-            bondChange:       300 * 1e18,
+            quoteTokenAmount: 999.9999999999999908 * 1e18,
+            bondChange:       299.99999999999999724 * 1e18,
             isReward:         false,
             lpAwardTaker:     0,
             lpAwardKicker:    0
@@ -858,7 +858,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:            _lender,
             borrower:        _borrower,
             maxCollateral:   1,
-            bondChange:      1_201.442307692307693000 * 1e18,
+            bondChange:      1_201.442307692307695760 * 1e18,
             givenAmount:     4_422.207326928504959735 * 1e18,
             collateralTaken: 0.286141493566424944 * 1e18,
             isReward:        false
@@ -994,19 +994,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             kicker:           _lender,
             index:            2502,
             collateralArbed:  0.747044074730990508 * 1e18,
-            quoteTokenAmount: 2_000.370359297605594000 * 1e18,
-            bondChange:       600.111107789281678200 * 1e18,
+            quoteTokenAmount: 2_857.671941853722277733 * 1e18,
+            bondChange:       857.301582556116683320 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    600 * 1e27
+            lpAwardKicker:    857.142857142857143034 * 1e27
         });
 
         _assertBucket({
             index:        2502,
-            lpBalance:    2_600 * 1e27,
+            lpBalance:    2_857.142857142857143034 * 1e27,
             collateral:   0.747044074730990508 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414512504812 * 1e27
+            exchangeRate: 1.000185179648802797144467916 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -1162,19 +1162,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             kicker:           _lender,
             index:            2502,
             collateralArbed:  0.747044074730990508 * 1e18,
-            quoteTokenAmount: 2_000.370359297605594000 * 1e18,
-            bondChange:       600.111107789281678200 * 1e18,
+            quoteTokenAmount: 2_857.671941853722277733 * 1e18,
+            bondChange:       857.301582556116683320 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    600 * 1e27
+            lpAwardKicker:    857.142857142857143034 * 1e27
         });
 
         _assertBucket({
             index:        2502,
-            lpBalance:    2_600 * 1e27,
+            lpBalance:    2_857.142857142857143034 * 1e27,
             collateral:   0.747044074730990508 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414512504812 * 1e27
+            exchangeRate: 1.000185179648802797144467916 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -1245,10 +1245,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        2502,
-            lpBalance:    2_600 * 1e27,
+            lpBalance:    2_857.142857142857143034000000000 * 1e27,
             collateral:   0.747044074730990508 * 1e18,
             deposit:      0,
-            exchangeRate: 1.099104593020662414512504812 * 1e27
+            exchangeRate: 1.000185179648802797144467916 * 1e27
         });
         _assertBucket({
             index:        7388,


### PR DESCRIPTION
# scaledQuoteTokenAmount isn't updated to be collateral sell value in the quote token constraint case of _calculateTakeFlowsAndBondChange

## Summary

`scaledQuoteTokenAmount` isn't `C * p`, but `C * p * (1 - BFP)` for quote token amount constraint case of _calculateTakeFlowsAndBondChange().

## Vulnerability Detail

First case of the _calculateTakeFlowsAndBondChange() logic needs to use `scaledQuoteTokenAmount` in two steps, first as a constraint, then as a total collateral value. The second update is now missed. It affects kicker's reward as the difference takes place when `borrowerPrice < auctionPrice`, i.e. when `vars.isRewarded` is true.

## Impact

`scaledQuoteTokenAmount` is then used for kicker's bond change calculation, so in the quote token constraint case kickers will have the reward based on `C * p * (1 - BFP)`. As this value is proportional to `BFP`, the higher the reward should be, the more incorrect it will be, i.e. `(1 - BFP) * BFP` instead of `BFP`.

As this is regular functionality, there is no low probability prerequisites, and kicker's reward loss is material, setting the severity to be high.

## Recommendation

Consider setting the `scaledQuoteTokenAmount` to the `C * p` as a final step of quote token amount constraint case:

https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/libraries/external/Auctions.sol#L1139-L1149

```solidity
        vars.scaledQuoteTokenAmount = (vars.unscaledDeposit != type(uint256).max) ? Maths.wmul(vars.unscaledDeposit, vars.bucketScale) : type(uint256).max;

        uint256 borrowerCollateralValue = Maths.wmul(totalCollateral_, borrowerPrice);
        
        if (vars.scaledQuoteTokenAmount <= vars.borrowerDebt && vars.scaledQuoteTokenAmount <= borrowerCollateralValue) {
            // quote token used to purchase is constraining factor
            vars.collateralAmount         = _roundToScale(Maths.wdiv(vars.scaledQuoteTokenAmount, borrowerPrice), collateralScale_);
            vars.t0RepayAmount            = Maths.wdiv(vars.scaledQuoteTokenAmount, inflator_);
            vars.unscaledQuoteTokenAmount = vars.unscaledDeposit;
+           vars.scaledQuoteTokenAmount   = Maths.wmul(vars.collateralAmount, vars.auctionPrice);
        }