### PR TITLE
Restrict Deployment of Matching Quote and Collateral tokens

### DIFF
--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -36,8 +36,9 @@ abstract contract PoolDeployer {
      * @dev    Used by both ERC20, and ERC721 pool factory types.
      */
     modifier canDeploy(address collateral_, address quote_, uint256 interestRate_) {
-        if (collateral_ == address(0) || quote_ == address(0))              revert IPoolFactory.DeployWithZeroAddress();
-        if (MIN_RATE > interestRate_ || interestRate_ > MAX_RATE)         revert IPoolFactory.PoolInterestRateInvalid();
+        if (collateral_ == quote_)                                  revert IPoolFactory.DeployQuoteCollateralSameToken();
+        if (collateral_ == address(0) || quote_ == address(0))      revert IPoolFactory.DeployWithZeroAddress();
+        if (MIN_RATE > interestRate_ || interestRate_ > MAX_RATE)   revert IPoolFactory.PoolInterestRateInvalid();
         _;
     }
 

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -11,6 +11,10 @@ interface IPoolFactory {
     /**************/
     /*** Errors ***/
     /**************/
+    /**
+     *  @notice Can't deploy with quote and collateral being the same token.
+     */
+    error DeployQuoteCollateralSameToken();
 
     /**
      *  @notice Can't deploy with one of the args pointing to the 0x0 address.

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -12,7 +12,7 @@ interface IPoolFactory {
     /*** Errors ***/
     /**************/
     /**
-     *  @notice Can't deploy with quote and collateral being the same token.
+     *  @notice Can't deploy if quote and collateral are the same token.
      */
     error DeployQuoteCollateralSameToken();
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
@@ -74,7 +74,8 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         });
 
         // should deploy different pool
-        address poolTwo = _poolFactory.deployPool(address(_collateral), address(_collateral), 0.05 * 10**18);
+        address compAddress = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
+        address poolTwo = _poolFactory.deployPool(address(_collateral), compAddress, 0.05 * 10**18);
         assertFalse(poolOne == poolTwo);
 
         // check tracking of deployed pools
@@ -238,6 +239,14 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
 
         vm.expectRevert(IPoolErrors.AlreadyInitialized.selector);
         ERC20Pool(pool).initialize(0.05 * 10**18);
+    }
+
+    function testDeployERC20SameQuoteCollateral() external {
+        skip(333);
+
+        address usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+        vm.expectRevert(IPoolFactory.DeployQuoteCollateralSameToken.selector);
+        _poolFactory.deployPool(usdcAddress, usdcAddress, 0.0543 * 1e18 );
     }
 
 }

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
@@ -114,16 +114,16 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         // should revert if trying to deploy with interest rate lower than accepted
         _assertDeployWithInvalidRateRevert({
             poolFactory:  address(_factory),
-            collateral:   address(_quote),
-            quote:        address(new NFTCollateralToken()),
+            collateral:   address(new NFTCollateralToken()),
+            quote:        address(_quote),
             interestRate: 10**18
         });
 
         // should revert if trying to deploy with interest rate higher than accepted
         _assertDeployWithInvalidRateRevert({
             poolFactory:  address(_factory),
-            collateral:   address(_quote),
-            quote:        address(new NFTCollateralToken()),
+            collateral:   address(new NFTCollateralToken()),
+            quote:        address(_quote),
             interestRate: 2 * 10**18
         });
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
@@ -20,6 +20,7 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
     ERC721PoolFactory  internal _factory;
     uint256[]          internal _tokenIdsSubsetOne;
     uint256[]          internal _tokenIdsSubsetTwo;
