### PR TITLE
Removed `ExchangeRateUpdateTooLate` error and ensured `UpdateExchangeRates` event is not called

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -22,8 +22,6 @@ import { PositionManager } from './PositionManager.sol';
 
 import { Maths } from './libraries/internal/Maths.sol';
 
-import '@std/console.sol';
-
 /**
  *  @title  Rewards (staking) Manager contract
  *  @notice Pool lenders can optionally mint NFT that represents their positions.

--- a/src/interfaces/rewards/IRewardsManagerErrors.sol
+++ b/src/interfaces/rewards/IRewardsManagerErrors.sol
@@ -17,11 +17,6 @@ interface IRewardsManagerErrors {
     error EpochNotAvailable();
 
     /**
-     *  @notice User attempted to record updated exchange rates outside of the allowed period.
-     */
-    error ExchangeRateUpdateTooLate();
-
-    /**
      *  @notice User provided move index params that didn't match in size.
      */
     error MoveStakedLiquidityInvalid();

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -451,8 +451,7 @@ contract RewardsManagerTest is ERC20HelperContract {
 
         // check can't call update exchange rate after the update period has elapsed
         skip(2 weeks);
-        // changePrank(_updater);
-        // vm.expectRevert(IAjnaRewards.ExchangeRateUpdateTooLate.selector);
+
         uint256 updateRewards = _rewardsManager.updateBucketExchangeRatesAndClaim(address(_poolOne), depositIndexes);
         assertEq(updateRewards, 0);
     }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Removed unnecessary error and modified `_updateBucketExchangeRates` from firing a `updateExchangeRates` event when the action didn't transpire.
* Not particuarly in love with the solution I derived as it does make the logic a bit more confusing. Have thought about an alternate implementation of an if check outside of the `_updateBucketExchangeRates` method (could create a utility method to perform a check called `checkExchangeRateUpdate()`) which would ensure `currentBurnEpoch != 0` and we were within an update period. <- happy to experiment with that if others think I should.
* (decent gas reduction on `updateBucketExchangeRatesAndClaim`)


<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
Although seemingly cosmetic / informational there were two issues:
* `ExchangeRateUpdateTooLate` error was included in `IRewardsManagerErrors` but never used in the protocol
* `UpdateExchangeRates event` was being emitted even when the update period had passed because of where it was placed in the function.

To solve these issues the `_updateBucketExchangeRates()` method was updated to exit early when the update period had passed. Additionally the `ExchangeRateUpdateTooLate` error was removed from `IRewardsManagerErrors`.

# Contract size
## Pre Change
```
  RewardsManager           -   9,518B  (38.73%)
```
## Post Change
```
  RewardsManager           -   9,567B  (38.93%)
```

# Gas usage
## Pre Change
```
| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Deployment Cost                                | Deployment Size |         |         |         |         |
| 1950425                                        | 9898            |         |         |         |         |
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 38513           | 112455  | 83442   | 243121  | 17      |
| claimRewards                                   | 523             | 109925  | 118757  | 472208  | 18      |
| getBucketStateStakeInfo                        | 660             | 2659    | 2660    | 2660    | 59112   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 6       |
| moveStakedLiquidity                            | 1702924         | 1826496 | 1826496 | 1950068 | 2       |
| stake                                          | 2431            | 373227  | 395411  | 891150  | 33      |
| unstake                                        | 522             | 179300  | 148791  | 423960  | 12      |
| updateBucketExchangeRatesAndClaim              | 10695           | 337206  | 330965  | 531477  | 20      |

```
## Post Change
```

| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Deployment Cost                                | Deployment Size |         |         |         |         |
| 1960232                                        | 9947            |         |         |         |         |
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 38513           | 50495   | 39428   | 243121  | 176     |
| claimRewards                                   | 523             | 113907  | 107793  | 472279  | 177     |
| getBucketStateStakeInfo                        | 660             | 2659    | 2660    | 2660    | 59112   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 165     |
| moveStakedLiquidity                            | 1708392         | 1827686 | 1827686 | 1946981 | 2       |
| stake                                          | 2431            | 359967  | 404829  | 900569  | 35      |
| unstake                                        | 522             | 179041  | 148848  | 424016  | 12      |
| updateBucketExchangeRatesAndClaim              | 6516            | 245382  | 174008  | 531548  | 43      |

```

