### PR TITLE
Ensure PositionManager.moveLiquidity accrues interest

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -257,6 +257,9 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         // handle the case where owner attempts to move liquidity after they've already done so
         if (vars.depositTime == 0) revert RemovePositionFailed();
 
+        // ensure bucketDeposit accounts for accrued interest
+        IPool(params_.pool).updateInterest();
+
         // retrieve info of bucket from which liquidity is moved  
         (
             vars.bucketLPs,

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1922,7 +1922,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         });
 
         // lender 1 moves liquidity
-        changePrank(address(lender1));
+        changePrank(lender1);
         IPositionManagerOwnerActions.MoveLiquidityParams memory moveLiquidityParams = 
             IPositionManagerOwnerActions.MoveLiquidityParams(
             tokenId1, address(_pool), mintIndex, moveIndex, block.timestamp + 30

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1844,6 +1844,142 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.moveLiquidity(moveLiquidityParams);
     }
 
+    function testMoveLiquidityWithInterest() external tearDown {
+        address lender1 = makeAddr("lender1");
+        address lender2 = makeAddr("lender2");
+        address borrower = makeAddr("borrower");
+        _mintQuoteAndApproveManagerTokens(lender1, 2_000 * 1e18);
+        _mintQuoteAndApproveManagerTokens(lender2, 3_000 * 1e18);
+        _mintCollateralAndApproveTokens(borrower, 250 * 1e18);
+        _mintQuoteAndApproveTokens(borrower, 500 * 1e18);
+
+        uint256 mintIndex = _i9_91;
+        uint256 moveIndex = _i9_52;
+
+        // two lenders add liquidity to the same bucket
+        _addInitialLiquidity({
+            from:   lender1,
+            amount: 2_000 * 1e18,
+            index:  mintIndex
+        });
+        _addInitialLiquidity({
+            from:   lender2,
+            amount: 3_000 * 1e18,
+            index:  mintIndex
+        });
+        skip(2 hours);
+
+        // borrower draws debt
+        _drawDebt({
+            from:               borrower,
+            borrower:           borrower,
+            amountToBorrow:     1_000 * 1e18,
+            limitIndex:         mintIndex,
+            collateralToPledge: 250 * 1e18,
+            newLup:             _p9_91
+        });
+        skip(22 hours);
+
+        // lenders mint and memorialize positions
+        changePrank(lender1);
+        uint256 tokenId1 = _mintNFT(lender1, lender1, address(_pool));
+        uint256[] memory indexes = new uint256[](1);
+        indexes[0] = mintIndex;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 2_000 * 1e18;
+        _pool.increaseLPsAllowance(address(_positionManager), indexes, amounts);
+        IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParams = 
+            IPositionManagerOwnerActions.MemorializePositionsParams(tokenId1, indexes);
+        _positionManager.memorializePositions(memorializeParams);
+        skip(1 days);
+
+        changePrank(lender2);
+        uint256 tokenId2 = _mintNFT(lender2, lender2, address(_pool));
+        amounts[0] = 3_000 * 1e18;
+        _pool.increaseLPsAllowance(address(_positionManager), indexes, amounts);
+        memorializeParams = IPositionManagerOwnerActions.MemorializePositionsParams(tokenId2, indexes);
+        _positionManager.memorializePositions(memorializeParams);
+        skip(1 days);
+
+        // check pool state
+        _assertLenderLpBalance({
+            lender:      lender1,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      lender2,
+            index:       mintIndex,
+            lpBalance:   0,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   5_000 * 1e18,
+            depositTime: _startTime
+        });
+
+        // lender 1 moves liquidity
+        changePrank(address(lender1));
+        IPositionManagerOwnerActions.MoveLiquidityParams memory moveLiquidityParams = 
+            IPositionManagerOwnerActions.MoveLiquidityParams(
+            tokenId1, address(_pool), mintIndex, moveIndex, block.timestamp + 30
+        );
+        _positionManager.moveLiquidity(moveLiquidityParams);
+
+        // check pool state
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       mintIndex,
+            lpBalance:   3_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      address(_positionManager),
+            index:       moveIndex,
+            lpBalance:   1_999.870115955512241553 * 1e18,
+            depositTime: _startTime
+        });
+        skip(1 weeks);
+
+        // lender1 redeems their NFT
+        changePrank(lender1);
+        address[] memory transferors = new address[](1);
+        transferors[0] = address(_positionManager);
+        _pool.approveLPsTransferors(transferors);
+        indexes[0] = moveIndex;
+        IPositionManagerOwnerActions.RedeemPositionsParams memory reedemParams = 
+            IPositionManagerOwnerActions.RedeemPositionsParams(
+            tokenId1, address(_pool), indexes
+        );
+        _positionManager.reedemPositions(reedemParams);
+        skip(2 days);
+
+        // borrower repays
+        _repayDebt({
+            from:               borrower,
+            borrower:           borrower,
+            amountToRepay:      type(uint256).max,
+            amountRepaid:       1_002.608307827389905517 * 1e18,
+            collateralToPull:   250 * 1e18,
+            newLup:             MAX_PRICE
+        });
+
+        // lender2 redeems their NFT
+        skip(1 days);
+        changePrank(lender2);
+        _pool.approveLPsTransferors(transferors);
+        indexes[0] = mintIndex;
+        reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
+            tokenId2, address(_pool), indexes
+        );
+        _positionManager.reedemPositions(reedemParams);
+
+        // tearDown ensures buckets are empty
+    }
+
     function testRedeemPositions() external {
         address testMinter     = makeAddr("testMinter");
         address notOwner       = makeAddr("notOwner");

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1486,7 +1486,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.ownerOf(tokenId);
     }
 
