### PR TITLE
TOB-AJNA-4: Reset interest rate if debtEma < 5% of depositEma and pool rate > 10%

### DIFF
--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -324,7 +324,7 @@ interface IPoolEvents {
     );
 
     /**
-     *  @notice Emitted when pool interest rate is reset. This happens when interest rate > 10% and debtEma < 3% of depositEma
+     *  @notice Emitted when pool interest rate is reset. This happens when interest rate > 10% and debtEma < 5% of depositEma
      *  @param  oldRate Old pool interest rate.
      *  @param  newRate New pool interest rate.
      */

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -324,6 +324,16 @@ interface IPoolEvents {
     );
 
     /**
+     *  @notice Emitted when pool interest rate is reset. This happens when interest rate > 10% and debtEma < 3% of depositEma
+     *  @param  oldRate Old pool interest rate.
+     *  @param  newRate New pool interest rate.
+     */
+    event ResetInterestRate(
+        uint256 oldRate,
+        uint256 newRate
+    );
+
+    /**
      *  @notice Emitted when pool interest rate is updated.
      *  @param  oldRate Old pool interest rate.
      *  @param  newRate New pool interest rate.

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -152,9 +152,9 @@ library PoolCommons {
             emaParams_.emaUpdate = block.timestamp;
         }
 
-        // reset interest rate if debtEma < 3% of depositEma and pool rate > 10%
+        // reset interest rate if debtEma < 5% of depositEma and pool rate > 10%
         if (
-            vars.debtEma < Maths.wmul(vars.depositEma, 0.03 * 1e18)
+            vars.debtEma < Maths.wmul(vars.depositEma, 0.05 * 1e18)
             &&
             poolState_.rate > 0.1 * 1e18
         ) {

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -152,11 +152,11 @@ library PoolCommons {
             emaParams_.emaUpdate = block.timestamp;
         }
 
-        // reset interest rate if debtEma < 5% of depositEma and pool rate > 10%
+        // reset interest rate if pool rate > 10% and debtEma < 5% of depositEma
         if (
-            vars.debtEma < Maths.wmul(vars.depositEma, 0.05 * 1e18)
-            &&
             poolState_.rate > 0.1 * 1e18
+            &&
+            vars.debtEma < Maths.wmul(vars.depositEma, 0.05 * 1e18)
         ) {
             interestParams_.interestRate       = uint208(0.1 * 1e18);
             interestParams_.interestRateUpdate = uint48(block.timestamp);

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -167,7 +167,6 @@ library PoolCommons {
         else if (block.timestamp - interestParams_.interestRateUpdate > 12 hours) {
             vars.newInterestRate = _calculateInterestRate(
                 poolState_,
-                interestParams_.interestRate,
                 vars.debtEma,
                 vars.depositEma,
                 vars.debtColEma,
@@ -247,7 +246,6 @@ library PoolCommons {
      */
     function _calculateInterestRate(
         PoolState memory poolState_,
-        uint256 interestRate_,
         uint256 debtEma_,
         uint256 depositEma_,
         uint256 debtColEma_,
@@ -267,8 +265,6 @@ library PoolCommons {
         // calculate target utilization
         int256 tu = (lupt0DebtEma_ != 0) ? 
             int256(Maths.wdiv(debtColEma_, lupt0DebtEma_)) : int(Maths.WAD);
-
-        if (!poolState_.isNewInterestAccrued) poolState_.rate = interestRate_;
 
         newInterestRate_ = poolState_.rate;
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1347,17 +1347,11 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         (interestRate,) = _pool.interestRateInfo();
         assertEq(interestRate, 0.107179440500000000 * 1e18); // interest rate increased over 10% to 10.7%
 
-        // any repay action (even if 12 hours not passed) should reset interest rate to 10%
+        // lender can reset interest rate to 10% (even if 12 hours not passed) by triggering any action
+        changePrank(_lender);
         vm.expectEmit(true, true, true, true);
         emit ResetInterestRate(0.107179440500000000 * 1e18, 0.1 * 1e18);
-        _repayDebt({
-            from:             _borrower,
-            borrower:         _borrower,
-            amountToRepay:    10 * 1e18,
-            amountRepaid:     10 * 1e18,
-            collateralToPull: 0,
-            newLup:           0
-        });
+        _pool.updateInterest();
         (interestRate,) = _pool.interestRateInfo();
         assertEq(interestRate, 0.1 * 1e18); // interest rate resetted to 10%
     }
@@ -1399,17 +1393,11 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         (interestRate,) = _pool.interestRateInfo();
         assertEq(interestRate, 0.107179440500000000 * 1e18); // interest rate increased over 10% to 10.7%
 
-        // any repay action (even if 12 hours not passed) should reset interest rate to 10%
+        // lender can reset interest rate to 10% (even if 12 hours not passed) by triggering any action
+        changePrank(_lender);
         vm.expectEmit(true, true, true, true);
         emit ResetInterestRate(0.107179440500000000 * 1e18, 0.1 * 1e18);
-        _repayDebt({
-            from:             otherBorrowers[0],
-            borrower:         otherBorrowers[0],
-            amountToRepay:    1 * 1e18,
-            amountRepaid:     1 * 1e18,
-            collateralToPull: 0,
-            newLup:           0
-        });
+        _pool.updateInterest();
         (interestRate,) = _pool.interestRateInfo();
         assertEq(interestRate, 0.1 * 1e18); // interest rate resetted to 10%
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1319,4 +1319,99 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         assertEq(_poolUtils.lup(address(_pool)), MAX_PRICE);
     }
 
