### PR TITLE
Calculate EMA of meaningful deposit, use in MAU calculation

### DIFF
--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -273,6 +273,7 @@ struct InflatorState {
 struct InterestState {
     uint208 interestRate;       // [WAD] pool's interest rate
     uint48  interestRateUpdate; // [SEC] last time pool's interest rate was updated (not before 12 hours passed)
+    uint256 depositEma;         // [WAD] sample of meaningful deposit EMA
     uint256 debtEma;            // [WAD] sample of debt EMA
     uint256 lupColEma;          // [WAD] sample of LUP price * collateral EMA. capped at 10 times current pool debt
 }

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -32,7 +32,7 @@ library PoolCommons {
     uint256 internal constant DECREASE_COEFFICIENT = 0.9 * 1e18;
     uint256 internal constant LAMBDA_EMA_7D        = 0.905723664263906671 * 1e18; // Lambda used for interest EMAs calculated as exp(-1/7   * ln2)
     uint256 internal constant EMA_7D_RATE_FACTOR   = 1e18 - LAMBDA_EMA_7D;
-    uint256 internal constant LAMBDA_EMA_12H       = 0.999807477651317445 * 1e18; // Lambda used for deposit EMA calculated as exp(-ln(2)*1/3600)
+    uint256 internal constant LAMBDA_EMA_12H       = 0.5 * 1e18;                  // Lambda used for deposit EMA calculated as exp(-ln(2)*1/3600)
     uint256 internal constant EMA_12H_RATE_FACTOR  = 1e18 - LAMBDA_EMA_12H;
     int256  internal constant PERCENT_102          = 1.02 * 1e18;
 

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -523,7 +523,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 7_469.035011263740962170 * 1e18
+            settledDebt: 7_433.761162745459786285 * 1e18
         });
 
         _assertPool(
@@ -532,8 +532,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             0,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 6848559808.279468915882431047 * 1e18,
-                poolDebt:             683.734754408473222865 * 1e18,
+                encumberedCollateral: 7012727628.807446392899253904 * 1e18,
+                poolDebt:             700.124659380139131420 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -427,7 +427,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 minDebtAmount:        799.050391373015819039 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
-                interestRate:         0.04455 * 1e18,
+                interestRate:         0.03645 * 1e18,
                 interestRateUpdate:   block.timestamp
             })
         );
@@ -436,10 +436,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_105.430237884635118282 * 1e18,
+            borrowerDebt:              8_084.412285638162564830 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.471136974495192174 * 1e18,
-            borrowerCollateralization: 0.000000012317209569 * 1e18
+            borrowerCollateralization: 0.000000012349231999 * 1e18
         });
 
         // kick borrower 2
@@ -459,30 +459,30 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          1_211.097645963067762922 * 1e18,
-                bondFactor:        0.149418058069566641 * 1e18,
+                bondSize:          1_225.788317396965189520 * 1e18,
+                bondFactor:        0.151623677032721326 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.529276179422528643 * 1e18,
-                totalBondEscrowed: 1_211.097645963067762922 * 1e18,
+                totalBondEscrowed: 1_225.788317396965189520 * 1e18,
                 auctionPrice:      0.595579761213908032 * 1e18,
