### PR TITLE
Update Info methods for invariant testing

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -184,7 +184,7 @@ contract PoolInfoUtils {
 
         uint256 quoteTokenBalance = IERC20Token(pool.quoteTokenAddress()).balanceOf(ajnaPool_) * pool.quoteTokenScale();
 
-        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 auctionKickTime) = pool.reservesInfo();
+        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 auctionKickTime, ) = pool.reservesInfo();
 
         // due to rounding issues, especially in Auction.settle, this can be slighly negative
         if( poolDebt + quoteTokenBalance >= poolSize + bondEscrowed + unclaimedReserve) {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -601,7 +601,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 neutralPrice,
         address head,
         address next,
-        address prev
+        address prev,
+        bool alreadyTaken
     ) {
         Liquidation memory liquidation = auctions.liquidations[borrower_];
         return (
@@ -613,7 +614,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             liquidation.neutralPrice,
             auctions.head,
             liquidation.next,
-            liquidation.prev
+            liquidation.prev,
+            liquidation.alreadyTaken
         );
     }
 
@@ -772,11 +774,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     /// @inheritdoc IPoolState
-    function reservesInfo() external view override returns (uint256, uint256, uint256) {
+    function reservesInfo() external view override returns (uint256, uint256, uint256, uint256) {
         return (
             auctions.totalBondEscrowed,
             reserveAuction.unclaimed,
-            reserveAuction.kicked
+            reserveAuction.kicked,
+            reserveAuction.totalInterestEarned
         );
     }
 

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -19,6 +19,7 @@ interface IPoolState {
      *  @return head         Address of the head auction.
      *  @return next         Address of the next auction in queue.
      *  @return prev         Address of the prev auction in queue.
+     *  @return alreadyTaken True if take has been called on auction
      */
     function auctionInfo(address borrower)
         external
@@ -32,7 +33,8 @@ interface IPoolState {
             uint256 neutralPrice,
             address head,
             address next,
-            address prev
+            address prev,
+            bool alreadyTaken
         );
 
     /**
@@ -206,6 +208,7 @@ interface IPoolState {
      *  @return liquidationBondEscrowed Amount of liquidation bond across all liquidators.
      *  @return reserveAuctionUnclaimed Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
      *  @return reserveAuctionKicked    Time a Claimable Reserve Auction was last kicked.
+     *  @return totalInterestEarned     Total interest earned by all lenders in the pool
      */
     function reservesInfo()
         external
@@ -213,7 +216,8 @@ interface IPoolState {
         returns (
             uint256 liquidationBondEscrowed,
             uint256 reserveAuctionUnclaimed,
-            uint256 reserveAuctionKicked
+            uint256 reserveAuctionKicked,
+            uint256 totalInterestEarned
     );
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -677,9 +677,9 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         address head;
         address next;
         address prev;
-        (, , , , , , head, next, prev) = _pool.auctionInfo(address(0));
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(address(0));
         assertEq(head, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -713,11 +713,11 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(thresholdPrice, 0);
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower1);
@@ -751,15 +751,15 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(thresholdPrice, 0);
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
@@ -793,19 +793,19 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(thresholdPrice, 0);
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower4);
@@ -839,23 +839,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(thresholdPrice, 0);
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, _borrower2);
         assertEq(prev, _borrower4);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower3);
@@ -924,23 +924,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower4);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -987,23 +987,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower1);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1050,23 +1050,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower5);
         assertEq(next, _borrower3);
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1113,23 +1113,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1176,23 +1176,23 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower1);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower5);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower4);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower3);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , head, next, prev, ) = _pool.auctionInfo(_borrower2);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -294,6 +294,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
             uint256 auctionNeutralPrice,
             ,
             ,
+            ,
         ) = _pool.auctionInfo(_borrower);
 
         assertEq(auctionKicker,       kicker);
@@ -349,7 +350,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         }
 
         // confirm LPs were awarded to the kicker