+    function testPOCOverCollateralized_SingleBorrower() external {
+        // _borrower borrows 1,000 USDC collateralized by 100 eth
+        _drawDebt({
+            from: _borrower,
+            borrower: _borrower,
+            amountToBorrow: 1000 * 1e18,
+            limitIndex: 3_000,
+            collateralToPledge: 100 * 1e18,
+            newLup:0
+        });
+        (uint interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.05 * 1e18); // 5% initial interest rate
+
+        //pay down a little ($10) every 12 hours to trigger interestRate update
+        for (uint index; index < 8; ++index) {
+            skip(12.01 hours); // actually needs to be > 12 hours to trigger interestRate update
+            _repayDebt({
+                from:             _borrower,
+                borrower:         _borrower,
+                amountToRepay:    10 * 1e18,
+                amountRepaid:     10 * 1e18,
+                collateralToPull: 0,
+                newLup:           0
+            });
+        }
+        (interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.107179440500000000 * 1e18); // interest rate increased over 10% to 10.7%
+
+        // any repay action (even if 12 hours not passed) should reset interest rate to 10%
+        vm.expectEmit(true, true, true, true);
+        emit ResetInterestRate(0.107179440500000000 * 1e18, 0.1 * 1e18);
+        _repayDebt({
+            from:             _borrower,
+            borrower:         _borrower,
+            amountToRepay:    10 * 1e18,
+            amountRepaid:     10 * 1e18,
+            collateralToPull: 0,
+            newLup:           0
+        });
+        (interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.1 * 1e18); // interest rate resetted to 10%
+    }
+
+    function testPOCOverCollateralized_MultipleBorrowers_LowDebt() external {
+
+        // 10 borrowers borrow 120 usdc collateralized by 10 eth
+        address[] memory otherBorrowers = new address[](10);
+        for (uint index; index < 10; ++index) {
+            otherBorrowers[index] = address(bytes20(keccak256(abi.encodePacked(index + 0x1000))));
+            vm.stopPrank(); // test helper contains a startPrank without a stopPrank
+
+            _mintCollateralAndApproveTokens(otherBorrowers[index],  100 * 1e18);
+            _drawDebt({
+                from: otherBorrowers[index],
+                borrower: otherBorrowers[index],
+                amountToBorrow: 120 * 1e18, // borrow 120 usdc
+                limitIndex: 3_000,
+                collateralToPledge: 10 * 1e18, // collateralized by 10 eth
+                newLup:0
+            });
+        }
+
+        (uint interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.05 * 1e18); // 5% initial interest rate
+
+        //pay down a little ($1) every 12 hours to trigger interestRate update
+        for (uint index; index < 8; ++index) {
+            skip(12.01 hours); // actually needs to be > 12 hours to trigger interestRate update
+            _repayDebt({
+                from:             otherBorrowers[0],
+                borrower:         otherBorrowers[0],
+                amountToRepay:    1 * 1e18,
+                amountRepaid:     1 * 1e18,
+                collateralToPull: 0,
+                newLup:           0
+            });
+        }
+        (interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.107179440500000000 * 1e18); // interest rate increased over 10% to 10.7%
+
+        // any repay action (even if 12 hours not passed) should reset interest rate to 10%
+        vm.expectEmit(true, true, true, true);
+        emit ResetInterestRate(0.107179440500000000 * 1e18, 0.1 * 1e18);
+        _repayDebt({
+            from:             otherBorrowers[0],
+            borrower:         otherBorrowers[0],
+            amountToRepay:    1 * 1e18,
+            amountRepaid:     1 * 1e18,
+            collateralToPull: 0,
+            newLup:           0
+        });
+        (interestRate,) = _pool.interestRateInfo();
+        assertEq(interestRate, 0.1 * 1e18); // interest rate resetted to 10%
+    }
+
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -432,21 +432,21 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
             unchecked { ++i; }
         }
 
