### PR TITLE
Settle: Calculate reserve only when needed

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -341,21 +341,17 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     ) external override nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
-        uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getNormalizedPoolQuoteTokenBalance();
-
-        uint256 liabilities = Deposits.treeSum(deposits) + auctions.totalBondEscrowed + reserveAuction.unclaimed;
-
         SettleResult memory result = Auctions.settlePoolDebt(
             auctions,
             buckets,
             deposits,
             loans,
+            reserveAuction,
+            poolState,
             SettleParams({
                 borrower:    borrowerAddress_,
-                reserves:    (assets > liabilities) ? (assets - liabilities) : 0,
-                inflator:    poolState.inflator,
-                bucketDepth: maxDepth_,
-                poolType:    poolState.poolType
+                poolBalance: _getNormalizedPoolQuoteTokenBalance(),
+                bucketDepth: maxDepth_
             })
         );
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -379,25 +379,19 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
     ) external nonReentrant override {
         PoolState memory poolState = _accruePoolInterest();
 
-        uint256 assets = Maths.wmul(poolBalances.t0Debt, poolState.inflator) + _getNormalizedPoolQuoteTokenBalance();
-
-        uint256 liabilities = Deposits.treeSum(deposits) + auctions.totalBondEscrowed + reserveAuction.unclaimed;
-
-        SettleParams memory params = SettleParams(
-            {
-                borrower:    borrowerAddress_,
-                reserves:    (assets > liabilities) ? (assets-liabilities) : 0,
-                inflator:    poolState.inflator,
-                bucketDepth: maxDepth_,
-                poolType:    poolState.poolType
-            }
-        );
+        SettleParams memory params = SettleParams({
+            borrower:    borrowerAddress_,
+            poolBalance: _getNormalizedPoolQuoteTokenBalance(),
+            bucketDepth: maxDepth_
+        });
 
         SettleResult memory result = Auctions.settlePoolDebt(
             auctions,
             buckets,
             deposits,
             loans,
+            reserveAuction,
+            poolState,
             params
         );
 

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -37,10 +37,8 @@ struct KickResult {
 
 struct SettleParams {
     address borrower;    // borrower address to settle
-    uint256 reserves;    // current reserves in pool
-    uint256 inflator;    // current pool inflator
     uint256 bucketDepth; // number of buckets to use when settle debt
-    uint256 poolType;    // number of buckets to use when settle debt
+    uint256 poolBalance; // current pool quote token balance
 }
 
 struct SettleResult {


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* In settle action calculate reserves only when needed
  * currently reserves are calculated in pool and passed as a parameter to `Auction.settlePoolDebt` function
  * moved calculation of reserves in `Auction.settlePoolDebt` function and performed only when there's need to settle bad debt
  * this reduce gas costs (by reducing storage reads) and also simplifies code / reduce duplicate code as reserves are not calculated in both `ERC20Pool` and `ERC721Pool` anymore + contract size reduction

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,121B  (98.14%)
  ERC20Pool                -  23,604B  (96.04%)
  Auctions                 -  20,900B  (85.04%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,040B  (97.82%)
  ERC20Pool                -  23,486B  (95.56%)
  Auctions                 -  21,037B  (85.60%)
```


