### PR TITLE
PositionManager bug fixes: 13, 19, 116, 156

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -346,10 +346,10 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LPs.
      *  @param  lps_         The number of LPs to calculate amounts for.
      *  @param  index_       The price bucket index for which the value should be calculated.
-     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LPs, WAD units.
      */
     function lpsToQuoteTokens(
         address ajnaPool_,
@@ -369,10 +369,10 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LPs.
      *  @param  lps_              The number of LPs to calculate amounts for.
      *  @param  index_            The price bucket index for which the value should be calculated.
-     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LPs, WAD units.
      */
     function lpsToCollateral(
         address ajnaPool_,

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -339,7 +339,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     /**************************/
 
     /**
-     *  @dev    Retrieves token's next nonce for permit.
+     *  @notice Retrieves token's next nonce for permit.
      *  @param  tokenId_ Address of the Ajna pool to retrieve accumulators of.
      *  @return Incremented token permit nonce.
      */
@@ -350,7 +350,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     }
 
     /**
-     *  @dev    Checks that a provided pool address was deployed by an Ajna factory.
+     *  @notice Checks that a provided pool address was deployed by an Ajna factory.
      *  @param  pool_       Address of the Ajna pool.
      *  @param  subsetHash_ Factory's subset hash pool.
      *  @return True if a valid Ajna pool false otherwise.
@@ -368,12 +368,16 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         return (pool_ == erc20DeployedPoolAddress || pool_ == erc721DeployedPoolAddress);
     }
 
+    /**
+     *  @notice Checks that a bucket index associated with a given NFT didn't go bankrupt after memorialization.
+     *  @param  tokenId_    The ID of the NFT to check deposit time for.
+     *  @param  index_      The bucket index to check deposit time for.
+     *  @return True if the bucket went bankrupt after that position memorialzied their lpb.
+     */
     function _bucketBankruptAfterDeposit(
         uint256 tokenId_,
         uint256 index_
     ) internal view returns (bool) {
-        if (positionDepositTime[tokenId_][index_] == 0) return false;
-
         (, , uint256 bankruptcyTime, , ) = IPool(poolKey[tokenId_]).bucketInfo(index_);
         return positionDepositTime[tokenId_][index_] < bankruptcyTime;
     }

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -14,6 +14,7 @@ import { IPool }                        from './interfaces/pool/IPool.sol';
 import { IPositionManager }             from './interfaces/position/IPositionManager.sol';
 import { IPositionManagerOwnerActions } from './interfaces/position/IPositionManagerOwnerActions.sol';
 import { IPositionManagerDerivedState } from './interfaces/position/IPositionManagerDerivedState.sol';
+import { Position }                     from './interfaces/position/IPositionManagerState.sol';
 
 import { ERC20PoolFactory }  from './ERC20PoolFactory.sol';
 import { ERC721PoolFactory } from './ERC721PoolFactory.sol';
@@ -47,12 +48,11 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     /*** State Variables ***/
     /***********************/
 
-    mapping(uint256 => address)                     public override poolKey;     // token id => ajna pool address for which token was minted
-    mapping(uint256 => mapping(uint256 => uint256)) public override positionLPs; // token id => bucket index => LPs
-    mapping(uint256 => mapping(uint256 => uint256)) public positionDepositTime;  // token id => bucket index => bucket deposit time
+    mapping(uint256 => address) public override poolKey;     // token id => ajna pool address for which token was minted
 
-    mapping(uint256 => uint96)                internal nonces;          // token id => nonce value used for permit
-    mapping(uint256 => EnumerableSet.UintSet) internal positionIndexes; // token id => bucket indexes associated with position
+    mapping(uint256 => mapping(uint256 => Position)) internal positions; // token id => bucket index => Position struct
+    mapping(uint256 => uint96)                       internal nonces;          // token id => nonce value used for permit
+    mapping(uint256 => EnumerableSet.UintSet)        internal positionIndexes; // token id => bucket indexes associated with position
 
     uint176 private _nextId = 1; // id of the next token that will be minted. Skips 0
 
@@ -121,9 +121,9 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         delete nonces[params_.tokenId];
         delete poolKey[params_.tokenId];
 
-        emit Burn(msg.sender, params_.tokenId);
-
         _burn(params_.tokenId);
+
+        emit Burn(msg.sender, params_.tokenId);
     }
 
     /**
@@ -144,42 +144,47 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     ) external override {
         EnumerableSet.UintSet storage positionIndex = positionIndexes[params_.tokenId];
 
-        IPool pool = IPool(poolKey[params_.tokenId]);
-
+        IPool   pool  = IPool(poolKey[params_.tokenId]);
         address owner = ownerOf(params_.tokenId);
 
         uint256 indexesLength = params_.indexes.length;
+        uint256 index;
 
         for (uint256 i = 0; i < indexesLength; ) {
+            index = params_.indexes[i];
 
             // record bucket index at which a position has added liquidity
             // slither-disable-next-line unused-return
-            positionIndex.add(params_.indexes[i]);
+            positionIndex.add(index);
 
-            (uint256 lpBalance, uint256 depositTime) = pool.lenderInfo(params_.indexes[i], owner);
+            (uint256 lpBalance, uint256 depositTime) = pool.lenderInfo(index, owner);
+
+            Position memory position = positions[params_.tokenId][index];
 
             // check for previous deposits
-            if (positionDepositTime[params_.tokenId][params_.indexes[i]] != 0) {
+            if (position.depositTime != 0) {
                 // check that bucket didn't go bankrupt after prior memorialization
-                if (_bucketBankruptAfterDeposit(params_.tokenId, params_.indexes[i])) {
+                if (_bucketBankruptAfterDeposit(pool, index, position.depositTime)) {
                     // if bucket did go bankrupt, zero out the LPs tracked by position manager
-                    positionLPs[params_.tokenId][params_.indexes[i]] = 0;
+                    position.lps = 0;
                 }
             }
 
             // update token position LPs
-            positionLPs[params_.tokenId][params_.indexes[i]] += lpBalance;
-
+            position.lps += lpBalance;
             // set token's position deposit time to the original lender's deposit time
-            positionDepositTime[params_.tokenId][params_.indexes[i]] = depositTime;
+            position.depositTime = depositTime;
+
+            // save position in storage
+            positions[params_.tokenId][index] = position;
 
             unchecked { ++i; }
         }
 
-        emit MemorializePosition(owner, params_.tokenId);
-
         // update pool lps accounting and transfer ownership of lps to PositionManager contract
         pool.transferLPs(owner, address(this), params_.indexes);
+
+        emit MemorializePosition(owner, params_.tokenId);
     }
 
     /**
@@ -202,9 +207,9 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         // record which pool the tokenId was minted in
         poolKey[tokenId_] = params_.pool;
 
-        emit Mint(params_.recipient, params_.pool, tokenId_);
-
         _safeMint(params_.recipient, tokenId_);
+
+        emit Mint(params_.recipient, params_.pool, tokenId_);
     }
 
     /**
@@ -238,7 +243,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         ) = IPool(params_.pool).bucketInfo(params_.fromIndex);
 
         // check that bucket hasn't gone bankrupt since memorialization
-        if (positionDepositTime[params_.tokenId][params_.fromIndex] < bankruptcyTime) {
+        if (positions[params_.tokenId][params_.fromIndex].depositTime < bankruptcyTime) {
             revert BucketBankrupt();
         }
 
@@ -247,7 +252,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
             bucketLPs,
             bucketCollateral,
             bucketDeposit,
-            positionLPs[params_.tokenId][params_.fromIndex],
+            positions[params_.tokenId][params_.fromIndex].lps,
             bucketDeposit,
             _priceAt(params_.fromIndex)
         );
@@ -255,13 +260,11 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         EnumerableSet.UintSet storage positionIndex = positionIndexes[params_.tokenId];
 
         // remove bucket index from which liquidity is moved from tracked positions
-        if (!positionIndex.remove(params_.fromIndex)) revert RemoveLiquidityFailed();
+        if (!positionIndex.remove(params_.fromIndex)) revert RemovePositionFailed();
 
         // update bucket set at which a position has liquidity
         // slither-disable-next-line unused-return
         positionIndex.add(params_.toIndex);
-
-        emit MoveLiquidity(ownerOf(params_.tokenId), params_.tokenId);
 
         // move quote tokens in pool
         (
@@ -275,8 +278,10 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         );
 
         // update position LPs state
-        positionLPs[params_.tokenId][params_.fromIndex] -= lpbAmountFrom;
-        positionLPs[params_.tokenId][params_.toIndex]   += lpbAmountTo;
+        positions[params_.tokenId][params_.fromIndex].lps -= lpbAmountFrom;
+        positions[params_.tokenId][params_.toIndex].lps   += lpbAmountTo;
+
+        emit MoveLiquidity(ownerOf(params_.tokenId), params_.tokenId);
     }
 
     /**
@@ -299,39 +304,42 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     function reedemPositions(
         RedeemPositionsParams calldata params_
     ) external override mayInteract(params_.pool, params_.tokenId) {
-
         EnumerableSet.UintSet storage positionIndex = positionIndexes[params_.tokenId];
 
-        IPool pool = IPool(poolKey[params_.tokenId]);
-
-        address owner = ownerOf(params_.tokenId);
+        IPool pool = IPool(params_.pool);
 
         uint256 indexesLength = params_.indexes.length;
-
         uint256[] memory lpAmounts = new uint256[](indexesLength);
 
+        uint256 index;
+
         for (uint256 i = 0; i < indexesLength; ) {
+            index = params_.indexes[i];
+
+            Position memory position = positions[params_.tokenId][index];
 
             // check that bucket didn't go bankrupt after memorialization
-            if (_bucketBankruptAfterDeposit(params_.tokenId, params_.indexes[i])) revert BucketBankrupt();
+            if (_bucketBankruptAfterDeposit(pool, index, position.depositTime)) revert BucketBankrupt();
 
             // remove bucket index at which a position has added liquidity
-            if (!positionIndex.remove(params_.indexes[i])) revert RemoveLiquidityFailed();
+            if (!positionIndex.remove(index)) revert RemovePositionFailed();
 
-            lpAmounts[i] = positionLPs[params_.tokenId][params_.indexes[i]];
+            lpAmounts[i] = position.lps;
 
             // remove LPs tracked by position manager at bucket index
-            delete positionLPs[params_.tokenId][params_.indexes[i]];
+            delete positions[params_.tokenId][index];
 
             unchecked { ++i; }
         }
 
-        emit RedeemPosition(owner, params_.tokenId);
+        address owner = ownerOf(params_.tokenId);
 
         // approve owner to take over the LPs ownership (required for transferLPs pool call)
         pool.approveLpOwnership(owner, params_.indexes, lpAmounts);
         // update pool lps accounting and transfer ownership of lps from PositionManager contract
         pool.transferLPs(address(this), owner, params_.indexes);
+
+        emit RedeemPosition(owner, params_.tokenId);
     }
 
     /**************************/
