### PR TITLE
Include current burn epoch in ReserveAuction event (Oasis)

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -409,15 +409,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *          - ReserveAuction
      */
     function startClaimableReserveAuction() external override nonReentrant {
-        // retrieve timestamp of latest burn event and last burn timestamp
-        uint256 latestBurnEpoch   = reserveAuction.latestBurnEventEpoch;
-        uint256 lastBurnTimestamp = reserveAuction.burnEvents[latestBurnEpoch].timestamp;
-
-        // check that at least two weeks have passed since the last reserve auction completed, and that the auction was not kicked within the past 72 hours
-        if (block.timestamp < lastBurnTimestamp + 2 weeks || block.timestamp - reserveAuction.kicked <= 72 hours) {
-            revert ReserveAuctionTooSoon();
-        }
-
         // start a new claimable reserve auction, passing in relevant parameters such as the current pool size, debt, balance, and inflator value
         uint256 kickerAward = Auctions.startClaimableReserveAuction(
             auctions,
@@ -429,12 +420,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                 inflator:    inflatorState.inflator
             })
         );
-
-        // increment latest burn event epoch and update burn event timestamp
-        latestBurnEpoch += 1;
-
-        reserveAuction.latestBurnEventEpoch = latestBurnEpoch;
-        reserveAuction.burnEvents[latestBurnEpoch].timestamp = block.timestamp;
 
         // transfer kicker award to msg.sender
         _transferQuoteToken(msg.sender, kickerAward);
@@ -454,18 +439,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             reserveAuction,
             maxAmount_
         );
