### PR TITLE
Support Oasis by removing remaining references to safeTransferFrom

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -612,15 +612,4 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         IERC721Token(_getArgAddress(COLLATERAL_ADDRESS)).transferFrom(from_, to_, tokenId_);
     }
 
-    /************************/
-    /*** Helper Functions ***/
-    /************************/
-
-    /** @notice Implementing this method allows contracts to receive ERC721 tokens
-     *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828
-     */
-    function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
-        return this.onERC721Received.selector;
-    }
-
 }

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -191,7 +191,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
 
         emit Mint(params_.recipient, params_.pool, tokenId_);
 
-        _safeMint(params_.recipient, tokenId_);
+        _mint(params_.recipient, tokenId_);
     }
 
     /**

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -166,7 +166,7 @@ contract RewardsManager is IRewardsManager {
         emit Stake(msg.sender, ajnaPool, tokenId_);
 
         // transfer LP NFT to this contract
-        IERC721(address(positionManager)).safeTransferFrom(msg.sender, address(this), tokenId_);
+        IERC721(address(positionManager)).transferFrom(msg.sender, address(this), tokenId_);
 
         // calculate rewards for updating exchange rates, if any
         uint256 updateReward = _updateBucketExchangeRates(

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -218,7 +218,7 @@ contract RewardsManager is IRewardsManager {
         emit Unstake(msg.sender, ajnaPool, tokenId_);
 
         // transfer LP NFT from contract to sender
-        IERC721(address(positionManager)).safeTransferFrom(address(this), msg.sender, tokenId_);
+        IERC721(address(positionManager)).transferFrom(address(this), msg.sender, tokenId_);
     }
 
     /**
@@ -732,17 +732,6 @@ contract RewardsManager is IRewardsManager {
         if (rewardsEarned_ > ajnaBalance) rewardsEarned_ = ajnaBalance;
         // transfer rewards to sender
         IERC20(ajnaToken).safeTransfer(msg.sender, rewardsEarned_);
-    }
-
-    /************************/
-    /*** Helper Functions ***/
-    /************************/
-
-    /** @notice Implementing this method allows contracts to receive ERC721 tokens
-     *  @dev https://forum.openzeppelin.com/t/erc721holder-ierc721receiver-and-onerc721received/11828
-     */
-    function onERC721Received(address, address, uint256, bytes memory) external pure returns (bytes4) {
-        return this.onERC721Received.selector;
     }
 
 }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* The primary difference between `safeTransferFrom` and `transferFrom` is `safeTransferFrom` has a callback to `onERC721Recieved`. This method must be implemented in order for the transfer to execute. It also offers an avenue for reentrancy attacks. By utilizing `transferFrom` we are trusting that the receiver is either an EOA, or has support for the received NFT.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->