### PR TITLE
Prototech 17 - rounding of repayment amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Ajna protocol is a non-custodial, peer-to-peer, permissionless lending, borr
 - The following types of tokens are incompatible with Ajna, and no countermeasures exist to explicitly prevent creating a pool with such tokens, actors should use them at their own risk:
   - NFT and fungible tokens which charge a fee on transfer.
   - Fungible tokens whose balance rebases.
-  - Fungible tokens with more than 18 decimals or 0 decimals.
+  - Fungible tokens with more than 18 decimals or 0 decimals, or whose `decimals()` function does not return a constant value.
 - Borrowers cannot draw debt from a pool in the same block as when the pool was created.
 - With the exception of quantized prices, pool inputs and most accumulators are not explicitly limited.  The pool will stop functioning when the bounds of a `uint256` need to be exceeded to process a request.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Ajna protocol is a non-custodial, peer-to-peer, permissionless lending, borr
 - The following types of tokens are incompatible with Ajna, and no countermeasures exist to explicitly prevent creating a pool with such tokens, actors should use them at their own risk:
   - NFT and fungible tokens which charge a fee on transfer.
   - Fungible tokens whose balance rebases.
-  - Fungible tokens with more than 18 decimals or 0 decimals, or whose `decimals()` function does not return a constant value.
+  - Fungible tokens with more than 18 decimals or 0 decimals, whose `decimals()` function does not return a constant value, or which do not implement the optional [decimals()](https://eips.ethereum.org/EIPS/eip-20#decimals) function.
 - Borrowers cannot draw debt from a pool in the same block as when the pool was created.
 - With the exception of quantized prices, pool inputs and most accumulators are not explicitly limited.  The pool will stop functioning when the bounds of a `uint256` need to be exceeded to process a request.
 

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -212,8 +212,9 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
         PoolState memory poolState = _accruePoolInterest();
 
         // ensure accounting is performed using the appropriate token scale
-        maxQuoteTokenAmountToRepay_ = _roundToScale(maxQuoteTokenAmountToRepay_, _getArgUint256(QUOTE_SCALE));
-        collateralAmountToPull_     = _roundToScale(collateralAmountToPull_,     _bucketCollateralDust(0));
+        if (maxQuoteTokenAmountToRepay_ != type(uint256).max)
+            maxQuoteTokenAmountToRepay_ = _roundToScale(maxQuoteTokenAmountToRepay_, _getArgUint256(QUOTE_SCALE));
+        collateralAmountToPull_         = _roundToScale(collateralAmountToPull_,     _bucketCollateralDust(0));
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -29,6 +29,7 @@ import { IERC721Taker }         from './interfaces/pool/erc721/IERC721Taker.sol'
 import { IERC721PoolState }     from './interfaces/pool/erc721/IERC721PoolState.sol';
 
 import { FlashloanablePool } from './base/FlashloanablePool.sol';
+import { _roundToScale }     from './libraries/helpers/PoolHelper.sol';
 
 import { 
     _revertIfAuctionClearable,
@@ -219,6 +220,10 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         uint256 limitIndex_
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
+
+        // ensure accounting is performed using the appropriate token scale
+        if (maxQuoteTokenAmountToRepay_ != type(uint256).max)
+            maxQuoteTokenAmountToRepay_ = _roundToScale(maxQuoteTokenAmountToRepay_, _getArgUint256(QUOTE_SCALE));
 
         RepayDebtResult memory result = BorrowerActions.repayDebt(
             auctions,

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -15,6 +15,7 @@ import { IERC721PoolEvents } from 'src/interfaces/pool/erc721/IERC721PoolEvents.
 import 'src/interfaces/pool/erc721/IERC721Pool.sol';
 import 'src/interfaces/pool/IPoolFactory.sol';
 import 'src/interfaces/pool/IPool.sol';
+import 'src/libraries/helpers/PoolHelper.sol';
 import 'src/PoolInfoUtils.sol';
 
 import 'src/libraries/internal/Maths.sol';
@@ -52,6 +53,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
         // Calculate current debt of borrower (currentPoolInflator * borrowerT0Debt)
         uint256 currentDebt = Maths.wmul(Maths.wmul(poolInflator, factor), borrowerT0debt);
+        uint256 tokenDebt   = _roundUpToScale(currentDebt, ERC721Pool(address(_pool)).quoteTokenScale());
 
         // mint quote tokens to borrower address equivalent to the current debt
         deal(_pool.quoteTokenAddress(), borrower, currentDebt);
@@ -59,8 +61,8 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
 
         // repay current debt and pull all collateral
         uint256 noOfNfts = borrowerCollateral / 1e18; // round down to pull correct num of NFTs
-        if (currentDebt != 0 || noOfNfts != 0) {
-            _repayDebtNoLupCheck(borrower, borrower, currentDebt, currentDebt, noOfNfts);
+        if (tokenDebt != 0 || noOfNfts != 0) {
+            _repayDebtNoLupCheck(borrower, borrower, tokenDebt, currentDebt, noOfNfts);
         }
 
         // check borrower state after repay of loan and pull Nfts

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -333,7 +333,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrower:         _borrower,
             amountToRepay:    type(uint256).max,
             amountRepaid:     1_508.860066921599065131 * 1e18,
-            collateralToPull: 3,
+            collateralToPull: 3 * 1e18,
             newLup:           MAX_PRICE
         });
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -333,7 +333,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrower:         _borrower,
             amountToRepay:    type(uint256).max,
             amountRepaid:     1_508.860066921599065131 * 1e18,
-            collateralToPull: 3 * 1e18,
+            collateralToPull: 3,
             newLup:           MAX_PRICE
         });
 


### PR DESCRIPTION
# Description of change
## High level
* Resolve issue causing overflow upon full repayment of non-18-decimal token.
* Implement missing logic to round repayment amount in ERC-721 pools.

# Description of bug or vulnerability and solution
* See [Non-18 Decimal Quote Token Debt cannot be FULLY repaid as expected](https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/17) for details.
* Resolves using auditor recommendation of only rounding the input value if it is not `type(uint256).max`.
* ERC-721 pools with non-18-decimal quote tokens were apparently vulnerable to an attack.  In this attack, the borrower repays slightly less than the token precision.  This reduces borrower debt, while transferring 0 quote tokens from their wallet.  Attacker could repeat this process using multicall or a proxy, reducing debt while only incurring gas expense.

# Contract size
## Pre Change
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,417B  (99.35%)
  ERC20Pool                -  23,830B  (96.96%)

## Post Change
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,448B  (99.48%)
  ERC20Pool                -  23,840B  (97.00%)


# Gas usage
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |         |         |
|--------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                        | min             | avg    | median | max     | # calls |
| repayDebt                            | 574176          | 606318 | 596214 | 754485  | 16002   |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |        |         |
|----------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                          | min             | avg    | median | max    | # calls |
| repayDebt                              | 8852            | 154023 | 107409 | 682115 | 129     |

## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |         |         |
|--------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                        | min             | avg    | median | max     | # calls |
| repayDebt                            | 574202          | 606344 | 596240 | 754511  | 16002   |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |          |         |
|----------------------------------------|-----------------|--------|--------|----------|---------|
| Function Name                          | min             | avg    | median | max      | # calls |
| repayDebt                              | 9188            | 607377 | 107678 | 58798083 | 129     |

