### PR TITLE
Safety measure:

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1021,6 +1021,8 @@ library Auctions {
         // calculate new lup with repaid debt from take
         newLup_ = _lup(deposits_, poolState_.debt);
 
+        remainingCollateral_ = borrower_.collateral;
+
         if (_isCollateralized(borrowerDebt, borrower_.collateral, newLup_, poolState_.poolType)) {
             settledAuction_ = true;
 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -127,9 +127,13 @@ library BorrowerActions {
         result_.poolDebt       = poolState_.debt;
         result_.poolCollateral = poolState_.collateral;
 
+        result_.remainingCollateral = borrower.collateral;
+
         if (vars.pledge) {
             // add new amount of collateral to pledge to borrower balance
             borrower.collateral  += collateralToPledge_;
+
+            result_.remainingCollateral += collateralToPledge_;
 
             result_.newLup  = _lup(deposits_, result_.poolDebt);
             vars.inAuction = _inAuction(auctions_, borrowerAddress_);
@@ -277,6 +281,8 @@ library BorrowerActions {
         result_.t0PoolDebt     = poolState_.t0Debt;
         result_.poolDebt       = poolState_.debt;
         result_.poolCollateral = poolState_.collateral;
+
+        result_.remainingCollateral = borrower.collateral;
 
         if (vars.repay) {
             if (borrower.t0Debt == 0) revert NoDebt();


### PR DESCRIPTION
- setting the remaining collateral to the current by default in drawDebt/repayDebt/_takeLoan functions
- update alongside with borrower.colalteral when more collateral pledged
Note: the remainingCollateral is used by NFT pool and only in the case of auction settlement. This commit doesn't change any logic but it's a safety measure for future developments that could alter this logic

See discussion in https://github.com/ajna-finance/contracts/pull/567#issuecomment-1419991352