### PR TITLE
Remove transfer with permit

### DIFF
--- a/src/base/PermitERC721.sol
+++ b/src/base/PermitERC721.sol
@@ -106,23 +106,6 @@ abstract contract PermitERC721 is ERC721, IPermit {
     }
 
     /**
-     *  @notice Called by an NFT owner to enable their NFT to be transferred by a spender address without making a seperate approve call
-     *  @param  from_     The address of the current owner of the NFT
-     *  @param  to_       The address of the new owner of the NFT
-     *  @param  tokenId_  The id of the NFT being interacted with
-     *  @param  deadline_ The unix timestamp by which the permit must be called
-     *  @param  v_        Component of secp256k1 signature
-     *  @param  r_        Component of secp256k1 signature
-     *  @param  s_        Component of secp256k1 signature
-     */
-    function safeTransferFromWithPermit(
-        address from_, address to_, uint256 tokenId_, uint256 deadline_, uint8 v_, bytes32 r_, bytes32 s_
-    ) external {
-        this.permit(msg.sender, tokenId_, deadline_, v_, r_, s_);
-        safeTransferFrom(from_, to_, tokenId_);
-    }
-
-    /**
      *  @dev Gets the current chain ID
      *  @return chainId_ The current chain ID
      */

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1190,208 +1190,60 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
     }
 
