### PR TITLE
Sherlock 92: startClaimableReserveAuction using old inflator

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -350,15 +350,16 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             revert ReserveAuctionTooSoon();
         }
 
+        PoolState memory poolState = _accruePoolInterest();
+
         // start a new claimable reserve auction, passing in relevant parameters such as the current pool size, debt, balance, and inflator value
         uint256 kickerAward = Auctions.startClaimableReserveAuction(
             auctions,
             reserveAuction,
             StartReserveAuctionParams({
-                poolSize:    Deposits.treeSum(deposits),
-                t0PoolDebt:  poolBalances.t0Debt,
                 poolBalance: _getNormalizedPoolQuoteTokenBalance(),
-                inflator:    inflatorState.inflator
+                poolDebt:    poolState.debt,
+                poolSize:    Deposits.treeSum(deposits)
             })
         );
 
@@ -367,6 +368,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         reserveAuction.latestBurnEventEpoch = latestBurnEpoch;
         reserveAuction.burnEvents[latestBurnEpoch].timestamp = block.timestamp;
+
+        // update pool interest rate state
+        _updateInterestState(poolState, _lup(poolState.debt));
 
         // transfer kicker award to msg.sender
         _transferQuoteToken(msg.sender, kickerAward);

--- a/src/interfaces/pool/commons/IPoolReserveAuctionActions.sol
+++ b/src/interfaces/pool/commons/IPoolReserveAuctionActions.sol
@@ -26,8 +26,7 @@ interface IPoolReserveAuctionActions {
 /*********************/
 
 struct StartReserveAuctionParams {
-    uint256 poolSize;    // [WAD] total deposits in pool (with accrued debt)
-    uint256 t0PoolDebt;  // [WAD] current t0 pool debt
     uint256 poolBalance; // [WAD] pool quote token balance
-    uint256 inflator;    // [WAD] pool current inflator
+    uint256 poolDebt;    // [WAD] current pool debt
+    uint256 poolSize;    // [WAD] total deposits in pool (with accrued debt)
 }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -617,7 +617,7 @@ library Auctions {
         uint256 curUnclaimedAuctionReserve = reserveAuction_.unclaimed;
 
         uint256 claimable = _claimableReserves(
-            Maths.wmul(params_.t0PoolDebt, params_.inflator),
+            params_.poolDebt,
             params_.poolSize,
             auctions_.totalBondEscrowed,
             curUnclaimedAuctionReserve,


### PR DESCRIPTION
# `startClaimableReserveAuction()` is using old inflator rate to do its calculations

## Summary
`_accruePoolInterest()` should be called to update the `inflatorState.inflator` to the latest value. `startClaimableReserveAuction()` does not call this function and hence could be using an old inflator rate, resulting in wrong calculations done, having a wrong `claimable` and `kickerAward`.

## Vulnerability Detail
`inflator` is used by the protocol to easily calculate the current debt value by multiplying the t0 debt with inflator. We must ensure that when inflator is used, it is always updated to ensure the most accurate result. The wrong calculation will be as severe as the last point in time in which inflator is updated.

`_claimableReserves()` calculates `claimable_` in this way.

> `claimable_ = Maths.wmul(0.995 * 1e18, debt_) + quoteTokenBalance_`

and `debt_` is calculated this way.

> `Maths.wmul(params_.poolDebt, params_.inflator)`

The `debt_` value passed in is an incorrect one as it does not take the latest accrued interest into account, as inflator value is not updated before `startClaimableReserveAuction()` is called. This will lead to the wrong claimable reserves value to be set.

## Impact
Claimable reserve auction calculation is done incorrectly as old inflator rate is used to calculate current debt.

## Recommendation
We should update inflator rate to the latest one when we call `startClaimableReserveAuction()` before calculations are done.