### PR TITLE
LPs and bucket rate as WAD

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -388,13 +388,14 @@ library LenderActions {
 
         if (amount_ > bucketCollateral) revert InsufficientCollateral();
 
-        uint256 bucketPrice = _priceAt(index_);
-        uint256 bucketLPs   = bucket.lps;
+        uint256 bucketPrice   = _priceAt(index_);
+        uint256 bucketLPs     = bucket.lps;
+        uint256 bucketDeposit = Deposits.valueAt(deposits_, index_);
 
         lpAmount_ = Buckets.collateralToLPs(
             bucketCollateral,
             bucketLPs,
-            Deposits.valueAt(deposits_, index_),
+            bucketDeposit,
             amount_,
             bucketPrice
         );
@@ -405,12 +406,20 @@ library LenderActions {
         if (bucket.bankruptcyTime < lender.depositTime) lenderLpBalance = lender.lps;
         if (lenderLpBalance == 0 || lpAmount_ > lenderLpBalance) revert InsufficientLPs();
 
-        // update lender LPs balance
-        lender.lps -= lpAmount_;
-
         // update bucket LPs and collateral balance
-        bucket.lps        -= Maths.min(bucketLPs, lpAmount_);
-        bucket.collateral -= Maths.min(bucketCollateral, amount_);
+        bucketLPs         -= Maths.min(bucketLPs, lpAmount_);
+        bucketCollateral  -= amount_;
+        bucket.collateral = bucketCollateral;
+        if (bucketCollateral == 0 && bucketDeposit == 0 && bucketLPs != 0) {
+            emit BucketBankruptcy(index_, bucketLPs);
+            bucket.lps            = 0;
+            bucket.bankruptcyTime = block.timestamp;
+        } else {
+            // update lender LPs balance
+            lender.lps -= lpAmount_;
+
+            bucket.lps = bucketLPs;
+        }
     }
 
     /**

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -351,9 +351,6 @@ library LenderActions {
         // check loan book's htp against new lup
         if (htp > lup_) revert LUPBelowHTP();
 
-        // update lender and bucket LPs balances
-        lender.lps -= redeemedLPs_;
-
         uint256 lpsRemaining = removeParams.bucketLPs - redeemedLPs_;
 
         if (removeParams.bucketCollateral == 0 && unscaledRemaining == 0 && lpsRemaining != 0) {
@@ -361,6 +358,9 @@ library LenderActions {
             bucket.lps            = 0;
             bucket.bankruptcyTime = block.timestamp;
         } else {
+            // update lender and bucket LPs balances
+            lender.lps -= redeemedLPs_;
+
             bucket.lps = lpsRemaining;
         }
 
@@ -600,9 +600,13 @@ library LenderActions {
         collateralAmount_ = Maths.min(maxAmount_, bucketCollateral);
 
         // determine how much LP would be required to remove the requested amount
-        uint256 collateralValue     = Maths.wmul(bucketPrice, bucketCollateral);
-        uint256 lpsForAllCollateral = Maths.wmul(bucketLPs, Maths.wdiv(collateralValue, collateralValue + bucketDeposit));
-        uint256 requiredLPs         = Maths.wmul(lpsForAllCollateral, Maths.wdiv(collateralAmount_, bucketCollateral));
+        uint256 requiredLPs = Buckets.collateralToLPs(
+            bucketCollateral,
+            bucketLPs,
+            bucketDeposit,
+            collateralAmount_,
+            bucketPrice
+        );
 
         // limit withdrawal by the lender's LPB
         if (requiredLPs <= lenderLpBalance) {
@@ -610,11 +614,8 @@ library LenderActions {
             lpAmount_ = requiredLPs;
         } else {
             lpAmount_         = lenderLpBalance;
-            collateralAmount_ = Maths.wmul(Maths.wdiv(lenderLpBalance,lpsForAllCollateral), bucketCollateral);
+            collateralAmount_ = Maths.wmul(Maths.wdiv(lenderLpBalance, requiredLPs), bucketCollateral);
         }
-
-        // update lender LPs balance
-        lender.lps -= lpAmount_;
 
         // update bucket LPs and collateral balance
         bucketLPs         -= Maths.min(bucketLPs, lpAmount_);
@@ -625,6 +626,9 @@ library LenderActions {
             bucket.lps            = 0;
             bucket.bankruptcyTime = block.timestamp;
         } else {
+            // update lender LPs balance
+            lender.lps -= lpAmount_;
+
             bucket.lps = bucketLPs;
         }
     }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -88,8 +88,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
                 lenderLpBalance -= lpRedeemed;
             }
 
-            // confirm the redemption amount returned by removal methods is correct
-            assertEq(lenderLpBalance, 0);
             // confirm the user actually has 0 LPB in the bucket
             (lenderLpBalance, ) = _pool.lenderInfo(bucketIndex, lender);
             assertEq(lenderLpBalance, 0);

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -127,7 +127,9 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             // Checking if all bucket lps are redeemed
             assertEq(bucketLps, 0);
             assertEq(quoteTokens, 0);
-            assertEq(collateral, 0);
+            // changing assert below - there could be cases when collateral accumulates but we don't have a collateral reserves auction
+            // therefore there could still be collateral remaining in bucket even after LP redeem
+            assertTrue(collateral >= 0);
         }
         ( , uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         (uint256 debt, , ) = _pool.debtInfo();

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -75,16 +75,17 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             (, uint256 bucketQuote, uint256 bucketCollateral, , ,) = _poolUtils.bucketInfo(address(_pool), bucketIndex);
             (uint256 lenderLpBalance, ) = _pool.lenderInfo(bucketIndex, lender);
 
-            // redeem LP for quote token if available
             uint256 lpRedeemed;
-            if(lenderLpBalance != 0 && bucketQuote != 0) {
-                (, lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, bucketIndex);
-                lenderLpBalance -= lpRedeemed;
-            }
 
             // redeem LP for collateral if available
             if(lenderLpBalance != 0 && bucketCollateral != 0) {
                 (, lpRedeemed) = ERC20Pool(address(_pool)).removeCollateral(type(uint256).max, bucketIndex);
+                lenderLpBalance -= lpRedeemed;
+            }
+
+            // redeem LP for quote token if available
+            if(lenderLpBalance != 0 && bucketQuote != 0) {
+                (, lpRedeemed) = _pool.removeQuoteToken(type(uint256).max, bucketIndex);
                 lenderLpBalance -= lpRedeemed;
             }
 
@@ -127,9 +128,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             // Checking if all bucket lps are redeemed
             assertEq(bucketLps, 0);
             assertEq(quoteTokens, 0);
-            // changing assert below - there could be cases when collateral accumulates but we don't have a collateral reserves auction
-            // therefore there could still be collateral remaining in bucket even after LP redeem
-            assertTrue(collateral >= 0);
+            assertEq(collateral, 0);
         }
         ( , uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
         (uint256 debt, , ) = _pool.debtInfo();

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -551,8 +551,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         });
     }
 
-    // FIXME: fails
-    function _testAddRemoveCollateralBucketExchangeRateInvariantSameActor() external tearDown {
+    function testAddRemoveCollateralBucketExchangeRateInvariantSameActor() external tearDown {
         _mintCollateralAndApproveTokens(_lender,  50000000000 * 1e18);
 
         _addInitialLiquidity({
@@ -600,18 +599,18 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
             from:     _lender,
             amount:   3642907759.282013932739218713 * 1e18,
             index:    2570,
-            lpRedeem: 9927093687851.086595628225718496 * 1e18
+            lpRedeem: 9927093687851.086595628225711617 * 1e18
         });
 
         _assertLenderLpBalance({
             lender:      _lender,
             index:       2570,
-            lpBalance:   0, // LPs should get back to same value as before add / remove collateral
+            lpBalance:   6879, // LPs should get back to same value as before add / remove collateral
             depositTime: _startTime
         });
         _assertBucket({
             index:        2570,
-            lpBalance:    0,
+            lpBalance:    6879,
             collateral:   0,
             deposit:      6879,
             exchangeRate: 1 * 1e18 // exchange rate should not change

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -126,7 +126,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
         uint16 startBucketId_
-    ) external tearDown {
+    ) external { // FIXME add back tear down, currently fails with bucket that is settled having collateral but not LPs
 
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 6,    18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1,    18);
@@ -211,7 +211,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
         uint16 startBucketId_
-    ) external { // FIXME: add back tear down, failed because insufficient allowance to repay / pull
+    ) external tearDown {
 
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 12, 18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1,  18);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -126,7 +126,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint8  collateralPrecisionDecimals_, 
         uint8  quotePrecisionDecimals_,
         uint16 startBucketId_
-    ) external { // FIXME add back tear down, currently fails with bucket that is settled having collateral but not LPs
+    ) external tearDown {
 
         uint256 boundColPrecision   = bound(uint256(collateralPrecisionDecimals_), 6,    18);
         uint256 boundQuotePrecision = bound(uint256(quotePrecisionDecimals_),      1,    18);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -125,7 +125,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
     }
     
-    function testSettleOnAuctionKicked72HoursAgoAndPartiallyTaken() external { // FIXME teardown fails
+    function testSettleOnAuctionKicked72HoursAgoAndPartiallyTaken() external tearDown {
         // Borrower2 borrows
         _borrow({
             from:       _borrower2,
@@ -592,7 +592,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         });
     }
 
-    function testSettleAuctionReverts() external { // FIXME: teardown fails
+    function testSettleAuctionReverts() external tearDown {
         // Borrower2 borrows
         _borrow({
             from:       _borrower2,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1189,7 +1189,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
     }
 
-    function testTakeAndSettle() external { // FIXME: teardown fails
+    function testTakeAndSettle() external tearDown {
 
         // Borrower2 borrows
         _borrow({

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -188,8 +188,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         });
     }
 
-    // FIXME: fails
-    function _testAddRemoveCollateralPrecision (
+    function testAddRemoveCollateralPrecision (
         uint8   collateralPrecisionDecimals_,
         uint8   quotePrecisionDecimals_,
         uint16  bucketId_

--- a/tests/forge/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -147,7 +147,7 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
             from: _bidder,
             amount: 0.678725133191514712 * 1e18,
             index: testIndex,
-            lpRedeem: 2_043.56808879152623138 * 1e18
+            lpRedeem: 2_043.568088791526231161 * 1e18
         });
 
         // check pool balances

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -847,11 +847,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _mergeOrRemoveCollateral({
             from:                    _lender,
-            toIndex:                 3069,
+            toIndex:                 3070,
             noOfNFTsToRemove:        1.0,
             collateralMerged:        0.873785325289378771 * 1e18,
             removeCollateralAtIndex: removalIndexes,
-            toIndexLps:              197.657763058028917104 * 1e18
+            toIndexLps:              196.674391102516337019 * 1e18
         });
 
         _assertBucket({
@@ -859,26 +859,26 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             lpBalance:    0,
             collateral:   0,
             deposit:      0,
-            exchangeRate: 1.0 * 1e18
+            exchangeRate: 1 * 1e18
         });
         _assertBucket({
             index:        3061,
             lpBalance:    0,
             collateral:   0,
             deposit:      0,
-            exchangeRate: 1.0 * 1e18
+            exchangeRate: 1 * 1e18
         });
         _assertBucket({
-            index:        3069,
-            lpBalance:    197.657763058028917104 * 1e18, // new LPs amount accounting collateral merged in bucket
+            index:        3070,
+            lpBalance:    196.674391102516337019 * 1e18, // new LPs amount accounting collateral merged in bucket
             collateral:   0.873785325289378771 * 1e18,   // reflects collateral merged in the bucket
             deposit:      0,
             exchangeRate: 1 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
-            index:       3069,
-            lpBalance:   197.657763058028917104 * 1e18,
+            index:       3070,
+            lpBalance:   196.674391102516337019 * 1e18,
             depositTime: _startTime + 10000 days +  32 hours + 4210 minutes
         });
         _assertBucket({
@@ -911,7 +911,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         // collateral is now splitted accross buckets 3069 and 7388
         uint256[] memory allRemovalIndexes = new uint256[](2);
-        allRemovalIndexes[0] = 3069;
+        allRemovalIndexes[0] = 3070;
         allRemovalIndexes[1] = 7388;
 
         _mergeOrRemoveCollateral({
@@ -938,7 +938,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             exchangeRate: 1.0 * 1e18
         });
         _assertBucket({
-            index:        3069,
+            index:        3070,
             lpBalance:    0,
             collateral:   0,
             deposit:      0,
@@ -946,15 +946,15 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });   
         _assertBucket({
             index:        7388,
-            lpBalance:    10.000000000000000003 * 1e18, // LPs in bucket 7388 diminished when NFT merged and removed
-            collateral:   0,                            // no collateral remaining as it was merged and removed
+            lpBalance:    10 * 1e18, // LPs in bucket 7388 diminished when NFT merged and removed
+            collateral:   0,         // no collateral remaining as it was merged and removed
             deposit:      10 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       7388,
-            lpBalance:   9.999999987399196034 * 1e18, // lender LPs decreased with the amount used to merge NFT
+            lpBalance:   9.999999987399196031 * 1e18, // lender LPs decreased with the amount used to merge NFT
             depositTime: _startTime + 10000 days + (32 hours + 4210 minutes)
         });
         _assertLenderLpBalance({
@@ -966,25 +966,25 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   9.987201910492245719 * 1e18,
+            amount:   9.987201910492245716 * 1e18,
             index:    7388,
             newLup:   MAX_PRICE,
-            lpRedeem: 9.999999987399196034 * 1e18
+            lpRedeem: 9.999999987399196031 * 1e18
         });
 
         _assertBucket({
             index:        7388,
             lpBalance:    0.000000012600803969 * 1e18, // LPs in bucket 7388 diminished when NFT merged and removed
             collateral:   0,                           // no collateral remaining as it was merged and removed
-            deposit:      0.000000012600803967 * 1e18,
-            exchangeRate: 0.999999999841279969 * 1e18
+            deposit:      0.000000012600803970 * 1e18,
+            exchangeRate: 1.000000000079360016 * 1e18
         });
 
         _assertPool(
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             0.000000012600803967 * 1e18,
+                poolSize:             0.000000012600803970 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -355,10 +355,10 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    1_861.033884081553473424 * 1e18,
+            lpBalance:    1_861.033884081553472950 * 1e18,
             collateral:   0,
-            deposit:      1861.636634299022017158 * 1e18,
-            exchangeRate: 1.000323879227898104 * 1e18
+            deposit:      1_861.636634299022017158 * 1e18,
+            exchangeRate: 1.000323879227898105 * 1e18
         });
     }
 


### PR DESCRIPTION
- record lender LPs in remove collateral and quote token only if bucket doesn't go bankrupt
- for remove colalteral use the same way to calculate LPs as when rewarding, to avoid precision issues
- tearDown should consider that bucket can go bankrupt, hence lender LPs should be checked = 0 taking this into account (lenderInfo function is doing this)
- all tests passing but testAddRemoveCollateralPrecision fails in tearDown - that's because the bucket is settled and leave collateral but not LP / quote tokens
