### PR TITLE
(ToB) PoolUtilInfo htp calculation fix

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -43,13 +43,13 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
 
         (
-            uint256 poolInflatorSnapshot,
-            uint256 lastInflatorSnapshotUpdate
+            uint256 poolInflator,
+            uint256 lastInflatorUpdate
         ) = pool.inflatorInfo();
 
         (uint256 interestRate,) = pool.interestRateInfo();
 
-        uint256 pendingInflator = PoolCommons.pendingInflator(poolInflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
+        uint256 pendingInflator = PoolCommons.pendingInflator(poolInflator, lastInflatorUpdate, interestRate);
 
         uint256 t0Debt;
         (t0Debt, collateral_, t0Np_)  = pool.borrowerInfo(borrower_);
@@ -112,14 +112,14 @@ contract PoolInfoUtils {
         (maxBorrower_, , loansCount_) = pool.loansInfo();
 
         (
-            uint256 inflatorSnapshot,
-            uint256 lastInflatorSnapshotUpdate
+            uint256 inflator,
+            uint256 inflatorUpdate
         ) = pool.inflatorInfo();
 
         (uint256 interestRate, ) = pool.interestRateInfo();
 
-        pendingInflator_       = PoolCommons.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate);
-        pendingInterestFactor_ = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
+        pendingInflator_       = PoolCommons.pendingInflator(inflator, inflatorUpdate, interestRate);
+        pendingInterestFactor_ = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - inflatorUpdate);
     }
 
     /**
@@ -151,9 +151,8 @@ contract PoolInfoUtils {
         hpb_      = _priceAt(hpbIndex_);
 
         (, uint256 maxThresholdPrice,) = pool.loansInfo();
-        (uint256 inflatorSnapshot,)    = pool.inflatorInfo();
 
-        htp_      = Maths.wmul(maxThresholdPrice, inflatorSnapshot);
+        htp_      = maxThresholdPrice;
         htpIndex_ = htp_ >= MIN_PRICE ? _indexOf(htp_) : MAX_FENWICK_INDEX;
         lupIndex_ = pool.depositIndex(debt);
         lup_      = _priceAt(lupIndex_);
@@ -310,13 +309,8 @@ contract PoolInfoUtils {
 
     function htp(
         address ajnaPool_
-    ) external view returns (uint256) {
-        IPool pool = IPool(ajnaPool_);
-
-        (, uint256 maxThresholdPrice, ) = pool.loansInfo();
-        (uint256 inflatorSnapshot, )    = pool.inflatorInfo();
-
-        return Maths.wmul(maxThresholdPrice, inflatorSnapshot);
+    ) external view returns (uint256 htp_) {
+        (, htp_, ) = IPool(ajnaPool_).loansInfo();
     }
 
     function momp(

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -43,13 +43,13 @@ contract PoolInfoUtils {
         IPool pool = IPool(ajnaPool_);
 
         (
-            uint256 poolInflator,
+            uint256 inflator,
             uint256 lastInflatorUpdate
         ) = pool.inflatorInfo();
 
         (uint256 interestRate,) = pool.interestRateInfo();
 
-        uint256 pendingInflator = PoolCommons.pendingInflator(poolInflator, lastInflatorUpdate, interestRate);
+        uint256 pendingInflator = PoolCommons.pendingInflator(inflator, lastInflatorUpdate, interestRate);
 
         uint256 t0Debt;
         (t0Debt, collateral_, t0Np_)  = pool.borrowerInfo(borrower_);

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -51,7 +51,7 @@ interface IPoolState {
      *  @param  borrower   Address of the borrower.
      *  @return t0Debt     Amount of debt borrower would have had if their loan was the first debt drawn from the pool
      *  @return collateral Amount of collateral that the borrower has deposited, in collateral token.
-     *  @return t0Np       Np / borrowerInflatorSnapshot
+     *  @return t0Np       t0 Neutral Price
      */
     function borrowerInfo(address borrower)
         external