-    function testMoveLiquidityPermissions() external {
+    function testMoveLiquidityPermissions() external tearDown {
         // generate a new address
         address testAddress = makeAddr("testAddress");
         address notOwner    = makeAddr("notOwner");
@@ -1512,7 +1512,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _positionManager.moveLiquidity(moveLiquidityParams);
     }
 
-    function testMoveLiquidity() external {
+    function testMoveLiquidity() external tearDown {
         // generate a new address
         address testAddress1 = makeAddr("testAddress1");
         address testAddress2 = makeAddr("testAddress2");
@@ -1845,8 +1845,8 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
     }
 
     function testMoveLiquidityWithInterest() external tearDown {
-        address lender1 = makeAddr("lender1");
-        address lender2 = makeAddr("lender2");
+        address lender1  = makeAddr("lender1");
+        address lender2  = makeAddr("lender2");
         address borrower = makeAddr("borrower");
         _mintQuoteAndApproveManagerTokens(lender1, 2_000 * 1e18);
         _mintQuoteAndApproveManagerTokens(lender2, 3_000 * 1e18);
@@ -1959,12 +1959,12 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // borrower repays
         _repayDebt({
-            from:               borrower,
-            borrower:           borrower,
-            amountToRepay:      type(uint256).max,
-            amountRepaid:       1_002.608307827389905517 * 1e18,
-            collateralToPull:   250 * 1e18,
-            newLup:             MAX_PRICE
+            from:             borrower,
+            borrower:         borrower,
+            amountToRepay:    type(uint256).max,
+            amountRepaid:     1_002.608307827389905517 * 1e18,
+            collateralToPull: 250 * 1e18,
+            newLup:           MAX_PRICE
         });
 
         // lender2 redeems their NFT
@@ -2635,7 +2635,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // call pool contract directly to add quote tokens
         uint256[] memory indexes = new uint256[](1);
         indexes[0] = 2550;
-        uint256[] memory amounts = new uint256[] (1);
+        uint256[] memory amounts = new uint256[](1);
         amounts[0] = 3_000 * 1e18;
         address[] memory transferors = new address[](1);
         transferors[0] = address(_positionManager);

--- a/tests/forge/PositionManager.t.sol
+++ b/tests/forge/PositionManager.t.sol
@@ -1939,7 +1939,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         _assertLenderLpBalance({
             lender:      address(_positionManager),
             index:       moveIndex,
-            lpBalance:   1_999.870115955512241553 * 1e18,
+            lpBalance:   1_999.870115955512239554 * 1e18,
             depositTime: _startTime
         });
         skip(1 weeks);

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1266,7 +1266,7 @@ contract RewardsManagerTest is ERC20HelperContract {
         // need to retrieve the position managers index set since positionIndexes are stored unordered in EnnumerableSets
         firstIndexes = _positionManager.getPositionIndexes(tokenId);
 
-        _updateExchangeRates(_updater, address(_poolOne), firstIndexes, 4.173045926578320535 * 1e18);
+        _updateExchangeRates(_updater, address(_poolOne), firstIndexes, 4.173045926578320550 * 1e18);
 
         /*********************/
         /*** Claim Rewards ***/
@@ -1276,7 +1276,7 @@ contract RewardsManagerTest is ERC20HelperContract {
         changePrank(_minterOne);
         assertEq(_ajnaToken.balanceOf(_minterOne), 44.989657989464570280 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.730459265783249565 * 1e18);
+        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.730459265783249745 * 1e18);
         _rewardsManager.claimRewards(tokenId, currentBurnEpoch);
     }
 

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -1266,7 +1266,7 @@ contract RewardsManagerTest is ERC20HelperContract {
         // need to retrieve the position managers index set since positionIndexes are stored unordered in EnnumerableSets
         firstIndexes = _positionManager.getPositionIndexes(tokenId);
 
-        _updateExchangeRates(_updater, address(_poolOne), firstIndexes, 4.173045773803754366 * 1e18);
+        _updateExchangeRates(_updater, address(_poolOne), firstIndexes, 4.173045926578320535 * 1e18);
 
         /*********************/
         /*** Claim Rewards ***/
@@ -1276,7 +1276,7 @@ contract RewardsManagerTest is ERC20HelperContract {
         changePrank(_minterOne);
         assertEq(_ajnaToken.balanceOf(_minterOne), 44.989657989464570280 * 1e18);
         vm.expectEmit(true, true, true, true);
-        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.730457738037587904 * 1e18);
+        emit ClaimRewards(_minterOne, address(_poolOne), tokenId, _epochsClaimedArray(1, 1), 41.730459265783249565 * 1e18);
         _rewardsManager.claimRewards(tokenId, currentBurnEpoch);
     }
 


### PR DESCRIPTION
# Description of change
## High level
Fixes issue #690 reported by Oasis team.
Implemented a test which fails upon `tearDown` without the fix.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
This bug is caused because `PositionManager.moveLiquidity` is not accruing interest prior to calling `_lpsToQuoteToken`. As such, we ignore interest the lender earned since the last time pool interest had accrued, leaving unclaimable quote token in the bucket.

To remedy, `PositionManager.moveLiquidity` should call `Pool.updateInterest()` prior to `bucketInfo` and `_lpsToQuoteToken` calls.

# Contract size
Only `PositionManager` contract was touched.
## Pre Change
============ Deployment Bytecode Sizes ============
  PositionManager          -  18,688B  (76.04%)
## Post Change
============ Deployment Bytecode Sizes ============
  PositionManager          -  18,787B  (76.44%)

# Gas usage
Significant increase in cost of `moveLiquidity`, as expected.  Other gas changes perceived to be due to different test conditions.
## Pre Change
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |
|--------------------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                                    | min             | avg    | median | max     | # calls |
| memorializePositions                             | 18112           | 320829 | 253448 | 1135007 | 69      |
| moveLiquidity                                    | 5864            | 189732 | 206150 | 466112  | 18      |
| reedemPositions                                  | 2879            | 35123  | 8039   | 140106  | 22      |
## Post Change
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |
|--------------------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                                    | min             | avg    | median | max     | # calls |
| memorializePositions                             | 18112           | 315149 | 253448 | 1135007 | 62      |
| moveLiquidity                                    | 5864            | 237283 | 247632 | 614091  | 19      |
| reedemPositions                                  | 2879            | 37866  | 25538  | 140106  | 24      |
