### PR TITLE
ToB improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ The Ajna protocol is a non-custodial, peer-to-peer, permissionless lending, borr
 ## Accepted tokens:
 - Fungible tokens (following the [ERC20 token standard](https://eips.ethereum.org/EIPS/eip-20)).
 - Non-fungible tokens (following the [ERC721 token standard](https://eips.ethereum.org/EIPS/eip-721))
-- Special considerations have been made to support specific NFTs with nonstandard ERC721 implementations, including _CryptoPunks_ and _CryptoKitties_.  This support is limited to Ethereum mainnet.
 
 ### Token limitations
 - The following types of tokens are incompatible with Ajna, and no countermeasures exist to explicitly prevent creating a pool with such tokens, actors should use them at their own risk:

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -650,9 +650,9 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         IERC721Token(_getArgAddress(COLLATERAL_ADDRESS)).transferFrom(from_, to_, tokenId_);
     }
 
-    /**************************/
-    /*** External Functions ***/
-    /**************************/
+    /*******************************/
+    /*** External View Functions ***/
+    /*******************************/
 
     /// @inheritdoc IERC721PoolState
     function totalBorrowerTokens(address borrower_) external view override returns(uint256) {

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -645,9 +645,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         return _priceAt(Deposits.findIndexOfSum(deposits, debt_));
     }
 
-    /**************************/
-    /*** External Functions ***/
-    /**************************/
+    /*******************************/
+    /*** External View Functions ***/
+    /*******************************/
 
     /// @inheritdoc IPoolState
     function auctionInfo(

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -42,9 +42,9 @@ abstract contract PoolDeployer {
         _;
     }
 
-    /**************************/
-    /*** External Functions ***/
-    /**************************/
+    /*******************************/
+    /*** External View Functions ***/
+    /*******************************/
 
     /**
      * @notice Returns the list of all deployed pools.

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -21,8 +21,7 @@ interface IPositionManagerOwnerActions {
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
      *  @dev    An additional call is made to the pool to transfer the LPs from their previous owner, to the Position Manager.
-     *  @dev    `Pool.increaseLPsAllowance` must be called prior to calling this method in order to provide Position manager contract allowance to transfer LPs to be memorialized.
-     *  @dev    `Pool.approveLPsTransferors` must be called prior to calling this method in order to whitelist Position manager contract as transferor for allowed LPs.
+     *  @dev    `Pool.increaseLPsAllowance` must be called prior to calling this method in order to allow Position manager contract to transfer LPs to be memorialized.
      *  @param  params Calldata struct supplying inputs required to conduct the memorialization.
      */
     function memorializePositions(
@@ -52,6 +51,7 @@ interface IPositionManagerOwnerActions {
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
      *  @dev    An additional call is made to the pool to transfer the LPs Position Manager to owner.
+     *  @dev    `Pool.approveLPsTransferors` must be called prior to calling this method in order to allow Position manager contract to transfer redeemed LPs.
      *  @param  params Calldata struct supplying inputs required to conduct the redeem.
      */
     function reedemPositions(

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -21,7 +21,6 @@ interface IPositionManagerOwnerActions {
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
      *  @dev    An additional call is made to the pool to transfer the LPs from their previous owner, to the Position Manager.
-     *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the memorialization.
      */
     function memorializePositions(
@@ -51,7 +50,6 @@ interface IPositionManagerOwnerActions {
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
      *  @dev    An additional call is made to the pool to transfer the LPs Position Manager to owner.
-     *  @dev    Pool.setPositionOwner() must be called prior to calling this method.
      *  @param  params Calldata struct supplying inputs required to conduct the redeem.
      */
     function reedemPositions(

--- a/src/interfaces/position/IPositionManagerOwnerActions.sol
+++ b/src/interfaces/position/IPositionManagerOwnerActions.sol
@@ -21,6 +21,8 @@ interface IPositionManagerOwnerActions {
      *  @dev    The array of buckets is expected to be constructed off chain by scanning events for that lender.
      *  @dev    The NFT must have already been created, and the number of buckets to be memorialized at a time determined by function caller.
      *  @dev    An additional call is made to the pool to transfer the LPs from their previous owner, to the Position Manager.
+     *  @dev    `Pool.increaseLPsAllowance` must be called prior to calling this method in order to provide Position manager contract allowance to transfer LPs to be memorialized.
+     *  @dev    `Pool.approveLPsTransferors` must be called prior to calling this method in order to whitelist Position manager contract as transferor for allowed LPs.
      *  @param  params Calldata struct supplying inputs required to conduct the memorialization.
      */
     function memorializePositions(

--- a/src/libraries/external/Auctions.sol
+++ b/src/libraries/external/Auctions.sol
@@ -1248,7 +1248,6 @@ library Auctions {
      *  @dev    write state:
      *              - borrower -> liquidation mapping update
      *              - increment auctions count accumulator
-     *              - increment auctions.totalBondEscrowed accumulator
      *              - updates auction queue state
      *  @param  borrowerAddress_ Address of the borrower that is kicked.
      *  @param  bondSize_        Bond size to cover newly kicked auction.
@@ -1300,7 +1299,6 @@ library Auctions {
      *  @dev    write state:
      *              - decrement kicker locked accumulator, increment kicker claimable accumumlator
      *              - decrement auctions count accumulator
-     *              - decrement auctions.totalBondEscrowed accumulator
      *              - update auction queue state
      *  @param  borrower_ Auctioned borrower address.
      */

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -289,7 +289,7 @@ library BorrowerActions {
         vars.repay = maxQuoteTokenAmountToRepay_ != 0;
         vars.pull  = collateralAmountToPull_     != 0;
 
-        // revert if no amount to pledge or borrow
+        // revert if no amount to pull or repay
         if (!vars.repay && !vars.pull) revert InvalidAmount();
 
         Borrower memory borrower = loans_.borrowers[borrowerAddress_];

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -190,12 +190,7 @@ library LenderActions {
         Deposits.unscaledAdd(deposits_, params_.index, Maths.wdiv(addedAmount, bucketScale));
 
         // update lender LPs
-        Lender storage lender = bucket.lenders[msg.sender];
-
-        if (bankruptcyTime >= lender.depositTime) lender.lps = bucketLPs_;
-        else lender.lps += bucketLPs_;
-
-        lender.depositTime = block.timestamp;
+        Buckets.addLenderLPs(bucket, bankruptcyTime, msg.sender, bucketLPs_);
 
         // update bucket LPs
         bucket.lps += bucketLPs_;

--- a/src/libraries/external/PositionNFTSVG.sol
+++ b/src/libraries/external/PositionNFTSVG.sol
@@ -26,9 +26,9 @@ library PositionNFTSVG {
         uint256[] indexes;            // the array of price buckets index with LPs to be tracked by the NFT
     }
 
-    /**************************/
-    /*** External Functions ***/
-    /**************************/
+    /*******************************/
+    /*** External View Functions ***/
+    /*******************************/
 
     function constructTokenURI(ConstructTokenURIParams memory params_) external pure returns (string memory) {
         // set token metadata

--- a/src/libraries/internal/Deposits.sol
+++ b/src/libraries/internal/Deposits.sol
@@ -192,7 +192,7 @@ library Deposits {
                 // Unset the bit in index to continue traversing up the Fenwick tree
                 index_ -= bit;
             } else {
-                // Case 1 above.  superRangeIndex is the index of the node to consider that
+                // Case 2 above.  superRangeIndex is the index of the node to consider that
                 //                contains the sub range that was already scaled in prior iteration
                 uint256 superRangeIndex = index_ + bit;
 

--- a/src/libraries/internal/Maths.sol
+++ b/src/libraries/internal/Maths.sol
@@ -11,19 +11,19 @@ library Maths {
     uint256 internal constant WAD = 1e18;
 
     function wmul(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * y + 1e18 / 2) / 1e18;
+        return (x * y + WAD / 2) / WAD;
     }
 
     function floorWmul(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * y) / 1e18;
+        return (x * y) / WAD;
     }
 
     function wdiv(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * 1e18 + y / 2) / y;
+        return (x * WAD + y / 2) / y;
     }
 
     function floorWdiv(uint256 x, uint256 y) internal pure returns (uint256) {
-        return (x * 1e18) / y;
+        return (x * WAD) / y;
     }
 
     function max(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -35,7 +35,7 @@ library Maths {
     }
 
     function wad(uint256 x) internal pure returns (uint256) {
-        return x * 1e18;
+        return x * WAD;
     }
 
     function rmul(uint256 x, uint256 y) internal pure returns (uint256) {

--- a/tests/forge/unit/MathTest.t.sol
+++ b/tests/forge/unit/MathTest.t.sol
@@ -68,4 +68,15 @@ contract MathTest is DSTestPlus {
         assertEq(Maths.wmul(     1.4534563955 * 1e18, 0.112224325121212178 * 1e18), 0.163113163078097153 * 1e18);
         assertEq(Maths.floorWmul(1.4534563955 * 1e18, 0.112224325121212178 * 1e18), 0.163113163078097152 * 1e18);
     }
+
+    function testMaxMinInt() external {
+        assertEq(Maths.maxInt(-1, 2),   2);
+        assertEq(Maths.minInt(-1, 2),  -1);
+
+        assertEq(Maths.maxInt(-1, -1), -1);
+        assertEq(Maths.minInt(-1, -1), -1);
+
+        assertEq(Maths.maxInt(2, -1),   2);
+        assertEq(Maths.minInt(2, -1),  -1);
+    }
 }


### PR DESCRIPTION
Ensure that comments in code always reflect the code’s intended behavior.
- the comment on `Deposits.sol#L195` says the following code is `Case 1 above` but it’s actually case 2.
- The section header in `Pool.sol#L702` says External Functions but is more precisely External View Functions.
- In `IPositionManagerOwnerActions.sol#L24` and `L54`, the references to `setPositionOwner` are incorrect.
- In `Contracts/README.MD#L8`, remove references to `cryptopunks` and `crypto kitties`.
- In `BorrowerActions#L292`, the comment should read: revert if no amount to pull or repay.
- The comment in `Auctions.sol#L1269`, should be removed, as `totalBondEscrowed `is updated in the Pool’s `withdrawBonds` function.

Constant variable WAD is declared but not used in Maths.sol.

Add tests for `Maths.maxInt` and `Maths.minInt`

In `LenderActions.sol#L185-191` should use `Buckets.addLenderLPs`.