@@ -119,14 +119,14 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about pool inflator.
-     *  @return inflatorSnapshot A snapshot of the last inflator value.
-     *  @return lastUpdate       The timestamp of the last `inflatorSnapshot` update.
+     *  @return inflator   Pool inflator value.
+     *  @return lastUpdate The timestamp of the last `inflator` update.
      */
     function inflatorInfo()
         external
         view
         returns (
-            uint256 inflatorSnapshot,
+            uint256 inflator,
             uint256 lastUpdate
     );
 

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -349,18 +349,18 @@ library PoolCommons {
 
     /**
      *  @notice Calculates pool pending inflator given the current inflator, time of last update and current interest rate.
-     *  @param  inflatorSnapshot_ Current pool interest rate.
-     *  @param  inflatorUpdate    Timestamp when inflator was updated.
-     *  @param  interestRate_     The interest rate of the pool.
+     *  @param  inflator_      Current pool inflator.
+     *  @param  inflatorUpdate Timestamp when inflator was updated.
+     *  @param  interestRate_  The interest rate of the pool.
      *  @return The pending value of pool inflator.
      */
     function pendingInflator(
-        uint256 inflatorSnapshot_,
+        uint256 inflator_,
         uint256 inflatorUpdate,
         uint256 interestRate_
     ) external view returns (uint256) {
         return Maths.wmul(
-            inflatorSnapshot_,
+            inflator_,
             PRBMathUD60x18.exp((interestRate_ * (block.timestamp - inflatorUpdate)) / 365 days)
         );
     }

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -39,13 +39,13 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         (borrowerT0debt, borrowerCollateral, ) = _pool.borrowerInfo(borrower);
 
         // calculate current pool Inflator
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorSnapshotUpdate) = _pool.inflatorInfo();
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = _pool.inflatorInfo();
 
-        uint256 elapsed = block.timestamp - lastInflatorSnapshotUpdate;
+        uint256 elapsed = block.timestamp - lastInflatorUpdate;
         (uint256 interestRate, ) = _pool.interestRateInfo();
         uint256 factor = PoolCommons.pendingInterestFactor(interestRate, elapsed);
 
-        uint256 currentPoolInflator = Maths.wmul(poolInflatorSnapshot, factor);
+        uint256 currentPoolInflator = Maths.wmul(poolInflator, factor);
 
         // Calculate current debt of borrower, rounding up to token precision
         uint256 currentDebt = Maths.wmul(currentPoolInflator, borrowerT0debt);

--- a/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -368,7 +368,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  352.454532537342231182 * 1e18,
+                htp:                  351.393939751686889789 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_055.509494601600700000 * 1e18,
                 pledgedCollateral:    60 * 1e18,
@@ -406,7 +406,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  424.349858731660857846 * 1e18,
+                htp:                  422.372244265211513602 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_086.111097974181150000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -441,7 +441,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  425.900107294311861922 * 1e18,
+                htp:                  423.143052860217066081 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_119.833720983122550000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -473,7 +473,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  427.611922756860156608 * 1e18,
+                htp:                  423.992567137945688846 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_157.001040562732750000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -503,7 +503,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  427.611922756860156608 * 1e18,
+                htp:                  423.992567137945688846 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_157.001040562732750000 * 1e18,
                 pledgedCollateral:    50 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -125,7 +125,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  421.557216751451801727 * 1e18,
+                htp:                  420.980136462780058369 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             30_024.492338129690940000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -161,7 +161,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  2_985.093792841086761332 * 1e18,
+                htp:                  2_981.007422784467321393 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             30_024.492338129690940000 * 1e18,
                 pledgedCollateral:    7.061038044473493202 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFactory.t.sol
@@ -120,8 +120,8 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(interestRate,       0.0543 * 10**18);
         assertEq(interestRateUpdate, _startTime + 333);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflator, 10**18);
         assertEq(lastInflatorUpdate,   _startTime + 333);
 
         // check tracking of deployed pools
