### PR TITLE
updated EMAs and TU info utils calculation to reflect prod

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -235,8 +235,8 @@ contract PoolInfoUtils {
         poolCollateralization_ = _collateralization(poolDebt, poolCollateral, currentLup);
         poolActualUtilization_ = pool.depositUtilization();
 
-        (uint256 debtEma, uint256 lupColEma) = pool.emasInfo();
-        poolTargetUtilization_ = _targetUtilization(debtEma, lupColEma);
+        (uint256 debtColEma, uint256 lupt0DebtEma, , ) = pool.emasInfo();
+        poolTargetUtilization_ = _targetUtilization(debtColEma, lupt0DebtEma);
     }
 
     /**
@@ -435,13 +435,13 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Calculates target utilization for given EMA values.
-     *  @param  debtEma_   The EMA of debt value.
-     *  @param  lupColEma_ The EMA of lup * collateral value.
+     *  @param  debtColEma_   The EMA of debt value.
+     *  @param  lupt0DebtEma_ The EMA of lup * collateral value.
      *  @return Target utilization of the pool.
      */
     function _targetUtilization(
-        uint256 debtEma_,
-        uint256 lupColEma_
+        uint256 debtColEma_,
+        uint256 lupt0DebtEma_
     ) pure returns (uint256) {
-        return (debtEma_ != 0 && lupColEma_ != 0) ? Maths.wdiv(lupColEma_, debtEma_) : Maths.WAD;
+        return (debtColEma_ != 0 && lupt0DebtEma_ != 0) ? Maths.wdiv(debtColEma_, lupt0DebtEma_) : Maths.WAD;
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -788,7 +788,6 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return PoolCommons.utilization(interestState);
     }
 
-    // TODO: update to return all four
     /// @inheritdoc IPoolState
     function emasInfo() external view override returns (uint256, uint256, uint256, uint256) {
         return (

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -790,8 +790,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
     // TODO: update to return all four
     /// @inheritdoc IPoolState
-    function emasInfo() external view override returns (uint256, uint256) {
+    function emasInfo() external view override returns (uint256, uint256, uint256, uint256) {
         return (
+            interestState.debtColEma,
+            interestState.lupt0DebtEma,
             interestState.debtEma,
             interestState.depositEma
         );

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -102,10 +102,10 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about the pool EMA (Exponential Moving Average) variables.
-     *  @return debtColEma   Exponential debt moving average.
-     *  @return lupt0DebtEma Exponential LUP * pledged collateral moving average.
-     *  @return debtEma   Exponential debt moving average.
-     *  @return depositEma Exponential LUP * pledged collateral moving average.
+     *  @return debtColEma   Debt squared to collateral Exponential, numerator to TU calculation
+     *  @return lupt0DebtEma Exponential of LUP * t0 debt, denominator to TU calculation
+     *  @return debtEma      Exponential debt moving average.
+     *  @return depositEma   sample of meaningful deposit Exponential, denominator to MAU calculation.
      */
     function emasInfo()
         external

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -102,15 +102,19 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about the pool EMA (Exponential Moving Average) variables.
+     *  @return debtColEma   Exponential debt moving average.
+     *  @return lupt0DebtEma Exponential LUP * pledged collateral moving average.
      *  @return debtEma   Exponential debt moving average.
-     *  @return lupColEma Exponential LUP * pledged collateral moving average.
+     *  @return depositEma Exponential LUP * pledged collateral moving average.
      */
     function emasInfo()
         external
         view
         returns (
+            uint256 debtColEma,
+            uint256 lupt0DebtEma,
             uint256 debtEma,
-            uint256 lupColEma
+            uint256 depositEma
     );
 
     /**

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -292,7 +292,7 @@ library PoolCommons {
     function utilization(
         InterestState storage interestParams_
     ) external view returns (uint256 utilization_) {
-        return _utilization(interestParams_.debtEma, interestParams_.depositEma );
+        return _utilization(interestParams_.debtEma, interestParams_.depositEma);
     }
 
     /**************************/

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -113,8 +113,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   0,
-            lupColEma: 670.486566033464515042 * 1e18
+            debtColEma:   0,
+            lupt0DebtEma: 670.486566033464515042 * 1e18,
+            debtEma:      0,
+            depositEma:   0
         });
 
         skip(14 hours);
@@ -141,8 +143,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   4_340.881358710158802477 * 1e18,
-            lupColEma: 1_278.637533654711320024 * 1e18
+            debtColEma:   4_340.881358710158802477 * 1e18,
+            lupt0DebtEma: 1_278.637533654711320024 * 1e18,
+            debtEma:      0,
+            depositEma:   0
         });
 
         vm.revertTo(snapshot);
