### PR TITLE
Recreated PR#610 - PoolInfoUtils.momp calculation correction 

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -327,6 +327,7 @@ contract PoolInfoUtils {
 
         (uint256 debt, , )       = pool.debtInfo();
         ( , , uint256 noOfLoans) = pool.loansInfo();
+        noOfLoans += pool.totalAuctionsInPool();
         return _priceAt(pool.depositIndex(Maths.wdiv(debt, noOfLoans * 1e18)));
     }
 

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -521,6 +521,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
                 interestRateUpdate:   _startTime + 50 days
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 2_981.007422784467321543 * 1e18);
         _assertBorrower({
             borrower:                  _borrower,
             borrowerDebt:              expectedDebt,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -218,6 +218,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 9.818751856078723036 * 1e18);
         _assertKicker({
             kicker:    _lender,
             claimable: 0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1849,6 +1849,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 neutralPrice:      10.449783245217816340 * 1e18
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 9.818751856078723036 * 1e18);
         _assertBorrower({
             borrower:                  _borrower2,
             borrowerDebt:              9_976.561670003961916237 * 1e18,

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -288,6 +288,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
                 interestRateUpdate:   _startTime + 10 days
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 3_010.892022197881557845 * 1e18);
         // check bucket state after partial repay
         _assertBucket({
             index:        2550,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -208,6 +208,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 neutralPrice:      11.932577910666902372 * 1e18
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 9.917184843435912074 * 1e18);
 
         _addLiquidity({
             from:    _lender,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -310,6 +310,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 neutralPrice:      11.932577910666902372 * 1e18
             })
         );
+        assertEq(_poolUtils.momp(address(_pool)), 9.917184843435912074 * 1e18);
         _assertBorrower({
             borrower:                  _borrower,
             borrowerDebt:              23.012828827714740289 * 1e18,


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
Incorporate auction count into PoolInfoUtils MOMP calculation, to be consistent with Auctions lib calculation.  PR #610 was completed and approved prior to TOB audit start, but was not merged into `fix-review`, thus was not delivered.  I could not rebase from `fix-review` to `develop`, so I unstaged the commit, stashed, and applied to new branch off `develop`.  #610 auto-closed and did not allow reopen after I force-pushed from that new branch.



<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
 `PoolInfoUtils` was omitting the auction count when dividing pool debt by the number of loans.
Resolved by adding (new) `pool.totalAuctionsInPool()` to loan count.
Sprinkled some checks around the unit tests.

# Contract size
This isn't called from pool and did not affect core contract sizes.
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  21,781B  (88.62%)
  ERC20Pool          -  21,170B  (86.14%)
  Auctions           -  19,710B  (80.20%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  21,781B  (88.62%)
  ERC20Pool                -  21,170B  (86.14%)
  Auctions                 -  19,710B  (80.20%)
```

# Gas usage
This is read-only call is not used in pool transactions.