@@ -370,16 +378,18 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
 
     /**
      *  @notice Checks that a bucket index associated with a given NFT didn't go bankrupt after memorialization.
-     *  @param  tokenId_    The ID of the NFT to check deposit time for.
-     *  @param  index_      The bucket index to check deposit time for.
+     *  @param  pool_        The address of the pool of memorialized position.
+     *  @param  index_       The bucket index to check deposit time for.
+     *  @param  depositTime_ The recorded deposit time of the position.
      *  @return True if the bucket went bankrupt after that position memorialzied their lpb.
      */
     function _bucketBankruptAfterDeposit(
-        uint256 tokenId_,
-        uint256 index_
+        IPool pool_,
+        uint256 index_,
+        uint256 depositTime_
     ) internal view returns (bool) {
-        (, , uint256 bankruptcyTime, , ) = IPool(poolKey[tokenId_]).bucketInfo(index_);
-        return positionDepositTime[tokenId_][index_] < bankruptcyTime;
+        (, , uint256 bankruptcyTime, , ) = pool_.bucketInfo(index_);
+        return depositTime_ < bankruptcyTime;
     }
 
     /**********************/
@@ -391,7 +401,8 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         uint256 tokenId_,
         uint256 index_
     ) external override view returns (uint256) {
-        return _bucketBankruptAfterDeposit(tokenId_, index_) ? 0 : positionLPs[tokenId_][index_];
+        Position memory position = positions[tokenId_][index_];
+        return _bucketBankruptAfterDeposit(IPool(poolKey[tokenId_]), index_, position.depositTime) ? 0 : position.lps;
     }
 
     /// @inheritdoc IPositionManagerDerivedState