-        // show the rate maxed out at 50000%
+        // show the rate reset to 10%
         _assertPool(
             PoolParams({
-                htp:                  0.001443490644739886 * 1e18,
+                htp:                  1028117286,
                 lup:                  _p1505_26,
-                poolSize:             10_012.269795822390450000 * 1e18,
+                poolSize:             10_000.000000230822950000 * 1e18,
                 pledgedCollateral:    10_000.0 * 1e18,
-                encumberedCollateral: 0.009589619533804370 * 1e18,
-                poolDebt:             14.434906454054174087 * 1e18,
-                actualUtilization:    0.000516541356456424 * 1e18,
-                targetUtilization:    0.000000093921320113 * 1e18,
-                minDebtAmount:        1.443490645405417409 * 1e18,
+                encumberedCollateral: 0.000000006830147214 * 1e18,
+                poolDebt:             0.000010281172862060 * 1e18,
+                actualUtilization:    0.000000001027819578 * 1e18,
+                targetUtilization:    0.000000000000681949 * 1e18,
+                minDebtAmount:        0.000001028117286206 * 1e18,
                 loans:                1,
                 maxBorrower:          _borrower,
-                interestRate:         500.0 * 1e18,
+                interestRate:         0.1 * 1e18, // rate reset to 10%
                 interestRateUpdate:   _startTime + (194 * 12 hours)
             })
         );


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Interest rates can become extreme, potentially opening up DOS vectors
## High level
* - introduce rate reset functionality: if the EMA of debt is less than 5% of the EMA of Meaningful Actual Deposit at any time,  reset the rate to 10% but *only if* the current rate is higher than 10% already

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* See https://github.com/ajna-finance/contracts/issues/698
* interest rate is automatically reset to 10% if if the EMA of debt is less than 5% of the EMA of Meaningful Actual Deposit
* raise `ResetInterestRate` event

# Contract size
## Pre Change
```
PoolCommons              -   9,202B  (37.44%)
```
## Post Change
```
  PoolCommons              -   9,320B  (37.92%)
```

# Gas usage
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 119315          | 176427 | 161115 | 706716  | 60004   |
| bucketTake                           | 322003          | 342801 | 342741 | 363719  | 4       |
| drawDebt                             | 248277          | 293651 | 268224 | 797643  | 136003  |
| kick                                 | 195595          | 221811 | 220838 | 1030647 | 48000   |
| kickWithDeposit                      | 242218          | 276761 | 271562 | 995701  | 8000    |
| moveQuoteToken                       | 268072          | 268072 | 268072 | 268072  | 1       |
| removeQuoteToken                     | 143395          | 165040 | 169087 | 191621  | 4000    |
| repayDebt                            | 569028          | 601171 | 591067 | 749338  | 16002   |
| settle                               | 350558          | 350558 | 350558 | 350558  | 1       |
| take                                 | 97007           | 101873 | 101550 | 324906  | 15998   |
```
## Post Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 119370          | 176471 | 161170 | 706601  | 60004   |
| bucketTake                           | 321911          | 342709 | 342649 | 363627  | 4       |
| drawDebt                             | 248332          | 293696 | 268279 | 797528  | 136003  |
| kick                                 | 195650          | 221866 | 220893 | 1030532 | 48000   |
| kickWithDeposit                      | 242273          | 276816 | 271617 | 995586  | 8000    |
| moveQuoteToken                       | 277580          | 277580 | 277580 | 277580  | 1       |
| removeQuoteToken                     | 143303          | 164936 | 168939 | 191440  | 4000    |
| repayDebt                            | 568913          | 601056 | 590952 | 749223  | 16002   |
| settle                               | 350466          | 350466 | 350466 | 350466  | 1       |
| take                                 | 97051           | 101917 | 101594 | 324950  | 15998   |
```

