### PR TITLE
Expose auction price and status

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -32,16 +32,26 @@ import { PoolCommons } from './libraries/external/PoolCommons.sol';
  */
 contract PoolInfoUtils {
 
+    /**
+     *  @notice Exposes status of a liquidation auction
+     *  @param  borrower_         Identifies the loan being liquidated
+     *  @return kickTime_         Time auction was kicked, implying end time
+     *  @return collateral_       Remaining collateral available to be purchased               (WAD)
+     *  @return debtToCover_      Borrower debt to be covered                                  (WAD)
+     *  @return isCollateralized_ If true, takes will revert
+     *  @return price_            Current price of the auction                                 (WAD)
+     *  @return neutralPrice_     Price at which bond holder is neither rewarded nor penalized (WAD)
+     */
     function auctionStatus(address ajnaPool_, address borrower_)
         external
         view
         returns (
-            uint256 kickTime_,         // time auction was kicked, implying end time
-            uint256 collateral_,       // remaining collateral available to be purchased               (WAD)
-            uint256 debtToCover_,      // borrower debt to be covered                                  (WAD)
-            bool    isCollateralized_, // if true, takes will revert
-            uint256 price_,            // current price of the auction                                 (WAD)
-            uint256 neutralPrice_      // price at which bond holder is neither rewarded nor penalized (WAD)
+            uint256 kickTime_,
+            uint256 collateral_,
+            uint256 debtToCover_,
+            bool    isCollateralized_,
+            uint256 price_,
+            uint256 neutralPrice_
         )
     {
         IPool pool = IPool(ajnaPool_);

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1929,9 +1929,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
 
         // Take should revert
-        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
-        changePrank(_borrower2);
-        _pool.take(_borrower2, 1_000 * 1e18, _borrower2, new bytes(0));
+        _assertTakeNoAuctionRevert(_borrower2, _borrower2, 1_000 * 1e18);
     }
 
     function testTakeAuctionPriceLtNeutralPrice() external tearDown {

--- a/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1878,6 +1878,62 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
     }
 
+    function testTakeAfterSettleReverts() external {
+        // Borrower draws debt
+        _borrow({
+            from:       _borrower2,
+            amount:     1_730 * 1e18,
+            indexLimit: _i9_72,
+            newLup:     9.721295865031779605 * 1e18
+        });
+
+        // Skip to make borrower undercollateralized and kick auction
+        skip(100 days);
+        _kick({
+            from:           _lender,
+            borrower:       _borrower2,
+            debt:           9_976.561670003961916237 * 1e18,
+            collateral:     1_000 * 1e18,
+            bond:           98.533942419792216457 * 1e18,
+            transferAmount: 98.533942419792216457 * 1e18
+        });
+
+        // Take everything
+        skip(10 hours);
+        _take({
+            from:            _lender,
+            borrower:        _borrower2,
+            maxCollateral:   1_000 * 1e18,
+            bondChange:      6.531114528261135360 * 1e18,
+            givenAmount:     653.111452826113536000 * 1e18,
+            collateralTaken: 1_000 * 1e18,
+            isReward:        true
+        });
+
+        // Partially settle the auction, such that it is not removed from queue
+        _settle({
+            from:        _lender,
+            borrower:    _borrower2,
+            maxDepth:    1,
+            settledDebt: 2_824.753001999316079070 * 1e18
+        });
+
+        // Borrower draws more debt
+        _drawDebt({
+            from:               _borrower2,
+            borrower:           _borrower2,
+            amountToBorrow:     1_000 * 1e18,
+            limitIndex:         _i9_72,
+            collateralToPledge: 1_000 * 1e18,
+            newLup:             9.721295865031779605 * 1e18
+        });
+
+        // Take should revert
+        vm.expectRevert(abi.encodeWithSignature('NoAuction()'));
+        changePrank(_borrower2);
+        _pool.take(_borrower2, 1_000 * 1e18, _borrower2, new bytes(0));
+    }
+
     function testTakeAuctionPriceLtNeutralPrice() external tearDown {
 
         _addLiquidity({

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -428,14 +428,27 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     /*** State asserts ***/
     /*********************/
 
+    struct AuctionLocalVars {
+        address auctionKicker;
+        uint256 auctionBondFactor;
+        uint256 auctionBondSize;
+        uint256 auctionKickTime;
+        uint256 auctionKickMomp;
+        uint256 auctionNeutralPrice;
+        uint256 auctionTotalBondEscrowed;
+        uint256 auctionDebtInAuction;
+        uint256 borrowerThresholdPrice;
+    }
+
     function _assertAuction(AuctionParams memory state_) internal {
+        AuctionLocalVars memory vars;
         (
-            address auctionKicker,
-            uint256 auctionBondFactor,
-            uint256 auctionBondSize,
-            uint256 auctionKickTime,
-            uint256 auctionKickMomp,
-            uint256 auctionNeutralPrice,
+            vars.auctionKicker,
+            vars.auctionBondFactor,
+            vars.auctionBondSize,
+            vars.auctionKickTime,
+            vars.auctionKickMomp,
+            vars.auctionNeutralPrice,
             ,
             ,
             ,
@@ -443,25 +456,51 @@ abstract contract DSTestPlus is Test, IPoolEvents {
 
         (uint256 borrowerDebt, uint256 borrowerCollateral , ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);
         (, uint256 lockedBonds) = _pool.kickerInfo(state_.kicker);
-        (uint256 auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
-        (,,uint256 auctionDebtInAuction)  = _pool.debtInfo(); 
-        uint256 borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerDebt * Maths.WAD / borrowerCollateral : 0;
+        (vars.auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
+        (,, vars.auctionDebtInAuction)  = _pool.debtInfo(); 
+        vars.borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerDebt * Maths.WAD / borrowerCollateral : 0;
 
-        assertEq(auctionKickTime != 0,     state_.active);
-        assertEq(auctionKicker,            state_.kicker);
-        assertGe(lockedBonds,              auctionBondSize);
-        assertEq(auctionBondSize,          state_.bondSize);
-        assertEq(auctionBondFactor,        state_.bondFactor);
-        assertEq(auctionKickTime,          state_.kickTime);
-        assertEq(auctionKickMomp,          state_.kickMomp);
-        assertEq(auctionTotalBondEscrowed, state_.totalBondEscrowed);
+        assertEq(vars.auctionKickTime != 0,     state_.active);
+        assertEq(vars.auctionKicker,            state_.kicker);
+        assertGe(lockedBonds,                   vars.auctionBondSize);
+        assertEq(vars.auctionBondSize,          state_.bondSize);
+        assertEq(vars.auctionBondFactor,        state_.bondFactor);
+        assertEq(vars.auctionKickTime,          state_.kickTime);
+        assertEq(vars.auctionKickMomp,          state_.kickMomp);
+        assertEq(vars.auctionTotalBondEscrowed, state_.totalBondEscrowed);
         assertEq(Auctions._auctionPrice(
-            auctionKickMomp,
-            auctionNeutralPrice,
-            auctionKickTime),              state_.auctionPrice);
-        assertEq(auctionDebtInAuction,     state_.debtInAuction);
-        assertEq(auctionNeutralPrice,      state_.neutralPrice);
-        assertEq(borrowerThresholdPrice,   state_.thresholdPrice);
+            vars.auctionKickMomp,
+            vars.auctionNeutralPrice,
+            vars.auctionKickTime),              state_.auctionPrice);
+        assertEq(vars.auctionDebtInAuction,     state_.debtInAuction);
+        assertEq(vars.auctionNeutralPrice,      state_.neutralPrice);
+        assertEq(vars.borrowerThresholdPrice,   state_.thresholdPrice);
+
+        (
+            uint256 kickTime, 
+            uint256 collateral, 
+            uint256 debtToCover, 
+            bool    isCollateralized,      
+            uint256 price,          
+            uint256 neutralPrice    
+        ) = _poolUtils.auctionStatus(address(_pool), state_.borrower);
+        assertEq(kickTime,     state_.kickTime);
+        assertEq(neutralPrice, state_.neutralPrice);
+        if (kickTime == 0) {
+            assertEq(collateral,  0);
+            assertEq(debtToCover, 0);
+            assertEq(price,       0);
+        } else {
+            assertEq(collateral,       borrowerCollateral);
+            assertEq(debtToCover,      borrowerDebt);
+            assertEq(isCollateralized, _isCollateralized(
+                borrowerDebt, 
+                borrowerCollateral, 
+                _lup(), 
+                _pool.poolType())
+            );
+            assertEq(price,            state_.auctionPrice);
+        }
     }
 
     function _assertPool(PoolParams memory state_) internal {


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
The price of an active liquidation auction is not currently exposed anywhere.  As such, a consumer would need to either replicate the math client-side, or wrap our contract and use the `Auctions` library directly to make such a calculation.

To determine other auction state, the consumer must call both `Pool.auctionInfo` and `PoolInfoUtils.borrowerInfo`.  Relevant fields are included herein to minimize RPC calls.

# Description of bug or vulnerability and solution
To improve developer experience, expose a function in `PoolInfoUtils` which provides the current state of a liquidation auction.
To test, tapped into exist `_assertAuction`, using a local vars struct to avoid a stack-too-deep error.

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  PoolInfoUtils            -  11,773B  (47.90%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  PoolInfoUtils            -  12,853B  (52.30%)
```

# Gas usage
This method is only called externally.  It would only incur gas costs if called from a proxy contract within the context of a transaction.
## Pre Change
n/a - method did not exist
## Post Change
| src/PoolInfoUtils.sol:PoolInfoUtils contract |                 |       |        |        |         |
|----------------------------------------------|-----------------|-------|--------|--------|---------|
| Function Name                                | min             | avg   | median | max    | # calls |
| auctionStatus                                | 3805            | 31414 | 47495  | 101734 | 149     |