-        (address kicker, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , ) = _pool.auctionInfo(_borrower);
+        (address kicker, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , , ) = _pool.auctionInfo(_borrower);
         uint256 auctionPrice = Auctions._auctionPrice(kickMomp, neutralPrice, kickTime);
         if (auctionPrice < neutralPrice) {
             uint256 kickerLPs = _kickerLPs(bucketId);
@@ -420,7 +421,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint256 auctionDebt_,
         uint256 auctionCollateral_
     ){
-        (, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , ) = _pool.auctionInfo(_borrower);
+        (, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , , ) = _pool.auctionInfo(_borrower);
         uint256 lastAuctionPrice = Auctions._auctionPrice(kickMomp, neutralPrice, kickTime);
         (uint256 lastAuctionDebt, uint256 lastAuctionCollateral, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         if (secondsToSkip != 0) {
@@ -441,7 +442,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     }
 
     function _auctionPrice() internal view returns (uint256) {
-        (, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , ) = _pool.auctionInfo(_borrower);
+        (, , , uint256 kickTime, uint256 kickMomp, uint256 neutralPrice, , , , ) = _pool.auctionInfo(_borrower);
         return Auctions._auctionPrice(kickMomp, neutralPrice, kickTime);
     }
 
@@ -451,7 +452,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     }
 
     function _kickerLPs(uint256 bucketId) internal view returns (uint256) {
-        (address kicker, , , , , , , , ) = _pool.auctionInfo(_borrower);
+        (address kicker, , , , , , , , , ) = _pool.auctionInfo(_borrower);
         (uint256 kickerLPs, ) = _pool.lenderInfo(bucketId, kicker);
         return kickerLPs;
     }

--- a/tests/forge/ERC20Pool/invariants/BasicInvariants.t.sol
+++ b/tests/forge/ERC20Pool/invariants/BasicInvariants.t.sol
@@ -113,7 +113,7 @@ contract BasicInvariants is TestBase {
         uint256 t0debt       = _pool.totalT0Debt();
         (uint256 inflator, ) = _pool.inflatorInfo();
         uint256 poolDebt     = Maths.wmul(t0debt, inflator);
-        (uint256 totalPoolBond, uint256 unClaimed, ) = _pool.reservesInfo();
+        (uint256 totalPoolBond, uint256 unClaimed, , ) = _pool.reservesInfo();
 
         assertGe(poolBalance + poolDebt, totalPoolBond + _pool.depositSize() + unClaimed, "Incorrect pool debt");
     }

--- a/tests/forge/ERC20Pool/invariants/LiquidationInvariant.t.sol
+++ b/tests/forge/ERC20Pool/invariants/LiquidationInvariant.t.sol
@@ -44,7 +44,7 @@ contract LiquidationInvariant is BasicInvariants {
         uint256 totalT0debtInAuction;
         for(uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (, , , uint256 kickTime, , , , , ) = _pool.auctionInfo(borrower);
+            (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
             if(kickTime != 0) {
                 (uint256 t0debt, , ) = _pool.borrowerInfo(borrower);
                 totalT0debtInAuction += t0debt;
@@ -67,13 +67,13 @@ contract LiquidationInvariant is BasicInvariants {
 
         for(uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (, , uint256 bondSize, , , , , , ) = _pool.auctionInfo(borrower);
+            (, , uint256 bondSize, , , , , , , ) = _pool.auctionInfo(borrower);
             totalBondInAuction += bondSize;
         }
 
         require(totalBondInAuction == totalKickerBond, "Incorrect bond");
 
-        (uint256 totalPoolBond, , ) = _pool.reservesInfo();
+        (uint256 totalPoolBond, , , ) = _pool.reservesInfo();
 
         require(totalPoolBond == totalKickerBond, "Incorrect bond");
     }   
@@ -97,7 +97,7 @@ contract LiquidationInvariant is BasicInvariants {
         uint256 borrowersKicked;
         for(uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (, , , uint256 kickTime, , , , , ) = _pool.auctionInfo(borrower);
+            (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
             if(kickTime != 0) {
                 borrowersKicked += 1;
             }
@@ -109,7 +109,7 @@ contract LiquidationInvariant is BasicInvariants {
         uint256 actorCount = IBaseHandler(_handler).getActorsCount();
         for(uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (address kicker, , uint256 bondSize, , , , , , ) = _pool.auctionInfo(borrower);
+            (address kicker, , uint256 bondSize, , , , , , , ) = _pool.auctionInfo(borrower);
             (, uint256 lockedAmount) = _pool.kickerInfo(kicker);
             require(lockedAmount >= bondSize, "Incorrect bond locked");
         }

--- a/tests/forge/ERC20Pool/invariants/handlers/LiquidationPoolHandler.sol
+++ b/tests/forge/ERC20Pool/invariants/handlers/LiquidationPoolHandler.sol
@@ -82,7 +82,7 @@ contract LiquidationPoolHandler is UnBoundedLiquidationPoolHandler, BasicPoolHan
         address kicker   = _actor;
         amount           = constrictToRange(amount, 1, 1e36);
 
-        ( , , , uint256 kickTime, , , , , ) = _pool.auctionInfo(borrower);
+        ( , , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
 
         if (kickTime == 0) {
             (uint256 debt, , ) = _pool.borrowerInfo(borrower);
@@ -116,7 +116,7 @@ contract LiquidationPoolHandler is UnBoundedLiquidationPoolHandler, BasicPoolHan
         address borrower = actors[borrowerIndex];
         address taker    = _actor;
 
-        ( , , , uint256 kickTime, , , , , ) = _pool.auctionInfo(borrower);
+        ( , , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
 
         if (kickTime == 0) {
             _kickAuction(borrowerIndex, amount * 100, actorIndex);
@@ -137,7 +137,7 @@ contract LiquidationPoolHandler is UnBoundedLiquidationPoolHandler, BasicPoolHan
         address borrower = actors[borrowerIndex];
         address taker    = _actor;
 
-        ( , , , uint256 kickTime, , , , , ) = _pool.auctionInfo(borrower);
+        ( , , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
 
         if (kickTime == 0) {
             _kickAuction(borrowerIndex, 1e24, bucketIndex);

--- a/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -202,7 +202,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // check that you can't start a new auction if a previous auction is active
         _assertReserveAuctionTooSoon();
 
-        (, uint256 unclaimed, ) = _pool.reservesInfo();
+        (, uint256 unclaimed, , ) = _pool.reservesInfo();
 
         uint256 expectedPrice = 59.604644775390625 * 1e18;
         _takeReserves(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -422,11 +422,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             uint256 auctionNeutralPrice,
             ,
             ,
+            ,
         ) = _pool.auctionInfo(state_.borrower);
 
         (uint256 borrowerDebt, uint256 borrowerCollateral , ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);
         (, uint256 lockedBonds) = _pool.kickerInfo(state_.kicker);
-        (uint256 auctionTotalBondEscrowed,,) = _pool.reservesInfo();
+        (uint256 auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
         (,,uint256 auctionDebtInAuction)  = _pool.debtInfo(); 
         uint256 borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerDebt * Maths.WAD / borrowerCollateral : 0;
 


### PR DESCRIPTION
# Description of change
## High level
Add returns for `alreadyTaken` flag from `auctionInfo` and `totalInterestEarned` from `reservesInfo`. Needed for reserve interest invariant `I2` and auctions invariant `A6` implementations.