@@ -178,8 +182,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         );
 
         _assertEMAs({
-            debtEma:   0 * 1e18,
-            lupColEma: 670.486566033464515042 * 1e18
+            debtColEma:   0,
+            lupt0DebtEma: 670.486566033464515042 * 1e18,
+            debtEma:      0,
+            depositEma:   0
         });
     }
 
@@ -555,8 +561,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   0,
-            lupColEma: 0
+            debtColEma:   0,
+            lupt0DebtEma: 0,
+            debtEma:      0,
+            depositEma:   0
         });
 
         // borrower 1 borrows 500 quote from the pool
@@ -580,7 +588,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 pledgedCollateral:    50 * 1e18,
                 encumberedCollateral: 1.529641632103338099 * 1e18,
                 poolDebt:             500.480769230769231000 * 1e18,
-                actualUtilization:    0.025024038461538462 * 1e18,
+                actualUtilization:    0,
                 targetUtilization:    1e18,
                 minDebtAmount:        50.048076923076923100 * 1e18,
                 loans:                1,
@@ -590,8 +598,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   0,
-            lupColEma: 0
+            debtColEma:   0,
+            lupt0DebtEma: 0,
+            debtEma:      0,
+            depositEma:   0
         });
 
         _pledgeCollateral({
@@ -624,8 +634,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   0,
-            lupColEma: 0
+            debtColEma:   0,
+            lupt0DebtEma: 0,
+            debtEma:      0,
+            depositEma:   0
         });
 
         skip(10 days);
@@ -656,8 +668,10 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
         _assertEMAs({
-            debtEma:   94.366986058916495706 * 1e18,
-            lupColEma: 2.949226520600595208 * 1e18
+            debtColEma:   10_235.360311264941798142 * 1e18,
+            lupt0DebtEma: 327_502.854410935285415297 * 1e18,
+            debtEma:      1_002.333658244714424687 * 1e18,
+            depositEma:   20_001.166301815699560000 * 1e18
         });
     }
 

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -364,8 +364,10 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             })
         );
         _assertEMAs({
-            debtEma:   283.100958176749487118 * 1e18,
-            lupColEma: 23.671097875440967733 * 1e18
+            debtColEma:   755_981.012555885345015825 * 1e18,
+            lupt0DebtEma: 9_041_361.332042292412966942 * 1e18,
+            debtEma:      3_007.000974734143274062 * 1e18,
+            depositEma:   30_003.498905447098710000 * 1e18
         });
         // check bucket state after fully repay
         _assertBucket({

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -598,13 +598,17 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     }
 
     function _assertEMAs(
+        uint256 debtColEma,
+        uint256 lupt0DebtEma,
         uint256 debtEma,
-        uint256 lupColEma
+        uint256 depositEma
     ) internal {
-        (uint256 curDebtEma, uint256 curLupColEma) = _pool.emasInfo();
+        (uint256 curDebtColEma, uint256 curLupt0DebtEma, uint256 curDebtEma, uint256 curDepositEma) = _pool.emasInfo();
 
-        assertEq(curDebtEma,   debtEma);
-        assertEq(curLupColEma, lupColEma);
+        assertEq(curDebtColEma,    debtColEma);
+        assertEq(curLupt0DebtEma,  lupt0DebtEma);
+        assertEq(curDebtEma,       debtEma);
+        assertEq(curDepositEma,    depositEma);
     }
 
     function _assertKicker(


### PR DESCRIPTION
* updated `emasInfo()` to now include the following:
  * `debtEma` (already exisited)
  * `lupt0DebtEma`
  * `debtColEma`
  * `depositEma`
 * fixed up `_assertEma()` method in tests to reflect change.
 * Tests do not pass so we can update them in `crf-sherlock-100` branch 