### PR TITLE
Pm bb approach improvements

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -346,10 +346,10 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of quote tokens in bucket for a given amount of LPs.
      *  @param  lps_         The number of LPs to calculate amounts for.
      *  @param  index_       The price bucket index for which the value should be calculated.
-     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return quoteAmount_ The exact amount of quote tokens that can be exchanged for the given LPs, WAD units.
      */
     function lpsToQuoteTokens(
         address ajnaPool_,
@@ -369,10 +369,10 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LP Tokens.
+     *  @notice Calculate the amount of collateral tokens in bucket for a given amount of LPs.
      *  @param  lps_              The number of LPs to calculate amounts for.
      *  @param  index_            The price bucket index for which the value should be calculated.
-     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LP Tokens, WAD units.
+     *  @return collateralAmount_ The exact amount of collateral tokens that can be exchanged for the given LPs, WAD units.
      */
     function lpsToCollateral(
         address ajnaPool_,

--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -11,6 +11,11 @@ interface IPoolErrors {
     /**************************/
 
     /**
+     *  @notice LPs allowance is already set by the owner.
+     */
+    error AllowanceAlreadySet();
+
+    /**
      *  @notice The action cannot be executed on an active auction.
      */
     error AuctionActive();
@@ -93,7 +98,7 @@ interface IPoolErrors {
     /**
      *  @notice Lender is attempting to move or remove more collateral they have claim to in the bucket.
      *  @notice Lender is attempting to remove more collateral they have claim to in the bucket.
-     *  @notice Lender must have enough LP tokens to claim the desired amount of quote from the bucket.
+     *  @notice Lender must have enough LPs to claim the desired amount of quote from the bucket.
      */
     error InsufficientLPs();
 
@@ -103,7 +108,7 @@ interface IPoolErrors {
     error InsufficientLiquidity();
 
     /**
-     *  @notice When transferring LP tokens between indices, the new index must be a valid index.
+     *  @notice When transferring LPs between indices, the new index must be a valid index.
      */
     error InvalidIndex();
 
@@ -129,7 +134,7 @@ interface IPoolErrors {
     error MoveToSamePrice();
 
     /**
-     *  @notice Owner of the LP tokens must have approved the new owner prior to transfer.
+     *  @notice Owner of the LPs must have approved the new owner prior to transfer.
      */
     error NoAllowance();
 
@@ -195,7 +200,7 @@ interface IPoolErrors {
     error TransferorNotApproved();
 
     /**
-     *  @notice Owner of the LP tokens attemps to transfer LPs to same address.
+     *  @notice Owner of the LPs attemps to transfer LPs to same address.
      */
     error TransferToSameOwner();
 

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -240,11 +240,11 @@ interface IPoolEvents {
     );
 
     /**
-     *  @notice Emitted when a lender transfers their LP tokens to a different address.
+     *  @notice Emitted when a lender transfers their LPs to a different address.
      *  @dev    Used by PositionManager.memorializePositions().
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
-     *  @param  indexes  Array of price bucket indexes at which LP tokens were transferred.
+     *  @param  indexes  Array of price bucket indexes at which LPs were transferred.
      *  @param  lps      Amount of LPs transferred.
      */
     event TransferLPs(

--- a/src/interfaces/pool/commons/IPoolLenderActions.sol
+++ b/src/interfaces/pool/commons/IPoolLenderActions.sol
@@ -11,7 +11,7 @@ interface IPoolLenderActions {
      *  @param  amount    The amount of quote token to be added by a lender.
      *  @param  index     The index of the bucket to which the quote tokens will be added.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added quote tokens.
+     *  @return lpbChange The amount of LPs changed for the added quote tokens.
      */
     function addQuoteToken(
         uint256 amount,
@@ -83,7 +83,7 @@ interface IPoolLenderActions {
      *  @param  maxAmount        The max amount of quote token to be removed by a lender.
      *  @param  index            The bucket index from which quote tokens will be removed.
      *  @return quoteTokenAmount The amount of quote token removed.
-     *  @return lpAmount         The amount of LP used for removing quote tokens amount.
+     *  @return lpAmount         The amount of LPs used for removing quote tokens amount.
      */
     function removeQuoteToken(
         uint256 maxAmount,
@@ -91,11 +91,11 @@ interface IPoolLenderActions {
     ) external returns (uint256 quoteTokenAmount, uint256 lpAmount);
 
     /**
-     *  @notice Called by lenders to transfers their LP tokens to a different address. approveLpOwnership needs to be run first
+     *  @notice Called by lenders to transfers their LPs to a different address. approveLpOwnership needs to be run first
      *  @dev    Used by PositionManager.memorializePositions().
      *  @param  owner    The original owner address of the position.
      *  @param  newOwner The new owner address of the position.
-     *  @param  indexes  Array of price buckets index at which LP tokens were moved.
+     *  @param  indexes  Array of price buckets index at which LPs were moved.
      */
     function transferLPs(
         address owner,

--- a/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
+++ b/src/interfaces/pool/erc20/IERC20PoolLenderActions.sol
@@ -12,7 +12,7 @@ interface IERC20PoolLenderActions {
      *  @param  amount    Amount of collateral to deposit.
      *  @param  index     The bucket index to which collateral will be deposited.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added collateral.
+     *  @return lpbChange The amount of LPs changed for the added collateral.
      */
     function addCollateral(
         uint256 amount,

--- a/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolLenderActions.sol
@@ -12,7 +12,7 @@ interface IERC721PoolLenderActions {
      *  @param  tokenIds Array of collateral to deposit.
      *  @param  index    The bucket index to which collateral will be deposited.
      *  @param  expiry    Timestamp after which this TX will revert, preventing inclusion in a block with unfavorable price.
-     *  @return lpbChange The amount of LP Tokens changed for the added collateral.
+     *  @return lpbChange The amount of LPs changed for the added collateral.
      */
     function addCollateral(
         uint256[] calldata tokenIds,

--- a/src/interfaces/position/IPositionManagerErrors.sol
+++ b/src/interfaces/position/IPositionManagerErrors.sol
@@ -28,9 +28,9 @@ interface IPositionManagerErrors {
     error NotAjnaPool();
 
     /**
-     * @notice User failed to remove liquidity in an index from their NFT.
+     * @notice User failed to remove position from their NFT.
      */
-    error RemoveLiquidityFailed();
+    error RemovePositionFailed();
 
     /**
      * @notice User attempting to interact with a pool that doesn't match the pool associated with the tokenId.

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -20,7 +20,7 @@ interface IPositionManagerOwnerActions {
      *  @notice Called to memorialize existing positions with a given NFT.
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
-     *  @dev    An additional call is made to the pool to transfer the LP tokens from their previous owner, to the Position Manager.
+     *  @dev    An additional call is made to the pool to transfer the LPs from their previous owner, to the Position Manager.
      *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the memorialization.
      */
@@ -50,7 +50,7 @@ interface IPositionManagerOwnerActions {
      *  @notice Called to reedem existing positions with a given NFT.
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
-     *  @dev    An additional call is made to the pool to transfer the LP tokens Position Manager to owner.
+     *  @dev    An additional call is made to the pool to transfer the LPs Position Manager to owner.
      *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the redeem.
      */

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -15,16 +15,9 @@ interface IPositionManagerState {
     function poolKey(
         uint256 tokenId
     ) external view returns (address);
+}
 
-    /**
-     *  @notice Returns the bucket LPs memorialized in a positions NFT.
-     *  @param  tokenId     The token id of the positions NFT.
-     *  @param  bucketIndex The bucket index memorialized in a positions NFT.
-     *  @return Amount of bucket LPs memorialized in positions NFT.
-     */
-    function positionLPs(
-        uint256 tokenId,
-        uint256 bucketIndex
-    ) external view returns (uint256);
-
+struct Position {
+    uint256 lps;         // [WAD] position LPs
+    uint256 depositTime; // deposit time for position
 }

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -282,7 +282,7 @@ library Auctions {
                     Deposits.unscaledRemove(deposits_, vars.index, vars.unscaledDeposit);              // Remove all deposit from bucket
                     Bucket storage hpbBucket = buckets_[vars.index];
                     
-                    if (hpbBucket.collateral == 0) {                                                   // existing LPB and LP tokens for the bucket shall become unclaimable.
+                    if (hpbBucket.collateral == 0) {                                                   // existing LPs for the bucket shall become unclaimable.
                         emit BucketBankruptcy(vars.index, hpbBucket.lps);
                         hpbBucket.lps            = 0;
                         hpbBucket.bankruptcyTime = block.timestamp;

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -563,55 +563,67 @@ library LenderActions {
         mapping(uint256 => Bucket) storage buckets_,
         mapping(address => mapping(address => mapping(uint256 => uint256))) storage allowances_,
         mapping(address => mapping(address => bool)) storage approvedTransferors_,
-        address owner_,
-        address newOwner_,
+        address ownerAddress_,
+        address newOwnerAddress_,
         uint256[] calldata indexes_
     ) external {
         // revert if msg.sender is not the new owner and is not approved as a transferor by the new owner
-        if (newOwner_ != msg.sender && !approvedTransferors_[newOwner_][msg.sender]) revert TransferorNotApproved();
+        if (newOwnerAddress_ != msg.sender && !approvedTransferors_[newOwnerAddress_][msg.sender]) revert TransferorNotApproved();
 
         // revert if new owner address is the same as old owner address
-        if (owner_ == newOwner_) revert TransferToSameOwner();
+        if (ownerAddress_ == newOwnerAddress_) revert TransferToSameOwner();
 
         uint256 indexesLength = indexes_.length;
-
-        uint256 tokensTransferred;
+        uint256 index;
+        uint256 lpsTransferred;
 
         for (uint256 i = 0; i < indexesLength; ) {
-            uint256 index = indexes_[i];
+            index = indexes_[i];
+
+            // revert if invalid index
             if (index > MAX_FENWICK_INDEX) revert InvalidIndex();
 
-            uint256 transferAmount = allowances_[owner_][newOwner_][index];
-
             Bucket storage bucket = buckets_[index];
-            Lender storage lender = bucket.lenders[owner_];
+            Lender storage owner  = bucket.lenders[ownerAddress_];
 
-            uint256 lenderDepositTime = lender.depositTime;
+            uint256 bankruptcyTime   = bucket.bankruptcyTime;
+            uint256 ownerDepositTime = owner.depositTime;
+            uint256 ownerLpBalance   = bankruptcyTime < ownerDepositTime ? owner.lps : 0;
 
-            uint256 lenderLpBalance;
+            uint256 allowedAmount = allowances_[ownerAddress_][newOwnerAddress_][index];
+            if (allowedAmount == 0) revert NoAllowance();
 
-            if (bucket.bankruptcyTime < lenderDepositTime) lenderLpBalance = lender.lps;
+            // transfer allowed amount or entire LP balance
+            allowedAmount = Maths.min(allowedAmount, ownerLpBalance);
 
-            if (transferAmount == 0 || transferAmount != lenderLpBalance) revert NoAllowance();
+            // move owner lps (if any) to the new owner
+            if (allowedAmount != 0) {
+                Lender storage newOwner = bucket.lenders[newOwnerAddress_];
 
-            delete allowances_[owner_][newOwner_][index]; // delete allowance
+                uint256 newOwnerDepositTime = newOwner.depositTime;
 
-            // move lps to the new owner address
-            Lender storage newLender = bucket.lenders[newOwner_];
+                if (newOwnerDepositTime > bankruptcyTime) {
+                    // deposit happened in a healthy bucket, add amount of LPs to new owner
+                    newOwner.lps += allowedAmount;
+                } else {
+                    // bucket bankruptcy happened after deposit, reset balance and add amount of LPs to new owner
+                    newOwner.lps = allowedAmount;
+                }
 
-            newLender.lps += transferAmount;
+                owner.lps      -= allowedAmount; // remove amount of LPs from old owner
+                lpsTransferred += allowedAmount; // add amount of LPs to total LPs transferred
 
-            newLender.depositTime = Maths.max(lenderDepositTime, newLender.depositTime);
+                // set the deposit time as the max of transferred deposit and current deposit time
+                newOwner.depositTime = Maths.max(ownerDepositTime, newOwnerDepositTime);
+            }
 
-            // reset owner lp balance for this index
-            delete bucket.lenders[owner_];
-
-            tokensTransferred += transferAmount;
+            // reset allowances of transferred LPs
+            delete allowances_[ownerAddress_][newOwnerAddress_][index];
 
             unchecked { ++i; }
         }
 
-        emit TransferLPs(owner_, newOwner_, indexes_, tokensTransferred);
+        emit TransferLPs(ownerAddress_, newOwnerAddress_, indexes_, lpsTransferred);
     }
 
     /**************************/

--- a/src/libraries/external/PositionNFTSVG.sol
+++ b/src/libraries/external/PositionNFTSVG.sol
@@ -23,7 +23,7 @@ library PositionNFTSVG {
         uint256 tokenId;              // the ID of positions NFT token
         address pool;                 // the address of pool tracked in positions NFT token
         address owner;                // the owner of positions NFT token
-        uint256[] indexes;            // the array of price buckets index with LP tokens to be tracked by the NFT
+        uint256[] indexes;            // the array of price buckets index with LPs to be tracked by the NFT
     }
 
     /**************************/

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -241,7 +241,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[2] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -367,7 +367,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[1] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, transferIndexes, amounts);
 
-        // transfer LP tokens for 2 indexes
+        // transfer LPs for 2 indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -423,7 +423,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         });
     }
 
-    function testTransferLPsToLenderWithLPTokens() external tearDown {
+    function testTransferLPsToLenderWithLPs() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;
         indexes[1] = 2551;
@@ -511,7 +511,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[2] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -622,7 +622,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         _pool.approveLpTransferors(transferors);
         assertTrue(_pool.approvedTransferors(_lender2, _lender));
 
-        // transfer LP tokens for all indexes
+        // transfer LPs for all indexes
         _transferLPs({
             operator:  _lender,
             from:      _lender1,
@@ -630,5 +630,46 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             indexes:   indexes,
             lpBalance: 60_000 * 1e18
         });
+    }
+
+    function testTransferLPsAllowances() external tearDown {
+        uint256[] memory indexes = new uint256[](3);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        indexes[2] = 2552;
+        // set allowed owner to lender2 address
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 10_000 * 1e18;
+        amounts[1] = 20_000 * 1e18;
+        amounts[2] = 30_000 * 1e18;
+
+        changePrank(_lender1);
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // reapproving same indexes with same amounts should revert - owner can only reset the approval
+        vm.expectRevert(IPoolErrors.AllowanceAlreadySet.selector);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // reset approval at 2 indexes
+        indexes = new uint256[](2);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        amounts = new uint256[](2);
+        amounts[0] = 0;
+        amounts[1] = 0;
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+
+        // approve a previous reseted index
+        indexes = new uint256[](1);
+        indexes[0] = 2550;
+        amounts = new uint256[](1);
+        amounts[0] = 5_000 * 1e18;
+        vm.expectEmit(true, true, false, true);
+        emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
     }
 }

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -79,7 +79,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         _assertTransferNoAllowanceRevert({
             operator: _lender,
             from:     _lender1,
-            to:       _lender2,
+            to:       _lender,
             indexes:  indexes
         });
     }
@@ -128,11 +128,24 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         amounts[1] = 30_000 * 1e18;
         _pool.approveLpOwnership(_lender2, indexes, amounts);
 
-        _assertTransferNoAllowanceRevert({
-            operator: _lender2,
-            from:     _lender1,
-            to:       _lender2,
-            indexes:  indexes
+        _transferLPs({
+            operator:  _lender2,
+            from:      _lender1,
+            to:        _lender2,
+            indexes:   indexes,
+            lpBalance: 30_000 * 1e18
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[0],
+            lpBalance:   10_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[1],
+            lpBalance:   20_000 * 1e18,
+            depositTime: _startTime
         });
     }
 
@@ -263,7 +276,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -275,7 +288,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -287,7 +300,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -389,7 +402,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       depositIndexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -413,7 +426,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       depositIndexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -533,7 +546,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -545,7 +558,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -557,7 +570,7 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
             lender:      _lender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
@@ -671,5 +684,92 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         vm.expectEmit(true, true, false, true);
         emit ApproveLpOwnership(_lender1, _lender2, indexes, amounts);
         _pool.approveLpOwnership(_lender2, indexes, amounts);
+    }
+
+    function testTransferPartialLPs() external tearDown {
+        uint256[] memory indexes = new uint256[](2);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+
+        _addInitialLiquidity({
+            from:   _lender1,
+            amount: 10_000 * 1e18,
+            index:  indexes[0]
+        });
+        _addInitialLiquidity({
+            from:   _lender1,
+            amount: 20_000 * 1e18,
+            index:  indexes[1]
+        });
+
+        // set transfer allowances for lender and lender2
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 5_000 * 1e18;
+        amounts[1] = 10_000 * 1e18;
+        _pool.approveLpOwnership(_lender2, indexes, amounts);
+        amounts = new uint256[](2);
+        amounts[0] = 1_000 * 1e18;
+        amounts[1] = 2_000 * 1e18;
+        _pool.approveLpOwnership(_lender, indexes, amounts);
+
+        // lender 2 approves lender as transferor of LPs
+        changePrank(_lender2);
+        address[] memory transferors = new address[](1);
+        transferors[0] = _lender;
+        _pool.approveLpTransferors(transferors);
+
+        // lender transfers allowed LPs from lender1
+        _transferLPs({
+            operator:  _lender,
+            from:      _lender1,
+            to:        _lender,
+            indexes:   indexes,
+            lpBalance: 3_000 * 1e18
+        });
+        // lender transfers allowed LPs from lender1 to lender2
+        _transferLPs({
+            operator:  _lender,
+            from:      _lender1,
+            to:        _lender2,
+            indexes:   indexes,
+            lpBalance: 15_000 * 1e18
+        });
+
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       indexes[0],
+            lpBalance:   1_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender1,
+            index:       indexes[0],
+            lpBalance:   4_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[0],
+            lpBalance:   5_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       indexes[1],
+            lpBalance:   2_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender1,
+            index:       indexes[1],
+            lpBalance:   8_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender2,
+            index:       indexes[1],
+            lpBalance:   10_000 * 1e18,
+            depositTime: _startTime
+        });
     }
 }

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -171,9 +171,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check memorialization success
@@ -279,9 +279,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance({
@@ -400,9 +400,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // rememorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress, address(_positionManager), indexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance
@@ -610,9 +610,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // memorialize lender 1 quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testLender1, tokenId1);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testLender1, address(_positionManager), lender1Indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testLender1, tokenId1);
         _positionManager.memorializePositions(memorializeParams);
 
         // check lender, position manager,  and pool state
@@ -692,9 +692,9 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testLender2, tokenId2);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testLender2, address(_positionManager), newIndexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testLender2, tokenId2);
         _positionManager.memorializePositions(memorializeParams);
 
         // // check lender, position manager,  and pool state
@@ -1833,7 +1833,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId2, address(_pool), 1000, 2000, block.timestamp + 30
         );
         changePrank(address(testAddress2));
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.moveLiquidity(moveLiquidityParams);
     }
 
@@ -1945,7 +1945,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
         // should fail if trying to redeem one more time
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.reedemPositions(reedemParams);
     }
 
@@ -1964,7 +1964,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // should fail if trying to redeem empty position
         changePrank(testMinter);
-        vm.expectRevert(IPositionManagerErrors.RemoveLiquidityFailed.selector);
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
         _positionManager.reedemPositions(reedemParams);
     }
 
@@ -2124,11 +2124,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
             tokenId, address(_pool), indexes
         );
-        vm.expectEmit(true, true, true, true);
-        emit RedeemPosition(testReceiver, tokenId);
+
+        changePrank(testReceiver);
         vm.expectEmit(true, true, true, true);
         emit TransferLPs(address(_positionManager), testReceiver, indexes, 15_000 * 1e18);
-        changePrank(testReceiver);
+        vm.expectEmit(true, true, true, true);
+        emit RedeemPosition(testReceiver, tokenId);
         _pool.approveLpTransferors(transferors);
         _positionManager.reedemPositions(reedemParams);
 
@@ -2608,9 +2609,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
 
         // memorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress1, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress1, address(_positionManager), indexes, 9_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress1, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         _assertLenderLpBalance({
@@ -2733,9 +2734,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
 
         // rememorialize quote tokens into minted NFT
         vm.expectEmit(true, true, true, true);
-        emit MemorializePosition(testAddress1, tokenId);
-        vm.expectEmit(true, true, true, true);
         emit TransferLPs(testAddress1, address(_positionManager), indexes, 6_000 * 1e18);
+        vm.expectEmit(true, true, true, true);
+        emit MemorializePosition(testAddress1, tokenId);
         _positionManager.memorializePositions(memorializeParams);
 
         // check LP balance

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -288,7 +288,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -300,7 +300,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -312,7 +312,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -410,7 +410,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -422,7 +422,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -434,7 +434,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -620,7 +620,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -632,7 +632,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -644,7 +644,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -702,7 +702,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender2,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -738,7 +738,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testLender2,
             index:       indexes[3],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -883,7 +883,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -958,7 +958,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -988,13 +988,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: block.timestamp
         });
-        // TODO: check position manager lp balance != amount?
+        // check position manager lp balance does not account 2000 lps memorialized before bucket bankruptcy
         _assertLenderLpBalance({
             lender:      address(_positionManager),
             index:       testIndex,
-            lpBalance:   32_000 * 1e18,
+            lpBalance:   30_000 * 1e18,
             depositTime: block.timestamp
         });
     }
@@ -1095,7 +1095,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1142,7 +1142,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1154,7 +1154,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -1230,7 +1230,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1302,7 +1302,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -1314,7 +1314,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -1600,7 +1600,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -1659,7 +1659,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -1719,13 +1719,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1785,13 +1785,13 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testAddress1,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
             index:       mintIndex,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1897,7 +1897,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -1937,7 +1937,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // check position manager state
@@ -2063,7 +2063,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -2138,7 +2138,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      testMinter,
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testReceiver,
@@ -2150,7 +2150,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       testIndexPrice,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      testMinter,
@@ -2231,7 +2231,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      lender,
             index:       2550,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      minter,
@@ -2318,7 +2318,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      address(_positionManager),
             index:       2551,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
 
         // minter can burn NFT on behalf of lender
@@ -2392,7 +2392,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             lender:      lender,
             index:       2550,
             lpBalance:   0,
-            depositTime: 0
+            depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      minter,
@@ -2477,6 +2477,124 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         string memory uriString = _positionManager.tokenURI(tokenId);
         // emit log(uriString);
         assertGt(bytes(uriString).length, 0);
+    }
+
+    function testMemorializePositionsTwoAccountsSameBucket() external {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        uint256 mintAmount  = 10_000 * 1e18;
+
+        uint256 lpBalance;
+        uint256 depositTime;
+
+        _mintQuoteAndApproveManagerTokens(alice, mintAmount);
+        _mintQuoteAndApproveManagerTokens(bob, mintAmount);
+
+        // call pool contract directly to add quote tokens
+        uint256[] memory indexes = new uint256[](1);
+        indexes[0] = 2550;
+        uint256[] memory amounts = new uint256[] (1);
+        amounts[0] = 3_000 * 1e18;
+        address[] memory transferors = new address[](1);
+        transferors[0] = address(_positionManager);
+
+        // alice adds liquidity now
+        _addInitialLiquidity({
+            from:   alice,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        uint256 aliceDepositTime = block.timestamp;
+        assertEq(lpBalance, amounts[0]);
+        assertEq(depositTime, aliceDepositTime);
+
+        // bob adds liquidity later
+        skip(1 hours);
+        _addInitialLiquidity({
+            from:   bob,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, amounts[0]);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+
+        // bob memorializes first, alice memorializes second
+        address[] memory addresses = new address[](2);
+        addresses[0] = bob;
+        addresses[1] = alice;
+        uint256[] memory tokenIds = new uint256[](2);
+
+        // bob and alice mint an NFT to later memorialize existing positions into
+        tokenIds[0] = _mintNFT(bob, bob, address(_pool));
+        assertFalse(_positionManager.isIndexInPosition(tokenIds[0], 2550));
+        tokenIds[1] = _mintNFT(alice, alice, address(_pool));
+        assertFalse(_positionManager.isIndexInPosition(tokenIds[1], 2550));
+
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
+                tokenIds[i], indexes
+            );
+
+            // allow position manager to take ownership of the position
+            changePrank(addresses[i]);
+            _pool.approveLpTransferors(transferors);
+            _pool.approveLpOwnership(address(_positionManager), indexes, amounts);
+
+            // memorialize quote tokens into minted NFT
+            vm.expectEmit(true, true, true, true);
+            emit TransferLPs(addresses[i], address(_positionManager), indexes, amounts[0]);
+            vm.expectEmit(true, true, true, true);
+            emit MemorializePosition(addresses[i], tokenIds[i]);
+
+            _positionManager.memorializePositions(memorializeParams);
+        }
+
+        // LPs transferred to position manager
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], address(_positionManager));
+        assertEq(lpBalance, 6_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+        // both alice and bob redeem
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.RedeemPositionsParams memory params = IPositionManagerOwnerActions.RedeemPositionsParams(
+                tokenIds[i], address(_pool), indexes
+            );
+            changePrank(addresses[i]);
+            _positionManager.reedemPositions(params);
+        }
+
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], alice);
+        assertEq(lpBalance, 3_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], bob);
+        assertEq(lpBalance, 3_000 * 1e18);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+        (lpBalance, depositTime) = _pool.lenderInfo(indexes[0], address(_positionManager));
+        assertEq(lpBalance, 0);
+        assertEq(depositTime, aliceDepositTime + 1 hours);
+
+        // attempt to redeem again should fail
+        for(uint256 i = 0; i < addresses.length; ++i) {
+            // construct memorialize params struct
+            IPositionManagerOwnerActions.RedeemPositionsParams memory params = IPositionManagerOwnerActions.RedeemPositionsParams(
+                tokenIds[i], address(_pool), indexes
+            );
+            changePrank(addresses[i]);
+            vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
+            _positionManager.reedemPositions(params);
+        }
     }
 
 }
@@ -2618,7 +2736,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2630,7 +2748,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2642,7 +2760,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2744,7 +2862,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2756,7 +2874,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2768,7 +2886,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2801,7 +2919,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2813,7 +2931,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2825,7 +2943,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      address(_positionManager),
@@ -2885,7 +3003,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      testAddress1,
             index:       indexes[0],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2901,9 +3019,9 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         });
         _assertLenderLpBalance({
             lender:      testAddress1,
-            index:       indexes[0],
+            index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2915,13 +3033,13 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      address(_positionManager),
             index:       indexes[1],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress1,
-            index:       indexes[0],
+            index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
         _assertLenderLpBalance({
             lender:      testAddress2,
@@ -2933,7 +3051,7 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
             lender:      address(_positionManager),
             index:       indexes[2],
             lpBalance:   0,
-            depositTime: 0
+            depositTime: currentTime
         });
 
         // check position manager state

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -158,7 +158,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             tokenId, indexes
         );
 
-        // should revert if access hasn't been granted to transfer LP tokens
+        // should revert if access hasn't been granted to transfer LPs
         vm.expectRevert(IPoolErrors.NoAllowance.selector);
         _positionManager.memorializePositions(memorializeParams);
 
@@ -454,7 +454,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
     /**
      *  @notice Tests attachment of multiple previously created position to already existing NFTs.
-     *          LP tokens are checked to verify ownership of position.
+     *          LPs are checked to verify ownership of position.
      */
     function testMemorializeMultiple() external {
         address testLender1 = makeAddr("testLender1");


### PR DESCRIPTION
`PositionManager`
 - Add `Position` struct to keep lps and deposit time of memorialized position. remove `positionLPs` and `positionDepositTime` mappings, keep only one `positions` mapping to `Position` struct
- Emit events at the end of functions
- Small gas improvements by reusing pool address / reading only once from storage
- Rename `RemoveLiquidityFailed` error to `RemovePositionFailed`

`Pool.approveLpOwnership`:  allow approval of partial amounts, allow reset an approved allowance but not changing it

`LenderActions.transferLPs`:
- Allow partial transfer of deposit
- Transfer the min(approvedAmount, availableAmount)
- Account bucket bankruptcy on new owner