### PR TITLE
Fenwick gas improvements

### DIFF
--- a/src/libraries/internal/Deposits.sol
+++ b/src/libraries/internal/Deposits.sol
@@ -40,13 +40,17 @@ library Deposits {
         // 2- We often need to precisely change the value in the tree, avoiding the rounding that dividing by scale(index).
         //    This is more relevant to unscaledRemove(...), where we need to ensure the value is precisely set to 0, but we
         //    also prefer it here for consistency.
-        
+
+        uint256 value;
+        uint256 scaling;
+        uint256 newValue;
+
         while (index_ <= SIZE) {
-            uint256 value    = deposits_.values[index_];
-            uint256 scaling  = deposits_.scaling[index_];
+            value    = deposits_.values[index_];
+            scaling  = deposits_.scaling[index_];
 
             // Compute the new value to be put in location index_
-            uint256 newValue = value + unscaledAddAmount_;
+            newValue = value + unscaledAddAmount_;
 
             // Update unscaledAddAmount to propogate up the Fenwick tree
             // Note: we can't just multiply addAmount_ by scaling[i_] due to rounding
@@ -82,15 +86,18 @@ library Deposits {
         // up to the current value of sumIndex_
         uint256 lowerIndexSum;
         uint256 curIndex;
+        uint256 value;
+        uint256 scaling;
+        uint256 scaledValue;
 
         while (i > 0) {
             // Consider if the target index is less than or greater than sumIndex_ + i
             curIndex = sumIndex_ + i;
-            uint256 value   = deposits_.values[curIndex];
-            uint256 scaling = deposits_.scaling[curIndex];
+            value    = deposits_.values[curIndex];
+            scaling  = deposits_.scaling[curIndex];
 
             // Compute sum up to sumIndex_ + i
-            uint256 scaledValue =
+            scaledValue =
                 lowerIndexSum +
                 (scaling != 0 ?  (runningScale * scaling * value + 5e35) / 1e36 : Maths.wmul(runningScale, value));
 
@@ -358,12 +365,14 @@ library Deposits {
 
         unscaledDepositValue_ = deposits_.values[index_];
         uint256 curIndex;
+        uint256 value;
+        uint256 scaling;
 
         while (j & index_ == 0) {
             curIndex = index_ - j;
 
-            uint256 value   = deposits_.values[curIndex];
-            uint256 scaling = deposits_.scaling[curIndex];
+            value   = deposits_.values[curIndex];
+            scaling = deposits_.scaling[curIndex];
 
             unscaledDepositValue_ -= scaling != 0 ? Maths.wmul(scaling, value) : value;
             j = j << 1;


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Fenwick gas improvements
  * calculate indexes only once, move local vars outside of for loop

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Reduce number of operations, move local vars outside loops
* in `unscaledAdd` move `value`, `scaling` and `newValue` local vars outside while loop
* in `findIndexAndSumOfSum` calculate `sumIndex_ + i` only once, move `value`, `scaling` and `scaledValue` local vars outside while loop
* in `prefixSum` calculate `index + j` only once
* in `unscaledValueAt` calculate `index_ - j` only once, move `value` and `scaling` local vars outside while loop

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,537B  (99.84%)
  ERC20Pool                -  23,892B  (97.21%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,498B  (99.68%)
  ERC20Pool                -  23,853B  (97.05%)
```

# Gas usage
## Pre Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 121212          | 178481 | 163012 | 710685  | 60004   |
| bucketTake                           | 327701          | 348523 | 348463 | 369465  | 4       |
| drawDebt                             | 252160          | 297513 | 272011 | 802412  | 136003  |
| kick                                 | 198074          | 224339 | 223376 | 1034990 | 48000   |
| kickWithDeposit                      | 246022          | 280553 | 275336 | 1001653 | 8000    |
| moveQuoteToken                       | 282469          | 282469 | 282469 | 282469  | 1       |
| removeQuoteToken                     | 147273          | 169202 | 173664 | 196225  | 4000    |
| repayDebt                            | 572898          | 605041 | 594937 | 753208  | 16002   |
| settle                               | 356184          | 356184 | 356184 | 356184  | 1       |
| take                                 | 98391           | 103323 | 103004 | 330008  | 15998   |
```
## Post Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 119228          | 176162 | 161053 | 704259  | 60004   |
| bucketTake                           | 321033          | 341855 | 341795 | 362797  | 4       |
| drawDebt                             | 247098          | 291377 | 265932 | 795189  | 136003  |
| kick                                 | 192955          | 218751 | 217810 | 1027030 | 48000   |
| kickWithDeposit                      | 239107          | 273695 | 268547 | 991828  | 8000    |
| moveQuoteToken                       | 257246          | 257246 | 257246 | 257246  | 1       |
| removeQuoteToken                     | 142273          | 163603 | 165022 | 187516  | 4000    |
| repayDebt                            | 566751          | 598894 | 588790 | 747061  | 16002   |
| settle                               | 349516          | 349516 | 349516 | 349516  | 1       |
| take                                 | 96822           | 100785 | 100368 | 323529  | 15998   |
```

