### PR TITLE
feedback from PR #600

### DIFF
--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -606,7 +606,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     function testMinBorrowAmountCheck() external tearDown {
         // 10 borrowers draw debt
         for (uint i=0; i<10; ++i) {
-            _anonBorrowerDrawsDebt(100 * 1e18, 1_200 * 1e18, 7777);
+            _anonBorrowerDrawsDebt(100 * 1e18, 1_200 * 1e18, MAX_FENWICK_INDEX);
         }
 
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
@@ -622,7 +622,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         _assertBorrowMinDebtRevert({
             from:       _borrower,
             amount:     10 * 1e18,
-            indexLimit: 7_777
+            indexLimit: MAX_FENWICK_INDEX
         });
     }
 
@@ -761,7 +761,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         // 9 other borrowers draw debt
         for (uint i=0; i<9; ++i) {
-            _anonBorrowerDrawsDebt(100 * 1e18, 1_000 * 1e18, 7777);
+            _anonBorrowerDrawsDebt(100 * 1e18, 1_000 * 1e18, MAX_FENWICK_INDEX);
         }
 
         (, uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -702,7 +702,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         // 10 borrowers draw debt to enable the min debt check
         for (uint i=0; i<10; ++i) {
-            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7777);
+            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, MAX_FENWICK_INDEX);
         }
 
         // should revert if auction leaves borrower with debt under minimum pool debt

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -695,7 +695,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         // 10 borrowers draw debt to enable the min debt check
         for (uint256 i=0; i<10; ++i) {
-            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7777);
+            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, MAX_FENWICK_INDEX);
         }
 
         // should revert if auction leaves borrower with debt under minimum pool debt

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -147,7 +147,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -203,7 +203,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -412,7 +412,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -620,7 +620,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -807,7 +807,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -1008,7 +1008,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _borrow({
             from:       _borrower2,
             amount:     1_700.0 * 1e18,
-            indexLimit: _p9_72,
+            indexLimit: _i9_72,
             newLup:     _p9_72
         });
 
@@ -1792,7 +1792,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         // 10 borrowers draw debt to enable the min debt check
         for (uint i=0; i<10; ++i) {
-            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, 7_777);
+            _anonBorrowerDrawsDebt(1_000 * 1e18, 6_000 * 1e18, MAX_FENWICK_INDEX);
         }
 
         // should revert if auction leaves borrower with debt under minimum pool debt

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -787,7 +787,7 @@ abstract contract ERC721NDecimalsHelperContract is ERC721DSTestPlus {
             from:           borrower,
             borrower:       borrower,
             amountToBorrow: loanAmount,
-            limitIndex:     7_777,
+            limitIndex:     MAX_FENWICK_INDEX,
             tokenIds:       tokenIdsToAdd
         });
     }

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -7,7 +7,7 @@ import 'src/ERC721Pool.sol';
 
 import 'src/libraries/internal/Maths.sol';
 
-import { MAX_PRICE, _priceAt } from 'src/libraries/helpers/PoolHelper.sol';
+import { MAX_FENWICK_INDEX, MAX_PRICE, _priceAt } from 'src/libraries/helpers/PoolHelper.sol';
 
 abstract contract ERC721PoolBorrowTest is ERC721HelperContract {
     address internal _borrower;
@@ -584,7 +584,7 @@ contract ERC721CollectionPoolBorrowTest is ERC721NDecimalsHelperContract(18) {
         _assertBorrowMinDebtRevert({
             from:       _borrower,
             amount:     100 * 1e18,
-            indexLimit: 7_777
+            indexLimit: MAX_FENWICK_INDEX
         });
     }
 

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -638,7 +638,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         _borrow({
             from:       _borrower,
             amount:     150 * 1e18,
-            indexLimit: 8191,
+            indexLimit: MAX_FENWICK_INDEX,
             newLup:     228.476350374240318479 * 1e18
         });
 


### PR DESCRIPTION
**Changes**
From PR #600 feedback:
- Made LUP index check implementation consistent between `drawDebt` and `repayDebt`.
- Moved check to `RevertsHelper`.

Doing so produced several test failures, because the `_priceAt` call is now invoked prior to the revert, the caller must pass a legitimate fenwick index.  Updated several tests to use valid indices.