--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -11,6 +11,11 @@ interface IPoolErrors {
     /**************************/
 
     /**
+     *  @notice LPs allowance is already set by the owner.
+     */
+    error AllowanceAlreadySet();
+
+    /**
      *  @notice The action cannot be executed on an active auction.
      */
     error AuctionActive();
@@ -93,7 +98,7 @@ interface IPoolErrors {
     /**
      *  @notice Lender is attempting to move or remove more collateral they have claim to in the bucket.
      *  @notice Lender is attempting to remove more collateral they have claim to in the bucket.
-     *  @notice Lender must have enough LP tokens to claim the desired amount of quote from the bucket.
+     *  @notice Lender must have enough LPs to claim the desired amount of quote from the bucket.
      */
     error InsufficientLPs();
 
@@ -103,7 +108,7 @@ interface IPoolErrors {
     error InsufficientLiquidity();
 
     /**
-     *  @notice When transferring LP tokens between indices, the new index must be a valid index.
+     *  @notice When transferring LPs between indices, the new index must be a valid index.
      */
     error InvalidIndex();
 
@@ -129,7 +134,7 @@ interface IPoolErrors {
     error MoveToSamePrice();
 
     /**
-     *  @notice Owner of the LP tokens must have approved the new owner prior to transfer.
+     *  @notice Owner of the LPs must have approved the new owner prior to transfer.
      */
     error NoAllowance();
 
@@ -195,7 +200,7 @@ interface IPoolErrors {
     error TransferorNotApproved();
 
     /**
-     *  @notice Owner of the LP tokens attemps to transfer LPs to same address.
+     *  @notice Owner of the LPs attemps to transfer LPs to same address.
      */
     error TransferToSameOwner();
 

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -240,11 +240,11 @@ interface IPoolEvents {
     );
 
     /**
-     *  @notice Emitted when a lender transfers their LP tokens to a different address.
+     *  @notice Emitted when a lender transfers their LPs to a different address.
      *  @dev    Used by PositionManager.memorializePositions().
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
-     *  @param  indexes  Array of price bucket indexes at which LP tokens were transferred.
+     *  @param  indexes  Array of price bucket indexes at which LPs were transferred.
      *  @param  lps      Amount of LPs transferred.
      */
     event TransferLPs(

--- a/src/interfaces/pool/commons/IPoolLenderActions.sol
+++ b/src/interfaces/pool/commons/IPoolLenderActions.sol
@@ -11,7 +11,7 @@ interface IPoolLenderActions {
      *  @param  amount    The amount of quote token to be added by a lender.
      *  @param  index     The index of the bucket to which the quote tokens will be added.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added quote tokens.
+     *  @return lpbChange The amount of LPs changed for the added quote tokens.
      */
     function addQuoteToken(
         uint256 amount,
@@ -83,7 +83,7 @@ interface IPoolLenderActions {
      *  @param  maxAmount        The max amount of quote token to be removed by a lender.
      *  @param  index            The bucket index from which quote tokens will be removed.
      *  @return quoteTokenAmount The amount of quote token removed.
-     *  @return lpAmount         The amount of LP used for removing quote tokens amount.
+     *  @return lpAmount         The amount of LPs used for removing quote tokens amount.
      */
     function removeQuoteToken(
         uint256 maxAmount,
@@ -91,11 +91,11 @@ interface IPoolLenderActions {
     ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
 
     /**
-     *  @notice Called by lenders to transfers their LP tokens to a different address. approveLpOwnership needs to be run first
+     *  @notice Called by lenders to transfers their LPs to a different address. approveLpOwnership needs to be run first
      *  @dev    Used by PositionManager.memorializePositions().
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
-     *  @param  indexes  Array of price buckets index at which LP tokens were moved.
+     *  @param  indexes  Array of price buckets index at which LPs were moved.
      */
     function transferLPs(
         address owner,

--- a/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
+++ b/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
@@ -12,7 +12,7 @@ interface IERC20PoolLenderActions {
      *  @param  amount    Amount of collateral to deposit.
      *  @param  index     The bucket index to which collateral will be deposited.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added collateral.
+     *  @return lpbChange The amount of LPs changed for the added collateral.
      */
     function addCollateral(
         uint256 amount,

--- a/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
@@ -12,7 +12,7 @@ interface IERC721PoolLenderActions {
      *  @param  tokenIds Array of collateral to deposit.
      *  @param  index    The bucket index to which collateral will be deposited.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added collateral.
+     *  @return lpbChange The amount of LPs changed for the added collateral.
      */
     function addCollateral(
         uint256[] calldata tokenIds,

--- a/src/interfaces/position/IPositionManagerErrors.sol
+++ b/src/interfaces/position/IPositionManagerErrors.sol
@@ -8,6 +8,11 @@ pragma solidity 0.8.14;
 interface IPositionManagerErrors {
 
     /**
+     * @notice User attempting to utilize LPB from a bankrupt bucket.
+     */
+    error BucketBankrupt();
+
+    /**
      * @notice User attempting to burn a LPB NFT before removing liquidity.
      */
     error LiquidityNotRemoved();

--- a/src/interfaces/position/IPositionManagerErrors.sol
+++ b/src/interfaces/position/IPositionManagerErrors.sol
@@ -28,9 +28,9 @@ interface IPositionManagerErrors {
     error NotAjnaPool();
 
     /**
-     * @notice User failed to remove liquidity in an index from their NFT.
+     * @notice User failed to remove position from their NFT.
      */
-    error RemoveLiquidityFailed();
+    error RemovePositionFailed();
 
     /**
      * @notice User attempting to interact with a pool that doesn't match the pool associated with the tokenId.

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -20,7 +20,7 @@ interface IPositionManagerOwnerActions {
      *  @notice Called to memorialize existing positions with a given NFT.
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
-     *  @dev    An additional call is made to the pool to transfer the LP tokens from their previous owner, to the Position Manager.
+     *  @dev    An additional call is made to the pool to transfer the LPs from their previous owner, to the Position Manager.
      *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the memorialization.
      */
@@ -50,7 +50,7 @@ interface IPositionManagerOwnerActions {
      *  @notice Called to reedem existing positions with a given NFT.
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
-     *  @dev    An additional call is made to the pool to transfer the LP tokens Position Manager to owner.
+     *  @dev    An additional call is made to the pool to transfer the LPs Position Manager to owner.
      *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the redeem.
      */

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -15,16 +15,9 @@ interface IPositionManagerState {
     function poolKey(
         uint256 tokenId
     ) external view returns (address);
+}
 
-    /**
-     *  @notice Returns the bucket LPs memorialized in a positions NFT.
-     *  @param  tokenId     The token id of the positions NFT.
-     *  @param  bucketIndex The bucket index memorialized in a positions NFT.
-     *  @return Amount of bucket LPs memorialized in positions NFT.
-     */
-    function positionLPs(
-        uint256 tokenId,
-        uint256 bucketIndex
-    ) external view returns (uint256);
-
+struct Position {
+    uint256 lps;         // [WAD] position LPs
+    uint256 depositTime; // deposit time for position
 }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -282,7 +282,7 @@ library Auctions {
                     Deposits.unscaledRemove(deposits_, vars.index, vars.unscaledDeposit);              // Remove all deposit from bucket
                     Bucket storage hpbBucket = buckets_[vars.index];
                     
-                    if (hpbBucket.collateral == 0) {                                                   // existing LPB and LP tokens for the bucket shall become unclaimable.
+                    if (hpbBucket.collateral == 0) {                                                   // existing LPs for the bucket shall become unclaimable.
                         emit BucketBankruptcy(vars.index, hpbBucket.lps);
                         hpbBucket.lps            = 0;
                         hpbBucket.bankruptcyTime = block.timestamp;

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -563,55 +563,67 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         mapping(address => mapping(address => mapping(uint256 => uint256))) storage allowances_,
         mapping(address => mapping(address => bool)) storage approvedTransferors_,
-        address owner_,
-        address newOwner_,
+        address ownerAddress_,
+        address newOwnerAddress_,
         uint256[] calldata indexes_
     ) external {
         // revert if msg.sender is not the new owner and is not approved as a transferor by the new owner
-        if (newOwner_ != msg.sender && !approvedTransferors_[newOwner_][msg.sender]) revert TransferorNotApproved();
+        if (newOwnerAddress_ != msg.sender && !approvedTransferors_[newOwnerAddress_][msg.sender]) revert TransferorNotApproved();
 
         // revert if new owner address is the same as old owner address
-        if (owner_ == newOwner_) revert TransferToSameOwner();
+        if (ownerAddress_ == newOwnerAddress_) revert TransferToSameOwner();
 
         uint256 indexesLength = indexes_.length;
-
-        uint256 tokensTransferred;
+        uint256 index;
+        uint256 lpsTransferred;
 
         for (uint256 i = 0; i < indexesLength; ) {
-            uint256 index = indexes_[i];
+            index = indexes_[i];
+
+            // revert if invalid index
             if (index > MAX_FENWICK_INDEX) revert InvalidIndex();
 
-            uint256 transferAmount = allowances_[owner_][newOwner_][index];
-
             Bucket storage bucket = buckets_[index];
-            Lender storage lender = bucket.lenders[owner_];
+            Lender storage owner  = bucket.lenders[ownerAddress_];
 
-            uint256 lenderDepositTime = lender.depositTime;
+            uint256 bankruptcyTime   = bucket.bankruptcyTime;
+            uint256 ownerDepositTime = owner.depositTime;
+            uint256 ownerLpBalance   = bankruptcyTime < ownerDepositTime ? owner.lps : 0;
 
-            uint256 lenderLpBalance;
+            uint256 allowedAmount = allowances_[ownerAddress_][newOwnerAddress_][index];
+            if (allowedAmount == 0) revert NoAllowance();
 
-            if (bucket.bankruptcyTime < lenderDepositTime) lenderLpBalance = lender.lps;
+            // transfer allowed amount or entire LP balance
+            allowedAmount = Maths.min(allowedAmount, ownerLpBalance);
 
-            if (transferAmount == 0 || transferAmount != lenderLpBalance) revert NoAllowance();
+            // move owner lps (if any) to the new owner
+            if (allowedAmount != 0) {
+                Lender storage newOwner = bucket.lenders[newOwnerAddress_];
 
-            delete allowances_[owner_][newOwner_][index]; // delete allowance
+                uint256 newOwnerDepositTime = newOwner.depositTime;
 
-            // move lps to the new owner address
-            Lender storage newLender = bucket.lenders[newOwner_];
+                if (newOwnerDepositTime > bankruptcyTime) {
+                    // deposit happened in a healthy bucket, add amount of LPs to new owner
+                    newOwner.lps += allowedAmount;
+                } else {
+                    // bucket bankruptcy happened after deposit, reset balance and add amount of LPs to new owner
+                    newOwner.lps = allowedAmount;
+                }
 
-            newLender.lps += transferAmount;
+                owner.lps      -= allowedAmount; // remove amount of LPs from old owner
+                lpsTransferred += allowedAmount; // add amount of LPs to total LPs transferred
 
-            newLender.depositTime = Maths.max(lenderDepositTime, newLender.depositTime);
+                // set the deposit time as the max of transferred deposit and current deposit time
+                newOwner.depositTime = Maths.max(ownerDepositTime, newOwnerDepositTime);
+            }
 
-            // reset owner lp balance for this index
-            delete bucket.lenders[owner_];
-
-            tokensTransferred += transferAmount;
+            // reset allowances of transferred LPs
+            delete allowances_[ownerAddress_][newOwnerAddress_][index];
 
             unchecked { ++i; }
         }
 
-        emit TransferLPs(owner_, newOwner_, indexes_, tokensTransferred);
+        emit TransferLPs(ownerAddress_, newOwnerAddress_, indexes_, lpsTransferred);
     }
 
     /**************************/

--- a/src/libraries/external/PositionNFTSVG.sol
+++ b/src/libraries/external/PositionNFTSVG.sol
@@ -23,7 +23,7 @@ library PositionNFTSVG {
         uint256 tokenId;              // the ID of positions NFT token
         address pool;                 // the address of pool tracked in positions NFT token
         address owner;                // the owner of positions NFT token
-        uint256[] indexes;            // the array of price buckets index with LP tokens to be tracked by the NFT
+        uint256[] indexes;            // the array of price buckets index with LPs to be tracked by the NFT
     }
 
     /**************************/

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -79,7 +79,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         _assertTransferNoAllowanceRevert({
             operator: _lender,
             from:     _lender1,
-            to:       _lender2,
+            to:       _lender,
             indexes:  indexes
         });
     }
@@ -128,11 +128,24 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[1] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        _assertTransferNoAllowanceRevert({
-            operator: _lender2,
-            from:     _lender1,
-            to:       _lender2,
-            indexes:  indexes
+        _transferLPs({
+            operator:  _lender2,
+            from:      _lender1,
+            to:        _lender2,
+            indexes:   indexes,
+            lpBalance: 30_000 * 1e18
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[0],
+            lpBalance:   10_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[1],
+            lpBalance:   20_000 * 1e18,
+            depositTime: _startTime
         });
     }
 
@@ -241,7 +254,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[2] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -263,7 +276,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -275,7 +288,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -287,7 +300,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -367,7 +380,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[1] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, transferIndexes, amounts);
 
-        // transfer LP tokens for 2 indexes
+        // transfer LPs for 2 indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -389,7 +402,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       depositIndexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -413,7 +426,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       depositIndexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -423,7 +436,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         });
     }
 
-    function testTransferLPsToLenderWithLPTokens() external tearDown {
+    function testTransferLPsToLenderWithLPs() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -511,7 +524,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[2] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -533,7 +546,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -545,7 +558,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -557,7 +570,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -622,13 +635,141 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         _pool.approveLpTransferors(transferors);
         assertTrue(_pool.approvedTransferors(_lender2, _lender));
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
             to:        _lender2,
             indexes:   indexes,
             lpBalance: 60_000 * 1e18
+        });
+    }
+
+    function testTransferLPsAllowances() external tearDown {
+        uint256[] memory indexes = new uint256[](3);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        indexes[2] = 2552;
+        // set allowed owner to lender2 address
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 10_000 * 1e18;
+        amounts[1] = 20_000 * 1e18;
+        amounts[2] = 30_000 * 1e18;
+
+        changePrank(_lender1);
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // reapproving same indexes with same amounts should revert - owner can only reset the approval
+        vm.expectRevert(IPoolErrors.AllowanceAlreadySet.selector);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // reset approval at 2 indexes
+        indexes = new uint256[](2);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        amounts = new uint256[](2);
+        amounts[0] = 0;
+        amounts[1] = 0;
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // approve a previous reseted index
+        indexes = new uint256[](1);
+        indexes[0] = 2550;
+        amounts = new uint256[](1);
+        amounts[0] = 5_000 * 1e18;
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+    }
+
+    function testTransferPartialLPs() external tearDown {
+        uint256[] memory indexes = new uint256[](2);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+
+        _addInitialLiquidity({
+            from:   _lender1,
+            amount: 10_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   _lender1,
+            amount: 20_000 * 1e18,
+            index:  indexes[1]
+        });
+
+        // set transfer allowances for lender and lender2
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 5_000 * 1e18;
+        amounts[1] = 10_000 * 1e18;
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+        amounts = new uint256[](2);
+        amounts[0] = 1_000 * 1e18;
+        amounts[1] = 2_000 * 1e18;
+        _pool.approveLpOwnership(_lender, indexes, amounts);
+
+        // lender 2 approves lender as transferor of LPs
+        changePrank(_lender2);
+        address[] memory transferors = new address[](1);
+        transferors[0] = _lender;
+        _pool.approveLpTransferors(transferors);
+
+        // lender transfers allowed LPs from lender1
+        _transferLPs({
+            operator:  _lender,
+            from:      _lender1,
+            to:        _lender,
+            indexes:   indexes,
+            lpBalance: 3_000 * 1e18
+        });
+        // lender transfers allowed LPs from lender1 to lender2
+        _transferLPs({
+            operator:  _lender,
+            from:      _lender1,
+            to:        _lender2,
+            indexes:   indexes,
+            lpBalance: 15_000 * 1e18
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       indexes[0],
+            lpBalance:   1_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender1,
+            index:       indexes[0],
+            lpBalance:   4_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[0],
+            lpBalance:   5_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       indexes[1],
+            lpBalance:   2_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender1,
+            index:       indexes[1],
+            lpBalance:   8_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[1],
+            lpBalance:   10_000 * 1e18,
+            depositTime: _startTime
         });
     }
 }

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -9,6 +9,7 @@ import { ERC721HelperContract } from './ERC721Pool/ERC721DSTestPlus.sol';
 import 'src/interfaces/position/IPositionManager.sol';
 import 'src/PositionManager.sol';
 import 'src/libraries/helpers/SafeTokenNamer.sol';
+import 'src/libraries/helpers/PoolHelper.sol';
 
 import 'src/interfaces/pool/commons/IPoolErrors.sol';
 
@@ -93,10 +94,11 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
 
         require(tokenId != 0, "tokenId nonce not incremented");
+        assertEq(tokenId, 1);
 
         // check position info
         address owner = _positionManager.ownerOf(tokenId);
-        uint256 lps   = _positionManager.getLPs(tokenId, mintPrice);
+        uint256 lps   = _positionManager.getLPs(tokenId, _indexOf(mintPrice));
 
         assertEq(owner, testAddress);
         assertEq(lps,   0);
@@ -179,7 +181,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertGt(positionAtPriceOneLPs, 0);
 
         // check lps at non added to price
-        uint256 positionAtWrongPriceLPs = _positionManager.getLPs(tokenId, 4000000 * 1e18);
+        uint256 positionAtWrongPriceLPs = _positionManager.getLPs(tokenId, uint256(MAX_BUCKET_INDEX));
         assertEq(positionAtWrongPriceLPs, 0);
 
         assertTrue(_positionManager.isIndexInPosition(tokenId, 2550));
@@ -574,12 +576,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             depositTime: 0
         });
 
-        assertEq(_positionManager.getLPs(indexes[0], tokenId1), 0);
-        assertEq(_positionManager.getLPs(indexes[1], tokenId1), 0);
-        assertEq(_positionManager.getLPs(indexes[2], tokenId1), 0);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[1]), 0);
+        assertEq(_positionManager.getLPs(tokenId1, indexes[2]), 0);
 
-        assertEq(_positionManager.getLPs(indexes[0], tokenId2), 0);
-        assertEq(_positionManager.getLPs(indexes[3], tokenId2), 0);
+        assertEq(_positionManager.getLPs(tokenId2, indexes[0]), 0);
+        assertEq(_positionManager.getLPs(tokenId2, indexes[3]), 0);
 
         (uint256 poolSize, , , , ) = _poolUtils.poolLoansInfo(address(_pool));
         assertEq(poolSize, 15_000 * 1e18);

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -158,7 +158,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId, indexes
         );
 
-        // should revert if access hasn't been granted to transfer LP tokens
+        // should revert if access hasn't been granted to transfer LPs
         vm.expectRevert(IPoolErrors.NoAllowance.selector);
         _positionManager.memorializePositions(memorializeParams);
 
@@ -171,9 +171,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check memorialization success
@@ -279,16 +279,16 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance({
             lender:      testAddress,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -300,7 +300,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -312,7 +312,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -400,9 +400,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // rememorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -410,7 +410,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -422,7 +422,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -434,7 +434,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -454,7 +454,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
     /**
      *  @notice Tests attachment of multiple previously created position to already existing NFTs.
-     *          LP tokens are checked to verify ownership of position.
+     *          LPs are checked to verify ownership of position.
      */
     function testMemorializeMultiple() external {
         address testLender1 = makeAddr("testLender1");
@@ -610,9 +610,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize lender 1 quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testLender1, tokenId1);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testLender1, tokenId1);
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
@@ -620,7 +620,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -632,7 +632,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -644,7 +644,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -692,9 +692,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testLender2, tokenId2);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testLender2, address(_positionManager), newIndexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testLender2, tokenId2);
         _positionManager.memorializePositions(memorializeParams);
 
         // // check lender, position manager,  and pool state
@@ -702,7 +702,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender2,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -738,7 +738,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender2,
             index:       indexes[3],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -883,7 +883,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -958,7 +958,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -988,13 +988,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: block.timestamp
         });
-        // TODO: check position manager lp balance != amount?
+        // check position manager lp balance does not account 2000 lps memorialized before bucket bankruptcy
         _assertLenderLpBalance({
             lender:      address(_positionManager),
             index:       testIndex,
-            lpBalance:   32_000 * 1e18,
+            lpBalance:   30_000 * 1e18,
             depositTime: block.timestamp
         });
     }
@@ -1095,7 +1095,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1142,7 +1142,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1154,7 +1154,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -1230,7 +1230,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1302,7 +1302,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1314,7 +1314,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -1600,7 +1600,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -1659,7 +1659,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -1719,13 +1719,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1785,13 +1785,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1833,7 +1833,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId2, address(_pool), 1000, 2000, block.timestamp + 30
         );
         changePrank(address(testAddress2));
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.moveLiquidity(moveLiquidityParams);
     }
 
@@ -1897,7 +1897,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1937,7 +1937,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -1945,7 +1945,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // should fail if trying to redeem one more time
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.reedemPositions(reedemParams);
     }
 
@@ -1964,7 +1964,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // should fail if trying to redeem empty position
         changePrank(testMinter);
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.reedemPositions(reedemParams);
     }
 
@@ -2063,7 +2063,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -2124,11 +2124,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
             tokenId, address(_pool), indexes
         );
-        vm.expectEmit(true, true, true, true);
-        emit RedeemPosition(testReceiver, tokenId);
+
+        changePrank(testReceiver);
         vm.expectEmit(true, true, true, true);
         emit TransferLPs(address(_positionManager), testReceiver, indexes, 15_000 * 1e18);
-        changePrank(testReceiver);
+        vm.expectEmit(true, true, true, true);
+        emit RedeemPosition(testReceiver, tokenId);
         _pool.approveLpTransferors(transferors);
         _positionManager.reedemPositions(reedemParams);
 
@@ -2137,7 +2138,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -2149,7 +2150,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testMinter,
@@ -2230,7 +2231,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      lender,
             index:       2550,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      minter,
@@ -2317,7 +2318,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       2551,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // minter can burn NFT on behalf of lender
@@ -2391,7 +2392,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      lender,
             index:       2550,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      minter,
@@ -2476,6 +2477,124 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         string memory uriString = _positionManager.tokenURI(tokenId);
         // emit log(uriString);
         assertGt(bytes(uriString).length, 0);
+    }
+
+    function testMemorializePositionsTwoAccountsSameBucket() external {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        uint256 mintAmount  = 10_000 * 1e18;
+
+        uint256 lpBalance;
+        uint256 depositTime;
+
+        _mintQuoteAndApproveManagerTokens(alice, mintAmount);
+        _mintQuoteAndApproveManagerTokens(bob, mintAmount);
+
+        // call pool contract directly to add quote tokens
+        uint256[] memory indexes = new uint256[](1);
+        indexes[0] = 2550;
+        uint256[] memory amounts = new uint256[] (1);
+        amounts[0] = 3_000 * 1e18;
+        address[] memory transferors = new address[](1);
+        transferors[0] = address(_positionManager);
+
+        // alice adds liquidity now
+        _addInitialLiquidity({
+            from:   alice,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        uint256 aliceDepositTime = block.timestamp;
+        assertEq(lpBalance, amounts[0]);
+        assertEq(depositTime, aliceDepositTime);
+
+        // bob adds liquidity later
+        skip(1 hours);
+        _addInitialLiquidity({
+            from:   bob,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, amounts[0]);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+
+        // bob memorializes first, alice memorializes second
+        address[] memory addresses = new address[](2);
+        addresses[0] = bob;
+        addresses[1] = alice;
+        uint256[] memory tokenIds = new uint256[](2);
+
+        // bob and alice mint an NFT to later memorialize existing positions into
+        tokenIds[0] = _mintNFT(bob, bob, address(_pool));
+        assertFalse(_positionManager.isIndexInPosition(tokenIds[0], 2550));
+        tokenIds[1] = _mintNFT(alice, alice, address(_pool));
+        assertFalse(_positionManager.isIndexInPosition(tokenIds[1], 2550));
+
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
+                tokenIds[i], indexes
+            );
+
+            // allow position manager to take ownership of the position
+            changePrank(addresses[i]);
+            _pool.approveLpTransferors(transferors);
+            _pool.approveLpOwnership(address(_positionManager), indexes, amounts);
+
+            // memorialize quote tokens into minted NFT
+            vm.expectEmit(true, true, true, true);
+            emit TransferLPs(addresses[i], address(_positionManager), indexes, amounts[0]);
+            vm.expectEmit(true, true, true, true);
+            emit MemorializePosition(addresses[i], tokenIds[i]);
+
+            _positionManager.memorializePositions(memorializeParams);
+        }
+
+        // LPs transferred to position manager
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], address(_positionManager));
+        assertEq(lpBalance, 6_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+        // both alice and bob redeem
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.RedeemPositionsParams memory params = IPositionManagerOwnerActions.RedeemPositionsParams(
+                tokenIds[i], address(_pool), indexes
+            );
+            changePrank(addresses[i]);
+            _positionManager.reedemPositions(params);
+        }
+
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        assertEq(lpBalance, 3_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, 3_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], address(_positionManager));
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+        // attempt to redeem again should fail
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.RedeemPositionsParams memory params = IPositionManagerOwnerActions.RedeemPositionsParams(
+                tokenIds[i], address(_pool), indexes
+            );
+            changePrank(addresses[i]);
+            vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
+            _positionManager.reedemPositions(params);
+        }
     }
 
 }
