### PR TITLE
Update debt and deposit EMAs upon every pool interaction

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [push]
+on: [fork]
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,5 +1,5 @@
 name: Size Check
-on: [push]
+on: [fork]
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,5 +1,5 @@
 name: Slither Analysis
-on: [push]
+on: [fork]
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -233,7 +233,7 @@ contract PoolInfoUtils {
         uint256 currentLup = _priceAt(pool.depositIndex(poolDebt));
 
         poolCollateralization_ = _collateralization(poolDebt, poolCollateral, currentLup);
-        poolActualUtilization_ = pool.depositUtilization(poolDebt, poolCollateral);
+        poolActualUtilization_ = pool.depositUtilization();
 
         (uint256 debtEma, uint256 lupColEma) = pool.emasInfo();
         poolTargetUtilization_ = _targetUtilization(debtEma, lupColEma);
@@ -250,9 +250,7 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 poolDebt,,)   = pool.debtInfo();
-        uint256 poolCollateral = pool.pledgedCollateral();
-        uint256 utilization    = pool.depositUtilization(poolDebt, poolCollateral);
+        uint256 utilization   = pool.depositUtilization();
 
         lenderInterestMargin_ = PoolCommons.lenderInterestMargin(utilization);
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -714,11 +714,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     /// @inheritdoc IPoolDerivedState
-    function depositUtilization(
-        uint256 debt_,
-        uint256 collateral_
-    ) external view override returns (uint256) {
-        return PoolCommons.utilization(deposits, debt_, collateral_);
+    function depositUtilization() external view override returns (uint256) {
+        return PoolCommons.utilization(interestState);
     }
 
     /// @inheritdoc IPoolState

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -560,9 +560,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         PoolState memory poolState_,
         uint256 lup_
     ) internal {
+        // update EMAs required to calculate utilization
+        PoolCommons.updateUtilizationEmas(interestState, deposits, poolState_);
+
         // if it has been more than 12 hours since the last interest rate update, call updateInterestRate function
         if (block.timestamp - interestState.interestRateUpdate > 12 hours) {
-            PoolCommons.updateInterestRate(interestState, deposits, poolState_, lup_);
+            PoolCommons.updateInterestRate(interestState, poolState_, lup_);
         }
 
         // update pool inflator

--- a/src/interfaces/pool/commons/IPoolDerivedState.sol
+++ b/src/interfaces/pool/commons/IPoolDerivedState.sol
@@ -27,14 +27,9 @@ interface IPoolDerivedState {
     function depositSize() external view returns (uint256);
 
     /**
-     *  @notice Returns the deposit utilization for given debt and collateral amounts.
-     *  @param  debt_       The debt amount to calculate utilization for.
-     *  @param  collateral_ The collateral amount to calculate utilization for.
+     *  @notice Returns the meaningful actual utilization of the pool.
      *  @return Deposit utilization.
      */
-    function depositUtilization(
-        uint256 debt_,
-        uint256 collateral_
-    ) external view returns (uint256);
+    function depositUtilization() external view returns (uint256);
 
 }

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -276,6 +276,7 @@ struct InterestState {
     uint256 depositEma;         // [WAD] sample of meaningful deposit EMA
     uint256 debtEma;            // [WAD] sample of debt EMA
     uint256 lupColEma;          // [WAD] sample of LUP price * collateral EMA. capped at 10 times current pool debt
+    uint256 emaUpdate;          // [SEC] last time pool's EMAs were updated
 }
 
 struct PoolBalancesState {

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -273,6 +273,7 @@ struct InflatorState {
 struct InterestState {
     uint208 interestRate;       // [WAD] pool's interest rate
     uint48  interestRateUpdate; // [SEC] last time pool's interest rate was updated (not before 12 hours passed)
+    uint256 depositEma;         // [WAD] sample of meaningful deposit EMA
     uint256 debtEma;            // [WAD] sample of debt EMA
     uint256 lupColEma;          // [WAD] sample of LUP price * collateral EMA. capped at 10 times current pool debt
 }

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -273,6 +273,9 @@ struct InflatorState {
 struct InterestState {
     uint208 interestRate;       // [WAD] pool's interest rate
     uint48  interestRateUpdate; // [SEC] last time pool's interest rate was updated (not before 12 hours passed)
+    uint256 t0Debt;
+    uint256 t0DebtEma;
+    uint256 meaningfulDeposit;  // [WAD] previous update's meaningfulDeposit
     uint256 depositEma;         // [WAD] sample of meaningful deposit EMA
     uint256 debtEma;            // [WAD] sample of debt EMA
     uint256 lupColEma;          // [WAD] sample of LUP price * collateral EMA. capped at 10 times current pool debt

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -273,8 +273,7 @@ struct InflatorState {
 struct InterestState {
     uint208 interestRate;       // [WAD] pool's interest rate
     uint48  interestRateUpdate; // [SEC] last time pool's interest rate was updated (not before 12 hours passed)
-    uint256 t0Debt;
-    uint256 t0DebtEma;
+    uint256 debt;               // [WAD] previous update's debt
     uint256 meaningfulDeposit;  // [WAD] previous update's meaningfulDeposit
     uint256 depositEma;         // [WAD] sample of meaningful deposit EMA
     uint256 debtEma;            // [WAD] sample of debt EMA

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -32,7 +32,7 @@ library PoolCommons {
     uint256 internal constant DECREASE_COEFFICIENT = 0.9 * 1e18;
     uint256 internal constant LAMBDA_EMA_7D        = 0.905723664263906671 * 1e18; // Lambda used for interest EMAs calculated as exp(-1/7   * ln2)
     uint256 internal constant EMA_7D_RATE_FACTOR   = 1e18 - LAMBDA_EMA_7D;
-    uint256 internal constant LAMBDA_EMA_12H       = 0.999807477651317445 * 1e18; // Lambda used for deposit EMA calculated as exp(-ln(2)*1/3600)
+    uint256 internal constant LAMBDA_EMA_12H       = 0.5 * 1e18;                  // Lambda used for deposit EMA calculated as exp(-ln(2)*1/3600)
     uint256 internal constant EMA_12H_RATE_FACTOR  = 1e18 - LAMBDA_EMA_12H;
     int256  internal constant PERCENT_102          = 1.02 * 1e18;
 

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 pragma solidity 0.8.14;
+import "forge-std/console.sol";
 
+import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
 import { InterestState, PoolState, DepositsState } from '../../interfaces/pool/commons/IPoolState.sol';
@@ -35,6 +37,8 @@ library PoolCommons {
     uint256 internal constant LAMBDA_EMA_12H       = 0.5 * 1e18;                  // Lambda used for deposit EMA calculated as exp(-ln(2)*1/3600)
     uint256 internal constant EMA_12H_RATE_FACTOR  = 1e18 - LAMBDA_EMA_12H;
     int256  internal constant PERCENT_102          = 1.02 * 1e18;
+    int256  internal constant NEG_H_MAU_SEC        = -0.000016045073624073 * 1e18; // ln(2)/(12*3600)
+    int256  internal constant NEG_H_MAU_HOURS      = -0.057762265046662105 * 1e18; // ln(2)/12
 
     /**************/
     /*** Events ***/
@@ -52,19 +56,34 @@ library PoolCommons {
         DepositsState storage deposits_,
         PoolState memory poolState_
     ) external {
+        // return if a previous transaction in this block updated the EMA
+        if (interestParams_.emaUpdate == block.timestamp) return;
+
+        // FIXME: This should be previous/current meaningful deposit, not new.
+        // May need to record this in InterestState somehow.
         uint256 meaningfulDeposit = _meaningfulDeposit(deposits_, poolState_.debt, poolState_.collateral);
+
         uint256 curDepositEma = interestParams_.depositEma;
         // initialize the EMA to the actual value for the first calculation
         if (curDepositEma == 0) {
             curDepositEma = meaningfulDeposit;    
         } else {
-            curDepositEma = 
-                Maths.wmul(meaningfulDeposit, EMA_12H_RATE_FACTOR) +
-                Maths.wmul(curDepositEma,     LAMBDA_EMA_12H
+            // curDepositEma = 
+            //     Maths.wmul(meaningfulDeposit, EMA_12H_RATE_FACTOR) +
+            //     Maths.wmul(curDepositEma,     LAMBDA_EMA_12H
+            // );
+            int256 elapsed = int256(Maths.wdiv(block.timestamp - interestParams_.emaUpdate, 1 hours));
+            int256 weight = PRBMathSD59x18.exp(PRBMathSD59x18.mul(NEG_H_MAU_HOURS, elapsed));
+            console.log("  %s elapsed, weight %s", uint256(elapsed)/2, uint256(weight));
+            curDepositEma = uint256(
+                PRBMathSD59x18.mul(weight, int256(interestParams_.depositEma)) +
+                PRBMathSD59x18.mul((1e18 - weight), int256(meaningfulDeposit))
             );
         }
+        console.log("meaningfulDeposit %s, curDepositEma %s", meaningfulDeposit, curDepositEma);
 
         interestParams_.depositEma = curDepositEma;
+        interestParams_.emaUpdate = block.timestamp;
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -739,7 +739,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.0405 * 1e18,
+                interestRate:         0.0495 * 1e18,
                 interestRateUpdate:   _startTime + 100 days + 14 hours
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -523,7 +523,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 7_469.035011263740962170 * 1e18
+            settledDebt: 7_433.761162745459786285 * 1e18
         });
 
         _assertPool(
@@ -532,8 +532,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             0,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 6848559808.279468915882431047 * 1e18,
-                poolDebt:             683.734754408473222865 * 1e18,
+                encumberedCollateral: 7012727628.807446392899253904 * 1e18,
+                poolDebt:             700.124659380139131420 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -427,7 +427,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 minDebtAmount:        799.050391373015819039 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
-                interestRate:         0.04455 * 1e18,
+                interestRate:         0.03645 * 1e18,
                 interestRateUpdate:   block.timestamp
             })
         );
@@ -436,10 +436,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_105.430237884635118282 * 1e18,
+            borrowerDebt:              8_084.412285638162564830 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.471136974495192174 * 1e18,
-            borrowerCollateralization: 0.000000012317209569 * 1e18
+            borrowerCollateralization: 0.000000012349231999 * 1e18
         });
 
         // kick borrower 2
@@ -459,30 +459,30 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          1_211.097645963067762922 * 1e18,
-                bondFactor:        0.149418058069566641 * 1e18,
+                bondSize:          1_225.788317396965189520 * 1e18,
+                bondFactor:        0.151623677032721326 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
                 kickMomp:          9.529276179422528643 * 1e18,
-                totalBondEscrowed: 1_211.097645963067762922 * 1e18,
+                totalBondEscrowed: 1_225.788317396965189520 * 1e18,
                 auctionPrice:      0.595579761213908032 * 1e18,
-                debtInAuction:     8_195.704467159075241912 * 1e18,
-                thresholdPrice:    8.196162962286455648 * 1e18,
-                neutralPrice:      8.596021534820399875 * 1e18
+                debtInAuction:     8_158.081492591040321202 * 1e18,
+                thresholdPrice:    8.158387007288001486 * 1e18,
+                neutralPrice:      8.573731444741769263 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_196.162962286455648823 * 1e18,
+            borrowerDebt:              8_158.387007288001486366 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.471136974495192174 * 1e18,
-            borrowerCollateralization: 0.000000012180856255 * 1e18
+            borrowerCollateralization: 0.000000012237257536 * 1e18
         });
 
         _take({
             from:            _lender,
             borrower:        _borrower2,
             maxCollateral:   1_000.0 * 1e18,
-            bondChange:      88.990371346118344167 * 1e18,
+            bondChange:      90.303993361522878877 * 1e18,
             givenAmount:     595.579761213908032000 * 1e18,
             collateralTaken: 1_000 * 1e18,
             isReward:        true
@@ -492,22 +492,22 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             6_903.714005325230313356 * 1e18,
+                poolSize:             6_868.201140928720466905 * 1e18,
                 pledgedCollateral:    1.742368450520005091 * 1e18,
-                encumberedCollateral: 82768556085.799578753126793220 * 1e18,
-                poolDebt:             8_263.304979778717856240 * 1e18,
+                encumberedCollateral: 82376848294.795087171258765602 * 1e18,
+                poolDebt:             8_224.198329945776437412 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174756997670024034 * 1e18,
+                targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.049005000000000000 * 1e18,
+                interestRate:         0.032805000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_263.304979778717856240 * 1e18,
+            borrowerDebt:              8_224.198329945776437412 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              8.471136974495192174 * 1e18,
             borrowerCollateralization: 0
@@ -535,11 +535,11 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 encumberedCollateral: 6848559808.279468915882431047 * 1e18,
                 poolDebt:             683.734754408473222865 * 1e18,
                 actualUtilization:    0,
-                targetUtilization:    1.174756997670024034 * 1e18,
+                targetUtilization:    1.173175843719475841 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.049005000000000000 * 1e18,
+                interestRate:         0.032805000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp - 10 hours
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1139,7 +1139,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  1_000 * 1e18,
             index:   2873,
-            lpAward: 999.956320611641422443 * 1e18,
+            lpAward: 999.956661906703638280 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
 
@@ -1151,7 +1151,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             amount:       2_500 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
-            lpRedeemFrom: 2_499.810182702901761331 * 1e18,
+            lpRedeemFrom: 2_499.811035936079517439 * 1e18,
             lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
@@ -1163,7 +1163,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  9_000 * 1e18,
             index:   2873,
-            lpAward: 8_993.373316759001213155 * 1e18,
+            lpAward: 8_993.376387354878192779 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
         
@@ -1172,10 +1172,10 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   5_003.981613396490344248 * 1e18,
+            amount:   5_003.979051028590388555 * 1e18,
             index:    2873,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 5_000.290483387144984401 * 1e18
+            lpRedeem: 5_000.289630153967228293 * 1e18
         });
 
         _removeAllLiquidity({

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1151,7 +1151,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             amount:       2_500 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
-            lpRedeemFrom: 2_499.810182702901761331 * 1e18,
+            lpRedeemFrom: 2_499.801225069756157243 * 1e18,
             lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
@@ -1163,19 +1163,19 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  9_000 * 1e18,
             index:   2873,
-            lpAward: 8_993.373316759001213155 * 1e18,
+            lpAward: 8_992.680876390590002224 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
-
+        
         // lender removes all their quote, with interest
         skip(1 hours);
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   5_003.981613396490344248 * 1e18,
+            amount:   5_004.377462406385073960 * 1e18,
             index:    2873,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 5_000.290483387144984401 * 1e18
+            lpRedeem: 5_000.299441020290588489 * 1e18
         });
 
         _removeAllLiquidity({

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1151,7 +1151,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             amount:       2_500 * 1e18,
             fromIndex:    2873,
             toIndex:      2954,
-            lpRedeemFrom: 2_499.801225069756157243 * 1e18,
+            lpRedeemFrom: 2_499.810182702901761331 * 1e18,
             lpAwardTo:    2_500 * 1e18,
             newLup:       _lup()
         });
@@ -1163,7 +1163,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             from:    _lender1,
             amount:  9_000 * 1e18,
             index:   2873,
-            lpAward: 8_992.680876390590002224 * 1e18,
+            lpAward: 8_993.373316759001213155 * 1e18,
             newLup:  601.252968524772188572 * 1e18
         });
         
@@ -1172,10 +1172,10 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   5_004.377462406385073960 * 1e18,
+            amount:   5_003.981613396490344248 * 1e18,
             index:    2873,
             newLup:   601.252968524772188572 * 1e18,
-            lpRedeem: 5_000.299441020290588489 * 1e18
+            lpRedeem: 5_000.290483387144984401 * 1e18
         });
 
         _removeAllLiquidity({

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -961,22 +961,22 @@ contract RewardsManagerTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdTwo,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            30.544499416187009794 * 1e18,
+            reward:            28.767569698570175332 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterTwoBalance = _ajnaToken.balanceOf(_minterTwo);
-        assertEq(minterTwoBalance, 30.544499416187009794 * 1e18);
+        assertEq(minterTwoBalance, 28.767569698570175332 * 1e18);
 
         _unstakeToken({
             minter:            _minterThree,
             pool:              address(_poolOne),
             tokenId:           tokenIdThree,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            25.446417670471808628 * 1e18,
+            reward:            23.965537532955127777 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterThreeBalance = _ajnaToken.balanceOf(_minterThree);
-        assertEq(minterThreeBalance, 25.446417670471808628 * 1e18);
+        assertEq(minterThreeBalance, 23.965537532955127777 * 1e18);
 
         assertGt(minterTwoBalance, minterThreeBalance);
     }

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -961,22 +961,22 @@ contract RewardsManagerTest is DSTestPlus {
             pool:              address(_poolOne),
             tokenId:           tokenIdTwo,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            28.767569698570175332 * 1e18,
+            reward:            30.544499416187009794 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterTwoBalance = _ajnaToken.balanceOf(_minterTwo);
-        assertEq(minterTwoBalance, 28.767569698570175332 * 1e18);
+        assertEq(minterTwoBalance, 30.544499416187009794 * 1e18);
 
         _unstakeToken({
             minter:            _minterThree,
             pool:              address(_poolOne),
             tokenId:           tokenIdThree,
             claimedArray:      _epochsClaimedArray(1, 0),
-            reward:            23.965537532955127777 * 1e18,
+            reward:            25.446417670471808628 * 1e18,
             updateRatesReward: 0
         });
         uint256 minterThreeBalance = _ajnaToken.balanceOf(_minterThree);
-        assertEq(minterThreeBalance, 23.965537532955127777 * 1e18);
+        assertEq(minterThreeBalance, 25.446417670471808628 * 1e18);
 
         assertGt(minterTwoBalance, minterThreeBalance);
     }


### PR DESCRIPTION
# Description of change
## High level
* Update EMAs upon each interaction with the pool rather than every 12 hours.
* Calculate EMAs for MAU calculation
  * debt EMA is intended implementation
  * deposit EMA is placeholder until we can update `meaningfulDeposit` to use new accumulators from TU branch
* Update interest calculation to use the new EMAs 

# Description of bug or vulnerability and solution
Reduces impact of deposit manipulation for the purpose of disturbing interest rates or perpetrating a MEV attack where attacker earns interest without any quote token being at risk.

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,766B  (92.63%)
  ERC20Pool                -  22,479B  (91.46%)
  PoolInfoUtils            -  12,279B  (49.96%)
  PoolCommons              -   7,585B  (30.86%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,869B  (93.05%)
  ERC20Pool                -  22,582B  (91.88%)
  PoolInfoUtils            -  12,006B  (48.85%)
  PoolCommons              -   8,395B  (34.16%)
```

# Gas usage
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addQuoteToken                        | 115097          | 170644 | 156897 | 653492 | 60004   |
| borrowerInfo                         | 6889            | 6889   | 6889   | 6889   | 8001    |
| bucketTake                           | 332864          | 351036 | 351018 | 369244 | 4       |
| collateralScale                      | 408             | 408    | 408    | 408    | 8003    |
| drawDebt                             | 216948          | 261202 | 237990 | 736749 | 136003  |
| inflatorInfo                         | 421             | 421    | 421    | 421    | 8001    |
| initialize                           | 91393           | 91393  | 91393  | 91393  | 16      |
| interestRateInfo                     | 2411            | 2411   | 2411   | 2411   | 8001    |
| kick                                 | 166010          | 191060 | 189931 | 975101 | 48000   |
| kickWithDeposit                      | 209652          | 244485 | 239374 | 993988 | 8000    |
| loansInfo                            | 1774            | 2472   | 2472   | 8472   | 48019   |
| moveQuoteToken                       | 248902          | 248902 | 248902 | 248902 | 1       |
| quoteTokenScale                      | 388             | 388    | 388    | 388    | 8002    |
| removeQuoteToken                     | 142987          | 164311 | 164552 | 188096 | 4000    |
| repayDebt                            | 508281          | 540320 | 529722 | 688291 | 16002   |
| settle                               | 209860          | 209860 | 209860 | 209860 | 1       |
| take                                 | 76475           | 78373  | 77732  | 302101 | 15998   |
## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |         |         |
|--------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 117371          | 175711 | 159171 | 729322  | 60004   |
| borrowerInfo                         | 6889            | 6889   | 6889   | 6889    | 8001    |
| bucketTake                           | 354995          | 373029 | 372993 | 391136  | 4       |
| collateralScale                      | 408             | 408    | 408    | 408     | 8003    |
| drawDebt                             | 244936          | 291369 | 264851 | 812698  | 136003  |
| inflatorInfo                         | 421             | 421    | 421    | 421     | 8001    |
| initialize                           | 91393           | 91393  | 91393  | 91393   | 16      |
| interestRateInfo                     | 2411            | 2411   | 2411   | 2411    | 8001    |
| kick                                 | 190212          | 216273 | 215161 | 1042893 | 48000   |
| kickWithDeposit                      | 234478          | 269680 | 264886 | 1023635 | 8000    |
| loansInfo                            | 1774            | 2472   | 2472   | 8472    | 48019   |
| moveQuoteToken                       | 286833          | 286833 | 286833 | 286833  | 1       |
| quoteTokenScale                      | 388             | 388    | 388    | 388     | 8002    |
| removeQuoteToken                     | 151772          | 173466 | 178167 | 202211  | 4000    |
| repayDebt                            | 584111          | 616171 | 605612 | 764181  | 16002   |
| settle                               | 217982          | 217982 | 217982 | 217982  | 1       |
| take                                 | 92400           | 100258 | 99706  | 325794  | 15998   |

