### PR TITLE
Improve MoveLiquidity event params

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -313,7 +313,9 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
             ownerOf(params_.tokenId),
             params_.tokenId,
             params_.fromIndex,
-            params_.toIndex
+            params_.toIndex,
+            vars.lpbAmountFrom,
+            vars.lpbAmountTo
         );
     }
 

--- a/src/interfaces/position/IPositionManagerEvents.sol
+++ b/src/interfaces/position/IPositionManagerEvents.sol
@@ -42,16 +42,20 @@ interface IPositionManagerEvents {
 
     /**
      *  @notice Emitted when a position's liquidity is moved between buckets.
-     *  @param  lender    Lender address.
-     *  @param  tokenId   The tokenId of the newly minted NFT.
-     *  @param  fromIndex Index of bucket from where liquidity is moved.
-     *  @param  toIndex   Index of bucket where liquidity is moved.
+     *  @param  lender         Lender address.
+     *  @param  tokenId        The tokenId of the newly minted NFT.
+     *  @param  fromIndex      Index of bucket from where liquidity is moved.
+     *  @param  toIndex        Index of bucket where liquidity is moved.
+     *  @param  lpRedeemedFrom Amount of LP removed from the `from` bucket.
+     *  @param  lpAwardedTo    Amount of LP credited to the `to` bucket.
      */
     event MoveLiquidity(
         address indexed lender,
         uint256 tokenId,
         uint256 fromIndex,
-        uint256 toIndex
+        uint256 toIndex,
+        uint256 lpRedeemedFrom,
+        uint256 lpAwardedTo
     );
 
     /**

--- a/tests/forge/unit/PositionManager.t.sol
+++ b/tests/forge/unit/PositionManager.t.sol
@@ -1656,8 +1656,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // move liquidity called by testAddress1 owner
+        uint256 lpRedeemed = 2_500 * 1e18;
+        uint256 lpAwarded  = 2_500 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit MoveLiquidity(testAddress1, tokenId1, mintIndex, moveIndex);
+        emit MoveLiquidity(testAddress1, tokenId1, mintIndex, moveIndex, lpRedeemed, lpAwarded);
         changePrank(address(testAddress1));
         _positionManager.moveLiquidity(moveLiquidityParams);
 
@@ -1782,8 +1784,10 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         });
 
         // move liquidity called by testAddress2 owner
+        lpRedeemed = 5_500 * 1e18;
+        lpAwarded  = 5_500 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit MoveLiquidity(testAddress2, tokenId2, mintIndex, moveIndex);
+        emit MoveLiquidity(testAddress2, tokenId2, mintIndex, moveIndex, lpRedeemed, lpAwarded);
         changePrank(address(testAddress2));
         _positionManager.moveLiquidity(moveLiquidityParams);
 
@@ -3050,8 +3054,10 @@ contract PositionManagerERC721PoolTest is PositionManagerERC721PoolHelperContrac
         );
 
         // move liquidity called by testAddress1
+        uint256 lpRedeemed = 4_000 * 1e18;
+        uint256 lpAwarded  = 4_000 * 1e18;
         vm.expectEmit(true, true, true, true);
-        emit MoveLiquidity(testAddress1, tokenId, indexes[0], indexes[1]);
+        emit MoveLiquidity(testAddress1, tokenId, indexes[0], indexes[1], lpRedeemed, lpAwarded);
         changePrank(testAddress1);
         _positionManager.moveLiquidity(moveLiquidityParams);
 

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -171,8 +171,10 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         address from,
         uint256 tokenId,
         uint256[] memory fromIndexes,
+        uint256[] memory lpsRedeemed,
         bool fromIndStaked,
         uint256[] memory toIndexes,
+        uint256[] memory lpsAwarded,
         uint256 expiry
     ) internal {
         
@@ -181,7 +183,7 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         // check MoveLiquidity emits
         for (uint256 i = 0; i < fromIndexes.length; ++i) {
             vm.expectEmit(true, true, true, true);
-            emit MoveLiquidity(address(_rewardsManager), tokenId, fromIndexes[i], toIndexes[i]);
+            emit MoveLiquidity(address(_rewardsManager), tokenId, fromIndexes[i], toIndexes[i], lpsRedeemed[i], lpsAwarded[i]);
         }
 
         vm.expectEmit(true, true, true, true);

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -1032,13 +1032,27 @@ contract RewardsManagerTest is RewardsHelperContract {
         secondIndexes[2] = 2558;
         secondIndexes[3] = 2559;
         secondIndexes[4] = 2560;
+        uint256[] memory secondLpsRedeemed = new uint256[](5);
+        secondLpsRedeemed[0] = 1_000 * 1e18;
+        secondLpsRedeemed[1] = 1_000 * 1e18;
+        secondLpsRedeemed[2] = 1_000 * 1e18;
+        secondLpsRedeemed[3] = 1_000 * 1e18;
+        secondLpsRedeemed[4] = 1_000 * 1e18;
+        uint256[] memory secondLpsAwarded = new uint256[](5);
+        secondLpsAwarded[0] = 1_000 * 1e18;
+        secondLpsAwarded[1] = 1_000 * 1e18;
+        secondLpsAwarded[2] = 1_000 * 1e18;
+        secondLpsAwarded[3] = 1_000 * 1e18;
+        secondLpsAwarded[4] = 1_000 * 1e18;
 
         _moveStakedLiquidity({
             from:             _minterOne,
             tokenId:          tokenIdOne,
             fromIndexes:      depositIndexes,
+            lpsRedeemed:      secondLpsRedeemed,
             fromIndStaked:    false,
             toIndexes:        secondIndexes,
+            lpsAwarded:       secondLpsAwarded,
             expiry:           block.timestamp + 1000
         });
 
@@ -1060,16 +1074,25 @@ contract RewardsManagerTest is RewardsHelperContract {
         /***********************/
 
         // retrieve the position managers index set, recreating typical tx flow since positionIndexes are stored unordered in EnnumerableSets
-        secondIndexes = _positionManager.getPositionIndexes(tokenIdOne);
+        secondIndexes       = _positionManager.getPositionIndexes(tokenIdOne);
+        secondLpsAwarded[0] = 1_000.000164743206012000 * 1e18;
+        secondLpsAwarded[1] = 1_006.443804104948552000 * 1e18;
+        secondLpsAwarded[2] = 1_000.000164743206012000 * 1e18;
+        secondLpsAwarded[3] = 1_000.000164743206012000 * 1e18;
+        secondLpsAwarded[4] = 1_000.000164743206012000 * 1e18;
 
         _moveStakedLiquidity({
             from:             _minterOne,
             tokenId:          tokenIdOne,
             fromIndexes:      secondIndexes,
+            lpsRedeemed:      secondLpsRedeemed,
             fromIndStaked:    true,
             toIndexes:        depositIndexes,
+            lpsAwarded:       secondLpsAwarded,
             expiry:           block.timestamp + 1000
         });
+        return;
+
 
         /******************************/
         /*** Second Reserve Auction ***/

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1366,7 +1366,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     event Burn(address indexed lender_, uint256 indexed price_);
     event MemorializePosition(address indexed lender_, uint256 tokenId_, uint256[] indexes_);
     event Mint(address indexed lender_, address indexed pool_, uint256 tokenId_);
-    event MoveLiquidity(address indexed owner_, uint256 tokenId_, uint256 fromIndex_, uint256 toIndex_);
+    event MoveLiquidity(address indexed owner_, uint256 tokenId_, uint256 fromIndex_, uint256 toIndex_, uint256 lpRedeemedFrom_, uint256 lpAwardedTo_);
     event RedeemPosition(address indexed lender_, uint256 tokenId_, uint256[] indexes_);
 
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
Update `PositionManager.MoveLiquidity` event to expose amount of LP redeemed from the _from_ bucket and awarded to the _to_ bucket.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
Our indexer's `Lend` entity records an actor's LP whether or not they've memorialized their position into a position NFT. This breaks when moving liquidity in `PositionManager`, because the event does not reveal the amount of LP redeemed from the _from_ bucket or awarded to the _to_ bucket. We cannot query amounts from `Pool.lenderInfo` because the LP belongs to position manager.  We should not get this from the `Pool.MoveQuoteToken` event because we cannot reliably associate the _Pool_ event with the _PositionManager_ event.

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  PositionManager          -  18,787B  (76.44%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  PositionManager          -  18,858B  (76.73%)
```

# Gas usage
## Pre Change
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |
|--------------------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                                    | min             | avg    | median | max     | # calls |
| moveLiquidity                                    | 5864            | 235506 | 238824 | 621753  | 19      |

| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Function Name                                  | min             | avg     | median  | max     | # calls |
| moveStakedLiquidity                            | 1819004         | 1971829 | 1971829 | 2124655 | 2       |


## Post Change
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |
|--------------------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                                    | min             | avg    | median | max     | # calls |
| moveLiquidity                                    | 5864            | 235879 | 239281 | 622325  | 19      |

| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Function Name                                  | min             | avg     | median  | max     | # calls |
| moveStakedLiquidity                            | 1821292         | 1974117 | 1974117 | 2126943 | 2       |


