### PR TITLE
Remove early withdrawal penalty, implement unutilized deposit fee

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -6,7 +6,7 @@ import { IPool, IERC20Token } from './interfaces/pool/IPool.sol';
 
 import {
     _claimableReserves,
-    _feeRate,
+    _borrowFeeRate,
     _indexOf,
     _lpsToCollateral,
     _lpsToQuoteToken,
@@ -336,14 +336,14 @@ contract PoolInfoUtils {
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
      *  @return Fee rate calculated from the given interest rate.
      */
-    function feeRate(
+    function borrowFeeRate(
         address ajnaPool_
     ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
 
         (uint256 interestRate,) = pool.interestRateInfo();
 
-        return _feeRate(interestRate);
+        return _borrowFeeRate(interestRate);
     }
 
     /**

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -7,6 +7,7 @@ import { IPool, IERC20Token } from './interfaces/pool/IPool.sol';
 import {
     _claimableReserves,
     _borrowFeeRate,
+    _depositFeeRate,
     _indexOf,
     _lpsToCollateral,
     _lpsToQuoteToken,
@@ -334,7 +335,7 @@ contract PoolInfoUtils {
     /**
      *  @notice Calculates origination fee rate for a pool.
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
-     *  @return Fee rate calculated from the given interest rate.
+     *  @return Fee rate calculated from the pool interest rate.
      */
     function borrowFeeRate(
         address ajnaPool_
@@ -344,6 +345,21 @@ contract PoolInfoUtils {
         (uint256 interestRate,) = pool.interestRateInfo();
 
         return _borrowFeeRate(interestRate);
+    }
+
+    /**
+     *  @notice Calculates unutilized deposit fee for a pool.
+     *  @notice Calculated as current annualized rate divided by 365 (24 hours of interest).
+     *  @return Fee rate calculated from the pool interest rate.
+     */
+    function unutilizedDepositFeeRate(
+        address ajnaPool_
+    ) external view returns (uint256) {
+        IPool pool = IPool(ajnaPool_);
+
+        (uint256 interestRate,) = pool.interestRateInfo();
+
+        return _depositFeeRate(interestRate);  
     }
 
     /**

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -348,7 +348,7 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculates unutilized deposit fee for a pool.
+     *  @notice Calculates unutilized deposit fee rate for a pool.
      *  @notice Calculated as current annualized rate divided by 365 (24 hours of interest).
      *  @return Fee rate calculated from the pool interest rate.
      */

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -340,10 +340,7 @@ contract PoolInfoUtils {
     function borrowFeeRate(
         address ajnaPool_
     ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (uint256 interestRate,) = pool.interestRateInfo();
-
+        (uint256 interestRate,) = IPool(ajnaPool_).interestRateInfo();
         return _borrowFeeRate(interestRate);
     }
 
@@ -355,10 +352,7 @@ contract PoolInfoUtils {
     function unutilizedDepositFeeRate(
         address ajnaPool_
     ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (uint256 interestRate,) = pool.interestRateInfo();
-
+        (uint256 interestRate,) = IPool(ajnaPool_).interestRateInfo();
         return _depositFeeRate(interestRate);  
     }
 

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -332,9 +332,9 @@ contract PoolInfoUtils {
     }
 
     /**
-     *  @notice Calculates fee rate for a pool.
+     *  @notice Calculates origination fee rate for a pool.
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
-     *  @return Fee rate applied to the given interest rate.
+     *  @return Fee rate calculated from the given interest rate.
      */
     function feeRate(
         address ajnaPool_

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -16,7 +16,7 @@ import {
 }                   from '../../interfaces/pool/commons/IPoolInternals.sol';
 
 import {
-    _feeRate,
+    _borrowFeeRate,
     _priceAt,
     _isCollateralized
 }                           from '../helpers/PoolHelper.sol';
@@ -185,7 +185,7 @@ library BorrowerActions {
             vars.t0BorrowAmount = Maths.wdiv(amountToBorrow_, poolState_.inflator);
 
             // t0 debt change is t0 amount to borrow plus the origination fee
-            vars.t0DebtChange = Maths.wmul(vars.t0BorrowAmount, _feeRate(poolState_.rate) + Maths.WAD);
+            vars.t0DebtChange = Maths.wmul(vars.t0BorrowAmount, _borrowFeeRate(poolState_.rate) + Maths.WAD);
 
             borrower.t0Debt += vars.t0DebtChange;
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -160,7 +160,8 @@ library LenderActions {
 
         // charge unutilized deposit fee where appropriate
         uint256 lupIndex = Deposits.findIndexOfSum(deposits_, poolState_.debt);
-        if (lupIndex != 0 && params_.index > lupIndex) {
+        bool depositBelowLup = lupIndex != 0 && params_.index > lupIndex;
+        if (depositBelowLup) {
             addedAmount = Maths.wmul(addedAmount, Maths.WAD - _depositFeeRate(poolState_.rate));
         }
 
@@ -186,7 +187,7 @@ library LenderActions {
         bucket.lps += bucketLPs_;
 
         // only need to recalculate LUP if the deposit was above it
-        if (params_.amount == addedAmount) {
+        if (!depositBelowLup) {
             lupIndex = Deposits.findIndexOfSum(deposits_, poolState_.debt);
         }
         lup_ = _priceAt(lupIndex);

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -185,7 +185,11 @@ library LenderActions {
         // update bucket LPs
         bucket.lps += bucketLPs_;
 
-        lup_ = _lup(deposits_, poolState_.debt);
+        // only need to recalculate LUP if the deposit was above it
+        if (params_.amount == addedAmount) {
+            lupIndex = Deposits.findIndexOfSum(deposits_, poolState_.debt);
+        }
+        lup_ = _priceAt(lupIndex);
 
         emit AddQuoteToken(msg.sender, params_.index, addedAmount, bucketLPs_, lup_);
     }
@@ -255,8 +259,6 @@ library LenderActions {
                 dustLimit:         poolState_.quoteDustLimit
             })
         );
-
-        vars.ptp = _ptp(poolState_.debt, poolState_.collateral);
 
         vars.toBucketUnscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.toIndex);
         vars.toBucketScale           = Deposits.scale(deposits_, params_.toIndex);

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -14,7 +14,7 @@ import {
     PoolState
 }                     from '../../interfaces/pool/commons/IPoolState.sol';
 
-import { _feeRate, _priceAt, _ptp, MAX_FENWICK_INDEX } from '../helpers/PoolHelper.sol';
+import { _priceAt, _ptp, MAX_FENWICK_INDEX } from '../helpers/PoolHelper.sol';
 
 import { Deposits } from '../internal/Deposits.sol';
 import { Buckets }  from '../internal/Buckets.sol';

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -251,13 +251,6 @@ library LenderActions {
 
         vars.ptp = _ptp(poolState_.debt, poolState_.collateral);
 
-        // apply early withdrawal penalty if quote token is moved from above the PTP to below the PTP
-        if (vars.fromBucketDepositTime != 0 && block.timestamp - vars.fromBucketDepositTime < 1 days) {
-            if (vars.fromBucketPrice > vars.ptp && vars.toBucketPrice < vars.ptp) {
-                movedAmount_ = Maths.wmul(movedAmount_, Maths.WAD - _feeRate(poolState_.rate));
-            }
-        }
-
         vars.toBucketUnscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.toIndex);
         vars.toBucketScale           = Deposits.scale(deposits_, params_.toIndex);
         vars.toBucketDeposit         = Maths.wmul(vars.toBucketUnscaledDeposit, vars.toBucketScale);
@@ -367,13 +360,6 @@ library LenderActions {
             deposits_,
             removeParams
         );
-
-        // apply early withdrawal penalty if quote token is removed from above the PTP
-        if (depositTime != 0 && block.timestamp - depositTime < 1 days) {
-            if (removeParams.price > _ptp(poolState_.debt, poolState_.collateral)) {
-                removedAmount_ = Maths.wmul(removedAmount_, Maths.WAD - _feeRate(poolState_.rate));
-            }
-        }
 
         lup_ = _lup(deposits_, poolState_.debt);
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -110,13 +110,25 @@ import { Maths }   from '../internal/Maths.sol';
      *  @notice Calculates origination fee for a given interest rate.
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
      *  @param  interestRate_ The current interest rate.
-     *  @return Fee rate applied to the given interest rate.
+     *  @return Fee rate based upon the given interest rate.
      */
     function _borrowFeeRate(
         uint256 interestRate_
     ) pure returns (uint256) {
         // greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps
         return Maths.max(Maths.wdiv(interestRate_, 52 * 1e18), 0.0005 * 1e18);
+    }
+
+    /**
+     * @notice Calculates the unutilized deposit fee, charged to lenders who deposit below the LUP.
+     * @param  interestRate_ The current interest rate.
+     * @return Fee rate based upon the given interest rate.
+     */
+    function _depositFeeRate(
+        uint256 interestRate_
+    ) pure returns (uint256) {
+        // current annualized rate divided by 365 (24 hours of interest)
+        return Maths.wdiv(interestRate_, 365 * 1e18);
     }
 
     /**

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -107,12 +107,12 @@ import { Maths }   from '../internal/Maths.sol';
     }
 
     /**
-     *  @notice Calculates fee rate for a given interest rate.
+     *  @notice Calculates origination fee for a given interest rate.
      *  @notice Calculated as greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps.
      *  @param  interestRate_ The current interest rate.
      *  @return Fee rate applied to the given interest rate.
      */
-    function _feeRate(
+    function _borrowFeeRate(
         uint256 interestRate_
     ) pure returns (uint256) {
         // greater of the current annualized interest rate divided by 52 (one week of interest) or 5 bps

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -960,7 +960,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         );
     }
 
-    function testPoolBorrowRepayAndRemoveWithPenalty() external tearDown {
+    function testPoolBorrowRepayAndRemove() external tearDown {
         // check balances before borrow
         assertEq(_quote.balanceOf(_lender), 150_000 * 1e18);
 
@@ -1007,8 +1007,6 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             newLup:  2_981.007422784467321543 * 1e18
         });
 
-        // penalty should not be applied on buckets with prices lower than PTP
-
         assertEq(_quote.balanceOf(_lender), 140_000 * 1e18);
 
         _removeAllLiquidity({
@@ -1019,7 +1017,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 150_000 * 1e18); // no tokens paid as penalty
+        assertEq(_quote.balanceOf(_lender), 150_000 * 1e18);
 
         // repay entire loan
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 40 * 1e18);
@@ -1045,22 +1043,22 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lupIndex: 0
         });
 
-        // lender removes everything from above PTP, penalty should be applied
+        // lender removes everything from above PTP
         uint256 snapshot = vm.snapshot();
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   9_990.384615384615380000 * 1e18,
+            amount:   10_000.000000000000000000 * 1e18,
             index:    highest,
             newLup:   MAX_PRICE,
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 159_990.384615384615380000 * 1e18); // 5 tokens paid as penalty
+        assertEq(_quote.balanceOf(_lender), 160_000 * 1e18);
 
         vm.revertTo(snapshot);
 
-        // borrower pulls first all their collateral pledged, PTP goes to 0, penalty should be applied
+        // borrower pulls first all their collateral pledged, PTP goes to 0
         _repayDebtNoLupCheck({
             from:             _borrower,
             borrower:         _borrower,
@@ -1074,15 +1072,15 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   9_990.384615384615380000 * 1e18,
+            amount:   10_000 * 1e18,
             index:    highest,
             newLup:   MAX_PRICE,
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 159_990.384615384615380000 * 1e18); // 5 tokens paid as penalty
+        assertEq(_quote.balanceOf(_lender), 160_000 * 1e18);
 
-        // lender removes everything from price above PTP after 24 hours, penalty should not be applied
+        // lender removes everything from price above PTP after 24 hours
         skip(1 days);
 
         _removeAllLiquidity({
@@ -1093,7 +1091,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 169_990.384615384615380000 * 1e18); // no tokens paid as penalty
+        assertEq(_quote.balanceOf(_lender), 170_000 * 1e18);
     }
 }
 

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -999,25 +999,27 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lupIndex: 2_552
         });
 
-        _addLiquidity({
-            from:    _lender,
-            amount:  10_000 * 1e18,
-            index:   _indexOf(200 * 1e18),
-            lpAward: 10_000 * 1e18,
-            newLup:  2_981.007422784467321543 * 1e18
+        // add liquidity below LUP, ensuring fee is levied
+        _addLiquidityWithPenalty({
+            from:        _lender,
+            amount:      10_000 * 1e18,
+            amountAdded: 9_998.630136986301370000 * 1e18,
+            index:       _indexOf(200 * 1e18),
+            lpAward:     9_998.630136986301370000 * 1e18,
+            newLup:      2_981.007422784467321543 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 140_000 * 1e18);
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   10_000 * 1e18,
+            amount:   9_998.630136986301370000 * 1e18,
             index:    _indexOf(200 * 1e18),
             newLup:   2_981.007422784467321543 * 1e18,
-            lpRedeem: 10_000 * 1e18
+            lpRedeem: 9_998.630136986301370000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 150_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 149_998.630136986301370000 * 1e18);
 
         // repay entire loan
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 40 * 1e18);
@@ -1054,7 +1056,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 160_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 159_998.630136986301370000 * 1e18);
 
         vm.revertTo(snapshot);
 
@@ -1078,7 +1080,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 160_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 159_998.630136986301370000 * 1e18);
 
         // lender removes everything from price above PTP after 24 hours
         skip(1 days);
@@ -1091,7 +1093,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             lpRedeem: 10_000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), 170_000 * 1e18);
+        assertEq(_quote.balanceOf(_lender), 169_998.630136986301370000 * 1e18);
     }
 }
 

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -898,7 +898,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         });
         _removeAllLiquidity({
             from:     _lender,
-            amount:   2722,
+            amount:   2725,
             index:    2570,
             newLup:   MAX_PRICE,
             lpRedeem: 2725
@@ -929,7 +929,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         // bucket should be cleaned out if quote token swap happens first
         _removeAllLiquidity({
             from:     _lender,
-            amount:   2722,
+            amount:   2725,
             index:    2570,
             newLup:   MAX_PRICE,
             lpRedeem: 2725

--- a/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -210,6 +210,10 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
         assertEq(_poolUtils.borrowFeeRate(address(_pool)), 0.000961538461538462 * 1e18);
     }
 
+    function testUnutilizedDepositFeeRate() external {
+        assertEq(_poolUtils.unutilizedDepositFeeRate(address(_pool)), 0.000136986301369863 * 1e18);
+    }
+
     function testPoolInfoUtilsLPsToCollateralAndQuote() external {
         assertEq(
             _poolUtils.lpsToCollateral(

--- a/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -206,8 +206,8 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
         assertEq(_poolUtils.momp(address(_pool)), 2_981.007422784467321543 * 1e18);
     }
 
-    function testPoolFeeRate() external {
-        assertEq(_poolUtils.feeRate(address(_pool)), 0.000961538461538462 * 1e18);
+    function testBorrowFeeRate() external {
+        assertEq(_poolUtils.borrowFeeRate(address(_pool)), 0.000961538461538462 * 1e18);
     }
 
     function testPoolInfoUtilsLPsToCollateralAndQuote() external {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -224,12 +224,13 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
 
         // add liquidity to accrue interest and update reserves before arb take
-        _addLiquidity({
-            from:    _lender1,
-            amount:  1 * 1e18,
-            index:   _i9_52,
-            lpAward: 0.99999682656208 * 1e18,
-            newLup:  9.721295865031779605 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender1,
+            amount:      1 * 1e18,
+            amountAdded: 0.999876712328767123 * 1e18,
+            index:       _i9_52,
+            lpAward:     0.999873539282092894 * 1e18,
+            newLup:      9.721295865031779605 * 1e18
         });
 
         _assertBucket({
@@ -240,7 +241,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             exchangeRate: 1.013503541960817259 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   23.911413759224212224 * 1e18,
+            reserves:                   23.911537046895445101 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -306,7 +307,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         // reserves should remain the same after arb take
         _assertReserveAuction({
-            reserves:                   25.295951940381566551 * 1e18,
+            reserves:                   25.296075228052799428 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -222,12 +222,13 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
 
         // add liquidity to accrue interest and update reserves before deposit take
-        _addLiquidity({
-            from:    _lender1,
-            amount:  1 * 1e18,
-            index:   _i9_52,
-            lpAward: 0.999996755983514720 * 1e18,
-            newLup:  9.721295865031779605 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender1,
+            amount:      1 * 1e18,
+            amountAdded: 0.999876712328767123 * 1e18,
+            index:       _i9_52,
+            lpAward:     0.999873468712229081 * 1e18,
+            newLup:      9.721295865031779605 * 1e18
         });
 
         _assertBucket({
@@ -238,8 +239,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             exchangeRate: 1.000003244027008957 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   286.940475866492567343 * 1e18,
-            claimableReserves :         245.508339417301835201 * 1e18,
+            reserves:                   286.940599154163800220 * 1e18,
+            claimableReserves :         245.508462704973068078 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -304,8 +305,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         // reserves should remain the same after deposit take
         _assertReserveAuction({
-            reserves:                   288.353757763140844694 * 1e18,
-            claimableReserves :         247.012735034416886695 * 1e18,
+            reserves:                   288.353881050812077571 * 1e18,
+            claimableReserves :         247.012858322088119572 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -1314,12 +1314,13 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
         });
 
         // Lender 2 adds Quote token at a much lower price the tries to kick with deposit
-        _addLiquidity({
-            from:    _lender3,
-            amount:  150_000 * 1e18,
-            index:   7000,
-            lpAward: 150_000 * 1e18,
-            newLup:  3_844.432207828138682757 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender3,
+            amount:      150_000 * 1e18,
+            amountAdded: 149_979.452054794520550000 * 1e18,
+            index:       7000,
+            lpAward:     149_979.452054794520550000 * 1e18,
+            newLup:      3_844.432207828138682757 * 1e18
         });
 
         _assertKickPriceBelowProposedLupRevert({

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -523,7 +523,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 7_468.035011263740962170 * 1e18
+            settledDebt: 7_469.035011263740962170 * 1e18
         });
 
         _assertPool(
@@ -532,8 +532,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             0,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 6858724440.814063856459349796 * 1e18,
-                poolDebt:             684.749553537669941064 * 1e18,
+                encumberedCollateral: 6848559808.279468915882431047 * 1e18,
+                poolDebt:             683.734754408473222865 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.174756997670024034 * 1e18,
                 minDebtAmount:        0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -730,12 +730,13 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         });
 
         // adding to a different bucket for testing move in same block with bucket bankruptcy
-        _addLiquidity({
-            from:   _lender1,
-            amount: 100 * 1e18,
-            index:  _i9_52,
-            lpAward: 100 * 1e18,
-            newLup: 9.721295865031779605 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender1,
+            amount:      100 * 1e18,
+            amountAdded: 99.987671232876712300 * 1e18,
+            index:       _i9_52,
+            lpAward:     99.987671232876712300 * 1e18,
+            newLup:      9.721295865031779605 * 1e18
         });
 
         // settle to make buckets insolvent

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1122,14 +1122,13 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         // lender moves some liquidity below the pool threshold price; penalty should be assessed
         skip(16 hours);
 
-        _moveLiquidityWithPenalty({
+        _moveLiquidity({
             from:         _lender,
             amount:       2_500 * 1e18,
-            amountMoved:  2_497.596153846153845 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
             lpRedeemFrom: 2_499.899333909953254268000000000 * 1e18,
-            lpAwardTo:    2_497.596153846153845 * 1e18,
+            lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
 
@@ -1181,10 +1180,10 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   4_997.596153846153845 * 1e18,
+            amount:   5_000 * 1e18,
             index:    2954,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 4_997.596153846153845 * 1e18
+            lpRedeem: 5_000 * 1e18
         });
 
         assertGt(_quote.balanceOf(_lender), 200_000 * 1e18);

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -727,17 +727,11 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             depositTime: _startTime + 1 minutes
         });
 
-        // lender makes a partial withdrawal, paying an early withdrawal penalty - current annualized interest rate divided by 52 (one week of interest)
-        (uint256 interestRate, ) = _pool.interestRateInfo();
-        uint256 penalty = Maths.WAD - Maths.wdiv(interestRate, 52 * 10**18);
-        assertLt(penalty, Maths.WAD);
-
-        uint256 expectedWithdrawal1 = Maths.wmul(1_700 * 1e18, penalty);
-
-        _removeLiquidityWithPenalty({
+        // lender makes a partial withdrawal
+        uint256 withdrawal1 = 1_700 * 1e18;
+        _removeLiquidity({
             from:          _lender,
-            amount:        1_700 * 1e18,
-            amountRemoved: expectedWithdrawal1,
+            amount:        withdrawal1,
             index:         1606,
             newLup:        _priceAt(1663),
             lpRedeem:      1_699.988795593461528952000000000 * 1e18
@@ -749,7 +743,6 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         assertGt(_priceAt(1606), _htp());
 
         uint256 expectedWithdrawal2 = 1_700.144243451229452671 * 1e18;
-
         _removeAllLiquidity({
             from:     _lender,
             amount:   expectedWithdrawal2,
@@ -758,7 +751,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             lpRedeem: 1_700.011204406538471048000000000 * 1e18
         });
 
-        assertEq(_quote.balanceOf(_lender), lenderBalanceBefore + expectedWithdrawal1 + expectedWithdrawal2);
+        assertEq(_quote.balanceOf(_lender), lenderBalanceBefore + withdrawal1 + expectedWithdrawal2);
 
         _assertBucket({
             index:        1606,

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -851,7 +851,7 @@ abstract contract ERC721FuzzyHelperContract is ERC721DSTestPlus {
         // calculate the required collateral based upon the borrow amount and index price
         (uint256 interestRate, ) = _pool.interestRateInfo();
         uint256 newInterestRate = Maths.wmul(interestRate, 1.1 * 10**18); // interest rate multipled by increase coefficient
-        uint256 expectedDebt = Maths.wmul(borrowAmount, _feeRate(newInterestRate) + Maths.WAD);
+        uint256 expectedDebt = Maths.wmul(borrowAmount, _borrowFeeRate(newInterestRate) + Maths.WAD);
 
         // get an integer amount rounding up
         requiredCollateral_ = 1 + Maths.wdiv(expectedDebt, _poolUtils.indexToPrice(indexPrice)) / 1e18;

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -1075,7 +1075,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   9.987201910492245717 * 1e18,
+            amount:   9.999999987399196031 * 1e18,
             index:    7388,
             newLup:   MAX_PRICE,
             lpRedeem: 9.999999987399196031 * 1e18

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -433,12 +433,13 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         assertEq(ERC721Pool(address(_pool)).bucketTokenIds(1), 1);
 
         // lender adds liquidity in min bucket and merge / removes the other 2 NFTs
-        _addLiquidity({
-            from:    _lender,
-            amount:  100 * 1e18,
-            index:   MAX_FENWICK_INDEX,
-            lpAward: 100 * 1e18,
-            newLup:  3_806.274307891526195092 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender,
+            amount:      100 * 1e18,
+            amountAdded: 99.984931506849315100 * 1e18,
+            index:       MAX_FENWICK_INDEX,
+            lpAward:     99.984931506849315100 * 1e18,
+            newLup:      3_806.274307891526195092 * 1e18
         });
 
         uint256[] memory removalIndexes = new uint256[](3);
@@ -587,12 +588,13 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
 
         // lender adds liquidity in bucket 6113 and merge / removes the other 2 NFTs
-        _addLiquidity({
-            from:    _lender,
-            amount:  1000 * 1e18,
-            index:   6113,
-            lpAward: 1_000 * 1e18,
-            newLup:  3_844.432207828138682757 * 1e18
+        _addLiquidityWithPenalty({
+            from:        _lender,
+            amount:      1000 * 1e18,
+            amountAdded: 999.849315068493151000 * 1e18,
+            index:       6113,
+            lpAward:     999.849315068493151000 * 1e18,
+            newLup:      3_844.432207828138682757 * 1e18
         });
         uint256[] memory removalIndexes = new uint256[](2);
         removalIndexes[0] = 2500;

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -618,7 +618,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // borrower removes tokens from auction price bucket for compensated collateral fraction
         _removeAllLiquidity({
             from:     _borrower,
-            amount:   0.000008757551393712 * 1e18,
+            amount:   0.000008766823996015 * 1e18,
             index:    6113,
             newLup:   MAX_PRICE,
             lpRedeem: 0.000008766823996015 * 1e18
@@ -781,7 +781,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // borrower removes tokens from auction price bucket for compensated collateral fraction
         _removeAllLiquidity({
             from:     _borrower,
-            amount:   0.000008757551393712 * 1e18,
+            amount:   0.000008766823996015 * 1e18,
             index:    6113,
             newLup:   MAX_PRICE,
             lpRedeem: 0.000008766823996015 * 1e18
@@ -957,7 +957,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // borrower removes tokens from auction price bucket for compensated collateral fraction
         _removeAllLiquidity({
             from:     _borrower,
-            amount:   15_113.342952807040348884 * 1e18,
+            amount:   15_127.888999922350308085 * 1e18,
             index:    2222,
             newLup:   MAX_PRICE,
             lpRedeem: 15_127.888999922350308085 * 1e18
@@ -1125,7 +1125,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // borrower removes tokens from auction price bucket for compensated collateral fraction
         _removeAllLiquidity({
             from:     _borrower,
-            amount:   0.000027911002546377 * 1e18,
+            amount:   0.000027940555056533 * 1e18,
             index:    6113,
             newLup:   MAX_PRICE,
             lpRedeem: 0.000027940555056533 * 1e18

--- a/tests/forge/PoolHelperTest.t.sol
+++ b/tests/forge/PoolHelperTest.t.sol
@@ -113,11 +113,11 @@ contract PoolHelperTest is DSTestPlus {
     /**
      *  @notice Tests fee rate for originations
      */
-    function testFeeRate() external {
+    function testBorrowFeeRate() external {
         uint256 interestRate = 0.12 * 1e18;
-        assertEq(_feeRate(interestRate),  0.002307692307692308 * 1e18);
-        assertEq(_feeRate(0.52 * 1e18),     0.01 * 1e18);
-        assertEq(_feeRate(0.26 * 1e18),     0.005 * 1e18);
+        assertEq(_borrowFeeRate(interestRate),  0.002307692307692308 * 1e18);
+        assertEq(_borrowFeeRate(0.52 * 1e18),     0.01 * 1e18);
+        assertEq(_borrowFeeRate(0.26 * 1e18),     0.005 * 1e18);
     }
 
     /**

--- a/tests/forge/PoolHelperTest.t.sol
+++ b/tests/forge/PoolHelperTest.t.sol
@@ -115,9 +115,18 @@ contract PoolHelperTest is DSTestPlus {
      */
     function testBorrowFeeRate() external {
         uint256 interestRate = 0.12 * 1e18;
-        assertEq(_borrowFeeRate(interestRate),  0.002307692307692308 * 1e18);
-        assertEq(_borrowFeeRate(0.52 * 1e18),     0.01 * 1e18);
-        assertEq(_borrowFeeRate(0.26 * 1e18),     0.005 * 1e18);
+        assertEq(_borrowFeeRate(interestRate), 0.002307692307692308 * 1e18);
+        assertEq(_borrowFeeRate(0.52 * 1e18),  0.01 * 1e18);
+        assertEq(_borrowFeeRate(0.26 * 1e18),  0.005 * 1e18);
+    }
+
+    /**
+     *  @notice Tests fee rate for depositing under the LUP
+     */
+    function testDepositFeeRate() external {
+        uint256 interestRate = 0.07 * 1e18;
+        assertEq(_depositFeeRate(interestRate), 0.000191780821917808 * 1e18);
+        assertEq(_depositFeeRate(0.2 * 1e18),   0.000547945205479452 * 1e18);
     }
 
     /**

--- a/tests/forge/PoolHelperTest.t.sol
+++ b/tests/forge/PoolHelperTest.t.sol
@@ -111,7 +111,7 @@ contract PoolHelperTest is DSTestPlus {
     }
 
     /**
-     *  @notice Tests fee rate for early withdrawals
+     *  @notice Tests fee rate for originations
      */
     function testFeeRate() external {
         uint256 interestRate = 0.12 * 1e18;

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -13,7 +13,7 @@ import 'src/interfaces/position/IPositionManager.sol';
 import 'src/PositionManager.sol';
 import 'src/PoolInfoUtils.sol';
 
-import { _feeRate } from 'src/libraries/helpers/PoolHelper.sol';
+import { _borrowFeeRate } from 'src/libraries/helpers/PoolHelper.sol';
 
 import { DSTestPlus }  from './utils/DSTestPlus.sol';
 import { Token }       from './utils/Tokens.sol';
@@ -1467,7 +1467,7 @@ contract RewardsManagerTest is DSTestPlus {
         // calculate the required collateral based upon the borrow amount and index price
         (uint256 interestRate, ) = pool_.interestRateInfo();
         uint256 newInterestRate = Maths.wmul(interestRate, 1.1 * 10**18); // interest rate multipled by increase coefficient
-        uint256 expectedDebt = Maths.wmul(borrowAmount, _feeRate(newInterestRate) + Maths.WAD);
+        uint256 expectedDebt = Maths.wmul(borrowAmount, _borrowFeeRate(newInterestRate) + Maths.WAD);
         requiredCollateral_ = Maths.wdiv(expectedDebt, _poolUtils.indexToPrice(indexPrice)) + Maths.WAD;
     }
     

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -961,22 +961,22 @@ contract RewardsManagerTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdTwo,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            20.035397317001861795 * 1e18,
+            reward:            28.767569698570175332 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterTwoBalance = _ajnaToken.balanceOf(_minterTwo);
-        assertEq(minterTwoBalance, 20.035397317001861795 * 1e18);
+        assertEq(minterTwoBalance, 28.767569698570175332 * 1e18);
 
         _unstakeToken({
             minter:            _minterThree,
             pool:              address(_poolOne),
             tokenId:           tokenIdThree,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            16.692493739675875940 * 1e18,
+            reward:            23.965537532955127777 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterThreeBalance = _ajnaToken.balanceOf(_minterThree);
-        assertEq(minterThreeBalance, 16.692493739675875940 * 1e18);
+        assertEq(minterThreeBalance, 23.965537532955127777 * 1e18);
 
         assertGt(minterTwoBalance, minterThreeBalance);
     }
@@ -1033,7 +1033,7 @@ contract RewardsManagerTest is DSTestPlus {
         uint256 tokenIdTwo = _mintAndMemorializePositionNFT(mintMemorializeParams);
         // second depositor stakes NFT, generating an update reward
         _stakeToken(address(_poolOne), _minterTwo, tokenIdTwo);
-        assertEq(_ajnaToken.balanceOf(_minterTwo), 8.038657281009010230 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), 8.038290823108615564 * 1e18);
 
         // calculate rewards earned since exchange rates have been updated
         uint256 idOneRewardsAtOne = _rewardsManager.calculateRewards(tokenIdOne, _poolOne.currentBurnEpoch());
@@ -1099,11 +1099,11 @@ contract RewardsManagerTest is DSTestPlus {
 
         // minter two claims rewards accrued since deposit
         changePrank(_minterTwo);
-        assertEq(_ajnaToken.balanceOf(_minterTwo), 8.038657281009010230 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), 8.038290823108615564 * 1e18);
         vm.expectEmit(true, true, true, true);
         emit ClaimRewards(_minterTwo, address(_poolOne), tokenIdTwo, _epochsClaimedArray(1, 1), idTwoRewardsAtTwo);
         _rewardsManager.claimRewards(tokenIdTwo, _poolOne.currentBurnEpoch());
-        assertEq(_ajnaToken.balanceOf(_minterTwo), idTwoRewardsAtTwo + 8.038657281009010230 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), idTwoRewardsAtTwo + 8.038290823108615564 * 1e18);
 
         // check there are no remaining rewards available after claiming
         uint256 remainingRewards = _rewardsManager.calculateRewards(tokenIdOne, _poolOne.currentBurnEpoch());

--- a/tests/forge/interactions/BalancerUniswapExample.sol
+++ b/tests/forge/interactions/BalancerUniswapExample.sol
@@ -137,8 +137,8 @@ contract BalancerUniswapPurchaser {
         uint256 lps             = IAjnaPool(decoded.ajnaPool).addCollateral(loanAmount, decoded.bucketIndex, block.timestamp + 5 minutes);
         (uint256 quoteAmount, ) = IAjnaPool(decoded.ajnaPool).removeQuoteToken(type(uint256).max, decoded.bucketIndex);
         assert(lps                                 == 83008350.10362729922336157 * 1e18);   // LPS in bucket
-        assert(quoteAmount                         == 4995.19230769230769 * 1e18);          // Purchased quote amount
-        assert(quote.balanceOf(address(this))      == 4995.192307 * 1e6); // USDC balance after Ajna purchase
+        assert(quoteAmount                         == 5000 * 1e18);       // Purchased quote amount
+        assert(quote.balanceOf(address(this))      == 5000 * 1e6);        // USDC balance after Ajna purchase
         assert(collateral.balanceOf(address(this)) == 0);                 // WETH balance after Ajna purchase
 
         // swap USDC to WETH on Uniswap, approve router to spend USDC purchased from ajna

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -130,11 +130,22 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 lpAward,
         uint256 newLup
     ) internal {
+        _addLiquidityWithPenalty(from, amount, amount, index, lpAward, newLup);
+    }
+
+    function _addLiquidityWithPenalty(
+        address from,
+        uint256 amount,
+        uint256 amountAdded,    // amount less penalty, where applicable
+        uint256 index,
+        uint256 lpAward,
+        uint256 newLup
+    ) internal {
         uint256 quoteTokenScale = IPool(address(_pool)).quoteTokenScale();
         changePrank(from);
 
         vm.expectEmit(true, true, false, true);
-        emit AddQuoteToken(from, index, (amount / quoteTokenScale) * quoteTokenScale, lpAward, newLup);
+        emit AddQuoteToken(from, index, (amountAdded / quoteTokenScale) * quoteTokenScale, lpAward, newLup);
         _assertQuoteTokenTransferEvent(from, address(_pool), amount);
         _pool.addQuoteToken(amount, index, type(uint256).max);
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -260,22 +260,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 lpAwardTo,
         uint256 newLup
     ) internal {
-        _moveLiquidityWithPenalty(from, amount, amount, fromIndex, toIndex, lpRedeemFrom, lpAwardTo, newLup);
-    }
-
-    function _moveLiquidityWithPenalty(
-        address from,
-        uint256 amount,
-        uint256 amountMoved,    // amount less penalty, where applicable
-        uint256 fromIndex,
-        uint256 toIndex,
-        uint256 lpRedeemFrom,
-        uint256 lpAwardTo,
-        uint256 newLup
-    ) internal {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
-        emit MoveQuoteToken(from, fromIndex, toIndex, amountMoved, lpRedeemFrom, lpAwardTo, newLup);
+        emit MoveQuoteToken(from, fromIndex, toIndex, amount, lpRedeemFrom, lpAwardTo, newLup);
         (uint256 lpbFrom, uint256 lpbTo, ) = _pool.moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max);
         assertEq(lpbFrom, lpRedeemFrom);
         assertEq(lpbTo,   lpAwardTo);
@@ -333,23 +320,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 newLup,
         uint256 lpRedeem
     ) internal {
-        _removeLiquidityWithPenalty(from, amount, amount, index, newLup, lpRedeem);
-    }
-
-    function _removeLiquidityWithPenalty(
-        address from,
-        uint256 amount,
-        uint256 amountRemoved,  // amount less penalty, where applicable
-        uint256 index,
-        uint256 newLup,
-        uint256 lpRedeem
-    ) internal {
         changePrank(from);
         vm.expectEmit(true, true, false, true);
-        emit RemoveQuoteToken(from, index, amountRemoved, lpRedeem, newLup);
-        _assertQuoteTokenTransferEvent(address(_pool), from, amountRemoved);
+        emit RemoveQuoteToken(from, index, amount, lpRedeem, newLup);
+        _assertQuoteTokenTransferEvent(address(_pool), from, amount);
         (uint256 removedAmount, uint256 lpRedeemed) = _pool.removeQuoteToken(amount, index);
-        assertEq(removedAmount, amountRemoved);
+        assertEq(removedAmount, amount);
         assertEq(lpRedeemed,    lpRedeem);
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1348,7 +1348,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         // calculate the required collateral based upon the borrow amount and index price
         (uint256 interestRate, ) = _pool.interestRateInfo();
         uint256 newInterestRate = Maths.wmul(interestRate, 1.1 * 10**18); // interest rate multipled by increase coefficient
-        uint256 expectedDebt = Maths.wmul(borrowAmount, _feeRate(newInterestRate) + Maths.WAD);
+        uint256 expectedDebt = Maths.wmul(borrowAmount, _borrowFeeRate(newInterestRate) + Maths.WAD);
         requiredCollateral_ = Maths.wdiv(expectedDebt, _poolUtils.indexToPrice(indexPrice));
     }
 
@@ -1357,7 +1357,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         (uint256 interestRate, ) = _pool.interestRateInfo();
         uint256 newInterestRate = Maths.wmul(interestRate, 1.1 * 10**18); // interest rate multipled by increase coefficient
         // calculate the fee rate based upon the interest rate
-        feeRate_ = _feeRate(newInterestRate) + Maths.WAD;
+        feeRate_ = _borrowFeeRate(newInterestRate) + Maths.WAD;
     }
 
 }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
The early withdrawal penalty introduced complexities regarding `PositionManager`, and was detrimental to the lender's experience.  This change eliminates the early withdrawal penalty.  In place, a fee for depositing quote token below the LUP is levied.  The downside of this fee is it requires an extra LUP calculation in `addQuoteToken`, which is assumed to have a nontrivial cost.

Resolves https://github.com/ajna-finance/contracts/issues/617

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
An attack exists where malicious actors deposit "phantom liquidity" in the pool between the LUP and HTP.  As debt is drawn, these actors frontrun transactions, moving their liquidity just in front of the HTP.  Here they earn interest with liquidity which is unutilizable.  This fee disincentivizes such an attack.

# Contract size
Small reduction in `LenderActions` library size.  No other size change observed.
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  22,480B  (91.47%)
  ERC20Pool          -  22,161B  (90.17%)
  LenderActions      -  10,659B  (43.37%)
```

## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,480B  (91.47%)
  ERC20Pool                -  22,161B  (90.17%)
  LenderActions            -  10,534B  (42.86%)
```

# Gas usage
Increase in median `addQuoteToken` cost, decrease in median `moveQuoteToken` and `removeQuoteToken` costs, as expected.
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addQuoteToken                        | 102891          | 159113 | 144691 | 652649 | 60004   |
| moveQuoteToken                       | 256564          | 256564 | 256564 | 256564 | 1       |
| removeQuoteToken                     | 142989          | 164518 | 165478 | 188551 | 4000    |


## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addQuoteToken                        | 115071          | 170618 | 156871 | 653466 | 60004   |
| moveQuoteToken                       | 248739          | 248739 | 248739 | 248739 | 1       |
| removeQuoteToken                     | 142994          | 164318 | 164254 | 188105 | 4000    |