-
-        uint256 totalBurned = reserveAuction.totalAjnaBurned + ajnaRequired;
-        
-        // accumulate additional ajna burned
-        reserveAuction.totalAjnaBurned = totalBurned;
-
-        uint256 burnEventEpoch = reserveAuction.latestBurnEventEpoch;
-
-        // record burn event information to enable querying by staking rewards
-        BurnEvent storage burnEvent = reserveAuction.burnEvents[burnEventEpoch];
-        burnEvent.totalInterest = reserveAuction.totalInterestEarned;
-        burnEvent.totalBurned   = totalBurned;
 
         // burn required number of ajna tokens to take quote from reserves
         IERC20(_getArgAddress(AJNA_ADDRESS)).safeTransferFrom(msg.sender, address(this), ajnaRequired);

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -206,10 +206,12 @@ interface IPoolEvents {
      *  @notice Emitted when a Claimaible Reserve Auction is started or taken.
      *  @return claimableReservesRemaining Amount of claimable reserves which has not yet been taken.
      *  @return auctionPrice               Current price at which 1 quote token may be purchased, denominated in Ajna.
+     *  @return currentBurnEpoch           Current burn epoch.
      */
     event ReserveAuction(
         uint256 claimableReservesRemaining,
-        uint256 auctionPrice
+        uint256 auctionPrice,
+        uint256 currentBurnEpoch
     );
 
     /**

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -10,6 +10,7 @@ import {
     AuctionsState,
     Borrower,
     Bucket,
+    BurnEvent,
     DepositsState,
     Kicker,
     Lender,
@@ -131,7 +132,7 @@ library Auctions {
     event Kick(address indexed borrower, uint256 debt, uint256 collateral, uint256 bond);
     event Take(address indexed borrower, uint256 amount, uint256 collateral, uint256 bondChange, bool isReward);
     event RemoveQuoteToken(address indexed lender, uint256 indexed price, uint256 amount, uint256 lpRedeemed, uint256 lup);
-    event ReserveAuction(uint256 claimableReservesRemaining, uint256 auctionPrice);
+    event ReserveAuction(uint256 claimableReservesRemaining, uint256 auctionPrice, uint256 currentBurnEpoch);
     event Settle(address indexed borrower, uint256 settledDebt);
 
     /**************/
@@ -151,6 +152,7 @@ library Auctions {
     error NoReserves();
     error NoReservesAuction();
     error PriceBelowLUP();
+    error ReserveAuctionTooSoon();
     error TakeNotPastCooldown();
 
     /***************************/
@@ -617,6 +619,15 @@ library Auctions {
         ReserveAuctionState storage reserveAuction_,
         StartReserveAuctionParams calldata params_
     ) external returns (uint256 kickerAward_) {
+        // retrieve timestamp of latest burn event and last burn timestamp
+        uint256 latestBurnEpoch   = reserveAuction_.latestBurnEventEpoch;
+        uint256 lastBurnTimestamp = reserveAuction_.burnEvents[latestBurnEpoch].timestamp;
+
+        // check that at least two weeks have passed since the last reserve auction completed, and that the auction was not kicked within the past 72 hours
+        if (block.timestamp < lastBurnTimestamp + 2 weeks || block.timestamp - reserveAuction_.kicked <= 72 hours) {
+            revert ReserveAuctionTooSoon();
+        }
+
         uint256 curUnclaimedAuctionReserve = reserveAuction_.unclaimed;
 
         uint256 claimable = _claimableReserves(
@@ -636,7 +647,17 @@ library Auctions {
         reserveAuction_.unclaimed = curUnclaimedAuctionReserve;
         reserveAuction_.kicked    = block.timestamp;
 
-        emit ReserveAuction(curUnclaimedAuctionReserve, _reserveAuctionPrice(block.timestamp));
+        // increment latest burn event epoch and update burn event timestamp
+        latestBurnEpoch += 1;
+
+        reserveAuction_.latestBurnEventEpoch = latestBurnEpoch;
+        reserveAuction_.burnEvents[latestBurnEpoch].timestamp = block.timestamp;
+
+        emit ReserveAuction(
+            curUnclaimedAuctionReserve,
+            _reserveAuctionPrice(block.timestamp),
+            latestBurnEpoch
+        );
     }
 
     /**
@@ -665,7 +686,19 @@ library Auctions {
 
             reserveAuction_.unclaimed = unclaimed;
 
-            emit ReserveAuction(unclaimed, price);
+            uint256 totalBurned = reserveAuction_.totalAjnaBurned + ajnaRequired_;
+            
+            // accumulate additional ajna burned
+            reserveAuction_.totalAjnaBurned = totalBurned;
+
+            uint256 burnEventEpoch = reserveAuction_.latestBurnEventEpoch;
+
+            // record burn event information to enable querying by staking rewards
+            BurnEvent storage burnEvent = reserveAuction_.burnEvents[burnEventEpoch];
+            burnEvent.totalInterest = reserveAuction_.totalInterestEarned;
+            burnEvent.totalBurned   = totalBurned;
+
+            emit ReserveAuction(unclaimed, price, burnEventEpoch);
         } else {
             revert NoReservesAuction();
         }

--- a/tests/forge/ERC20Pool/ERC20PoolReserveAuction.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolReserveAuction.t.sol
@@ -89,7 +89,8 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         _startClaimableReserveAuction({
             from:              _bidder,
             remainingReserves: 1.284989524180968870 * 1e18,
-            price:             1000000000 * 1e18
+            price:             1000000000 * 1e18,
+            epoch:             1
         });
 
         skip(60 hours);

--- a/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -121,7 +121,8 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         _startClaimableReserveAuction({
             from:              _bidder,
             remainingReserves: 494.189491516041968090 * 1e18,
-            price:             1_000_000_000 * 1e18
+            price:             1_000_000_000 * 1e18,
+            epoch:             1
         });
 
         _assertReserveAuctionPrice(1_000_000_000 * 1e18);
@@ -188,13 +189,12 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
 
         // kick off a new auction
-        _startClaimableReserveAuction(
-            {
-                from:              _bidder,
-                remainingReserves: 494.189491516041968090 * 1e18,
-                price:             1_000_000_000 * 1e18
-            }
-        );
+        _startClaimableReserveAuction({
+            from:              _bidder,
+            remainingReserves: 494.189491516041968090 * 1e18,
+            price:             1_000_000_000 * 1e18,
+            epoch:             1
+        });
 
         // pass time to allow the price to decrease
         skip(24 hours);
@@ -205,14 +205,13 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         (, uint256 unclaimed, ) = _pool.reservesInfo();
 
         uint256 expectedPrice = 59.604644775390625 * 1e18;
-        _takeReserves(
-            {
-                from:              _bidder,
-                amount:            Maths.wdiv(unclaimed, Maths.wad(2)),
-                remainingReserves: Maths.wdiv(unclaimed, Maths.wad(2)),
-                price:             expectedPrice
-            }
-        );
+        _takeReserves({
+            from:              _bidder,
+            amount:            Maths.wdiv(unclaimed, Maths.wad(2)),
+            remainingReserves: Maths.wdiv(unclaimed, Maths.wad(2)),
+            price:             expectedPrice,
+            epoch:             1
+        });
 
         // pass time to allow auction to complete
         skip(48 hours);
@@ -237,15 +236,13 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         uint256 reserves          = 499.181304561658553626 * 1e18;
         uint256 claimableReserves = reserves;
         uint256 expectedReserves  = reserves;
-        _assertReserveAuction(
-            {
-                reserves:                   reserves,
-                claimableReserves :         claimableReserves,
-                claimableReservesRemaining: 0,
-                auctionPrice:               0,
-                timeRemaining:              0
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   reserves,
+            claimableReserves :         claimableReserves,
+            claimableReservesRemaining: 0,
+            auctionPrice:               0,
+            timeRemaining:              0
+        });
 
         // kick off a new auction
         uint256 expectedPrice = 1_000_000_000 * 1e18;
@@ -254,114 +251,97 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         uint256 expectedQuoteBalance = _quote.balanceOf(_bidder) + kickAward;
         expectedReserves -= kickAward;
 
-        _startClaimableReserveAuction(
-            {
-                from:              _bidder,
-                remainingReserves: expectedReserves,
-                price:             expectedPrice
-            }
-        );
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              3 days
-            }
-        );
+        _startClaimableReserveAuction({
+            from:              _bidder,
+            remainingReserves: expectedReserves,
+            price:             expectedPrice,
+            epoch:             1
+        });
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              3 days
+        });
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
 
         // bid once the price becomes attractive
         skip(24 hours);
         expectedPrice = 59.604644775390625 * 1e18;
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              2 days
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              2 days
+        });
 
-        _takeReserves(
-            {
-                from:              _bidder,
-                amount:            300 * 1e18,
-                remainingReserves: 194.189491516041968090 * 1e18,
-                price:             expectedPrice
-            }
-        );
+        _takeReserves({
+            from:              _bidder,
+            amount:            300 * 1e18,
+            remainingReserves: 194.189491516041968090 * 1e18,
+            price:             expectedPrice,
+            epoch:             1
+        });
 
         expectedQuoteBalance += 300 * 1e18;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
         assertEq(_ajnaToken.balanceOf(_bidder), 22_118.6065673828125 * 1e18);
         expectedReserves -= 300 * 1e18;
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              2 days
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              2 days
+        });
 
         // bid max amount
         skip(5 minutes);
         expectedPrice = 56.259293120008319416 * 1e18;
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              2875 minutes
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              2875 minutes
+        });
 
-        _takeReserves(
-            {
-                from:              _bidder,
-                amount:            400 * 1e18,
-                remainingReserves: 0,
-                price:             expectedPrice
-            }
-        );
+        _takeReserves({
+            from:              _bidder,
+            amount:            400 * 1e18,
+            remainingReserves: 0,
+            price:             expectedPrice,
+            epoch:             1
+        });
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
         assertEq(_ajnaToken.balanceOf(_bidder),  11_193.643043356438691840 * 1e18);
 
         expectedReserves = 0;
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              2875 minutes
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              2875 minutes
+        });
 
         // ensure take reverts after auction ends
         skip(72 hours);
 
-        _assertTakeReservesNoAuctionRevert(
-            {
-                amount: 777 * 1e18
-            }
-        );
+        _assertTakeReservesNoAuctionRevert({
+            amount: 777 * 1e18
+        });
 
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: 0,
-                auctionPrice:               0,
-                timeRemaining:              0
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: 0,
+            auctionPrice:               0,
+            timeRemaining:              0
+        });
     }
 
     function testReserveAuctionPartiallyTaken() external {
@@ -376,15 +356,13 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
         uint256 reserves          = 499.181304561658553626 * 1e18;
         uint256 claimableReserves = 101.229434828705361858 * 1e18;
-        _assertReserveAuction(
-            {
-                reserves:                   reserves,
-                claimableReserves :         claimableReserves,
-                claimableReservesRemaining: 0,
-                auctionPrice:               0,
-                timeRemaining:              0
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   reserves,
+            claimableReserves :         claimableReserves,
+            claimableReservesRemaining: 0,
+            auctionPrice:               0,
+            timeRemaining:              0
+        });
 
         // kick off a new auction
         uint256 expectedPrice     = 1_000_000_000 * 1e18;
@@ -392,60 +370,52 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         uint256 kickAward = Maths.wmul(expectedReserves, 0.01 * 1e18);
         expectedReserves -= kickAward;
 
-        _startClaimableReserveAuction(
-            {
-                from:              _bidder,
-                remainingReserves: expectedReserves,
-                price:             expectedPrice
-            }
-        );
+        _startClaimableReserveAuction({
+            from:              _bidder,
+            remainingReserves: expectedReserves,
+            price:             expectedPrice,
+            epoch:             1
+        });
         reserves          = 610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18;
         claimableReserves = 0;
-        _assertReserveAuction(
-            {
-                reserves:                   reserves,
-                claimableReserves :         claimableReserves,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              3 days
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   reserves,
+            claimableReserves :         claimableReserves,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              3 days
+        });
 
         // partial take
         skip(1 days);
 
         expectedPrice = 59.604644775390625 * 1e18;
         expectedReserves -= 100 * 1e18;
-        _takeReserves(
-            {
-                from:              _bidder,
-                amount:            100 * 1e18,
-                remainingReserves: expectedReserves,
-                price:             expectedPrice
-            }
-        );
-        _assertReserveAuction(
-            {
-                reserves:                   reserves,
-                claimableReserves :         claimableReserves,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              2 days
-            }
-        );
+        _takeReserves({
+            from:              _bidder,
+            amount:            100 * 1e18,
+            remainingReserves: expectedReserves,
+            price:             expectedPrice,
+            epoch:             1
+        });
+        _assertReserveAuction({
+            reserves:                   reserves,
+            claimableReserves :         claimableReserves,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              2 days
+        });
 
         // wait until auction ends
         skip(3 days);
         expectedPrice = 0;
-        _assertReserveAuction(
-            {
-                reserves:                   610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              0
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   610.479702351371553626 * 1e18 - 212.527832618418361858 * 1e18,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              0
+        });
 
         // after more interest accumulates, borrower repays remaining debt
         skip(4 weeks);
@@ -465,57 +435,49 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
 
         reserves = 442.433476150631444321 * 1e18;
         uint256 newClaimableReserves = reserves;
-        _assertReserveAuction(
-            {
-                reserves:                   reserves,
-                claimableReserves :         newClaimableReserves,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              0
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   reserves,
+            claimableReserves :         newClaimableReserves,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              0
+        });
         expectedPrice = 1_000_000_000 * 1e18;
         kickAward = Maths.wmul(newClaimableReserves, 0.01 * 1e18);
         expectedReserves += newClaimableReserves - kickAward;
-        _startClaimableReserveAuction(
-            {
-                from:              _bidder,
-                remainingReserves: expectedReserves,
-                price:             expectedPrice
-            }
-        );
+        _startClaimableReserveAuction({
+            from:              _bidder,
+            remainingReserves: expectedReserves,
+            price:             expectedPrice,
+            epoch:             2
+        });
 
         // take everything
         skip(28 hours);
         assertEq(expectedReserves, 438.226281869543438117 * 1e18);
         expectedPrice = 3.725290298461914062 * 1e18;
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              44 hours
-            }
-        );
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              44 hours
+        });
 
         expectedReserves = 0;
-        _takeReserves(
-            {
-                from:              _bidder,
-                amount:            600 * 1e18,
-                remainingReserves: expectedReserves,
-                price:             expectedPrice
-            }
-        );
-        _assertReserveAuction(
-            {
-                reserves:                   0,
-                claimableReserves :         0,
-                claimableReservesRemaining: expectedReserves,
-                auctionPrice:               expectedPrice,
-                timeRemaining:              44 hours
-            }
-        );
+        _takeReserves({
+            from:              _bidder,
+            amount:            600 * 1e18,
+            remainingReserves: expectedReserves,
+            price:             expectedPrice,
+            epoch:             2
+        });
+        _assertReserveAuction({
+            reserves:                   0,
+            claimableReserves :         0,
+            claimableReservesRemaining: expectedReserves,
+            auctionPrice:               expectedPrice,
+            timeRemaining:              44 hours
+        });
     }
 }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -356,11 +356,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     function _startClaimableReserveAuction(
         address from,
         uint256 remainingReserves,
-        uint256 price
+        uint256 price,
+        uint256 epoch
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
-        emit ReserveAuction(remainingReserves, price);
+        emit ReserveAuction(remainingReserves, price, epoch);
         _pool.startClaimableReserveAuction();
     }
 
@@ -384,11 +385,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         address from,
         uint256 amount,
         uint256 remainingReserves,
-        uint256 price
+        uint256 price,
+        uint256 epoch
     ) internal {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
-        emit ReserveAuction(remainingReserves, price);
+        emit ReserveAuction(remainingReserves, price, epoch);
         _pool.takeReserves(amount);
     }
 


### PR DESCRIPTION
- Include current burn epoch in ReserveAuction event
- Move start and take reserve auction logic from Pool contract to Auctions library

contract size reduced to
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,486B  (91.49%)
  ERC20Pool                -  21,918B  (89.18%)
  Auctions                 -  19,934B  (81.11%)
```

from

```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,762B  (92.62%)
  ERC20Pool                -  22,184B  (90.26%)
  Auctions                 -  19,710B  (80.20%)
```