-    // /**
-    //  *  @notice Tests minting an NFT, transfering NFT by permit, memorialize and redeem positions.
-    //  *          Checks that old owner cannot redeem positions.
-    //  *          Old owner reverts: attempts to redeem positions without permission.
-    //  */
-    // function testNFTTransferByPermit() external {
-    //     // generate addresses and set test params
-    //     (address testMinter, uint256 minterPrivateKey) = makeAddrAndKey("testMinter");
-
-    //     address testReceiver   = makeAddr("testReceiver");
-    //     uint256 testIndexPrice = 2550;
-
-    //     // add initial liquidity
-    //     uint256 mintAmount = 50_000 * 1e18;
-    //     _mintQuoteAndApproveManagerTokens(testMinter, mintAmount);
-
-    //     _addInitialLiquidity({
-    //         from:   testMinter,
-    //         amount: 15_000 * 1e18,
-    //         index:  testIndexPrice
-    //     });
-
-    //     uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
-    //     // check owner
-    //     assertEq(_positionManager.ownerOf(tokenId), testMinter);
-
-    //     // check LPs
-    //     _assertLenderLpBalance({
-    //         lender:      testMinter,
-    //         index:       testIndexPrice,
-    //         lpBalance:   15_000 * 1e18,
-    //         depositTime: _startTime
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      testReceiver,
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: 0
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      address(_positionManager),
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: 0
-    //     });
-
-    //     // check position manager state
-    //     assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
-    //     assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
-
-    //     // memorialize positions
-    //     uint256[] memory indexes = new uint256[](1);
-    //     indexes[0] = testIndexPrice;
-    //     uint256[] memory amounts = new uint256[](1);
-    //     amounts[0] = 15_000 * 1e18;
-    //     // allow position manager to take ownership of the position of testMinter
-    //     _pool.approveLpOwnership(address(_positionManager), indexes, amounts);
-    //     // memorialize positions of testMinter
-    //     IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(
-    //         tokenId, indexes
-    //     );
-    //     _positionManager.memorializePositions(memorializeParams);
-
-    //     // check pool state
-    //     _assertLenderLpBalance({
-    //         lender:      testMinter,
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: _startTime
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      testReceiver,
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: 0
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      address(_positionManager),
-    //         index:       testIndexPrice,
-    //         lpBalance:   15_000 * 1e18,
-    //         depositTime: _startTime
-    //     });
-
-    //     // check position manager state
-    //     assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e18);
-    //     assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
-
-    //     address testSpender = makeAddr("testSpender");
-
-    //     // approve and transfer NFT by permit to different address
-    //     {
-    //         uint256 deadline = block.timestamp + 1 days;
-    //         (uint8 v, bytes32 r, bytes32 s) = vm.sign(
-    //             minterPrivateKey,
-    //             keccak256(
-    //                 abi.encodePacked(
-    //                     "\x19\x01",
-    //                     _positionManager.DOMAIN_SEPARATOR(),
-    //                     keccak256(
-    //                         abi.encode(
-    //                             _positionManager.PERMIT_TYPEHASH(),
-    //                             testSpender,
-    //                             tokenId,
-    //                             0,
-    //                             deadline
-    //                         )
-    //                     )
-    //                 )
-    //             )
-    //         );
-    //         changePrank(testSpender);
-    //         _positionManager.safeTransferFromWithPermit(testMinter, testReceiver, tokenId, deadline, v, r, s );
-    //     }
-
-    //     // check owner
-    //     assertEq(_positionManager.ownerOf(tokenId), testReceiver);
-
-    //     // check old owner cannot redeem positions
-    //     // construct redeem liquidity params
-    //     IPositionManagerOwnerActions.RedeemPositionsParams memory reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
-    //         tokenId, address(_pool), indexes
-    //     );
-    //     // redeem liquidity called by old owner
-    //     vm.expectRevert(IPositionManagerErrors.NoAuth.selector);
-    //     _positionManager.reedemPositions(reedemParams);
-
-    //     // check new owner can redeem positions
-    //     changePrank(testReceiver);
-    //     // allow position manager as transferor
-    //     address[] memory transferors = new address[](1);
-    //     transferors[0] = address(_positionManager);
-    //     _pool.approveLpTransferors(transferors);
-
-    //     _positionManager.reedemPositions(reedemParams);
-
-    //     // check pool state
-    //     _assertLenderLpBalance({
-    //         lender:      testMinter,
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: _startTime
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      testReceiver,
-    //         index:       testIndexPrice,
-    //         lpBalance:   15_000 * 1e18,
-    //         depositTime: _startTime
-    //     });
-    //     _assertLenderLpBalance({
-    //         lender:      address(_positionManager),
-    //         index:       testIndexPrice,
-    //         lpBalance:   0,
-    //         depositTime: _startTime
-    //     });
-
-    //     // check position manager state
-    //     assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
-    //     assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
-    // }
-
-    // FIXME: determine why this is failing with magic amounts
-    function xtestNFTTransferByPermit() external {
+    /**
+     *  @notice Tests minting an NFT, transfering NFT by permit, memorialize and redeem positions.
+     *          Checks that old owner cannot redeem positions.
+     *          Old owner reverts: attempts to redeem positions without permission.
+     */
+    function testNFTTransferByPermit() external {
+        // generate addresses and set test params
         (address testMinter, uint256 minterPrivateKey) = makeAddrAndKey("testMinter");
-        address testReceiver = makeAddr("testReceiver");
+
+        address testReceiver   = makeAddr("testReceiver");
         uint256 testIndexPrice = 2550;
 
-        // reciever adds initial liquidity
-        // uint256 mintAmount = 50_000 * 1e18;
-        _mintQuoteAndApproveManagerTokens(testReceiver, 50_000 * 1e18);
+        // add initial liquidity
+        _mintQuoteAndApproveManagerTokens(testMinter, 50_000 * 1e18);
 
         _addInitialLiquidity({
-            from:   testReceiver,
+            from:   testMinter,
             amount: 15_000 * 1e18,
             index:  testIndexPrice
         });
 
-        // mint NFT
         uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
-
         // check owner
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
-        // deploy spender contract
-        ContractNFTSpender spenderContract = new ContractNFTSpender(address(_positionManager));
-
-        // permit params
-        uint256 deadline = block.timestamp + 10000;
-        (uint8 v, bytes32 r, bytes32 s) = _getPermitSig(address(spenderContract), tokenId, deadline, minterPrivateKey);
-
-        changePrank(testMinter);
-        spenderContract.transferFromWithPermit(testReceiver, tokenId, deadline, v, r, s);
+        // check LPs
+        _assertLenderLpBalance({
+            lender:      testMinter,
+            index:       testIndexPrice,
+            lpBalance:   15_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      testReceiver,
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       testIndexPrice,
+            lpBalance:   0,
+            depositTime: 0
+        });
 
         // check position manager state
         assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 0);
         assertFalse(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
 
-        // reciever memorialize positions
+        // memorialize positions
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = testIndexPrice;
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = 15_000 * 1e18;
-        changePrank(testReceiver);
         // allow position manager to take ownership of the position of testMinter
         _pool.approveLpOwnership(address(_positionManager), indexes, amounts);
         // memorialize positions of testMinter
@@ -1420,17 +1272,33 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             depositTime: _startTime
         });
 
