### PR TITLE
Update lender deposit time only when non-zero lps are added

### DIFF
--- a/src/libraries/internal/Buckets.sol
+++ b/src/libraries/internal/Buckets.sol
@@ -65,7 +65,7 @@ library Buckets {
 
     /**
      *  @notice Add amount of LPs for a given lender in a given bucket.
-     *  @dev    Increments bucket.collateral and bucket.lps accumulator state.
+     *  @dev    Increments lender lps accumulator and updates the deposit time.
      *  @param  bucket_         Bucket to record lender LPs.
      *  @param  bankruptcyTime_ Time when bucket become insolvent.
      *  @param  lender_         Lender address to add LPs for in the given bucket.

--- a/src/libraries/internal/Buckets.sol
+++ b/src/libraries/internal/Buckets.sol
@@ -77,12 +77,14 @@ library Buckets {
         address lender_,
         uint256 lpsAmount_
     ) internal {
-        Lender storage lender = bucket_.lenders[lender_];
+        if (lpsAmount_ != 0) {
+            Lender storage lender = bucket_.lenders[lender_];
 
-        if (bankruptcyTime_ >= lender.depositTime) lender.lps = lpsAmount_;
-        else lender.lps += lpsAmount_;
+            if (bankruptcyTime_ >= lender.depositTime) lender.lps = lpsAmount_;
+            else lender.lps += lpsAmount_;
 
-        lender.depositTime = block.timestamp;
+            lender.depositTime = block.timestamp;
+        }
     }
 
     /**********************/

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -763,7 +763,7 @@ contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
             lender:      actor1,
             index:       2572,
             lpBalance:   0,
-            depositTime: _startTime + 200 days // FIXME: kicker didn't get any LP because auction price was zero but deposit time increased
+            depositTime: 0
         });
     }
 }

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.14;
 
 import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
+import 'src/ERC20Pool.sol';
 import 'src/libraries/helpers/PoolHelper.sol';
 
 contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
@@ -704,6 +705,65 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             from:     _taker,
             borrower: _borrower,
             index:    _i9_91
+        });
+    }
+}
+
+contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
+
+    function testDepositTakeOnAuctionPriceZero() external {
+        address actor1 = makeAddr("actor1");
+        _mintQuoteAndApproveTokens(actor1, type(uint256).max);
+        _mintCollateralAndApproveTokens(actor1, type(uint256).max);
+
+        address actor2 = makeAddr("actor2");
+        _mintQuoteAndApproveTokens(actor2, type(uint256).max);
+        _mintCollateralAndApproveTokens(actor2, type(uint256).max);
+
+        address actor4 = makeAddr("actor4");
+        _mintQuoteAndApproveTokens(actor4, type(uint256).max);
+        _mintCollateralAndApproveTokens(actor4, type(uint256).max);
+
+        changePrank(actor2);
+        _pool.addQuoteToken(1791670358647.909977170293982862 * 1e18, 2572, block.timestamp + 100);
+        _pool.updateInterest();
+        ERC20Pool(address(_pool)).drawDebt(actor2, 895835179323.954988585146991431 * 1e18, 7388, 333688779.021420071719646593 * 1e18);
+        skip(100 days);
+
+        changePrank(actor1);
+        _pool.updateInterest();
+        _pool.kick(actor2, 7388);
+        skip(100 days);
+
+        changePrank(actor4);
+        _pool.updateInterest();
+
+        (uint256 bucketLps, uint256 collateral, , uint256 deposit, ) = _pool.bucketInfo(2572);
+        assertEq(bucketLps, 1791670358647.909977170293982862 * 1e18);
+        assertEq(collateral, 0);
+        assertEq(deposit, 1801723269843.804345891389974172 * 1e18);
+
+        // assert kicker balances in bucket before take
+        _assertLenderLpBalance({
+            lender:      actor1,
+            index:       2572,
+            lpBalance:   0,
+            depositTime: 0
+        });
+
+        ERC20Pool(address(_pool)).bucketTake(actor2, false, 2572);
+
+        (bucketLps, collateral, , deposit, ) = _pool.bucketInfo(2572);
+        assertEq(bucketLps, 2686939151758.589782375606219371 * 1e18);
+        assertEq(collateral, 333688779.021420071719646593 * 1e18);
+        assertEq(deposit, 1801723269843.804345891389974172 * 1e18);
+
+        // assert kicker balances in bucket after take, deposit time increased
+        _assertLenderLpBalance({
+            lender:      actor1,
+            index:       2572,
+            lpBalance:   0,
+            depositTime: _startTime + 200 days // FIXME: kicker didn't get any LP because auction price was zero but deposit time increased
         });
     }
 }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* In cases when bucket take happens for an auction with auction price zero, the bond change is calculated as zero and LPs awarded to kicker are 0. We want to avoid executing the logic within `Bucket.addLenderLPs` as it only updates kicker's deposit time resulting in additional gas costs.
*  Added a check to update Lender/kicker `depositTime` only when non-zero lps are added