### PR TITLE
Charge unutilized deposit fee moving quote from above LUP to below LUP

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -270,6 +270,12 @@ library LenderActions {
             })
         );
 
+        lup_ = _lup(deposits_, poolState_.debt);
+        // apply unutilized deposit fee if quote token is moved from above the LUP to below the LUP
+        if (vars.fromBucketPrice > lup_ && vars.toBucketPrice <= lup_) {
+            movedAmount_ = Maths.wmul(movedAmount_, Maths.WAD - _depositFeeRate(poolState_.rate));
+        }
+
         vars.toBucketUnscaledDeposit = Deposits.unscaledValueAt(deposits_, params_.toIndex);
         vars.toBucketScale           = Deposits.scale(deposits_, params_.toIndex);
         vars.toBucketDeposit         = Maths.wmul(vars.toBucketUnscaledDeposit, vars.toBucketScale);
@@ -284,7 +290,6 @@ library LenderActions {
 
         Deposits.unscaledAdd(deposits_, params_.toIndex, Maths.wdiv(movedAmount_, vars.toBucketScale));
 
-        lup_     = _lup(deposits_, poolState_.debt);
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -37,7 +37,7 @@ import { Maths }   from '../internal/Maths.sol';
      *  @dev    Price expected to be inputted as a 18 decimal WAD
      *  @dev    Fenwick index is converted to bucket index
      *  @dev    Fenwick index to bucket index conversion
-     *          1.00      : bucket index 0,     fenwick index 4146: 7388-4156-3232=0
+     *          1.00      : bucket index 0,     fenwick index 4156: 7388-4156-3232=0
      *          MAX_PRICE : bucket index 4156,  fenwick index 0:    7388-0-3232=4156.
      *          MIN_PRICE : bucket index -3232, fenwick index 7388: 7388-7388-3232=-3232.
      *  @dev    V1: price = MIN_PRICE + (FLOAT_STEP * index)

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1076,15 +1076,28 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             expiry:    block.timestamp - 20
         });
 