-        // check minter cannot redeem positions
+        // check position manager state
+        assertEq(_positionManager.getLPs(tokenId, testIndexPrice), 15_000 * 1e18);
+        assertTrue(_positionManager.isIndexInPosition(tokenId, testIndexPrice));
+
+        // deploy spender contract
+        ContractNFTSpender spenderContract = new ContractNFTSpender(address(_positionManager));
+
+        {
+            uint256 deadline = block.timestamp + 10000;
+            (uint8 v, bytes32 r, bytes32 s) = _getPermitSig(address(spenderContract), tokenId, deadline, minterPrivateKey);
+            changePrank(testMinter);
+            spenderContract.transferFromWithPermit(testReceiver, tokenId, deadline, v, r, s);
+        }
+
+        // check owner
+        assertEq(_positionManager.ownerOf(tokenId), testReceiver);
+
+        // check old owner cannot redeem positions
         // construct redeem liquidity params
-        changePrank(testMinter);
         IPositionManagerOwnerActions.RedeemPositionsParams memory reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
             tokenId, address(_pool), indexes
         );
-        // redeem liquidity called by minter
+        // redeem liquidity called by old owner
         vm.expectRevert(IPositionManagerErrors.NoAuth.selector);
         _positionManager.reedemPositions(reedemParams);
 
-        // check reciever can redeem positions
+        // check new owner can redeem positions
         changePrank(testReceiver);
         // allow position manager as transferor
         address[] memory transferors = new address[](1);

--- a/tests/forge/utils/ContractNFTSpender.sol
+++ b/tests/forge/utils/ContractNFTSpender.sol
@@ -4,20 +4,26 @@ pragma solidity 0.8.14;
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import '@openzeppelin/contracts/interfaces/IERC1271.sol';
 
-import "@src/interfaces/rewards/IRewardsManager.sol";
+import { PositionManager } from "src/PositionManager.sol";
 
-contract ContractNFTSpender is IERC1271 {
+contract ContractNFTSpender {
 
-    IRewardsManager rewardsManager;
+    PositionManager positionManager;
 
-    constructor(address rewardsManager_) {
-        rewardsManager = IRewardsManager(rewardsManager_);
+    constructor(address positionManager_) {
+        positionManager = PositionManager(positionManager_);
     }
 
-    function transferAndStakeNFT(address NFTAddress_, address receiver_, uint256 tokenId_) external {
-        IERC721 nft = IERC721(NFTAddress_);
-
-        nft.transferFrom(address(this), receiver_, tokenId_);
+    function transferFromWithPermit(
+        address receiver_,
+        uint256 tokenId_,
+        uint256 deadline_,
+        uint8 v_,
+        bytes32 r_,
+        bytes32 s_
+    ) external {
+        positionManager.permit(address(this), tokenId_, deadline_, v_, r_, s_);
+        positionManager.transferFrom(msg.sender, receiver_, tokenId_);
     }
 
 }

--- a/tests/forge/utils/ContractNFTSpender.sol
+++ b/tests/forge/utils/ContractNFTSpender.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import '@openzeppelin/contracts/interfaces/IERC1271.sol';
+
+import "@src/interfaces/rewards/IRewardsManager.sol";
+
+contract ContractNFTSpender is IERC1271 {
+
+    IRewardsManager rewardsManager;
+
+    constructor(address rewardsManager_) {
+        rewardsManager = IRewardsManager(rewardsManager_);
+    }
+
+    function transferAndStakeNFT(address NFTAddress_, address receiver_, uint256 tokenId_) external {
+        IERC721 nft = IERC721(NFTAddress_);
+
+        nft.transferFrom(address(this), receiver_, tokenId_);
+    }
+
+}


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Removes unnecessary `transferFromWithPermit` method. We weren't using Permit as intended, as interactions with `permit` would normally occur in external contracts where the *spender* is the actual initiator of the transaction. There's no vulnerability, but I believe it's better to simply remove this function to simplify the code.
  * Removes unnecessary function and updates tests. Implements new `contractNFTSpender` utility contract to handle permit interactions.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* No vulnerability, but not useful either.

