### PR TITLE
Revert if encumbered collateral is calculated as zero for non zero debt

### DIFF
--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -380,9 +380,9 @@ library BorrowerActions {
 
             _revertIfPriceDroppedBelowLimit(result_.newLup, limitIndex_);
 
-            uint256 encumberedCollateral = borrower.t0Debt != 0 ? Maths.wdiv(vars.borrowerDebt, result_.newLup) : 0;
-
+            uint256 encumberedCollateral = Maths.wdiv(vars.borrowerDebt, result_.newLup);
             if (
+                borrower.t0Debt != 0 && encumberedCollateral == 0 || // case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
                 borrower.collateral < encumberedCollateral ||
                 borrower.collateral - encumberedCollateral < collateralAmountToPull_
             ) revert InsufficientCollateral();

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -1024,4 +1024,22 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
         vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
         ERC20Pool(address(_pool)).repayDebt(actor, 0, 149220, actor, 7388);
     }
+
+    function testPullBorrowerWithDebtCollateralEncumberedCalculatedAsZero() external {
+        address actor = makeAddr("actor");
+
+        _mintCollateralAndApproveTokens(actor, 1000000000 * 1e18);
+        _mintQuoteAndApproveTokens(actor, 1000000000000 * 1e18);
+
+        changePrank(actor);
+        _pool.addQuoteToken(200, 2572, block.timestamp + 100);
+        ERC20Pool(address(_pool)).drawDebt(actor, 100, 7388, 1);
+
+        // actor should not be able to pull his collateral without repaying the debt
+        vm.expectRevert(IPoolErrors.InsufficientCollateral.selector);
+        ERC20Pool(address(_pool)).repayDebt(actor, 0, 1, actor, 7388);
+
+        // borrower should be able to repay and pull collateral
+        ERC20Pool(address(_pool)).repayDebt(actor, 120, 1, actor, 7388);
+    }
 }


### PR DESCRIPTION
- encumbered collateral can be calculated as zero when tiny debt and a big LUP (encumbered = debt / LUP)
- in such case borrower could pull collateral leaving pool in a state where borrower has debt but not reflected in loans heap or auction queue
- fix scenario by reverting when encumbered collateral is 0 but debt is greater than 0

