### PR TITLE
cleaned up t0Debt2ToCollateral invariant check I4

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -145,7 +145,7 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 debt,,) = pool.debtInfo();
+        (uint256 debt,,,) = pool.debtInfo();
 
         hpbIndex_ = pool.depositIndex(1);
         hpb_      = _priceAt(hpbIndex_);
@@ -179,8 +179,8 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        (,uint256 poolDebt,) = pool.debtInfo();
-        uint256 poolSize     = pool.depositSize();
+        (,uint256 poolDebt,,) = pool.debtInfo();
+        uint256 poolSize      = pool.depositSize();
 
         uint256 quoteTokenBalance = IERC20Token(pool.quoteTokenAddress()).balanceOf(ajnaPool_) * pool.quoteTokenScale();
 
@@ -223,7 +223,7 @@ contract PoolInfoUtils {
     {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 poolDebt,,)    = pool.debtInfo();
+        (uint256 poolDebt,,,)    = pool.debtInfo();
         uint256 poolCollateral  = pool.pledgedCollateral();
         (, , uint256 noOfLoans) = pool.loansInfo();
 
@@ -273,7 +273,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 debt,,) = pool.debtInfo();
+        (uint256 debt,,,) = pool.debtInfo();
         uint256 currentLupIndex = pool.depositIndex(debt);
 
         return _priceAt(currentLupIndex);
@@ -284,7 +284,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 debt,,) = pool.debtInfo();
+        (uint256 debt,,,) = pool.debtInfo();
 
         return pool.depositIndex(debt);
     }
