### PR TITLE
Gracefully revert when collateral pull

### DIFF
--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -382,7 +382,10 @@ library BorrowerActions {
 
             uint256 encumberedCollateral = borrower.t0Debt != 0 ? Maths.wdiv(vars.borrowerDebt, result_.newLup) : 0;
 
-            if (borrower.collateral - encumberedCollateral < collateralAmountToPull_) revert InsufficientCollateral();
+            if (
+                borrower.collateral < encumberedCollateral ||
+                borrower.collateral - encumberedCollateral < collateralAmountToPull_
+            ) revert InsufficientCollateral();
 
             // stamp borrower t0Np when pull collateral action
             vars.stampT0Np = true;


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* When pull collateral, revert with `InsufficientCollateral` if pledged collateral is lower than encumbered collateral
  * check condition `pledgedCollateral < encumberedCollateral` before attempting to `pledgedCollateral - encumberedCollateral`
  * no major impact but bad UX reverting with underflow instead meaningful error


