### PR TITLE
Forge 1.0 support

### DIFF
--- a/.github/workflows/forge-test.yml
+++ b/.github/workflows/forge-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-87bc53fc6c874bd4c92d97ed180b949e3a36d78c
+          version: nightly
 
       - name: Run Forge build
         run: |

--- a/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/ERC20TakeWithExternalLiquidity.t.sol
@@ -77,7 +77,7 @@ contract ERC20TakeWithExternalLiquidityTest is Test {
 
         // wait for borrower to become undercollateralized due to interest accrual
         skip(100 days);
-        vm.prank(_lender);
+        vm.startPrank(_lender);
         // liquidate the borrower
         _ajnaPool.kick(_borrower, MAX_FENWICK_INDEX);
         // wait for the price to become profitable

--- a/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
+++ b/tests/forge/interactions/ERC721TakeWithExternalLiquidity.sol
@@ -21,6 +21,7 @@ contract ERC721TakeWithExternalLiquidityTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
 
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -135,13 +135,16 @@ abstract contract BaseHandler is Test {
     }
 
     modifier useRandomActor(uint256 actorIndex_) {
-        vm.stopPrank();
-
         _actor = actors[constrictToRange(actorIndex_, 0, actors.length - 1)];
 
-        vm.startPrank(_actor);
+        // if prank already started in test then use change prank to change actor
+        try vm.startPrank(_actor) {
+        } catch {
+            changePrank(_actor);
+        }
+
         _;
-        vm.stopPrank();
+
     }
 
     modifier useRandomLenderBucket(uint256 bucketIndex_) {

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -723,7 +723,6 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     function _anonBorrowerDrawsDebt(uint256 collateralAmount, uint256 loanAmount, uint256 limitIndex) internal {
         _anonBorrowerCount += 1;
         address borrower = makeAddr(string(abi.encodePacked("anonBorrower", _anonBorrowerCount)));
-        vm.stopPrank();
         _mintCollateralAndApproveTokens(borrower,  collateralAmount);
         _drawDebtNoLupCheck(
             {
@@ -739,18 +738,16 @@ abstract contract ERC20HelperContract is ERC20DSTestPlus {
     function _mintQuoteAndApproveTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
-        vm.prank(operator_);
         _collateral.approve(address(_pool), type(uint256).max);
     }
 
     function _mintCollateralAndApproveTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_collateral), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _collateral.approve(address(_pool), type(uint256).max);
-        vm.prank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
     }
 
@@ -780,20 +777,16 @@ abstract contract ERC20FuzzyHelperContract is ERC20DSTestPlus {
     function _mintQuoteAndApproveTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
-        vm.prank(operator_);
         _collateral.approve(address(_pool), type(uint256).max);
     }
 
     function _mintCollateralAndApproveTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_collateral), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _collateral.approve(address(_pool), type(uint256).max);
-        vm.prank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
     }
-
-
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -22,6 +22,8 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     uint256 lowest  = 2554;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1116,6 +1116,8 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
     uint256 lowest  = 2554;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -1362,7 +1364,6 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         address[] memory otherBorrowers = new address[](10);
         for (uint index; index < 10; ++index) {
             otherBorrowers[index] = address(bytes20(keccak256(abi.encodePacked(index + 0x1000))));
-            vm.stopPrank(); // test helper contains a startPrank without a stopPrank
 
             _mintCollateralAndApproveTokens(otherBorrowers[index],  100 * 1e18);
             _drawDebt({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -17,6 +17,8 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
     address internal _bidder;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolFlashloan.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolFlashloan.t.sol
@@ -23,6 +23,8 @@ contract ERC20PoolFlashloanTest is ERC20HelperContract {
     uint    internal _bucketPrice;
 
     function setUp() external {
+        _startTest();
+
         _lender    = makeAddr("lender");
         _borrower  = makeAddr("borrower");
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolGasLoadTest.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolGasLoadTest.t.sol
@@ -136,8 +136,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
 
         address borrower = _borrowers[borrowerId_];
 
-        vm.prank(borrower);
-
+        vm.startPrank(borrower);
         _drawDebtNoLupCheck({
             from:               borrower,
             borrower:           borrower,
@@ -145,6 +144,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
             limitIndex:         5000,
             collateralToPledge: 0
         });
+        vm.stopPrank();
 
         assertEq(_noOfLoans(), LOANS_COUNT);
     }
@@ -245,6 +245,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
 
             address borrower = _borrowers[i];
 
+            vm.startPrank(borrower);
             _drawDebtNoLupCheck({
                 from:               borrower,
                 borrower:           borrower,
@@ -252,6 +253,7 @@ contract ERC20PoolCommonActionsGasLoadTest is ERC20PoolGasLoadTest {
                 limitIndex:         5000,
                 collateralToPledge: 0
             });
+            vm.stopPrank();
 
             assertEq(_noOfLoans(), LOANS_COUNT);
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -23,6 +23,8 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
     uint256 lowest  = 2554;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -16,6 +16,8 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
     address internal _lender2;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -14,6 +14,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
     address internal _taker;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -16,6 +16,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
     address internal _taker;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -710,6 +712,10 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 }
 
 contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
+
+    function setUp() external {
+        _startTest();
+    }
 
     function testDepositTakeOnAuctionPriceZero() external {
         // initialize kicker to be rewarded after bucket take

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -15,6 +15,8 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
     address internal _withdrawRecipient;
 
     function setUp() external {
+        _startTest();
+
         _borrower          = makeAddr("borrower");
         _borrower2         = makeAddr("borrower2");
         _lender            = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKickWithDeposit.t.sol
@@ -18,6 +18,8 @@ contract ERC20PoolLiquidationsKickWithDepositTest is ERC20HelperContract {
     address internal _lender4;
 
     function setUp() external {
+        _startTest();
+
         _borrower1 = makeAddr("borrower1");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -14,6 +14,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
     address internal _lender1;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -14,6 +14,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
     address internal _lender1;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -899,6 +901,8 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
     address internal actor8;
 
     function setUp() external {
+        _startTest();
+
         actor1 = makeAddr("actor1");
         _mintQuoteAndApproveTokens(actor1, type(uint256).max);
         _mintCollateralAndApproveTokens(actor1, type(uint256).max);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -13,6 +13,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
     address internal _lender1;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -2097,6 +2099,8 @@ contract ERC20PoolLiquidationsTakeAndRepayAllDebtInPoolTest is ERC20HelperContra
     address internal _taker;
 
     function setUp() external {
+        _startTest();
+
         _lender   = makeAddr("lender");
         _borrower = makeAddr("borrower");
         _kicker   = makeAddr("kicker");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -19,6 +19,8 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
     address internal _lender4;
 
     function setUp() external {
+        _startTest();
+
         _borrower1 = makeAddr("borrower1");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolMulticall.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolMulticall.t.sol
@@ -19,6 +19,8 @@ contract ERC20PoolMulticallTest is ERC20HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _lender = makeAddr("lender");
         lenders.add(_lender);
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -46,7 +46,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _quoteDust      = _pool.quoteTokenDust();
         assertEq(_quoteDust, _pool.quoteTokenScale());
         assertEq(_quoteDust, 10 ** (18 - quotePrecisionDecimals_));
-        
+
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -60,7 +62,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _lenderDepositNormalized = 200_000 * 1e18;
         deal(address(_quote), _lender,  _lenderDepositDenormalized);
 
-        vm.startPrank(_borrower);
+        changePrank(_borrower);
         _collateral.approve(address(_pool), 150 * _collateralPrecision);
         _quote.approve(address(_pool), _lenderDepositDenormalized);
 
@@ -74,7 +76,6 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         changePrank(_lender);
         _quote.approve(address(_pool), _lenderDepositDenormalized);
 
-        vm.stopPrank();
         skip(1 days); // to avoid deposit time 0 equals bucket bankruptcy time
     }
 
@@ -709,6 +710,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1);
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(4166), 100);
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
+        vm.stopPrank();
 
         // check dust limits for 12-decimal collateral
         init(12, 18);
@@ -716,6 +718,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(1),    1000000);
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(6466), 100000000);
         assertEq(IERC20Pool(address(_pool)).bucketCollateralDust(7388), 1000000000);
+        vm.stopPrank();
 
         // check dust limits for 6-decimal collateral
         init(6, 18);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPurchaseQuote.t.sol
@@ -13,6 +13,8 @@ contract ERC20PoolPurchaseQuoteTokenTest is ERC20HelperContract {
     address internal _lender1;
 
     function setUp() external {
+        _startTest();
+
         _borrower = makeAddr("borrower");
         _bidder   = makeAddr("bidder");
         _lender   = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -14,6 +14,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
     address internal _lender1;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -14,6 +14,8 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
     address internal _lender2;
 
     function setUp() external {
+        _startTest();
+
         _lender  = makeAddr("lender");
         _lender1 = makeAddr("lender1");
         _lender2 = makeAddr("lender2");

--- a/tests/forge/unit/ERC20Pool/ERC20SafeTransferTokens.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20SafeTransferTokens.sol
@@ -23,6 +23,8 @@ contract ERC20SafeTransferTokens is ERC20HelperContract {
     address internal USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
 
     function setUp() external {
+        _startTest();
+
         _lender      = makeAddr("lender");
         _borrower    = makeAddr("borrower");
         usdt         = IUSDT(USDT);

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -693,19 +693,19 @@ abstract contract ERC721HelperContract is ERC721DSTestPlus {
 
     function _mintAndApproveQuoteTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
     }
 
     function _mintAndApproveCollateralTokens(address operator_, uint256 mintAmount_) internal {
         _collateral.mint(operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _collateral.setApprovalForAll(address(_pool), true);
     }
 
     function _mintAndApproveAjnaTokens(address operator_, uint256 mintAmount_) internal {
         deal(_ajna, operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _ajnaToken.approve(address(_pool), type(uint256).max);
     }
 
@@ -762,13 +762,13 @@ abstract contract ERC721NDecimalsHelperContract is ERC721DSTestPlus {
 
     function _mintAndApproveQuoteTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
     }
 
     function _mintAndApproveCollateralTokens(address operator_, uint256 mintAmount_) internal {
         _collateral.mint(operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _collateral.setApprovalForAll(address(_pool), true);
     }
 
@@ -779,7 +779,6 @@ abstract contract ERC721NDecimalsHelperContract is ERC721DSTestPlus {
         // _anonBorrowerCount += 1;
         
         address borrower = makeAddr(string(abi.encodePacked("anonBorrower", borrowers.length())));
-        vm.stopPrank();
         _mintAndApproveCollateralTokens(borrower, 1);
         uint256[] memory tokenIdsToAdd = new uint256[](1);
         tokenIdsToAdd[0] = _collateral.totalSupply();
@@ -822,19 +821,19 @@ abstract contract ERC721FuzzyHelperContract is ERC721DSTestPlus {
 
     function _mintAndApproveQuoteTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
     }
 
     function _mintAndApproveCollateralTokens(address operator_, uint256 mintAmount_) internal {
         _collateral.mint(operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _collateral.setApprovalForAll(address(_pool), true);
     }
 
     function _mintAndApproveAjnaTokens(address operator_, uint256 mintAmount_) internal {
         deal(_ajna, operator_, mintAmount_);
-        vm.prank(operator_);
+        changePrank(operator_);
         _ajnaToken.approve(address(_pool), type(uint256).max);
     }
 
@@ -843,7 +842,6 @@ abstract contract ERC721FuzzyHelperContract is ERC721DSTestPlus {
         changePrank(borrower_);
         tokenIds_ = new uint256[](requiredCollateral_);
         for (uint i = 0; i < requiredCollateral_; ++i) {
-            vm.stopPrank();
             _mintAndApproveCollateralTokens(borrower_, 1);
             tokenIds_[i] = _collateral.totalSupply();
         }

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -20,6 +20,8 @@ abstract contract ERC721PoolBorrowTest is ERC721HelperContract {
     function createPool() external virtual returns (ERC721Pool);
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");
@@ -34,7 +36,7 @@ abstract contract ERC721PoolBorrowTest is ERC721HelperContract {
         _mintAndApproveCollateralTokens(_borrower2, 10);
         _mintAndApproveCollateralTokens(_borrower3, 13);
 
-        vm.prank(_borrower);
+        changePrank(_borrower);
         _quote.approve(address(_pool), 200_000 * 1e18);
     }
 }
@@ -550,13 +552,15 @@ contract ERC721CollectionPoolBorrowTest is ERC721NDecimalsHelperContract(18) {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _lender    = makeAddr("lender");
 
         _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
         _mintAndApproveCollateralTokens(_borrower, 52);
 
-        vm.prank(_borrower);
+        changePrank(_borrower);
         _quote.approve(address(_pool), 200_000 * 1e18);
     }
 
@@ -630,6 +634,8 @@ contract ERC721ScaledQuoteTokenBorrowTest is ERC721NDecimalsHelperContract(4) {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _lender    = makeAddr("lender");
 
@@ -682,6 +688,8 @@ contract ERC721PoolBorrowFuzzyTest is ERC721FuzzyHelperContract {
     address internal _lender2;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");
@@ -696,7 +704,7 @@ contract ERC721PoolBorrowFuzzyTest is ERC721FuzzyHelperContract {
         _mintAndApproveCollateralTokens(_borrower2, 10);
         _mintAndApproveCollateralTokens(_borrower3, 13);
 
-        vm.prank(_borrower);
+        changePrank(_borrower);
         _quote.approve(address(_pool), 200_000 * 1e18);
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -16,6 +16,8 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
     address internal _lender2;
 
     function setUp() virtual external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");
@@ -1186,6 +1188,8 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 contract ERC721SubsetPoolCollateralTest is ERC721PoolCollateralTest {
 
     function setUp() override external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolEMAs.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolEMAs.t.sol
@@ -12,6 +12,8 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _lender    = makeAddr("lender");
         _borrower  = makeAddr("borrower");
         _attacker  = makeAddr("attacker");
@@ -217,7 +219,6 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         );
 
         // draw additional debt
-        vm.stopPrank();
         _mintAndApproveCollateralTokens(_borrower,  6);
         uint256[] memory tokenIdsToAdd = new uint256[](6);
         for (uint i=0; i<6; ++i) {

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFlashloan.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFlashloan.t.sol
@@ -16,6 +16,8 @@ contract ERC721PoolFlashloanTest is ERC721HelperContract {
     uint    internal _bucketPrice;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _lender    = makeAddr("lender");
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolInterest.t.sol
@@ -17,6 +17,8 @@ abstract contract ERC721PoolInterestTest is ERC721HelperContract {
     function createPool() external virtual returns (ERC721Pool);
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _borrower3 = makeAddr("borrower3");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -14,6 +14,8 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
     address internal _taker;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -12,6 +12,8 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -12,6 +12,8 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -14,6 +14,8 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -15,6 +15,8 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
     address internal _withdrawRecipient;
 
     function setUp() external {
+        _startTest();
+
         _borrower          = makeAddr("borrower");
         _borrower2         = makeAddr("borrower2");
         _lender            = makeAddr("lender");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolPurchaseQuote.t.sol
@@ -14,6 +14,8 @@ contract ERC721PoolPurchaseQuoteTest is ERC721HelperContract {
     address internal _lender2;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _borrower2 = makeAddr("borrower2");
         _bidder    = makeAddr("bidder");

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -12,6 +12,8 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
     address internal _lender;
 
     function setUp() external {
+        _startTest();
+
         _borrower  = makeAddr("borrower");
         _bidder    = makeAddr("bidder");
         _lender    = makeAddr("lender");

--- a/tests/forge/unit/PositionManager.t.sol
+++ b/tests/forge/unit/PositionManager.t.sol
@@ -24,16 +24,19 @@ abstract contract PositionManagerERC20PoolHelperContract is ERC20HelperContract 
         _positionManager = new PositionManager(_poolFactory, new ERC721PoolFactory(_ajna));
     }
 
+    function setUp() external {
+        _startTest();
+    }
+
     function _mintQuoteAndApproveManagerTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
         address[] memory transferors = new address[](1);
         transferors[0] = address(_positionManager);
         _pool.approveLPTransferors(transferors);
 
-        vm.prank(operator_);
         _quote.approve(address(_positionManager), type(uint256).max);
         _pool.approveLPTransferors(transferors);
     }
@@ -1404,7 +1407,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         // generate a new address and set test params
         address testAddress = makeAddr("testAddress");
 
-        vm.prank(testAddress);
+        changePrank(testAddress);
         uint256 tokenId = _mintNFT(testAddress, testAddress, address(_pool));
         assertEq(_positionManager.ownerOf(tokenId), testAddress);
         // construct BurnParams
@@ -2753,12 +2756,15 @@ abstract contract PositionManagerERC721PoolHelperContract is ERC721HelperContrac
         _pool = _deployCollectionPool();
     }
 
+    function setUp() external {
+        _startTest();
+    }
+
     function _mintQuoteAndApproveManagerTokens(address operator_, uint256 mintAmount_) internal {
         deal(address(_quote), operator_, mintAmount_);
 
-        vm.prank(operator_);
+        changePrank(operator_);
         _quote.approve(address(_pool), type(uint256).max);
-        vm.prank(operator_);
         _quote.approve(address(_positionManager), type(uint256).max);
     }
 

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -22,6 +22,7 @@ contract RewardsManagerTest is RewardsHelperContract {
     mapping (address => uint256) internal minterToBalance;
 
     function setUp() external {
+        _startTest();
 
         // borrowers
         _borrower = makeAddr("borrower");
@@ -42,9 +43,8 @@ contract RewardsManagerTest is RewardsHelperContract {
         _bidder      = makeAddr("bidder");
         deal(address(_ajna), _bidder, 900_000_000 * 10**18);
 
-        vm.prank(_bidder);
+        changePrank(_bidder);
         _ajnaToken.approve(address(_pool), type(uint256).max);
-        vm.prank(_bidder);
         ERC20(address(_quoteOne)).approve(address(_pool), type(uint256).max);
         ERC20(address(_quoteTwo)).approve(address(_pool), type(uint256).max);
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -91,6 +91,13 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     EnumerableSet.AddressSet borrowers;
     EnumerableSet.UintSet bucketsUsed;
 
+    /**
+     *  @dev fake start prank in order to avoid https://github.com/foundry-rs/foundry/issues/4835
+     **/
+    function _startTest() internal {
+        vm.startPrank(address(this));
+    }
+
     function _registerLender(
         address lender,
         uint256[] memory indexes


### PR DESCRIPTION
- adapt tests to work with forge 1.0

Unit tests:
- all tests start with fake `startPrank` by calling` _startTest()`
- through test helper functions only `changePrank` is used (as start prank ensured in `_startTest()`)

Gas load tests:
- always `startPrank` before using test helper functions (which use `changePrank`)
- always `soptPrank` after using test helper functions

Invariant tests - in `useRandomActor` modifier:
- try to start prank using `startPrank`, if that fails then fallback to `changePrank`
- remove `stopPrank` as not needed (`changePrank` does stop/startPrank)

Switch CI back to use nightly forge