### PR TITLE
Remove update too late err

### DIFF
--- a/src/interfaces/rewards/IRewardsManagerErrors.sol
+++ b/src/interfaces/rewards/IRewardsManagerErrors.sol
@@ -17,11 +17,6 @@ interface IRewardsManagerErrors {
     error EpochNotAvailable();
 
     /**
-     *  @notice User attempted to record updated exchange rates outside of the allowed period.
-     */
-    error ExchangeRateUpdateTooLate();
-
-    /**
      *  @notice User provided move index params that didn't match in size.
      */
     error MoveStakedLiquidityInvalid();

--- a/tests/forge/RewardsManager.t.sol
+++ b/tests/forge/RewardsManager.t.sol
@@ -451,8 +451,8 @@ contract RewardsManagerTest is ERC20HelperContract {
 
         // check can't call update exchange rate after the update period has elapsed
         skip(2 weeks);
-        // changePrank(_updater);
-        // vm.expectRevert(IAjnaRewards.ExchangeRateUpdateTooLate.selector);
+
+        // Although an `UpdateExchangeRates` is emmited the rates are not updated, as demonstrated by updateRewards == 0
         uint256 updateRewards = _rewardsManager.updateBucketExchangeRatesAndClaim(address(_poolOne), depositIndexes);
         assertEq(updateRewards, 0);
     }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Removed unnecessary `ExchangeRateUpdateTooLate` error that wasn't being used in the contracts.