@@ -2608,16 +2727,16 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress1, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress1, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress1, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance({
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2629,7 +2748,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2641,7 +2760,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2733,9 +2852,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
 
         // rememorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress1, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress1, address(_positionManager), indexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress1, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -2743,7 +2862,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2755,7 +2874,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2767,7 +2886,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2800,7 +2919,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2812,7 +2931,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2824,7 +2943,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2884,7 +3003,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2900,9 +3019,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         });
         _assertLenderLpBalance({
             lender:      testAddress1,
-            index:       indexes[0],
+            index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2914,13 +3033,13 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      address(_positionManager),
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress1,
-            index:       indexes[0],
+            index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2932,7 +3051,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      address(_positionManager),
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
 
         // check position manager state


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Position manager changes to fix issues raised in the Sherlock audits.
  * Adds new error raised if an NFT owner attempts to redeem or move their position containing a bankrupt bucket. They can memorialize additional liquidity after the bucket has gone bankrupt, but it will be starting from zero.
  * We are not going to handle early withdrawal penalties. The assumption is that a lender who memorialized a position would choose to redeem their position and wait 24 hours in order to avoid the penalty.
  * Includes changes made by George to how `transferLPs` works that fixes several bugs and vulnerabilities.
  

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* https://github.com/sherlock-audit/2023-01-ajna-judging/issues/13
* https://github.com/sherlock-audit/2023-01-ajna-judging/issues/19
* https://github.com/sherlock-audit/2023-01-ajna-judging/issues/116
* https://github.com/sherlock-audit/2023-01-ajna-judging/issues/156
* resolves https://github.com/ajna-finance/contracts/issues/616

# Contract size
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>

# Gas usage
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>