+    uint256[]          internal tokenIds;
 
     function setUp() external {
         _startTime   = block.timestamp;
@@ -30,7 +31,6 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _factory = new ERC721PoolFactory(_ajna);
 
         // deploy NFT collection pool
-        uint256[] memory tokenIds;
         _NFTCollectionPoolAddress = _factory.deployPool(address(_collateral), address(_quote), tokenIds, 0.05 * 10**18);
         _NFTCollectionPool        = ERC721Pool(_NFTCollectionPoolAddress);
 
@@ -115,7 +115,7 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _assertDeployWithInvalidRateRevert({
             poolFactory:  address(_factory),
             collateral:   address(_quote),
-            quote:        address(_quote),
+            quote:        address(new NFTCollateralToken()),
             interestRate: 10**18
         });
 
@@ -123,7 +123,7 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _assertDeployWithInvalidRateRevert({
             poolFactory:  address(_factory),
             collateral:   address(_quote),
-            quote:        address(_quote),
+            quote:        address(new NFTCollateralToken()),
             interestRate: 2 * 10**18
         });
 
@@ -153,7 +153,6 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
     }
 
     function testDeployERC721PoolWithMinRate() external {
-        uint256[] memory tokenIds = new uint256[](0);
         _factory.deployPool(
             address(new NFTCollateralToken()), 
             address(new TokenWithNDecimals("Quote", "Q1", 18)), 
@@ -167,7 +166,6 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
     }
 
     function testDeployERC721PoolWithMaxRate() external {
-        uint256[] memory tokenIds = new uint256[](0);
         _factory.deployPool(
             address(new NFTCollateralToken()), 
             address(new TokenWithNDecimals("Quote", "Q1", 18)), 
@@ -316,6 +314,20 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         assertTrue(_NFTSubsetOnePool.tokenIdsAllowed(61));
 
         assertFalse(_NFTSubsetOnePool.tokenIdsAllowed(10));
+    }
+
+    function testDeployERC721SameQuoteCollateral() external {
+        skip(333);
+
+        address NFTCollectionAddress = address(new NFTCollateralToken());
+
+        vm.expectRevert(IPoolFactory.DeployQuoteCollateralSameToken.selector);
+        _factory.deployPool(
+            address(NFTCollectionAddress), 
+            address(NFTCollectionAddress), 
+            tokenIds, 
+            0.5 * 10**18
+        );
     }
 
 }


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* added a revert in the `canDeploy` pool modifier: `DeployQuoteCollateralSameToken()`.
* The revert fires if the `quote` and `collateral` addresses are equal to one another.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Protocol allowed for pools that had the same `quote` and `collateral` token. 
  * Not a bug but an undesired user experience and could result in UI confusion / error

# Contract size
## Pre Change
```
  ERC721PoolFactory        -   3,340B  (13.59%)
  ERC20PoolFactory         -   2,473B  (10.06%)
```
## Post Change
```
  ERC721PoolFactory        -   3,390B  (13.79%)
  ERC20PoolFactory         -   2,523B  (10.27%)
```

# Gas usage
## Pre Change
```
| src/ERC20PoolFactory.sol:ERC20PoolFactory contract |                 |        |        |        |         |
|----------------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                                    | Deployment Size |        |        |        |         |
| 5393302                                            | 26753           |        |        |        |         |
| Function Name                                      | min             | avg    | median | max    | # calls |
| deployPool                                         | 602             | 226907 | 232241 | 255710 | 252     |
| deployedPools                                      | 854             | 2417   | 2854   | 2854   | 55      |
| deployedPoolsList                                  | 703             | 703    | 703    | 703    | 3       |

| src/ERC721PoolFactory.sol:ERC721PoolFactory contract |                 |                   |        |                     |         |
|------------------------------------------------------|-----------------|-------------------|--------|---------------------|---------|
| Deployment Cost                                      | Deployment Size |                   |        |                     |         |
| 5692525                                              | 28251           |                   |        |                     |         |
| Function Name                                        | min             | avg               | median | max                 | # calls |
| deployPool                                           | 926             | 66202914522633298 | 303974 | 8937393460516718734 | 135     |
| deployedPools                                        | 898             | 2461              | 2898   | 2898                | 55      |
| deployedPoolsList                                    | 614             | 614               | 614    | 614                 | 1       |
```
## Post Change
```
| src/ERC20PoolFactory.sol:ERC20PoolFactory contract |                 |        |        |        |         |
|----------------------------------------------------|-----------------|--------|--------|--------|---------|
| Deployment Cost                                    | Deployment Size |        |        |        |         |
| 5403305                                            | 26803           |        |        |        |         |
| Function Name                                      | min             | avg    | median | max    | # calls |
| deployPool                                         | 603             | 226105 | 232300 | 255769 | 254     |
| deployedPools                                      | 854             | 1970   | 2854   | 2854   | 77      |
| deployedPoolsList                                  | 703             | 703    | 703    | 703    | 3       |

| src/ERC721PoolFactory.sol:ERC721PoolFactory contract |                 |                   |        |                     |         |
|------------------------------------------------------|-----------------|-------------------|--------|---------------------|---------|
| Deployment Cost                                      | Deployment Size |                   |        |                     |         |
| 5702528                                              | 28301           |                   |        |                     |         |
| Function Name                                        | min             | avg               | median | max                 | # calls |
| deployPool                                           | 927             | 64297794680261978 | 304033 | 8937393460516718735 | 139     |
| deployedPools                                        | 898             | 2014              | 2898   | 2898                | 77      |
| deployedPoolsList                                    | 614             | 614               | 614    | 614                 | 1       |
```

