### PR TITLE
Fix fuzzed test `testLoadFenwickFuzzyScalingFind` when bound to max bucket 7388

### DIFF
--- a/tests/forge/unit/FenwickTree.t.sol
+++ b/tests/forge/unit/FenwickTree.t.sol
@@ -181,7 +181,13 @@ contract FenwickTreeTest is DSTestPlus {
         uint256 subMin = Maths.min(_tree.prefixSum(treeDirectedSubIndex), _tree.prefixSum(subIndex));
 
         // 2 >= scaling discrepency
-        assertLe(max - min, 2);
+        // also note that findIndexOfSum never returns index past the MAX_FENWICK_INDEX
+        if (scaleIndex == MAX_FENWICK_INDEX) {
+            assertEq(scaleIndex, treeDirectedIndex + 1);
+        } else {
+            assertLe(max - min, 2);
+        }
+
         assertLe(subMax - subMin, 2);
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Fix for fuzzed test `testLoadFenwickFuzzyScalingFind` when using max bucket 7388
  * Properly treat bucket 7388