@@ -318,7 +318,7 @@ contract PoolInfoUtils {
     ) external view returns (uint256) {
         IPool pool = IPool(ajnaPool_);
 
-        (uint256 debt, , )       = pool.debtInfo();
+        (uint256 debt, , ,)       = pool.debtInfo();
         ( , , uint256 noOfLoans) = pool.loansInfo();
         noOfLoans += pool.totalAuctionsInPool();
         return _priceAt(pool.depositIndex(Maths.wdiv(debt, noOfLoans * 1e18)));

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -736,7 +736,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     /// @inheritdoc IPoolState
-    function debtInfo() external view returns (uint256, uint256, uint256) {
+    function debtInfo() external view returns (uint256, uint256, uint256, uint256) {
         uint256 pendingInflator = PoolCommons.pendingInflator(
             inflatorState.inflator,
             inflatorState.inflatorUpdate,
@@ -745,9 +745,11 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return (
             Maths.wmul(poolBalances.t0Debt, pendingInflator),
             Maths.wmul(poolBalances.t0Debt, inflatorState.inflator),
-            Maths.wmul(poolBalances.t0DebtInAuction, inflatorState.inflator)
+            Maths.wmul(poolBalances.t0DebtInAuction, inflatorState.inflator),
+            interestState.t0Debt2ToCollateral
         );
     }
+
 
     /// @inheritdoc IPoolDerivedState
     function depositUpToIndex(uint256 index_) external view override returns (uint256) {

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -39,10 +39,10 @@ interface IPoolState {
 
     /**
      *  @notice Returns pool related debt values.
-     *  @return debt_                Current amount of debt owed by borrowers in pool.
-     *  @return accruedDebt_         Debt owed by borrowers based on last inflator snapshot.
+     *  @return debt_            Current amount of debt owed by borrowers in pool.
+     *  @return accruedDebt_     Debt owed by borrowers based on last inflator snapshot.
      *  @return debtInAuction_       Total amount of debt in auction.
-     *  @return t0Debt2ToCollateral_ Total amount of debt in auction.
+     *  @return t0Debt2ToCollateral_ t0debt accross all borrowers divided by their collateral, used in determining a collateraliation weighted debt.
      */
     function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_, uint256 t0Debt2ToCollateral_);
 

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -39,9 +39,10 @@ interface IPoolState {
 
     /**
      *  @notice Returns pool related debt values.
-     *  @return debt_            Current amount of debt owed by borrowers in pool.
-     *  @return accruedDebt_     Debt owed by borrowers based on last inflator snapshot.
-     *  @return debtInAuction_   Total amount of debt in auction.
+     *  @return debt_                Current amount of debt owed by borrowers in pool.
+     *  @return accruedDebt_         Debt owed by borrowers based on last inflator snapshot.
+     *  @return debtInAuction_       Total amount of debt in auction.
+     *  @return t0Debt2ToCollateral_ Total amount of debt in auction.
      */
     function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_, uint256 t0Debt2ToCollateral_);
 

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -43,7 +43,7 @@ interface IPoolState {
      *  @return accruedDebt_     Debt owed by borrowers based on last inflator snapshot.
      *  @return debtInAuction_   Total amount of debt in auction.
      */
-    function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_);
+    function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_, uint256 t0Debt2ToCollateral_);
 
     /**
      *  @notice Mapping of borrower addresses to {Borrower} structs.

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -42,7 +42,7 @@ interface IPoolState {
      *  @return debt_            Current amount of debt owed by borrowers in pool.
      *  @return accruedDebt_     Debt owed by borrowers based on last inflator snapshot.
      *  @return debtInAuction_       Total amount of debt in auction.
-     *  @return t0Debt2ToCollateral_ t0debt accross all borrowers divided by their collateral, used in determining a collateraliation weighted debt.
+     *  @return t0Debt2ToCollateral_ t0debt accross all borrowers divided by their collateral, used in determining a collateralization weighted debt.
      */
     function debtInfo() external view returns (uint256 debt_, uint256 accruedDebt_, uint256 debtInAuction_, uint256 t0Debt2ToCollateral_);
 

--- a/tests/INVARIANTS.md
+++ b/tests/INVARIANTS.md
@@ -42,6 +42,7 @@
 - **I1**: interest rate (`InterestState.interestRate`) cannot be updated more than once in a 12 hours period of time (`InterestState.interestRateUpdate`)  
 - **I2**: reserve interest (`ReserveAuctionState.totalInterestEarned`) accrues only once per block (`block.timestamp - InflatorState.inflatorUpdate != 0`) and only if there's debt in the pool (`PoolBalancesState.t0Debt != 0`)  
 - **I3**: pool inflator (`InflatorState.inflator`) cannot be updated more than once per block (`block.timestamp - InflatorState.inflatorUpdate != 0`) and equals `1e18` if there's no debt in the pool (`PoolBalancesState.t0Debt != 0`)
+- **I4**: for all borrowers where (`borrower.collateral != 0`) the sum of borrower debt squared divided by borrower collateral (`borrower.debt^2 / borrower.collateral`) should equal borrower collateralization accumulator (`t0Debt2ToCollateral`)
 
 ## Fenwick tree
 - **F1**: Value represented at index `i` (`Deposits.valueAt(i)`) is equal to the accumulation of scaled values incremented or decremented from index `i`

--- a/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/ERC20Pool/ERC20DSTestPlus.sol
@@ -133,7 +133,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
             assertEq(collateral, 0);
         }
         ( , uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
-        (uint256 debt, , ) = _pool.debtInfo();
+        (uint256 debt, , ,) = _pool.debtInfo();
         assertEq(debt, 0);
         assertEq(loansCount, 0);
         assertEq(_pool.pledgedCollateral(), 0);

--- a/tests/forge/ERC20Pool/ERC20PoolFlashloan.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolFlashloan.t.sol
@@ -54,7 +54,7 @@ contract ERC20PoolFlashloanTest is ERC20HelperContract {
             newLup:     _bucketPrice
         });
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, 25_024.038461538461550000 * 1e18);
     }
 

--- a/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -926,14 +926,14 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             })
         );
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedPoolDebt);
 
         // accrue interest
         _updateInterest();
 
         // check that no interest earned if HTP is over the highest price bucket
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedPoolDebt);
     }
 }

--- a/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -343,7 +343,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             maxThresholdPrice: 200.173076923076923000 * 1e18
         });
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
 
         assertEq(_pool.depositSize(),       150_000 * POOL_PRECISION);
         assertEq(poolDebt,                  debt);
@@ -405,7 +405,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             maxThresholdPrice: 100.173076923076923000 * 1e18
         });
 
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
 
         assertEq(_pool.depositSize(),       150_000 * 1e18);
         assertEq(poolDebt,                  debt);

--- a/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1128,7 +1128,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             newLup:     601.252968524772188572 * 1e18
         });
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         uint256 ptp = Maths.wdiv(poolDebt, 10 * 1e18);
         assertEq(ptp, 500.480769230769231000 * 1e18);
 

