### PR TITLE
ToB improvement: `UPDATE_CLAIM_REWARD` state var should be constant

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -56,7 +56,7 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
     /**
      * @notice Reward factor by which to scale rewards earned for updating a buckets exchange rate.
      */
-    uint256 internal UPDATE_CLAIM_REWARD = 0.05 * 1e18;
+    uint256 internal constant UPDATE_CLAIM_REWARD = 0.05 * 1e18;
     /**
      * @notice Time period after a burn event in which buckets exchange rates can be updated.
      */


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* `UPDATE_CLAIM_REWARD` state var should be constant

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* `UPDATE_CLAIM_REWARD` state var changed to constant

# Contract size
## Pre Change
```
RewardsManager     -   9,517B  (38.72%)
```
## Post Change
```
RewardsManager           -   9,523B  (38.75%)
```

# Gas usage
## Pre Change
```
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 33195           | 48647   | 35274   | 159797  | 89      |
| claimRewards                                   | 523             | 110209  | 103567  | 388866  | 92      |
| getBucketStateStakeInfo                        | 660             | 2658    | 2660    | 2660    | 81279   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 118     |
| moveStakedLiquidity                            | 1818564         | 1988274 | 1988274 | 2157984 | 2       |
| stake                                          | 118564          | 389067  | 434955  | 891224  | 32      |
| unstake                                        | 78223           | 179563  | 140509  | 395028  | 11      |
| updateBucketExchangeRatesAndClaim              | 9592            | 254807  | 175037  | 532539  | 37      |
```
## Post Change
```
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 33195           | 58879   | 35274   | 159797  | 35      |
| claimRewards                                   | 523             | 91217   | 103494  | 388896  | 38      |
| getBucketStateStakeInfo                        | 660             | 2658    | 2660    | 2660    | 81279   |
| getStakeInfo                                   | 683             | 683     | 683     | 683     | 66      |
| moveStakedLiquidity                            | 1818564         | 1987436 | 1987436 | 2156309 | 2       |
| stake                                          | 118564          | 368138  | 395485  | 891224  | 34      |
| unstake                                        | 78223           | 179351  | 140514  | 394637  | 11      |
| updateBucketExchangeRatesAndClaim              | 9592            | 301154  | 290010  | 531539  | 22      |
```

