### PR TITLE
Invariant improvements: better way to setup kick action

### DIFF
--- a/tests/forge/invariants/ERC20Pool/handlers/BasicERC20PoolHandler.sol
+++ b/tests/forge/invariants/ERC20Pool/handlers/BasicERC20PoolHandler.sol
@@ -2,8 +2,9 @@
 
 pragma solidity 0.8.14;
 
-import { PoolInfoUtils, _collateralization } from 'src/PoolInfoUtils.sol';
-import { Maths }                             from 'src/libraries/internal/Maths.sol';
+import { PoolInfoUtils }               from 'src/PoolInfoUtils.sol';
+import { Maths }                       from 'src/libraries/internal/Maths.sol';
+import { _priceAt, _isCollateralized } from 'src/libraries/helpers/PoolHelper.sol';
 
 import { BasicPoolHandler }               from '../../base/handlers/BasicPoolHandler.sol';
 import { UnboundedBasicPoolHandler }      from '../../base/handlers/unbounded/UnboundedBasicPoolHandler.sol';
@@ -187,11 +188,15 @@ contract BasicERC20PoolHandler is UnboundedBasicERC20PoolHandler, BasicPoolHandl
             _addQuoteToken(boundedAmount_ * 2, LENDER_MAX_BUCKET_INDEX);
         }
 
-        // 3. drawing of addition debt will make them under collateralized
-        uint256 lup = _poolInfo.lup(address(_pool));
+        // 3. check if drawing of addition debt will make borrower undercollateralized
+        // recalculate lup with new amount to be borrowed and check borrower collateralization at new lup
+        (uint256 currentPoolDebt, , , ) = _pool.debtInfo();
+        uint256 nextPoolDebt = currentPoolDebt + boundedAmount_;
+        uint256 newLup = _priceAt(_pool.depositIndex(nextPoolDebt));
         (debt, collateral, ) = _poolInfo.borrowerInfo(address(_pool), _actor);
 
-        if (_collateralization(debt, collateral, lup) < 1) {
+        // repay debt if borrower becomes undercollateralized with new debt at new lup
+        if (!_isCollateralized(debt + boundedAmount_, collateral, newLup, _pool.poolType())) {
             _repayDebt(debt);
 
             (debt, collateral, ) = _poolInfo.borrowerInfo(address(_pool), _actor);


### PR DESCRIPTION
- in `prekick` draw debt for borrower only if it is not collateralized. skip time only if borrower debt is not 0 after drawDebt
- in `preDrawDebt` repay debt to be able to draw again only if borrower becomes undercollateralized at the new lup
- change prank to kicker to make sure kicker is not borrower