--- a/tests/forge/ERC20Pool/invariants/BasicInvariants.t.sol
+++ b/tests/forge/ERC20Pool/invariants/BasicInvariants.t.sol
@@ -47,6 +47,7 @@ contract BasicInvariants is InvariantsTestBase {
         * I1: Interest rate should only update once in 12 hours
         * I2: ReserveAuctionState.totalInterestEarned accrues only once per block and equals to 1e18 if pool debt = 0
         * I3: Inflator should only update once per block
+        * I4: t0Debt2ToCollateral should sum correctly accross borrowers
 
     * Fenwick tree
         * F1: Value represented at index i (Deposits.valueAt(i)) is equal to the accumulation of scaled values incremented or decremented from index i
@@ -166,7 +167,7 @@ contract BasicInvariants is InvariantsTestBase {
     function invariant_quoteTokenBalance_QT1() public useCurrentTimestamp {
         // convert pool quote balance into WAD
         uint256 poolBalance    = _quote.balanceOf(address(_pool)) * 10**(18 - _quote.decimals());
-        (uint256 poolDebt, , ) = _pool.debtInfo();
+        (uint256 poolDebt, , ,) = _pool.debtInfo();
 
         (
             uint256 totalBondEscrowed,
@@ -324,6 +325,26 @@ contract BasicInvariants is InvariantsTestBase {
 
         previousInflator       = currentInflator;
         previousInflatorUpdate = currentInflatorUpdate;
+    }
+
+    function invariant_t0Debt2ToCollateral_I4() public useCurrentTimestamp {
+
+        uint256 actorCount = IBaseHandler(_handler).getActorsCount();
+        uint256 manualDebt2ToCollateral;
+
+        for (uint256 i = 0; i < actorCount; i++) {
+            address borrower = IBaseHandler(_handler).actors(i);
+            (uint256 borrowerT0Debt, uint256 borrowerCollateral, ) = _pool.borrowerInfo(borrower);
+
+            uint256 weight = borrowerCollateral != 0 ? borrowerT0Debt ** 2 / borrowerCollateral : 0; 
+
+            manualDebt2ToCollateral += weight;
+        }
+
+        (,,, uint256 t0Debt2ToCollateral) = _pool.debtInfo();
+
+        require(t0Debt2ToCollateral == manualDebt2ToCollateral, "Incorrect debt2ToCollateral");
+
     }
 
     // deposits at index i (Deposits.valueAt(i)) is equal to the accumulation of scaled values incremented or decremented from index i

--- a/tests/forge/ERC20Pool/invariants/base/BaseHandler.sol
+++ b/tests/forge/ERC20Pool/invariants/base/BaseHandler.sol
@@ -264,7 +264,7 @@ abstract contract BaseHandler is Test {
         uint256 pendingInflator;
         uint256 poolDebt;
         {
-            (, poolDebt ,) = _pool.debtInfo();
+            (, poolDebt ,,) = _pool.debtInfo();
 
             (uint256 inflator, uint256 inflatorUpdate) = _pool.inflatorInfo();
 

--- a/tests/forge/ERC20Pool/invariants/base/UnboundedBasicPoolHandler.sol
+++ b/tests/forge/ERC20Pool/invariants/base/UnboundedBasicPoolHandler.sol
@@ -34,7 +34,7 @@ abstract contract UnboundedBasicPoolHandler is BaseHandler {
         numberOfCalls['UBBasicHandler.addQuoteToken']++;
 
         (uint256 lpBalanceBeforeAction, ) = _pool.lenderInfo(bucketIndex_, _actor);
-        (uint256 poolDebt, , )   = _pool.debtInfo();
+        (uint256 poolDebt, , ,)   = _pool.debtInfo();
         uint256 lupIndex         = _pool.depositIndex(poolDebt);
         (uint256 interestRate, ) = _pool.interestRateInfo();
 
@@ -241,7 +241,7 @@ abstract contract UnboundedBasicPoolHandler is BaseHandler {
     ) internal updateLocalStateAndPoolInterest {
         numberOfCalls['UBBasicHandler.drawDebt']++;
 
-        (uint256 poolDebt, , ) = _pool.debtInfo();
+        (uint256 poolDebt, , ,) = _pool.debtInfo();
 
         // find bucket to borrow quote token
         uint256 bucket = _pool.depositIndex(amount_ + poolDebt) - 1;

--- a/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/ERC721Pool/ERC721DSTestPlus.sol
@@ -138,7 +138,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
             assertEq(collateral, 0);
         }
         ( , uint256 loansCount, , , ) = _poolUtils.poolLoansInfo(address(_pool));
-        (uint256 debt, , ) = _pool.debtInfo();
+        (uint256 debt, , ,) = _pool.debtInfo();
         assertEq(debt, 0);
         assertEq(loansCount, 0);
         assertEq(_pool.pledgedCollateral(), 0);

--- a/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -490,7 +490,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
 
         // check collateralization after pledge
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(_encumberance(poolDebt, _lup()), 0);
 
         // borrower borrows some quote
@@ -502,7 +502,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
 
         // check collateralization after borrow
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(_encumberance(poolDebt, _lup()), 2.992021560300836411 * 1e18);
 
         // should revert if borrower attempts to pull more collateral than is unencumbered

--- a/tests/forge/ERC721Pool/ERC721PoolFlashloan.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolFlashloan.t.sol
@@ -53,7 +53,7 @@ contract ERC721PoolFlashloanTest is ERC721HelperContract {
             newLup:     _bucketPrice
         });
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, 200.192307692307692400 * 1e18);
     }
 

--- a/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolInterest.t.sol
@@ -94,7 +94,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         uint256 expectedDebt = 5_004.326923076923075000 * 1e18;
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -118,7 +118,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 5_010.500446015624727374 * 1e18;
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -143,7 +143,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 5_016.063127975675193806 * 1e18;
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -167,7 +167,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 6_021.775783320497493092 * 1e18;
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -195,7 +195,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             newLup:           MAX_PRICE
         });
 
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, 0);  
 
         _assertBorrower({
@@ -250,7 +250,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         uint256 expectedBorrower1Debt = 8_007.692307692307696000 * 1e18;
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedBorrower1Debt);
 
         _assertBorrower({
@@ -283,7 +283,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         expectedBorrower1Debt = 8_007.875133804645608008 * 1e18;
         uint256 expectedBorrower2Debt = 2_752.644230769230770500 * 1e18;
         uint256 expectedPoolDebt = 10_760.519364573876378508 * 1e18;
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedPoolDebt);
 
         _assertBorrower({
@@ -327,7 +327,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         uint256 expectedBorrower3Debt = 2_502.403846153846154999 * 1e18;
         expectedPoolDebt = 13_263.168887490336411730 * 1e18;
 
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedPoolDebt);
 
         _assertBorrower({
@@ -369,7 +369,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         // check pool and borrower debt to confirm interest has accumulated
         expectedPoolDebt = 13_263.471703022178416339 * 1e18;
 
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt, expectedPoolDebt);
 
         _assertLenderInterest(liquidityAdded, 0.637680300600360000 * 1e18);
@@ -457,7 +457,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         uint256 expectedDebt = 5_004.326923076923075000 * 1e18;
-        (uint256 poolDebt, , ) = _pool.debtInfo();
+        (uint256 poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -472,7 +472,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         skip(30 days);
 
         expectedDebt = 5_022.870348947539432923 * 1e18;
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -498,7 +498,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             newLup:           MAX_PRICE
         });
 
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, 0);
 
         _assertBorrower({
@@ -520,7 +520,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 5_003.894230769230769999 * 1e18;
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -545,7 +545,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 5_009.449578476990224065 * 1e18;
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -570,7 +570,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 5_014.454664494689841709 * 1e18;
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -594,7 +594,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
         });
 
         expectedDebt = 6_019.594382773827921756 * 1e18;
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, expectedDebt);
 
         _assertBorrower({
@@ -622,7 +622,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             newLup:           MAX_PRICE
         });
 
-        (poolDebt, , ) = _pool.debtInfo();
+        (poolDebt, , ,) = _pool.debtInfo();
         assertEq(poolDebt, 0);
 
         _assertBorrower({

--- a/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -49,12 +49,12 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             newLup:     251_183.992399245533703810 * 1e18
         });
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt - 175_000 * 1e18, 168.26923076923085 * 1e18);
 
         skip(26 weeks);
 
-        (poolDebt,,) = _pool.debtInfo();
+        (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt - 175_000 * 1e18, 4_590.373946590638353626 * 1e18);  // debt matches develop
     }
 
