### PR TITLE
Sherlock 111: Adversary can grief kicker by frontrunning kick with a large amount of loan

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -327,7 +327,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *       - increment poolBalances.t0DebtInAuction and poolBalances.t0Debt accumulators
      */
     function kick(
-        address borrowerAddress_
+        address borrowerAddress_,
+        uint256 limitIndex_
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
@@ -337,7 +338,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             deposits,
             loans,
             poolState,
-            borrowerAddress_
+            borrowerAddress_,
+            limitIndex_
         );
 
         // update pool balances state
@@ -357,7 +359,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *       - increment poolBalances.t0DebtInAuction and poolBalances.t0Debt accumulators
      */
     function kickWithDeposit(
-        uint256 index_
+        uint256 index_,
+        uint256 limitIndex_
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
@@ -368,7 +371,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             buckets,
             loans,
             poolState,
-            index_
+            index_,
+            limitIndex_
         );
 
         // update pool balances state

--- a/src/interfaces/pool/commons/IPoolLiquidationActions.sol
+++ b/src/interfaces/pool/commons/IPoolLiquidationActions.sol
@@ -32,17 +32,21 @@ interface IPoolLiquidationActions {
     /**
      *  @notice Called by actors to initiate a liquidation.
      *  @param  borrower Identifies the loan to liquidate.
+     *  @param  npLimitIndex Lower bound of NP tolerated when kicking the auction.
      */
     function kick(
-        address borrower
+        address borrower,
+        uint256 npLimitIndex
     ) external;
 
     /**
      *  @notice Called by lenders to liquidate the top loan using their deposits.
-     *  @param  index_  The deposit index to use for kicking the top loan.
+     *  @param  index        The deposit index to use for kicking the top loan.
+     *  @param  npLimitIndex Lower bound of NP tolerated when kicking the auction.
      */
     function kickWithDeposit(
-        uint256 index_
+        uint256 index,
+        uint256 npLimitIndex
     ) external;
 
     /**

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -21,7 +21,7 @@ import {
     _isCollateralized
 }                           from '../helpers/PoolHelper.sol';
 import { 
-    _revertIfLupDroppedBelowLimit, 
+    _revertIfPriceDroppedBelowLimit,
     _revertOnMinDebt
 }                           from '../helpers/RevertsHelper.sol';
 
@@ -206,7 +206,7 @@ library BorrowerActions {
             result_.newLup = _lup(deposits_, result_.poolDebt);
 
             // revert if borrow drives LUP price under the specified price limit
-            _revertIfLupDroppedBelowLimit(result_.newLup, limitIndex_);
+            _revertIfPriceDroppedBelowLimit(result_.newLup, limitIndex_);
 
             // calculate new lup and check borrow action won't push borrower into a state of under-collateralization
             // this check also covers the scenario when loan is already auctioned
@@ -366,7 +366,7 @@ library BorrowerActions {
             // calculate LUP only if it wasn't calculated in repay action
             if (!vars.repay) result_.newLup = _lup(deposits_, result_.poolDebt);
 
-            _revertIfLupDroppedBelowLimit(result_.newLup, limitIndex_);
+            _revertIfPriceDroppedBelowLimit(result_.newLup, limitIndex_);
 
             uint256 encumberedCollateral = borrower.t0Debt != 0 ? Maths.wdiv(vars.borrowerDebt, result_.newLup) : 0;
 

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -61,16 +61,16 @@ import { Maths }    from '../internal/Maths.sol';
     }
 
     /**
-     * @notice  Check if LUP is at or above index limit provided by borrower.
+     * @notice  Check if provided price is at or above index limit provided by borrower.
      * @notice  Prevents stale transactions and certain MEV manipulations.
-     * @param newLup_     New LUP as a result of the borrower action.
+     * @param newPrice_   New price to be compared with given limit price (can be LUP, NP).
      * @param limitIndex_ Limit price index provided by user creating the TX.
      */
-    function _revertIfLupDroppedBelowLimit(
-        uint256 newLup_,
+    function _revertIfPriceDroppedBelowLimit(
+        uint256 newPrice_,
         uint256 limitIndex_
     ) pure {
-        if (newLup_ < _priceAt(limitIndex_)) revert LimitIndexExceeded();
+        if (newPrice_ < _priceAt(limitIndex_)) revert LimitIndexExceeded();
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -320,7 +320,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         vm.startPrank(kicker);
 
         for (uint256 i; i < LOANS_COUNT; i ++) {
-            _pool.kick(_borrowers[i]);
+            _pool.kick(_borrowers[i], MAX_FENWICK_INDEX);
         }
 
         skip(2 hours);
@@ -341,7 +341,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         vm.startPrank(kicker);
 
         for (uint256 i; i < LOANS_COUNT; i ++) {
-            _pool.kick(_borrowers[LOANS_COUNT - 1 - i]);
+            _pool.kick(_borrowers[LOANS_COUNT - 1 - i], MAX_FENWICK_INDEX);
         }
 
         skip(2 hours);
@@ -362,7 +362,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
         _pool.addQuoteToken(500_000_000_000_000 * 1e18, 3_000, block.timestamp + 2 minutes);
         vm.warp(100_000 days);
 
-        _pool.kickWithDeposit(3_000); // worst case scenario, pool interest accrues
+        _pool.kickWithDeposit(3_000, MAX_FENWICK_INDEX); // worst case scenario, pool interest accrues
 
         skip(80 hours);
 
@@ -370,7 +370,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
 
         // kick remaining loans with deposit to get average gas cost
         for (uint256 i; i < LOANS_COUNT - 1; i ++) {
-            _pool.kickWithDeposit(3_000);
+            _pool.kickWithDeposit(3_000, MAX_FENWICK_INDEX);
         }
 
         vm.stopPrank();
@@ -404,7 +404,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         vm.startPrank(kicker);
 
         for (uint256 i; i < LOANS_COUNT; i ++) {
-            _pool.kick(_borrowers[i]);
+            _pool.kick(_borrowers[i], MAX_FENWICK_INDEX);
         }
 
         // add quote tokens in bucket to arb
@@ -434,7 +434,7 @@ contract ERC20PoolGasArbTakeLoadTest is ERC20PoolGasLoadTest {
         vm.startPrank(kicker);
 
         for (uint256 i; i < LOANS_COUNT; i ++) {
-            _pool.kick(_borrowers[LOANS_COUNT - 1 - i]);
+            _pool.kick(_borrowers[LOANS_COUNT - 1 - i], MAX_FENWICK_INDEX);
         }
 
         // add quote tokens in bucket to arb

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -155,6 +155,12 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             borrowerCollateralization: 0.995306391810796636 * 1e18
         });
 
+        // should revert if NP goes below limit
+        _assertKickNpUnderLimitRevert({
+            from:     _lender,
+            borrower: _borrower
+        });
+
         _kick({
             from:           _lender,
             borrower:       _borrower,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -165,6 +165,12 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             exchangeRate: 1 * 1e18
         });
 
+        // should revert if NP goes below limit
+        _assertKickWithDepositNpUnderLimitRevert({
+            from:  _lender1,
+            index: 2500
+        });
+
         _kickWithDeposit({
             from:               _lender1,
             index:              2500,
@@ -290,6 +296,13 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_borrower3),     20_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower4),     20_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower5),     20_000 * 1e18);
+
+
+        // should revert if NP goes below limit
+        _assertKickWithDepositNpUnderLimitRevert({
+            from:  _lender3,
+            index: 2500
+        });
 
         _kickWithDeposit({
             from:               _lender3,
@@ -418,6 +431,12 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(_quote.balanceOf(_borrower4),     20_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower5),     20_000 * 1e18);
 
+        // should revert if NP goes below limit
+        _assertKickWithDepositNpUnderLimitRevert({
+            from:  _lender2,
+            index: 2500
+        });
+
         // lender 2 kicks using all LPs from bucket 2499 (10_000) and sending additional quote tokens to cover auction bond (510.096153846153851000)
         _kickWithDeposit({
             from:               _lender2,
@@ -532,6 +551,12 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             collateral:   10 * 1e18,
             deposit:      60_000 * 1e18,
             exchangeRate: 1 * 1e18
+        });
+
+        // should revert if NP goes below limit
+        _assertKickWithDepositNpUnderLimitRevert({
+            from:  _lender1,
+            index: 2500
         });
 
         _kickWithDeposit({
@@ -1314,6 +1339,6 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
 
         changePrank(_lender4);
         vm.expectRevert("ERC20: transfer amount exceeds balance");
-        _pool.kickWithDeposit(2499);
+        _pool.kickWithDeposit(2499, MAX_FENWICK_INDEX);
     }
 }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -444,7 +444,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         // kick borrower 2
         changePrank(_lender);
-        _pool.kickWithDeposit(_i9_52);
+        _pool.kickWithDeposit(_i9_52, MAX_FENWICK_INDEX);
 
         _assertRemoveDepositLockedByAuctionDebtRevert({
             from:   _lender,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -261,7 +261,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
 
     function _kick(address borrower, address kicker) internal {
         changePrank(kicker);
-        _pool.kick(borrower);
+        _pool.kick(borrower, MAX_FENWICK_INDEX);
         _checkAuctionStateUponKick(kicker);
     }
 
@@ -270,7 +270,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         (, uint256 lastBucketDeposit, , uint256 lastBucketLPs, , ) = _poolUtils.bucketInfo(address(_pool), bucketId);
 
         changePrank(lender);
-        _pool.kickWithDeposit(bucketId);
+        _pool.kickWithDeposit(bucketId, MAX_FENWICK_INDEX);
         _checkAuctionStateUponKick(lender);
 
         // confirm user has redeemed some of their LPs to post liquidation bond

--- a/tests/forge/ERC20Pool/invariants/handlers/LiquidationPoolHandler.sol
+++ b/tests/forge/ERC20Pool/invariants/handlers/LiquidationPoolHandler.sol
@@ -6,6 +6,7 @@ import '@std/Vm.sol';
 
 import { BasicPoolHandler } from './BasicPoolHandler.sol';
 import { LENDER_MIN_BUCKET_INDEX, LENDER_MAX_BUCKET_INDEX, BaseHandler } from './BaseHandler.sol';
+import { MAX_FENWICK_INDEX } from 'src/libraries/helpers/PoolHelper.sol';
 import { Maths } from 'src/libraries/internal/Maths.sol';
 
 abstract contract UnBoundedLiquidationPoolHandler is BaseHandler {
@@ -14,7 +15,7 @@ abstract contract UnBoundedLiquidationPoolHandler is BaseHandler {
 
         (uint256 borrowerDebt, , ) = _poolInfo.borrowerInfo(address(_pool), borrower);
 
-        try _pool.kick(borrower) {
+        try _pool.kick(borrower, MAX_FENWICK_INDEX) {
             shouldExchangeRateChange = true;
             shouldReserveChange      = true;
             loanKickIncreaseInReserve = Maths.wmul(borrowerDebt, 0.25 * 1e18);

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -79,7 +79,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
         skip(100 days);
         vm.prank(_lender);
         // liquidate the borrower
-        _ajnaPool.kick(_borrower);
+        _ajnaPool.kick(_borrower, MAX_FENWICK_INDEX);
         // wait for the price to become profitable
         skip(6.5 hours);
     }

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -59,7 +59,7 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
         skip(60 days);
         // lender kicks the liquidation
         changePrank(_lender);
-        _pool.kick(_borrower);
+        _pool.kick(_borrower, MAX_FENWICK_INDEX);
         // price becomes favorable
         skip(8 hours);
     }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -228,7 +228,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectEmit(true, true, false, true);
         emit Kick(borrower, debt, collateral, bond);
         if(transferAmount != 0) _assertQuoteTokenTransferEvent(from, address(_pool), transferAmount);
-        _pool.kick(borrower);
+        _pool.kick(borrower, MAX_FENWICK_INDEX);
     }
 
     function _kickWithDeposit(
@@ -248,7 +248,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectEmit(true, true, false, true);
         emit RemoveQuoteToken(from, index, removedFromDeposit, removedFromDeposit, lup);
         if(transferAmount != 0) _assertQuoteTokenTransferEvent(from, address(_pool), transferAmount);
-        _pool.kickWithDeposit(index);
+        _pool.kickWithDeposit(index, MAX_FENWICK_INDEX);
     }
 
     function _moveLiquidity(
@@ -967,7 +967,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('AuctionActive()'));
-        _pool.kick(borrower);
+        _pool.kick(borrower, MAX_FENWICK_INDEX);
     }
 
     function _assertKickCollateralizedBorrowerRevert(
@@ -976,7 +976,25 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(IPoolErrors.BorrowerOk.selector);
-        _pool.kick(borrower);
+        _pool.kick(borrower, MAX_FENWICK_INDEX);
+    }
+
+    function _assertKickNpUnderLimitRevert(
+        address from,
+        address borrower
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.LimitIndexExceeded.selector);
+        _pool.kick(borrower, 0);
+    }
+
+    function _assertKickWithDepositNpUnderLimitRevert(
+        address from,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.LimitIndexExceeded.selector);
+        _pool.kickWithDeposit(index, 0);
     }
 
     function _assertKickWithInsufficientLiquidityRevert(
@@ -985,7 +1003,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('InsufficientLiquidity()'));
-        _pool.kickWithDeposit(index);
+        _pool.kickWithDeposit(index, MAX_FENWICK_INDEX);
     }
 
     function _assertKickWithBadProposedLupRevert(
@@ -994,7 +1012,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('BorrowerOk()'));
-        _pool.kickWithDeposit(index);
+        _pool.kickWithDeposit(index, MAX_FENWICK_INDEX);
     }
 
     function _assertKickPriceBelowProposedLupRevert(
@@ -1003,7 +1021,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         changePrank(from);
         vm.expectRevert(abi.encodeWithSignature('PriceBelowLUP()'));
-        _pool.kickWithDeposit(index);
+        _pool.kickWithDeposit(index, MAX_FENWICK_INDEX);
     }
 
     function _assertRemoveCollateralAuctionNotClearedRevert(


### PR DESCRIPTION
- fix for #619 (Sherlock https://github.com/sherlock-audit/2023-01-ajna-judging/issues/111)
- add `limitIndex_` param to `kick` and `kickWithDeposit` functions (Lower bound of `NP` tolerated when kicking the auction.)
- renamed `_revertIfLupDroppedBelowLimit` to a more general `_revertIfPriceDroppedBelowLimit` and used it to check if `NP` below specified limit when auction kicked
- added `KickLocalVars` struct for local vars in `Auction._kick` function in order to prevent stack too deep error
- updated tests, added revert test when limit is specified as index 0

