### PR TITLE
Fix LPs calculation in removeMaxCollateral function 

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -620,9 +620,10 @@ library LenderActions {
         lender.lps -= lpAmount_;
 
         // update bucket LPs and collateral balance
-        bucketLPs         -= lpAmount_;
+        bucketLPs         -= Maths.min(bucketLPs, lpAmount_);
         bucketCollateral  -= Maths.min(bucketCollateral, collateralAmount_);
         bucket.collateral  = bucketCollateral;
+
         if (bucketCollateral == 0 && bucketDeposit == 0 && bucketLPs != 0) {
             emit BucketBankruptcy(index_, bucketLPs);
             bucket.lps            = 0;

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -466,4 +466,154 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         assertEq(_collateral.balanceOf(_borrower),  150 * 1e18);
         assertEq(_collateral.balanceOf(_borrower2), 0);
     }
+
+    function testAddRemoveCollateralBucketExchangeRateInvariantDifferentActor() external tearDown {
+        _mintCollateralAndApproveTokens(_lender,  50000000000 * 1e18);
+
+        _addInitialLiquidity({
+            from:   _bidder,
+            amount: 6879,
+            index:  2570
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      _bidder,
+            index:       2570,
+            lpBalance:   6879000000000,
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    6879000000000,
+            collateral:   0,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+
+        _addCollateral({
+            from:    _lender,
+            amount:  3642907759.282013932739218713 * 1e18,
+            index:   2570,
+            lpAward: 9927093687851.086595628225711616603275681 * 1e27
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   9927093687851.086595628225711616603275681 * 1e27,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _bidder,
+            index:       2570,
+            lpBalance:   6879000000000,
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    9927093687851.086595628225718495603275681 * 1e27,
+            collateral:   3642907759.282013932739218713 * 1e18,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+
+        _removeAllCollateral({
+            from:     _lender,
+            amount:   3642907759.282013932739218713 * 1e18,
+            index:    2570,
+            lpRedeem: 9927093687851.086595628225711616603275681 * 1e27
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   0, // LPs should get back to same value as before add / remove collateral
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _bidder,
+            index:       2570,
+            lpBalance:   6879000000000, // LPs should get back to same value as before add / remove collateral
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    6879000000000,
+            collateral:   0,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+    }
+
+    function testAddRemoveCollateralBucketExchangeRateInvariantSameActor() external tearDown {
+        _mintCollateralAndApproveTokens(_lender,  50000000000 * 1e18);
+
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 6879,
+            index:  2570
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   6879000000000,
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    6879000000000,
+            collateral:   0,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+
+        _addCollateral({
+            from:    _lender,
+            amount:  3642907759.282013932739218713 * 1e18,
+            index:   2570,
+            lpAward: 9927093687851.086595628225711616603275681 * 1e27
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   9927093687851.086595628225718495603275681 * 1e27,
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    9927093687851.086595628225718495603275681 * 1e27,
+            collateral:   3642907759.282013932739218713 * 1e18,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+
+        _removeAllCollateral({
+            from:     _lender,
+            amount:   3642907759.282013932739218713 * 1e18,
+            index:    2570,
+            lpRedeem: 9927093687851.086595628225711616603275681 * 1e27
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2570,
+            lpBalance:   6879000000000, // LPs should get back to same value as before add / remove collateral
+            depositTime: _startTime
+        });
+        _assertBucket({
+            index:        2570,
+            lpBalance:    6879000000000,
+            collateral:   0,
+            deposit:      6879,
+            exchangeRate: 1 * 1e27 // exchange rate should not change
+        });
+    }
 }

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -902,6 +902,13 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             newLup:  MAX_PRICE
         });
 
+        _assertBucket({
+            index:        7388,
+            lpBalance:    10.000000012600803969212666666 * 1e27,
+            collateral:   0.126214674710621229 * 1e18,
+            deposit:      10 * 1e18,
+            exchangeRate: 1.000000000000000000006624324 * 1e27
+        });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       7388,
@@ -946,15 +953,15 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });   
         _assertBucket({
             index:        7388,
-            lpBalance:    10.000000000000000000212666669 * 1e27, // LPs in bucket 7388 diminished when NFT merged and removed
+            lpBalance:    9.999999999999999999933756760 * 1e27, // LPs in bucket 7388 diminished when NFT merged and removed
             collateral:   0,                                    // no collateral remaining as it was merged and removed
             deposit:      10 * 1e18,
-            exchangeRate: 0.999999999999999999978733333 * 1e27
+            exchangeRate: 1.000000000000000000006624324 * 1e27
         });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       7388,
-            lpBalance:   9.999999987399196030933756763 * 1e27, // lender LPs decreased with the amount used to merge NFT
+            lpBalance:   9.999999987399196030654846854 * 1e27, // lender LPs decreased with the amount used to merge NFT
             depositTime: _startTime + 10000 days + (32 hours + 4210 minutes)
         });
         _assertLenderLpBalance({
@@ -969,7 +976,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             amount:   9.987201910492245717 * 1e18,
             index:    7388,
             newLup:   MAX_PRICE,
-            lpRedeem: 9.999999987399196030933756763 * 1e27
+            lpRedeem: 9.999999987399196030654846854 * 1e27
         });
 
         _assertBucket({

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -355,10 +355,10 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    1_861.033884081553472671582113012 * 1e27,
+            lpBalance:    1_861.033884081553472671752613566 * 1e27,
             collateral:   0,
             deposit:      1861.636634299022017158 * 1e18,
-            exchangeRate: 1.000323879227898104734699503 * 1e27
+            exchangeRate: 1.000323879227898104734607857 * 1e27
         });
     }
 

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -303,17 +303,17 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    14_853.187532758404035070648439563 * 1e27,
+            lpBalance:    14_853.187532758404035070386822316 * 1e27,
             collateral:   0,
             deposit:      14_860.064744955219223346 * 1e18,
-            exchangeRate: 1.000463012547417693082628591 * 1e27
+            exchangeRate: 1.000463012547417693082646213 * 1e27
         });
         _assertBucket({
             index:        MAX_FENWICK_INDEX,
-            lpBalance:    100.000000000000000000179003909 * 1e27,
+            lpBalance:    100.000000000000000000427025300 * 1e27,
             collateral:   0,
             deposit:      100 * 1e18,
-            exchangeRate: 0.999999999999999999998209960 * 1e27
+            exchangeRate: 0.999999999999999999995729747 * 1e27
         });
         _assertBorrower({
             borrower:                  _borrower,


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* In `_removeMaxCollateral` function calculate LPs to remove using same `Buckets.collateralToLPs` function
  * Reuse same function instead inline maths as it introduce rounding errors / break invariants

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* LPs for collateral to remove in `_removeMaxCollateral` were calculated differently than when adding collateral
* Due to this inconsistency the invariant for bucket exchange rate = 1 when add / remove collateral was broken
- calculate `requiredLPs = Buckets.collateralToLPs` in `LenderActions._removeMaxCollateral`
- add test to check bucket exchange rate invariant (= 1) when add quote token / add collateral / remove collateral
- fix other tests failing (minor change due to LPs and exchange rate rounding) 

# Contract size
## Pre Change
N/A
## Post Change
N/A

# Gas usage
## Pre Change
N/A
## Post Change
N/A