@@ -230,7 +230,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             collateralToPull: 0,
             newLup:           MAX_PRICE
         });
-        (uint256 debt,,) = _pool.debtInfo();
+        (uint256 debt,,,) = _pool.debtInfo();
         assertEq(debt, 0);
 
         uint256 reserves          = 831.584938142442153626 * 1e18;

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -444,7 +444,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         (uint256 borrowerDebt, uint256 borrowerCollateral , ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);
         (, uint256 lockedBonds) = _pool.kickerInfo(state_.kicker);
         (uint256 auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
-        (,,uint256 auctionDebtInAuction)  = _pool.debtInfo(); 
+        (,,uint256 auctionDebtInAuction,)  = _pool.debtInfo(); 
         uint256 borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerDebt * Maths.WAD / borrowerCollateral : 0;
 
         assertEq(auctionKickTime != 0,     state_.active);
@@ -485,7 +485,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             uint256 poolTargetUtilization
         ) = _poolUtils.poolUtilizationInfo(address(_pool));
 
-        (uint256 poolDebt,,) = _pool.debtInfo();
+        (uint256 poolDebt,,,) = _pool.debtInfo();
 
         assertEq(htp, state_.htp);
         assertEq(lup, state_.lup);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Added new invariant to ensure t0Debt2ToCollateral accumulator contains the correct value every time a borrower is touched. This invariant check loops over all actors, checks their debt and collateral then adds to a sum, once all borrowers are looped over this sum is checked against the pool's t0Debt2ToCollateral value.
