### PR TITLE
Invariants improvement: Make time to kick configurable SKIP_TIME_TO_KICK

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -63,6 +63,7 @@ Invariant test scenarios can be externally configured by customizing following e
 | BUCKET_INDEX_ERC20 | ERC20 | 2570 | First bucket index to be used in ERC20 pool actions |
 | BUCKET_INDEX_ERC721 | ERC721 | 850 | First bucket index to be used in ERC721 pool actions |
 | SKIP_TIME | ERC20 ERC721 | 24 hours | The upper limit of time that can be skipped after a pool action (fuzzed) |
+| SKIP_TIME_TO_KICK | ERC20 ERC721 | 200 days | The time to be skipped and drive a new loan undercollateralized. Use a big value to ensure a successful kick |
 | FOUNDRY_INVARIANT_RUNS | ERC20 ERC721 | 10 | The number of runs for each scenario |
 | FOUNDRY_INVARIANT_DEPTH | ERC20 ERC721 | 200 | The number of actions performed in each scenario |
 

--- a/tests/forge/invariants/base/handlers/LiquidationPoolHandler.sol
+++ b/tests/forge/invariants/base/handlers/LiquidationPoolHandler.sol
@@ -121,7 +121,7 @@ abstract contract LiquidationPoolHandler is UnboundedLiquidationPoolHandler, Bas
                 _drawDebt(drawDebtAmount);
 
                 // skip to make borrower undercollateralized
-                vm.warp(block.timestamp + 200 days);
+                vm.warp(block.timestamp + _getKickSkipTime());
             }
         }
     }

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -172,7 +172,7 @@ abstract contract BaseHandler is Test {
     }
 
     function _getKickSkipTime() internal returns (uint256) {
-        return vm.envOr("SKIP_TIME_TO_KICK", uint256(24 hours));
+        return vm.envOr("SKIP_TIME_TO_KICK", uint256(200 days));
     }
 
     /**

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -171,6 +171,10 @@ abstract contract BaseHandler is Test {
         _pool.updateInterest();
     }
 
+    function _getKickSkipTime() internal returns (uint256) {
+        return vm.envOr("SKIP_TIME_TO_KICK", uint256(24 hours));
+    }
+
     /**
      * @dev Ensure that error is an Pool expected error.
      */


### PR DESCRIPTION
- `SKIP_TIME_TO_KICK` config: The time to be skipped and drive a new loan undercollateralized