### PR TITLE
TOB-AJNA-8: Array lengths are not checked in LP allowance functions

### DIFF
--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -108,6 +108,11 @@ interface IPoolErrors {
     error InsufficientLiquidity();
 
     /**
+     *  @notice When increasing / decreasing LPs allowances indexes and amounts arrays parameters should have same length.
+     */
+    error InvalidAllowancesInput();
+
+    /**
      *  @notice When transferring LPs between indices, the new index must be a valid index.
      */
     error InvalidIndex();

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -86,6 +86,7 @@ library LenderActions {
     error CannotMergeToHigherPrice();
     error DustAmountNotExceeded();
     error NoAllowance();
+    error InvalidAllowancesInput();
     error InvalidIndex();
     error InvalidAmount();
     error LUPBelowHTP();
@@ -579,6 +580,8 @@ library LenderActions {
      *  @notice See `IPoolLenderActions` for descriptions
      *  @dev write state:
      *          - increment LPs allowances
+     *  @dev reverts on:
+     *          - invalid indexes and amounts input InvalidAllowancesInput()
      *  @dev emit events:
      *          - IncreaseLPsAllowance
      */
@@ -589,8 +592,10 @@ library LenderActions {
         uint256[] calldata amounts_
     ) external {
         uint256 indexesLength = indexes_.length;
-        uint256 index;
 
+        if (indexesLength != amounts_.length) revert InvalidAllowancesInput();
+
+        uint256 index;
         for (uint256 i = 0; i < indexesLength; ) {
             index = indexes_[i];
 
@@ -611,6 +616,8 @@ library LenderActions {
      *  @notice See `IPoolLenderActions` for descriptions
      *  @dev write state:
      *          - decrement LPs allowances
+     *  @dev reverts on:
+     *          - invalid indexes and amounts input InvalidAllowancesInput()
      *  @dev emit events:
      *          - DecreaseLPsAllowance
      */
@@ -621,6 +628,9 @@ library LenderActions {
         uint256[] calldata amounts_
     ) external {
         uint256 indexesLength = indexes_.length;
+
+        if (indexesLength != amounts_.length) revert InvalidAllowancesInput();
+
         uint256 index;
 
         for (uint256 i = 0; i < indexesLength; ) {

--- a/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -186,6 +186,25 @@ contract ERC20PoolTransferLPsTest is ERC20HelperContract {
         });
     }
 
+    function testIncreaseDecreaseLPsWithInvalidInput() external tearDown {
+        uint256[] memory indexes = new uint256[](3);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        indexes[2] = 2552;
+
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 10_000 * 1e18;
+        amounts[1] = 30_000 * 1e18;
+
+        // increase allowance should revert for invalid input
+        vm.expectRevert(IPoolErrors.InvalidAllowancesInput.selector);
+        _pool.increaseLPsAllowance(_lender2, indexes, amounts);
+
+        // decrease allowance should revert for invalid input
+        vm.expectRevert(IPoolErrors.InvalidAllowancesInput.selector);
+        _pool.decreaseLPsAllowance(_lender2, indexes, amounts);
+    }
+
     function testTransferLPsForAllIndexes() external tearDown {
         uint256[] memory indexes = new uint256[](3);
         indexes[0] = 2550;


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* add a check to both `increaseLPAllowance` and `decreaseLPAllowance` to ensure the lengths of `amounts_` and `indexes_` are the same
  * revert with `InvalidAllowancesInput` if arrays lengths are different

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Array lengths are not checked in LP allowance update functions
* Could be a case of user error where an index is accidentally omitted by the user when calling the method resulting in unintended actions.
* add a check to both `increaseLPAllowance` and `decreaseLPAllowance` to ensure the lengths of `amounts_` and `indexes_` are the same

# Contract size
## Pre Change
N/A
## Post Change
N/A

# Gas usage
## Pre Change
N/A
## Post Change
N/A