* pool.debtInfo() now returns t0Debt2ToCollateral (adjusted all returns)
* added new invariant to BasicInvariants.t.sol - - **I4**: for all borrowers where (borrower.collateral != 0) the sum of borrower debt squared divided by borrower collateral (borrower.debt^2 / borrower.collateral) should equal borrower collateralization accumulator (t0Debt2ToCollateral)


# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,356B  (99.10%)
  ERC20Pool                -  23,802B  (96.85%)
  Auctions                 -  21,067B  (85.72%)
  PositionManager          -  18,787B  (76.44%)
  PositionNFTSVG           -  15,261B  (62.09%)
  LenderActions            -  12,403B  (50.47%)
  BorrowerActions          -  11,939B  (48.58%)
  PoolInfoUtils            -  11,773B  (47.90%)
  RewardsManager           -   9,518B  (38.73%)
  PoolCommons              -   9,069B  (36.90%)
  ERC721                   -   4,421B  (17.99%)
  ERC721PoolFactory        -   3,340B  (13.59%)
  ERC20PoolFactory         -   2,473B  (10.06%)
  ERC20                    -   2,140B  (8.71%)
  Address                  -      86B  (0.35%)
  Base64                   -      86B  (0.35%)
  Buckets                  -      86B  (0.35%)
  ClonesWithImmutableArgs  -      86B  (0.35%)
  Deposits                 -      86B  (0.35%)
  EnumerableSet            -      86B  (0.35%)
  Loans                    -      86B  (0.35%)
  Maths                    -      86B  (0.35%)
  PRBMath                  -      86B  (0.35%)
  PRBMathSD59x18           -      86B  (0.35%)
  PRBMathUD60x18           -      86B  (0.35%)
  SafeERC20                -      86B  (0.35%)
  Strings                  -      86B  (0.35%)
  Clone                    -      63B  (0.26%)
```

## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,369B  (99.15%)
  ERC20Pool                -  23,815B  (96.90%)
  Auctions                 -  21,067B  (85.72%)
  PositionManager          -  18,787B  (76.44%)
  PositionNFTSVG           -  15,261B  (62.09%)
  LenderActions            -  12,403B  (50.47%)
  BorrowerActions          -  11,939B  (48.58%)
  PoolInfoUtils            -  11,779B  (47.93%)
  RewardsManager           -   9,518B  (38.73%)
  PoolCommons              -   8,762B  (35.65%)
  ERC721                   -   4,421B  (17.99%)
  ERC721PoolFactory        -   3,340B  (13.59%)
  ERC20PoolFactory         -   2,473B  (10.06%)
  ERC20                    -   2,140B  (8.71%)
  Address                  -      86B  (0.35%)
  Base64                   -      86B  (0.35%)
  Buckets                  -      86B  (0.35%)
  ClonesWithImmutableArgs  -      86B  (0.35%)
  Deposits                 -      86B  (0.35%)
  EnumerableSet            -      86B  (0.35%)
  Loans                    -      86B  (0.35%)
  Maths                    -      86B  (0.35%)
  PRBMath                  -      86B  (0.35%)
  PRBMathSD59x18           -      86B  (0.35%)
  PRBMathUD60x18           -      86B  (0.35%)
  SafeERC20                -      86B  (0.35%)
  Strings                  -      86B  (0.35%)
  Clone                    -      63B  (0.26%)
```

