### PR TITLE
Sherlock 145: Take adjustments: `msg.sender` provides QT instead of `_callee` 

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -405,7 +405,7 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
             );
         }
 
-        _transferQuoteTokenFrom(callee_, result.quoteTokenAmount);
+        _transferQuoteTokenFrom(msg.sender, result.quoteTokenAmount);
     }
 
     /**

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -459,7 +459,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         if (result.settledAuction) _rebalanceTokens(borrowerAddress_, result.remainingCollateral);
 
         // transfer from taker to pool the amount of quote tokens needed to cover collateral auctioned (including excess for rounded collateral)
-        _transferQuoteTokenFrom(callee_, totalQuoteTokenAmount);
+        _transferQuoteTokenFrom(msg.sender, totalQuoteTokenAmount);
 
         // transfer from pool to borrower the excess of quote tokens after rounding collateral auctioned
         if (result.excessQuoteToken != 0) _transferQuoteToken(borrowerAddress_, result.excessQuoteToken);

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -132,4 +132,27 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         // confirm we earned some quote token
         assertGt(usdc.balanceOf(address(taker)), 0);
     }
+
+    function testTakeCalleeDiffersFromSender() external {
+ 
+        // _lender is msg.sender, QT & CT balances pre take
+        assertEq(usdc.balanceOf(_lender), 119_999.999999926999804658 * 1e18);
+        assertEq(weth.balanceOf(_lender), 0);
+
+        // callee, _lender1 QT & CT balances pre take
+        assertEq(usdc.balanceOf(_lender1), 120_000.0 * 1e18);
+        assertEq(weth.balanceOf(_lender1), 4.0 * 1e18);
+
+        // lender calls take, passing _lender1 as the callee
+        changePrank(_lender);
+        _ajnaPool.take(_borrower, 1_001 * 1e18, _lender1, new bytes(0));
+
+        // _lender is has QT deducted from balance
+        assertEq(usdc.balanceOf(_lender), 119_999.999999926985301196 * 1e18);
+        assertEq(weth.balanceOf(_lender), 0);
+
+        // callee, _lender1 receives CT from take
+        assertEq(usdc.balanceOf(_lender1), 120_000.0 * 1e18);
+        assertEq(weth.balanceOf(_lender1), 6.0 * 1e18);
+    }
 }

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -19,17 +19,20 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
+    address internal _lender1;
 
     function setUp() external {
 
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
+        _lender1    = makeAddr("lender1");
 
         // deploy collection pool
         _pool = _deployCollectionPool();
 
         _mintAndApproveQuoteTokens(_lender, 100_000 * 1e18);
+        _mintAndApproveQuoteTokens(_lender1, 100_000 * 1e18);
         _mintAndApproveCollateralTokens(_borrower, 3);
         _mintAndApproveCollateralTokens(_borrower2, 5);
 
@@ -88,4 +91,37 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
         // confirm we earned some quote token
         assertEq(_quote.balanceOf(address(taker)), 970.423096682230524352 * 1e18);
     }
+
+    function testTakeNFTCalleeDiffersFromSender() external { 
+        // instantiate and fund a hypothetical NFT marketplace
+        NFTMarketPlace marketPlace = new NFTMarketPlace(_quote);
+        deal(address(_quote), address(marketPlace), 25_000 * 1e18);
+
+        // instantiate a taker contract which implements IERC721Taker and uses this marketplace
+        NFTTakeExample taker = new NFTTakeExample(address(marketPlace));
+        changePrank(address(taker));
+        assertEq(_quote.balanceOf(address(taker)), 0);
+        _quote.approve(address(_pool), type(uint256).max);
+        _collateral.setApprovalForAll(address(marketPlace), true);
+
+        // _lender is msg.sender, QT & CT balances pre take
+        assertEq(_quote.balanceOf(_lender), 49_979.825641778370686641 * 1e18);
+        assertEq(_quote.balanceOf(address(taker)), 0);
+
+        // call take using taker contract
+        changePrank(_lender);
+        bytes memory data = abi.encode(address(_pool));
+        vm.expectEmit(true, true, false, true);
+        uint256 quoteTokenPaid = 529.576903317769475648 * 1e18;
+        uint256 collateralPurchased = 2 * 1e18;
+        uint256 bondChange = 5.295769033177694756 * 1e18;
+        emit Take(_borrower, quoteTokenPaid, collateralPurchased, bondChange, true);
+        _pool.take(_borrower, 2, address(taker), data);
+
+        // _lender is msg.sender, QT & CT balances post take
+        assertEq(_quote.balanceOf(_lender), 49_450.248738460601210993 * 1e18);
+        assertEq(_quote.balanceOf(address(taker)), 1_500.0 * 1e18); // QT is increased as NFTTakeExample contract sells the NFT
+    }
+
+
 }

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -19,20 +19,17 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
     address internal _borrower;
     address internal _borrower2;
     address internal _lender;
-    address internal _lender1;
 
     function setUp() external {
 
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
-        _lender1    = makeAddr("lender1");
 
         // deploy collection pool
         _pool = _deployCollectionPool();
 
         _mintAndApproveQuoteTokens(_lender, 100_000 * 1e18);
-        _mintAndApproveQuoteTokens(_lender1, 100_000 * 1e18);
         _mintAndApproveCollateralTokens(_borrower, 3);
         _mintAndApproveCollateralTokens(_borrower2, 5);
 
@@ -122,6 +119,4 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 49_450.248738460601210993 * 1e18);
         assertEq(_quote.balanceOf(address(taker)), 1_500.0 * 1e18); // QT is increased as NFTTakeExample contract sells the NFT
     }
-
-
 }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* inside of `take` for ERC721 and ERC20 pools changed the argument passed in `_transferQuoteTokenFrom()` from `_callee` to `msg.sender`. 
* This update now makes the `_take` call match other implementations such as Maker
* NOTE: 10-30K spike in gas cost because of change.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
[ERC20Pool](https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/ERC20Pool.sol#L403) and [ERC721Pool](https://github.com/sherlock-audit/2023-01-ajna/blob/main/contracts/src/ERC721Pool.sol#L405) implement the take functions, which buy collateral from auction in exchange for quote tokens. The address to pull quote tokens from is specified in the `_callee` argument, which allows anyone to call the functions and pass an address that has previously approved spending of the quote token to the pool. As a result, such an address will pay for the liquidation and will receive the collateral.

The solution makes it so the `msg.sender` provides the QT when calling the `take()` method. 

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,267B  (90.60%)
  ERC20Pool                -  20,972B  (85.33%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,267B  (90.60%)
  ERC20Pool                -  20,972B  (85.33%)
```

# Gas usage
## Pre Change
```
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| take                                 | 8550            | 158087 | 165977 | 520357 | 32      |

 src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |        |         |
|----------------------------------------|-----------------|--------|--------|--------|---------|
| take                                   | 11246           | 292029 | 375721 | 632601 | 11      |
```

## Post Change
```
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| take                                 | 8550            | 164634 | 184194 | 520356 | 33      |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |          |         |
|----------------------------------------|-----------------|--------|--------|----------|---------|
| take                                   | 11246           | 320810 | 387200 | 637400   | 12      |
```

