### PR TITLE
638 feedback

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -170,7 +170,7 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
             positionManager.moveLiquidity(moveLiquidityParams);
 
             // update bucket state
-            toBucket.lpsAtStakeTime = uint128(fromBucket.lpsAtStakeTime);
+            toBucket.lpsAtStakeTime = uint128(positionManager.getLPs(tokenId_, toIndex));
             toBucket.rateAtStakeTime = uint128(IPool(ajnaPool).bucketExchangeRate(toIndex));
             delete stakeInfo.snapshot[fromIndex];
 

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1270,7 +1270,7 @@ contract RewardsManagerTest is ERC20HelperContract {
         changePrank(_minterOne);
         assertEq(_ajnaToken.balanceOf(_minterOne), 44.989657989464439745 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.676741657300861210 * 1e18);
+        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.730457738037587731 * 1e18);
         _rewardsManager.claimRewards(tokenId, currentBurnEpoch);
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Update `toBucket.lpsAtStakeTime` instead of using the stale LPB.
  * Changes to Rewards Manager as recommended by Dmitri here: https://github.com/ajna-finance/contracts/pull/638#pullrequestreview-1327068459

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Gas usage
## Pre Change
```
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 38579           | 46791   | 39494   | 243341  | 292     |
| claimRewards                                   | 523             | 111431  | 87932   | 472472  | 293     |
| getBucketStateStakeInfo                        | 660             | 2659    | 2660    | 2660    | 59112   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 281     |
| moveStakedLiquidity                            | 1673856         | 1797866 | 1797866 | 1921876 | 2       |
| stake                                          | 2431            | 306200  | 167669  | 891414  | 49      |
| unstake                                        | 522             | 179411  | 148914  | 424171  | 12      |
| updateBucketExchangeRatesAndClaim              | 10717           | 259969  | 174003  | 531719  | 38      |
```
## Post Change
```
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 38579           | 59451   | 40579   | 243341  | 73      |
| claimRewards                                   | 523             | 115394  | 107832  | 472472  | 74      |
| getBucketStateStakeInfo                        | 660             | 2659    | 2660    | 2660    | 59112   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 62      |
| moveStakedLiquidity                            | 1704089         | 1827776 | 1827776 | 1951464 | 2       |
| stake                                          | 2431            | 354237  | 386294  | 891414  | 34      |
| unstake                                        | 522             | 179411  | 148914  | 424171  | 12      |
| updateBucketExchangeRatesAndClaim              | 10717           | 278022  | 274287  | 531719  | 29      |
```