-        // should be able to moveQuoteToken if properly specified
-        _moveLiquidity({
+        // should be charged unutilized deposit fee if moving below LUP
+        _moveLiquidityWithPenalty({
             from:         _lender,
             amount:       10_000 * 1e18,
+            amountMoved:  9_998.630136986301370000 * 1e18,
             fromIndex:    4549,
-            toIndex:      4550,
+            toIndex:      5000,
             lpRedeemFrom: 10_000 * 1e18,
-            lpAwardTo:    10_000 * 1e18,
-            newLup:       _priceAt(4551)
+            lpAwardTo:    9_998.630136986301370000 * 1e18,
+            newLup:       _priceAt(4651)
+        });
+
+        // should be able to moveQuoteToken if properly specified
+        (uint256 amountToMove,) = _pool.lenderInfo(5000, _lender);
+        _moveLiquidity({
+            from:         _lender,
+            amount:       amountToMove,
+            fromIndex:    5000,
+            toIndex:      4550,
+            lpRedeemFrom: amountToMove,
+            lpAwardTo:    amountToMove,
+            newLup:       _priceAt(4651)
         });
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -281,9 +281,22 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 lpAwardTo,
         uint256 newLup
     ) internal {
+        _moveLiquidityWithPenalty(from, amount, amount, fromIndex, toIndex, lpRedeemFrom, lpAwardTo, newLup);
+    }
+
+    function _moveLiquidityWithPenalty(
+        address from,
+        uint256 amount,
+        uint256 amountMoved,    // amount less penalty, where applicable
+        uint256 fromIndex,
+        uint256 toIndex,
+        uint256 lpRedeemFrom,
+        uint256 lpAwardTo,
+        uint256 newLup
+    ) internal {
         changePrank(from);
         vm.expectEmit(true, true, true, true);
-        emit MoveQuoteToken(from, fromIndex, toIndex, amount, lpRedeemFrom, lpAwardTo, newLup);
+        emit MoveQuoteToken(from, fromIndex, toIndex, amountMoved, lpRedeemFrom, lpAwardTo, newLup);
         (uint256 lpbFrom, uint256 lpbTo, ) = _pool.moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max);
         assertEq(lpbFrom, lpRedeemFrom);
         assertEq(lpbTo,   lpAwardTo);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
Charge the unutilized deposit fee when moving quote token from above the LUP to below the LUP.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
Per [review](https://github.com/ajna-finance/contracts/pull/640#pullrequestreview-1325259359), the unutilized deposit fee could be sidestepped by depositing above LUP and then immediately moving below LUP.  To prevent this, charge the fee when moving from above LUP to below LUP.

# Contract size
Slight increase in `LenderActions` size.
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,958B  (93.41%)
  ERC20Pool                -  22,664B  (92.22%)
  Auctions                 -  20,252B  (82.40%)
  PositionManager          -  18,863B  (76.75%)
  PositionNFTSVG           -  15,261B  (62.09%)
  PoolInfoUtils            -  12,279B  (49.96%)
  BorrowerActions          -  11,647B  (47.39%)
  LenderActions            -  10,746B  (43.72%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  22,958B  (93.41%)
  ERC20Pool                -  22,664B  (92.22%)
  Auctions                 -  20,252B  (82.40%)
  PositionManager          -  18,863B  (76.75%)
  PositionNFTSVG           -  15,261B  (62.09%)
  PoolInfoUtils            -  12,279B  (49.96%)
  BorrowerActions          -  11,647B  (47.39%)
  LenderActions            -  10,794B  (43.92%)
```

# Gas usage
Larger than expected increase in `moveQuoteToken` cost.
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                      | Deployment Size |        |        |        |         |
| 4560192                              | 22702           |        |        |        |         |
| Function Name                        | min             | avg    | median | max    | # calls |
| addQuoteToken                        | 115097          | 170645 | 156897 | 653492 | 60004   |
| borrowerInfo                         | 6867            | 6867   | 6867   | 6867   | 8001    |
| bucketTake                           | 332864          | 351036 | 351018 | 369244 | 4       |
| collateralScale                      | 408             | 408    | 408    | 408    | 8003    |
| drawDebt                             | 216926          | 261180 | 237968 | 736727 | 136003  |
| inflatorInfo                         | 421             | 421    | 421    | 421    | 8001    |
| initialize                           | 91393           | 91393  | 91393  | 91393  | 16      |
| interestRateInfo                     | 2411            | 2411   | 2411   | 2411   | 8001    |
| kick                                 | 166010          | 191060 | 189931 | 975101 | 48000   |
| kickWithDeposit                      | 209630          | 244463 | 239352 | 993966 | 8000    |
| loansInfo                            | 1839            | 2537   | 2537   | 8537   | 48019   |
| moveQuoteToken                       | 267109          | 267109 | 267109 | 267109 | 1       |
| quoteTokenScale                      | 433             | 433    | 433    | 433    | 8002    |
| removeQuoteToken                     | 143039          | 164373 | 168145 | 190098 | 4000    |
| repayDebt                            | 508259          | 540298 | 529700 | 688269 | 16002   |
| settle                               | 209860          | 209860 | 209860 | 209860 | 1       |
| take                                 | 76457           | 78355  | 77715  | 302084 | 15998   |
## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                      | Deployment Size |        |        |        |         |
| 4560192                              | 22702           |        |        |        |         |
| Function Name                        | min             | avg    | median | max    | # calls |
| addQuoteToken                        | 115097          | 170645 | 156897 | 653492 | 60004   |
| borrowerInfo                         | 6867            | 6867   | 6867   | 6867   | 8001    |
| bucketTake                           | 332864          | 351036 | 351018 | 369244 | 4       |
| collateralScale                      | 408             | 408    | 408    | 408    | 8003    |
| drawDebt                             | 216926          | 261180 | 237968 | 736727 | 136003  |
| inflatorInfo                         | 421             | 421    | 421    | 421    | 8001    |
| initialize                           | 91393           | 91393  | 91393  | 91393  | 16      |
| interestRateInfo                     | 2411            | 2411   | 2411   | 2411   | 8001    |
| kick                                 | 166010          | 191060 | 189931 | 975101 | 48000   |
| kickWithDeposit                      | 209630          | 244463 | 239352 | 993966 | 8000    |
| loansInfo                            | 1839            | 2537   | 2537   | 8537   | 48019   |
| moveQuoteToken                       | 276810          | 276810 | 276810 | 276810 | 1       |
| quoteTokenScale                      | 433             | 433    | 433    | 433    | 8002    |
| removeQuoteToken                     | 143039          | 164373 | 168112 | 190032 | 4000    |
| repayDebt                            | 508259          | 540298 | 529700 | 688269 | 16002   |
| settle                               | 209860          | 209860 | 209860 | 209860 | 1       |
| take                                 | 76457           | 78355  | 77715  | 302084 | 15998   |

