### PR TITLE
Mul before div consistency

### DIFF
--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -890,7 +890,7 @@ library Auctions {
         Loans.remove(loans_, borrowerAddress_, loans_.indices[borrowerAddress_]);
 
         // when loan is kicked, penalty of three months of interest is added
-        vars.t0KickPenalty = Maths.wmul(kickResult_.t0KickedDebt, Maths.wdiv(poolState_.rate, 4 * 1e18));
+        vars.t0KickPenalty = Maths.wdiv(Maths.wmul(kickResult_.t0KickedDebt, poolState_.rate), 4 * 1e18);
         vars.kickPenalty   = Maths.wmul(vars.t0KickPenalty, poolState_.inflator);
 
         kickResult_.t0PoolDebt   = poolState_.t0Debt + vars.t0KickPenalty;

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -310,7 +310,7 @@ library PoolCommons {
             // cubic root of the percentage of meaningful unutilized deposit
             uint256 crpud = PRBMathUD60x18.pow(base, ONE_THIRD);
             // finish calculating Net Interest Margin, and then convert to Lender Interest Margin
-            return 1e18 - Maths.wmul(Maths.wdiv(crpud, CUBIC_ROOT_1000000), 0.15 * 1e18);
+            return 1e18 - Maths.wdiv(Maths.wmul(crpud, 0.15 * 1e18), CUBIC_ROOT_1000000);
         }
     }
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -142,7 +142,7 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 inflator_,
         uint256 t0Debt2ToCollateral_
     ) pure returns (uint256) {
-        return t0Debt_ == 0 ? 0 : Maths.wmul(inflator_, Maths.wdiv(t0Debt2ToCollateral_, t0Debt_));
+        return t0Debt_ == 0 ? 0 : Maths.wdiv(Maths.wmul(inflator_, t0Debt2ToCollateral_), t0Debt_);
     }
 
     /**

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -163,7 +163,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.778456451861613480 * 1e18,
+            debt:           19.778456451861613481 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195342779771472726 * 1e18,
             transferAmount: 0.195342779771472726 * 1e18
@@ -180,7 +180,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      328.175870016074179200 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
@@ -217,7 +217,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.779116873676490456 * 1e18,
+            borrowerDebt:              19.779116873676490457 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.982985835729561629 * 1e18
@@ -241,7 +241,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             exchangeRate: 1.013413645989143096 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   24.540805142364516444 * 1e18,
+            reserves:                   24.540805142364516445 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -259,14 +259,14 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      7.251730722192532064 * 1e18,
-                debtInAuction:     19.779116873676490456 * 1e18,
+                debtInAuction:     19.779116873676490457 * 1e18,
                 thresholdPrice:    9.889558436838245228 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.779116873676490456 * 1e18,
+            borrowerDebt:              19.779116873676490457 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.982985835729561629 * 1e18
@@ -307,7 +307,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         // reserves should remain the same after arb take
         _assertReserveAuction({
-            reserves:                   25.925343323521870782 * 1e18,
+            reserves:                   25.925343323521870783 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -315,7 +315,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              6.805228224892631302 * 1e18,
+            borrowerDebt:              6.805228224892631303 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0
@@ -331,7 +331,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      7.251730722192532064 * 1e18,
-                debtInAuction:     6.805228224892631302 * 1e18,
+                debtInAuction:     6.805228224892631303 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
@@ -360,8 +360,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      20.510991876004636192 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
-                thresholdPrice:    9.889482233342512889 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
+                thresholdPrice:    9.889482233342512890 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
@@ -376,7 +376,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.778964466685025779 * 1e18,
+            borrowerDebt:              19.778964466685025780 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 152.208547722958917634 * 1e18
@@ -389,7 +389,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i1505_26,
             collateralArbed:  1.031812215971460994 * 1e18,
-            quoteTokenAmount: 21.163491979352977584 * 1e18,
+            quoteTokenAmount: 21.163491979352977585 * 1e18,
             bondChange:       0.195342779771472726 * 1e18,
             isReward:         false,
             lpAwardTaker:     1_531.986011313779866429 * 1e18,
@@ -419,11 +419,11 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:        _i1505_26,
             lpBalance:    26_531.986011313779866429 * 1e18,
             collateral:   1.031812215971460994 * 1e18,
-            deposit:      24_978.836508020647022416 * 1e18,
+            deposit:      24_978.836508020647022415 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   26.111530884129144302 * 1e18,
+            reserves:                   26.111530884129144303 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -446,8 +446,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      20.510991876004636192 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
-                thresholdPrice:    9.889482233342512889 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
+                thresholdPrice:    9.889482233342512890 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
@@ -462,7 +462,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.778964466685025779 * 1e18,
+            borrowerDebt:              19.778964466685025780 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.982993410135902682 * 1e18
@@ -507,9 +507,9 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              6.163491979352977583 * 1e18,
+            borrowerDebt:              6.163491979352977584 * 1e18,
             borrowerCollateral:        1.268684806142984527 * 1e18,
-            borrowert0Np:              5.057793757429320955 * 1e18,
+            borrowert0Np:              5.057793757429320956 * 1e18,
             borrowerCollateralization: 2.001018319047304755  * 1e18
         });
         _assertLenderLpBalance({
@@ -568,14 +568,14 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      82.043967504018544800 * 1e18,
-                debtInAuction:     19.778761259189860403 * 1e18,
-                thresholdPrice:    9.889380629594930201 * 1e18,
+                debtInAuction:     19.778761259189860404 * 1e18,
+                thresholdPrice:    9.889380629594930202 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.778761259189860403 * 1e18,
+            borrowerDebt:              19.778761259189860404 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.983003509435146965 * 1e18
@@ -587,7 +587,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i10016,
             collateralArbed:  0.257950403803869741 * 1e18,
-            quoteTokenAmount: 21.163274547333150631 * 1e18,
+            quoteTokenAmount: 21.163274547333150632 * 1e18,
             bondChange:       0.195342779771472726 * 1e18,
             isReward:         false,
             lpAwardTaker:     2_562.597355112798042 * 1e18,
@@ -615,7 +615,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:        _i10016,
             lpBalance:    3_562.597355112798042 * 1e18,       // LP balance in arbed bucket increased with LPs awarded for arb taker
             collateral:   0.257950403803869741 * 1e18,        // arbed collateral added to the arbed bucket
-            deposit:      978.836725452666849368 * 1e18,      // quote token amount is diminished in arbed bucket
+            deposit:      978.836725452666849367 * 1e18,      // quote token amount is diminished in arbed bucket
             exchangeRate: 1 * 1e18
         });
         _assertAuction(
@@ -672,14 +672,14 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18, 
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      116.027691555080513536 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889355228821139433 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.778710457642278866 * 1e18,
+            borrowerDebt:              19.778710457642278867 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.983006034276170567 * 1e18

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -164,7 +164,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           20.189067248182664593 * 1e18,
+            debt:           20.189067248182664594 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.199398195043779403 * 1e18,
             transferAmount: 0.199398195043779403 * 1e18
@@ -181,8 +181,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      334.988967673549397664 * 1e18,
-                debtInAuction:     20.189067248182664592 * 1e18,
-                thresholdPrice:    10.094533624091332296 * 1e18,
+                debtInAuction:     20.189067248182664594 * 1e18,
+                thresholdPrice:    10.094533624091332297 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );
@@ -217,7 +217,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              20.189741380689676442 * 1e18,
+            borrowerDebt:              20.189741380689676443 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.962993599742653326 * 1e18
@@ -241,8 +241,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             exchangeRate: 1.000003244027008957 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   286.940599154163800220 * 1e18,
-            claimableReserves :         245.508462704973068078 * 1e18,
+            reserves:                   286.940599154163800221 * 1e18,
+            claimableReserves :         245.508462704973068079 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -259,14 +259,14 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      7.402280333270247968 * 1e18,
-                debtInAuction:     20.189741380689676442 * 1e18,
+                debtInAuction:     20.189741380689676443 * 1e18,
                 thresholdPrice:    10.094870690344838221 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              20.189741380689676442 * 1e18,
+            borrowerDebt:              20.189741380689676443 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.962993599742653326 * 1e18
@@ -307,8 +307,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         // reserves should remain the same after deposit take
         _assertReserveAuction({
-            reserves:                   288.353881050812077571 * 1e18,
-            claimableReserves :         247.012858322088119572 * 1e18,
+            reserves:                   288.353881050812077572 * 1e18,
+            claimableReserves :         247.012858322088119573 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -324,14 +324,14 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      7.402280333270247968 * 1e18,
-                debtInAuction:     1.966997287334847886 * 1e18,
+                debtInAuction:     1.966997287334847887 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         ); 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              1.966997287334847886 * 1e18,
+            borrowerDebt:              1.966997287334847887 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0
@@ -360,8 +360,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      20.936810479596837344 * 1e18,
-                debtInAuction:     20.189067248182664592 * 1e18,
-                thresholdPrice:    10.094792904825850359 * 1e18,
+                debtInAuction:     20.189067248182664594 * 1e18,
+                thresholdPrice:    10.094792904825850360 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );
@@ -376,7 +376,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              20.189585809651700719 * 1e18,
+            borrowerDebt:              20.189585809651700720 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 149.112888462473727465 * 1e18
@@ -396,7 +396,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i1505_26,
             collateralArbed:  0.014351542794629452 * 1e18,
-            quoteTokenAmount: 21.602856816327319769 * 1e18,
+            quoteTokenAmount: 21.602856816327319770 * 1e18,
             bondChange:       0.199398195043779403 * 1e18,
             isReward:         false,
             lpAwardTaker:     0,
@@ -426,12 +426,12 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             index:        _i1505_26,
             lpBalance:    25_000 * 1e18,
             collateral:   0.014351542794629452 * 1e18,
-            deposit:      24_978.397143183672680231 * 1e18,
+            deposit:      24_978.397143183672680230 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   288.543944498908261870 * 1e18,
-            claimableReserves :         247.213075232011850972 * 1e18,
+            reserves:                   288.543944498908261871 * 1e18,
+            claimableReserves :         247.213075232011850973 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -453,8 +453,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      20.936810479596837344 * 1e18,
-                debtInAuction:     20.189067248182664592 * 1e18,
-                thresholdPrice:    10.094792904825850359 * 1e18,
+                debtInAuction:     20.189067248182664594 * 1e18,
+                thresholdPrice:    10.094792904825850360 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );
@@ -469,7 +469,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              20.189585809651700719 * 1e18,
+            borrowerDebt:              20.189585809651700720 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.963001020098637267 * 1e18
@@ -501,7 +501,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.049398195043779403 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    3.317960196583009903 * 1e18,
+                thresholdPrice:    3.317960196583009904 * 1e18,
                 neutralPrice:      0
             })
         );
@@ -514,7 +514,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              6.602856816327319769 * 1e18,
+            borrowerDebt:              6.602856816327319770 * 1e18,
             borrowerCollateral:        1.990034968812238781 * 1e18,
             borrowert0Np:              3.384038787324199948 * 1e18,
             borrowerCollateralization: 2.929901291475173000 * 1e18
@@ -575,14 +575,14 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      83.747241918387349408 * 1e18,
-                debtInAuction:     20.189378383465778990 * 1e18,
+                debtInAuction:     20.189378383465778991 * 1e18,
                 thresholdPrice:    10.094689191732889495 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              20.189378383465778990 * 1e18,
+            borrowerDebt:              20.189378383465778991 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.963010913995558897 * 1e18
@@ -594,7 +594,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             kicker:           _lender,
             index:            _i10016,
             collateralArbed:  0.002156704581707556 * 1e18,
-            quoteTokenAmount: 21.602634870308383519 * 1e18,
+            quoteTokenAmount: 21.602634870308383520 * 1e18,
             bondChange:       0.199398195043779403 * 1e18,
             isReward:         false,
             lpAwardTaker:     0,
@@ -623,7 +623,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             index:        _i10016,
             lpBalance:    1_000 * 1e18,      // LP balance in arbed bucket increased with LPs awarded for deposit taker
             collateral:   0.002156704581707556 * 1e18,          // arbed collateral added to the arbed bucket
-            deposit:      978.397365129691616481* 1e18,        // quote token amount is diminished in arbed bucket
+            deposit:      978.397365129691616480 * 1e18,        // quote token amount is diminished in arbed bucket
             exchangeRate: 1 * 1e18
         });
         _assertAuction(
@@ -673,8 +673,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18, 
                 totalBondEscrowed: 0.199398195043779403 * 1e18,
                 auctionPrice:      118.436485332323967968 * 1e18,
-                debtInAuction:     20.189067248182664592 * 1e18,
-                thresholdPrice:    10.094663263626140337 * 1e18,
+                debtInAuction:     20.189067248182664594 * 1e18,
+                thresholdPrice:    10.094663263626140338 * 1e18,
                 neutralPrice:      10.468405239798418677 * 1e18
             })
         );

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -165,7 +165,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.778456451861613480 * 1e18,
+            debt:           19.778456451861613481 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195342779771472726 * 1e18,
             transferAmount: 0.195342779771472726 * 1e18
@@ -182,7 +182,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 poolSize:             73_093.873009488594553000 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
                 encumberedCollateral: 835.035237319063220561 * 1e18,
-                poolDebt:             8_117.624599705640061720 * 1e18,
+                poolDebt:             8_117.624599705640061721 * 1e18,
                 actualUtilization:    0.111200336982269042 * 1e18,
                 targetUtilization:    0.833449668459897038 * 1e18,
                 minDebtAmount:        811.762459970564006172 * 1e18,
@@ -194,7 +194,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.778456451861613480 * 1e18,
+            borrowerDebt:              19.778456451861613481 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              10.115967548076923081 * 1e18,
             borrowerCollateralization: 0.983018658578564579 * 1e18
@@ -220,7 +220,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      328.175870016074179200 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
@@ -232,7 +232,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             locked:    0.195342779771472726 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   24.501590217045508720 * 1e18,
+            reserves:                   24.501590217045508721 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -298,7 +298,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.778456451861613480 * 1e18,
+            debt:           19.778456451861613481 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195342779771472726 * 1e18,
             transferAmount: 0.195342779771472726 * 1e18
@@ -315,7 +315,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      328.175870016074179200 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
@@ -347,7 +347,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    8.889228225930806739 * 1e18,
+                thresholdPrice:    8.889228225930806740 * 1e18,
                 neutralPrice:      0
             })
         );
@@ -362,7 +362,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.500754673204780610 * 1e18,
+            borrowerDebt:              19.500754673204780611 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              9.254718877190426162 * 1e18,
             borrowerCollateralization: 0.997017400397270737 * 1e18
@@ -372,7 +372,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.720138163278334392 * 1e18,
+            debt:           19.720138163278334393 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195007546732047806 * 1e18,
             transferAmount: 0
@@ -401,7 +401,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      329.321295632797165376 * 1e18,
-                debtInAuction:     19.720038163278334392 * 1e18,
+                debtInAuction:     19.720038163278334393 * 1e18,
                 thresholdPrice:    9.860019081639167196 * 1e18,
                 neutralPrice:      10.291290488524911418 * 1e18
             })
@@ -431,7 +431,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    4.860069081639167195 * 1e18,
+                thresholdPrice:    4.860069081639167196 * 1e18,
                 neutralPrice:      0
             })
         );
@@ -512,7 +512,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.778456451861613480 * 1e18,
+            debt:           19.778456451861613481 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195342779771472726 * 1e18,
             transferAmount: 0.195342779771472726 * 1e18
@@ -529,7 +529,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      328.175870016074179200 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })
@@ -616,7 +616,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.778456451861613480 * 1e18,
+            debt:           19.778456451861613481 * 1e18,
             collateral:     2 * 1e18,
             bond:           0.195342779771472726 * 1e18,
             transferAmount: 0.195342779771472726 * 1e18
@@ -633,7 +633,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 kickMomp:          9.818751856078723036 * 1e18,
                 totalBondEscrowed: 0.195342779771472726 * 1e18,
                 auctionPrice:      328.175870016074179200 * 1e18,
-                debtInAuction:     19.778456451861613480 * 1e18,
+                debtInAuction:     19.778456451861613481 * 1e18,
                 thresholdPrice:    9.889228225930806740 * 1e18,
                 neutralPrice:      10.255495938002318100 * 1e18
             })

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -2102,7 +2102,7 @@ contract ERC20PoolLiquidationsTakeAndRepayAllDebtInPoolTest is ERC20HelperContra
         _kick({
             from:           _kicker,
             borrower:       _borrower,
-            debt:           104.162540773774892915 * 1e18,
+            debt:           104.162540773774892916 * 1e18,
             collateral:     0.067433366047580170 * 1e18,
             bond:           1.028765834802714992 * 1e18,
             transferAmount: 1.028765834802714992  * 1e18
@@ -2118,7 +2118,7 @@ contract ERC20PoolLiquidationsTakeAndRepayAllDebtInPoolTest is ERC20HelperContra
             borrower:        _borrower,
             maxCollateral:   0.067433366047580170 * 1e18,
             bondChange:      1.028765834802714992 * 1e18,
-            givenAmount:     111.455789568155429076 * 1e18,
+            givenAmount:     111.455789568155429077 * 1e18,
             collateralTaken: 0.010471063560951988 * 1e18,
             isReward:        false
         });


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Consistent mul before div across contracts
  * Mul before div when calculating `_dwatp`, `t0KickPenalty` and `_lenderInterestMargin`
  * no test change for `_dwatp` and `_lenderInterestMargin` changes
  * test updates with rounding for `t0KickPenalty` update

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Solidity best practice multiply before division

