### PR TITLE
Sherlock 096.md: Interest rate for pool is bounded wrongly

### DIFF
--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -38,7 +38,7 @@ abstract contract PoolDeployer {
     modifier canDeploy(bytes32 subsetHash_, address collateral_, address quote_, uint256 interestRate_) {
         if (collateral_ == address(0) || quote_ == address(0))              revert IPoolFactory.DeployWithZeroAddress();
         if (deployedPools[subsetHash_][collateral_][quote_] != address(0)) revert IPoolFactory.PoolAlreadyExists();
-        if (MIN_RATE >= interestRate_ || interestRate_ >= MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid();
+        if (MIN_RATE > interestRate_ || interestRate_ > MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid();
         _;
     }
 

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.14;
 
 import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
+import { Token } from '../utils/Tokens.sol';
+
 import { ERC20Pool }        from 'src/ERC20Pool.sol';
 import { ERC20PoolFactory } from 'src/ERC20PoolFactory.sol';
 import { IPoolErrors }      from 'src/interfaces/pool/commons/IPoolErrors.sol';
@@ -82,6 +84,22 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(_poolFactory.deployedPoolsList(0),          poolOne);
         assertEq(_poolFactory.getDeployedPoolsList()[1],     poolTwo);
         assertEq(_poolFactory.deployedPoolsList(1),          poolTwo);
+    }
+
+    function testDeployERC20PoolWithMinRate() external {
+        _poolFactory.deployPool(address(new Token("Collateral", "C1")), address(new Token("Quote", "Q1")), 0.01 * 10**18);
+
+        // check tracking of deployed pools
+        assertEq(_poolFactory.getDeployedPoolsList().length, 1);
+        assertEq(_poolFactory.getNumberOfDeployedPools(),    1);
+    }
+
+    function testDeployERC20PoolWithMaxRate() external {
+        _poolFactory.deployPool(address(new Token("Collateral", "C1")), address(new Token("Quote", "Q1")), 0.1 * 10**18);
+
+        // check tracking of deployed pools
+        assertEq(_poolFactory.getDeployedPoolsList().length, 1);
+        assertEq(_poolFactory.getNumberOfDeployedPools(),    1);
     }
 
     function testDeployERC20Pool() external {

--- a/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
@@ -151,6 +151,24 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         });
     }
 
+    function testDeployERC721PoolWithMinRate() external {
+        uint256[] memory tokenIds = new uint256[](0);
+        _factory.deployPool(address(new NFTCollateralToken()), address(new Token("Quote", "Q1")), tokenIds, 0.01 * 10**18);
+
+        // check tracking of deployed pools
+        assertEq(_factory.getDeployedPoolsList().length, 4);
+        assertEq(_factory.getNumberOfDeployedPools(),    4);
+    }
+
+    function testDeployERC721PoolWithMaxRate() external {
+        uint256[] memory tokenIds = new uint256[](0);
+        _factory.deployPool(address(new NFTCollateralToken()), address(new Token("Quote", "Q1")), tokenIds, 0.1 * 10**18);
+
+        // check tracking of deployed pools
+        assertEq(_factory.getDeployedPoolsList().length, 4);
+        assertEq(_factory.getNumberOfDeployedPools(),    4);
+    }
+
     function testDeployERC721CollectionPool() external {
         assertEq(address(_collateral), _NFTCollectionPool.collateralAddress());
         assertEq(address(_quote),      _NFTCollectionPool.quoteTokenAddress());


### PR DESCRIPTION
# Interest rate for pool is bounded wrongly

## Summary
It is documented that pools can be created for tokens with interest rate between 1-10%.

> Pool creators: create pool by providing a fungible token for quote and collateral and an interest rate between 1-10%

However, due to a wrong implementation, pools can only be created between 2-9%.

## Vulnerability Detail
In PoolDeployer.sol contract we have `MIN_RATE = 0.01 * 1e18` and `MAX_RATE = 0.1 * 1e18`. This indicates the 1% and 10% value in which we should allow interest rate to be set. 

However, in our `canDeploy` modifier, it causes a revert when the following condition is true.

> `if (MIN_RATE >= interestRate_ || interestRate_ >= MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid()`

A more than or equal sign is used to do the comparison, and reverts. This means that we can only set interest rate in the range of 2-9%, which I believe is not intended.

## Recommendation
Change to a strict comparison instead when doing the comparison.

```diff
- if (MIN_RATE >= interestRate_ || interestRate_ >= MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid();
+ if (MIN_RATE > interestRate_ || interestRate_ > MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid();
```