### PR TITLE
PROTOTECH-1: cap deposit fee rate at 10%

### DIFF
--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -119,13 +119,13 @@ import { Maths }   from '../internal/Maths.sol';
     /**
      * @notice Calculates the unutilized deposit fee, charged to lenders who deposit below the `LUP`.
      * @param  interestRate_ The current interest rate.
-     * @return Fee rate based upon the given interest rate.
+     * @return Fee rate based upon the given interest rate, capped at 10%.
      */
     function _depositFeeRate(
         uint256 interestRate_
     ) pure returns (uint256) {
-        // current annualized rate divided by 365 (24 hours of interest)
-        return Maths.wdiv(interestRate_, 365 * 1e18);
+        // current annualized rate divided by 365 (24 hours of interest), capped at 10%
+        return Maths.min(Maths.wdiv(interestRate_, 365 * 1e18), 0.1 * 1e18);
     }
 
     /**

--- a/tests/forge/unit/PoolHelperTest.t.sol
+++ b/tests/forge/unit/PoolHelperTest.t.sol
@@ -128,6 +128,9 @@ contract PoolHelperTest is DSTestPlus {
         uint256 interestRate = 0.07 * 1e18;
         assertEq(_depositFeeRate(interestRate), 0.000191780821917808 * 1e18);
         assertEq(_depositFeeRate(0.2 * 1e18),   0.000547945205479452 * 1e18);
+
+        // fee rate should be capped at 10%
+        assertEq(_depositFeeRate(1_000 * 1e18), 0.1 * 1e18);
     }
 
     /**


### PR DESCRIPTION

<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Cap deposit fee rate at 10%

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/pull/4/files#r1182823695

# Contract size
## Pre Change
```
PoolCommons        -   9,426B  (38.35%)
```
## Post Change
```
PoolCommons        -   9,426B  (38.35%)
```

# Gas usage
## Pre Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 119822          | 176963 | 161647 | 711343  | 60004   |
| bucketTake                           | 311870          | 330248 | 330248 | 348626  | 4       |
| drawDebt                             | 247478          | 292164 | 266312 | 802479  | 136003  |
| kick                                 | 151711          | 221290 | 219662 | 1031557 | 48000   |
| kickWithDeposit                      | 195774          | 273194 | 269338 | 996136  | 8000    |
| moveQuoteToken                       | 257892          | 257892 | 257892 | 257892  | 1       |
| removeQuoteToken                     | 142754          | 163060 | 165689 | 185949  | 4000    |
| repayDebt                            | 574112          | 606254 | 596150 | 754421  | 16002   |
| settle                               | 348359          | 348359 | 348359 | 348359  | 1       |
| take                                 | 80551           | 81966  | 81656  | 312980  | 15998   |
```
## Post Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 119822          | 176967 | 161647 | 711412  | 60004   |
| bucketTake                           | 311870          | 330248 | 330248 | 348626  | 4       |
| drawDebt                             | 247478          | 292164 | 266312 | 802479  | 136003  |
| kick                                 | 151711          | 221290 | 219662 | 1031557 | 48000   |
| kickWithDeposit                      | 195774          | 273194 | 269338 | 996136  | 8000    |
| moveQuoteToken                       | 276834          | 276834 | 276834 | 276834  | 1       |
| removeQuoteToken                     | 142754          | 163061 | 166884 | 188158  | 4000    |
| repayDebt                            | 574112          | 606254 | 596150 | 754421  | 16002   |
| settle                               | 348359          | 348359 | 348359 | 348359  | 1       |
| take                                 | 80551           | 81966  | 81656  | 312980  | 15998   |
```