-                debtInAuction:     8_195.704467159075241912 * 1e18,
-                thresholdPrice:    8.196162962286455648 * 1e18,
-                neutralPrice:      8.596021534820399875 * 1e18
+                debtInAuction:     8_158.081492591040321202 * 1e18,
+                thresholdPrice:    8.158387007288001486 * 1e18,
+                neutralPrice:      8.573731444741769263 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_196.162962286455648823 * 1e18,
+            borrowerDebt:              8_158.387007288001486366 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.471136974495192174 * 1e18,
-            borrowerCollateralization: 0.000000012180856255 * 1e18
+            borrowerCollateralization: 0.000000012237257536 * 1e18
         });
 
         _take({
             from:            _lender,
             borrower:        _borrower2,
             maxCollateral:   1_000.0 * 1e18,
-            bondChange:      88.990371346118344167 * 1e18,
+            bondChange:      90.303993361522878877 * 1e18,
             givenAmount:     595.579761213908032000 * 1e18,
             collateralTaken: 1_000 * 1e18,
             isReward:        true
@@ -492,22 +492,22 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             6_903.714005325230313356 * 1e18,
+                poolSize:             6_868.201140928720466905 * 1e18,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 82768556085.799578753126793220 * 1e18,
-                poolDebt:             8_263.304979778717856240 * 1e18,
+                encumberedCollateral: 82376848294.795087171258765602 * 1e18,
+                poolDebt:             8_224.198329945776437412 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174756997670024034 * 1e18,
+                targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.049005000000000000 * 1e18,
+                interestRate:         0.032805000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_263.304979778717856240 * 1e18,
+            borrowerDebt:              8_224.198329945776437412 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              8.471136974495192174 * 1e18,
             borrowerCollateralization: 0
@@ -535,11 +535,11 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 encumberedCollateral: 6848559808.279468915882431047 * 1e18,
                 poolDebt:             683.734754408473222865 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174756997670024034 * 1e18,
+                targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.049005000000000000 * 1e18,
+                interestRate:         0.032805000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1151,7 +1151,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             amount:       2_500 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
-            lpRedeemFrom: 2_499.810182702901761331 * 1e18,
+            lpRedeemFrom: 2_499.801225069756157243 * 1e18,
             lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
@@ -1163,19 +1163,19 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  9_000 * 1e18,
             index:   2873,
-            lpAward: 8_993.373316759001213155 * 1e18,
+            lpAward: 8_992.680876390590002224 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
-
+        
         // lender removes all their quote, with interest
         skip(1 hours);
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   5_003.981613396490344248 * 1e18,
+            amount:   5_004.377462406385073960 * 1e18,
             index:    2873,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 5_000.290483387144984401 * 1e18
+            lpRedeem: 5_000.299441020290588489 * 1e18
         });
 
         _removeAllLiquidity({

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1151,7 +1151,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             amount:       2_500 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
-            lpRedeemFrom: 2_499.801225069756157243 * 1e18,
+            lpRedeemFrom: 2_499.810182702901761331 * 1e18,
             lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
@@ -1163,7 +1163,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  9_000 * 1e18,
             index:   2873,
-            lpAward: 8_992.680876390590002224 * 1e18,
+            lpAward: 8_993.373316759001213155 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
         
@@ -1172,10 +1172,10 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   5_004.377462406385073960 * 1e18,
+            amount:   5_003.981613396490344248 * 1e18,
             index:    2873,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 5_000.299441020290588489 * 1e18
+            lpRedeem: 5_000.290483387144984401 * 1e18
         });
 
         _removeAllLiquidity({

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -961,22 +961,22 @@ contract RewardsManagerTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdTwo,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            28.767569698570175332 * 1e18,
+            reward:            30.544499416187009794 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterTwoBalance = _ajnaToken.balanceOf(_minterTwo);
-        assertEq(minterTwoBalance, 28.767569698570175332 * 1e18);
+        assertEq(minterTwoBalance, 30.544499416187009794 * 1e18);
 
         _unstakeToken({
             minter:            _minterThree,
             pool:              address(_poolOne),
             tokenId:           tokenIdThree,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            23.965537532955127777 * 1e18,
+            reward:            25.446417670471808628 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterThreeBalance = _ajnaToken.balanceOf(_minterThree);
-        assertEq(minterThreeBalance, 23.965537532955127777 * 1e18);
+        assertEq(minterThreeBalance, 25.446417670471808628 * 1e18);
 
         assertGt(minterTwoBalance, minterThreeBalance);
     }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
This is an implementation of the Monday (2023.02.27) design which calculates MAU using a 12-hour EMA of meaningful deposit, rather than the actual deposit amount.  This may be abandoned in favor of the Tuesday (2023.02.28) design change to keep an EMA of the MAU rather than meaningful deposit.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
Reduces impact of deposit manipulation for the purpose of disturbing interest rates.

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,480B  (91.47%)
  ERC20Pool                -  22,161B  (90.17%)
  Auctions                 -  20,191B  (82.15%)
  PositionManager          -  18,315B  (74.52%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,444B  (91.32%)
  ERC20Pool                -  22,125B  (90.02%)
  Auctions                 -  20,172B  (82.08%)
  PositionManager          -  18,315B  (74.52%)
```

# Gas usage
## Pre Change
```
| addCollateral(uint256,uint256,uint256)                                   | 187240          | 187240 | 187240 | 187240 | 1       |
| addCollateral(uint256,uint256,uint256)(uint256)                          | 715             | 152484 | 143426 | 396280 | 29      |
| addQuoteToken(uint256,uint256,uint256)                                   | 154833          | 298150 | 246141 | 450368 | 11      |
| addQuoteToken(uint256,uint256,uint256)(uint256)                          | 714             | 231189 | 172698 | 693533 | 599     |
| bucketCollateralDust                                                     | 790             | 1768   | 790    | 2902   | 15      |
| bucketExchangeRate                                                       | 14099           | 16083  | 15692  | 18413  | 339     |
| bucketInfo                                                               | 3739            | 7379   | 5431   | 43537  | 1933    |
| bucketTake                                                               | 8128            | 128720 | 132840 | 387104 | 36      |
| drawDebt                                                                 | 11109           | 171617 | 150072 | 595435 | 671     |
| kick                                                                     | 29085           | 450084 | 557313 | 681313 | 48      |
| kickWithDeposit                                                          | 71233           | 286517 | 223691 | 665649 | 19      |
| kickerInfo                                                               | 774             | 1869   | 774    | 4774   | 146     |
| moveQuoteToken(uint256,uint256,uint256,uint256)                          | 107426          | 170792 | 159568 | 271842 | 5       |
| moveQuoteToken(uint256,uint256,uint256,uint256)(uint256,uint256,uint256) | 758             | 124704 | 92936  | 632262 | 23      |
| removeCollateral                                                         | 3900            | 53586  | 56841  | 127780 | 65      |
| removeQuoteToken                                                         | 3922            | 61594  | 55641  | 564345 | 373     |
| repayDebt                                                                | 6248            | 110297 | 68244  | 460856 | 255     |
| settle                                                                   | 9790            | 193726 | 150179 | 402339 | 18      |
| take                                                                     | 8550            | 166950 | 187403 | 520219 | 34      |
| takeReserves                                                             | 69426           | 102052 | 124055 | 131660 | 22      |
```
## Post Change
```
| addCollateral(uint256,uint256,uint256)          | 182751          | 182751 | 182751 | 182751 | 1       |
| addCollateral(uint256,uint256,uint256)(uint256) | 715             | 151510 | 143426 | 419197 | 29      |
| addQuoteToken(uint256,uint256,uint256)          | 345133          | 410966 | 450065 | 450368 | 7       |
| addQuoteToken(uint256,uint256,uint256)(uint256) | 714             | 231011 | 175067 | 693570 | 617     |
| bucketCollateralDust                            | 790             | 1629   | 790    | 2902   | 15      |
| bucketExchangeRate                              | 14099           | 16085  | 15675  | 18413  | 408     |
| bucketInfo                                      | 3739            | 7269   | 5458   | 47839  | 2117    |
| bucketTake                                      | 8128            | 127496 | 132840 | 362311 | 36      |
| drawDebt                                        | 11109           | 174729 | 150275 | 595472 | 690     |
| kick                                            | 29085           | 466205 | 580230 | 704230 | 48      |
| kickWithDeposit                                 | 71233           | 286181 | 223691 | 670965 | 19      |
| kickerInfo                                      | 774             | 1869   | 774    | 4774   | 146     |
| moveQuoteToken                                  | 758             | 136419 | 110823 | 655179 | 28      |
| removeCollateral                                | 3900            | 53626  | 56177  | 127817 | 64      |
| removeQuoteToken                                | 3922            | 61687  | 55338  | 587262 | 384     |
| repayDebt                                       | 6248            | 119805 | 69013  | 479169 | 274     |
| settle                                          | 9790            | 195152 | 150179 | 425256 | 18      |
| take                                            | 8550            | 167275 | 187437 | 520252 | 34      |
| takeReserves                                    | 69426           | 86932  | 69426  | 131660 | 41      |
```