@@ -151,8 +151,8 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(interestRate,       0.0543 * 10**18);
         assertEq(interestRateUpdate, _startTime + 333);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflator, 10**18);
         assertEq(lastInflatorUpdate,   _startTime + 333);
     }
 
@@ -176,8 +176,8 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(interestRate,       0.0543 * 10**18);
         assertEq(interestRateUpdate, _startTime + 333);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflator, 10**18);
         assertEq(lastInflatorUpdate,   _startTime + 333);
     }
 
@@ -201,9 +201,9 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(interestRate,       0.0543 * 10**18);
         assertEq(interestRateUpdate, _startTime + 333);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
-        assertEq(lastInflatorUpdate,   _startTime + 333);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflator,       10**18);
+        assertEq(lastInflatorUpdate, _startTime + 333);
     }
 
     function testDeployERC20CompUsdcPool() external {
@@ -226,9 +226,9 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         assertEq(interestRate,       0.0543 * 10**18);
         assertEq(interestRateUpdate, _startTime + 333);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = pool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
-        assertEq(lastInflatorUpdate,   _startTime + 333);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = pool.inflatorInfo();
+        assertEq(poolInflator,       10**18);
+        assertEq(lastInflatorUpdate, _startTime + 333);
     }
 
     function testPoolAlreadyInitialized() external {

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -127,7 +127,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  461.913231889174987773 * 1e18,
+                htp:                  461.177183352194672960 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             110_064.287293030035100000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -235,7 +235,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.664069695689831259 * 1e18,
+                htp:                  0.664020422940018855 * 1e18,
                 lup:                  100.332368143282009890 * 1e18,
                 poolSize:             1_000.062818094677887000 * 1e18,
                 pledgedCollateral:    1_500 * 1e18,
@@ -307,7 +307,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  500.549332936289892272 * 1e18,
+                htp:                  500.515049909493508659 * 1e18,
                 lup:                  601.252968524772188572 * 1e18,
                 poolSize:             11_000.291385769156360000 * 1e18,
                 pledgedCollateral:    10 * 1e18,
@@ -373,7 +373,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // show the rate bottoms out at 10 bps
         _assertPool(
             PoolParams({
-                htp:                  1.003660230043452158 * 1e18,
+                htp:                  1.002309975983935259 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             10_000.000000011461690000 * 1e18,
                 pledgedCollateral:    0.00001 * 1e18,
@@ -439,7 +439,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // show the rate maxed out at 50000%
         _assertPool(
             PoolParams({
-                htp:                  2_081.663642755844195984 * 1e18,
+                htp:                  0.001443490644739886 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             10_012.269795822391370000 * 1e18,
                 pledgedCollateral:    10_000.0 * 1e18,
@@ -652,7 +652,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.237543320969223878 * 1e18,
+                htp:                  10.223528890139451939 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             20_001.166301815699560000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -798,7 +798,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  200.941998518054562754 * 1e18,
+                htp:                  200.666923956635192629 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_022.159734498291800000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -836,7 +836,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  201.493279375818240993 * 1e18,
+                htp:                  200.941998518054562716 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_045.121523671487120000 * 1e18,
                 pledgedCollateral:    50_100 * 1e18,
@@ -868,7 +868,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  201.548490576836267720 * 1e18,
+                htp:                  200.969526704670605713 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_047.420826509653040000 * 1e18,
                 pledgedCollateral:    50_100 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -177,7 +177,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.209538814158655264 * 1e18,
+                htp:                  8.097846143253778448 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             73_093.873009488594553000 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -315,7 +315,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  7.991488192808991114 * 1e18,
+                htp:                  7.989580407145861718 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             63_008.830844290339406730 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,
@@ -388,7 +388,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  7.991488192808991114 * 1e18,
+                htp:                  7.989580407145861718 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
                 poolSize:             8_000.423065889459267791 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,
@@ -416,7 +416,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  7.993335753787741967 * 1e18,
+                htp:                  7.990503913730158191 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
                 poolSize:             8_001.214422208222843222 * 1e18,
                 pledgedCollateral:    1_001.742368450520005091 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -391,7 +391,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  9.910303333009215085 * 1e18,
+                htp:                  9.771304290202671377 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             63_807.241482463513273501 * 1e18,
                 pledgedCollateral:    2 * 1e18,

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -308,7 +308,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.280695967198888513 * 1e18,
+                htp:                  9.154429955928583539 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_219.674636105806620000 * 1e18,
                 pledgedCollateral:    2_002.000000000000000000 * 1e18,
@@ -386,7 +386,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.281940892899682703 * 1e18,
+                htp:                  9.155043929439064212 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             83_220.780619576281748675 * 1e18,
                 pledgedCollateral:    1_002.0 * 1e18,
@@ -436,7 +436,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.281940892899682703 * 1e18,
+                htp:                  9.155043929439064212 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             83_220.780619576281748675 * 1e18,
                 pledgedCollateral:    2_002.0 * 1e18,
@@ -585,7 +585,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.280695967198888513 * 1e18,
+                htp:                  9.154429955928583539 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_219.674636105806620000 * 1e18,
                 pledgedCollateral:    2_002.000000000000000000 * 1e18,
@@ -754,7 +754,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              9_822.951211365485636462* 1e18,
+            borrowerDebt:              9_822.951211365485636462 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              1_575.326150647652569911 * 1e18,
             borrowerCollateralization: 0.989651241857326201 * 1e18
@@ -793,7 +793,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.280695967198888513 * 1e18,
+                htp:                  9.154429955928583539 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_219.674636105806620000 * 1e18,
                 pledgedCollateral:    2_002.000000000000000000 * 1e18,
@@ -955,7 +955,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.901856025849255254 * 1e18,
+                htp:                  9.767138988573636287 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             73_113.822894306622584000 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
@@ -1007,7 +1007,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.902059490734692431 * 1e18,
+                htp:                  9.767239336407496599 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             73_113.913540853182354328 * 1e18,
                 pledgedCollateral:    992.0 * 1e18,
@@ -1142,7 +1142,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              9_822.951211365485636462* 1e18,
+            borrowerDebt:              9_822.951211365485636462 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              1_575.326150647652569911 * 1e18,
             borrowerCollateralization: 0.989651241857326201 * 1e18
@@ -1181,7 +1181,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.280695967198888513 * 1e18,
+                htp:                  9.154429955928583539 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_219.674636105806620000 * 1e18,
                 pledgedCollateral:    2_002.000000000000000000 * 1e18,

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -45,13 +45,13 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         (borrowerT0debt, borrowerCollateral, ) = _pool.borrowerInfo(borrower);
 
         // calculate current pool Inflator
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorSnapshotUpdate) = _pool.inflatorInfo();
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = _pool.inflatorInfo();
 
         (uint256 interestRate, ) = _pool.interestRateInfo();
-        uint256 factor = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - lastInflatorSnapshotUpdate);
+        uint256 factor = PoolCommons.pendingInterestFactor(interestRate, block.timestamp - lastInflatorUpdate);
 
         // Calculate current debt of borrower (currentPoolInflator * borrowerT0Debt)
-        uint256 currentDebt = Maths.wmul(Maths.wmul(poolInflatorSnapshot, factor), borrowerT0debt);
+        uint256 currentDebt = Maths.wmul(Maths.wmul(poolInflator, factor), borrowerT0debt);
 
         // mint quote tokens to borrower address equivalent to the current debt
         deal(_pool.quoteTokenAddress(), borrower, currentDebt);

--- a/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -272,7 +272,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check pool state after partial repay
         _assertPool(
             PoolParams({
-                htp:                  503.022258079721182348 * 1e18,
+                htp:                  502.333658244714424687 * 1e18,
                 lup:                  _priceAt(2550),
                 poolSize:             30_003.498905447098710000 * 1e18,
                 pledgedCollateral:    Maths.wad(3),

--- a/tests/forge/ERC721Pool/ERC721PoolEMAs.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolEMAs.t.sol
@@ -128,7 +128,7 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         _pool.updateInterest();
         _assertPool(
             PoolParams({
-                htp:                  1_159.152924076894437152 * 1e18,
+                htp:                  1_159.080148495302209694 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             15_000.38784582038918 * 1e18,     // first interest accrual
                 pledgedCollateral:    6 * 1e18,
@@ -200,7 +200,7 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         assertEq(depositEma, 19_855.678232854988936290 * 1e18);         // reached (sort of) 20_000
         _assertPool(
             PoolParams({
-                htp:                  1_160.241132852523151748 * 1e18,
+                htp:                  1_159.624091089473286060 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             25_003.260972741349848786 * 1e18, // reflects additional 10_000 deposit
                 pledgedCollateral:    6 * 1e18,
@@ -260,7 +260,7 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         assertEq(debtEma, 17_945.800561906185304271 * 1e18);            // reached 18_000
         _assertPool(
             PoolParams({
-                htp:                  1_499.486002669294859183 * 1e18,
+                htp:                  1_497.940412039697435044 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             25_011.246566016078933954 * 1e18,
                 pledgedCollateral:    12 * 1e18,                        // 6 additional NFTs deposited
@@ -343,7 +343,7 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  1_276.656276295498190871 * 1e18,
+                htp:                  1_276.218508787651473374 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             15_002.306593887595240000 * 1e18,
                 pledgedCollateral:    6 * 1e18,

--- a/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolFactory.t.sol
@@ -197,9 +197,9 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         assertEq(interestRate,       0.05 * 10**18);
         assertEq(interestRateUpdate, _startTime);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTCollectionPool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
-        assertEq(lastInflatorUpdate,   _startTime);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = _NFTCollectionPool.inflatorInfo();
+        assertEq(poolInflator,       10**18);
+        assertEq(lastInflatorUpdate, _startTime);
     }
 
     /**************************************/
@@ -307,9 +307,9 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         assertEq(interestRate,       0.05 * 10**18);
         assertEq(interestRateUpdate, _startTime);
 
-        (uint256 poolInflatorSnapshot, uint256 lastInflatorUpdate) = _NFTSubsetOnePool.inflatorInfo();
-        assertEq(poolInflatorSnapshot, 10**18);
-        assertEq(lastInflatorUpdate,   _startTime);
+        (uint256 poolInflator, uint256 lastInflatorUpdate) = _NFTSubsetOnePool.inflatorInfo();
+        assertEq(poolInflator,       10**18);
+        assertEq(lastInflatorUpdate, _startTime);
 
         assertTrue(_NFTSubsetOnePool.tokenIdsAllowed(1));
         assertTrue(_NFTSubsetOnePool.tokenIdsAllowed(5));

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -157,7 +157,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582216822103492762 * 1e18,
+                htp:                  5.739575714606494647 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000 * 1e18,
                 pledgedCollateral:    5 * 1e18,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -177,7 +177,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582216822103492762 * 1e18,
+                htp:                  5.739575714606494647 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000 * 1e18,
                 pledgedCollateral:    5 * 1e18,

--- a/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -183,7 +183,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582216822103492762 * 1e18,
+                htp:                  5.739575714606494647 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000 * 1e18,
                 pledgedCollateral:    5 * 1e18,
@@ -290,7 +290,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.887140410855539624 * 1e18,
+                htp:                  7.749209044755361552 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000.000966222327608000 * 1e18,
                 pledgedCollateral:    4 * 1e18,
@@ -362,7 +362,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582588772946404613 * 1e18,
+                htp:                  5.739737879567360457 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000.000966222327608000 * 1e18,
                 pledgedCollateral:    3.0 * 1e18,
@@ -461,7 +461,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582216822103492762 * 1e18,
+                htp:                  5.739575714606494647 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000 * 1e18,
                 pledgedCollateral:    5 * 1e18,
@@ -571,7 +571,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  6.582893111996772890 * 1e18,
+                htp:                  5.739870563397816903 * 1e18,
                 lup:                  9.917184843435912074 * 1e18,
                 poolSize:             73_000.001756788173660000 * 1e18,
                 pledgedCollateral:    3 * 1e18,

--- a/tests/forge/PoolCommonsTest.t.sol
+++ b/tests/forge/PoolCommonsTest.t.sol
@@ -11,15 +11,15 @@ contract PoolCommonsTest is DSTestPlus {
      *  @notice Tests pending inflator calculation for varying parameters
      */
     function testPendingInflator() external {
-        uint256 inflatorSnapshot = 0.01 * 1e18; 
+        uint256 inflator = 0.01 * 1e18; 
         skip(730 days);
-        uint256 lastInflatorSnapshotUpdate = block.timestamp - 365 days; 
+        uint256 lastInflatorUpdate = block.timestamp - 365 days; 
         uint256 interestRate = 0.1 * 1e18;
-        assertEq(PoolCommons.pendingInflator(inflatorSnapshot, lastInflatorSnapshotUpdate, interestRate),   Maths.wmul(inflatorSnapshot,PRBMathUD60x18.exp(interestRate)));
-        assertEq(PoolCommons.pendingInflator(inflatorSnapshot, block.timestamp - 1 hours, interestRate),    0.010000114155902715 * 1e18);
-        assertEq(PoolCommons.pendingInflator(inflatorSnapshot, block.timestamp - 10 hours, interestRate),   0.010001141617671002 * 1e18);
-        assertEq(PoolCommons.pendingInflator(inflatorSnapshot, block.timestamp - 1 days, interestRate),     0.010002740101366609 * 1e18);
-        assertEq(PoolCommons.pendingInflator(inflatorSnapshot, block.timestamp - 5 hours, 0.042 * 1e18 ),   0.010000239728900849 * 1e18);
+        assertEq(PoolCommons.pendingInflator(inflator, lastInflatorUpdate, interestRate),   Maths.wmul(inflator, PRBMathUD60x18.exp(interestRate)));
+        assertEq(PoolCommons.pendingInflator(inflator, block.timestamp - 1 hours, interestRate),    0.010000114155902715 * 1e18);
+        assertEq(PoolCommons.pendingInflator(inflator, block.timestamp - 10 hours, interestRate),   0.010001141617671002 * 1e18);
+        assertEq(PoolCommons.pendingInflator(inflator, block.timestamp - 1 days, interestRate),     0.010002740101366609 * 1e18);
+        assertEq(PoolCommons.pendingInflator(inflator, block.timestamp - 5 hours, 0.042 * 1e18 ),   0.010000239728900849 * 1e18);
     }
 
     /**

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -506,9 +506,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         assertEq(loansCount,  state_.loans);
         assertEq(maxBorrower, state_.maxBorrower);
 
-        (uint256 poolInflatorSnapshot, ) = _pool.inflatorInfo();
-        assertGe(poolInflatorSnapshot, 1e18);
-        assertGe(pendingInflator,      poolInflatorSnapshot);
+        (uint256 poolInflator, ) = _pool.inflatorInfo();
+        assertGe(poolInflator,    1e18);
+        assertGe(pendingInflator, poolInflator);
 
         (uint256 interestRate, uint256 interestRateUpdate) = _pool.interestRateInfo();
         assertEq(interestRate,       state_.interestRate);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* `PoolUtilsInfo` multiplies twice the max t0 threshold price with pool inflator
  * in `PoolUtilsInfo.poolPricesInfo` and `PoolUtilsInfo.htp` functions do not multiply again the `maxThresholdPrice` value returned from `pool.loansInfo` function (as it's already multiplied)
  * consistent naming of `inflator` across contracts instead `inflatorSnapshot`

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->


