### PR TITLE
Change tokenIdsAllowed to return true if non-subset pool

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -561,8 +561,6 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         uint256[] storage poolTokens_,
         uint256[] calldata tokenIds_
     ) internal {
-        bool subset   = _getArgUint256(SUBSET) != 0;
-
         for (uint256 i = 0; i < tokenIds_.length;) {
             uint256 tokenId = tokenIds_[i];
             if (!tokenIdsAllowed(tokenId)) revert OnlySubset();

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -47,6 +47,10 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         tokenIdsToAdd[1] = 3;
         tokenIdsToAdd[2] = 5;
 
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(1));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(3));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(5));
+
         // borrower deposits three NFTs into the pool
         _pledgeCollateral({
             from:     _borrower,
@@ -904,7 +908,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrowerCollateralization: 0.000000000258794474 * 1e18,
             tokenIds:                  borrowerTokenIds
         });
-        
+
         // after depositTake but before take: NFTs pledged by liquidated borrower are owned by the pool
         assertEq(_collateral.ownerOf(1), address(_pool));
         assertEq(_collateral.ownerOf(3), address(_pool));
@@ -982,7 +986,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(1), address(_pool));
         assertEq(_collateral.ownerOf(3), _lender);
 
-        _assertAuction( 
+        _assertAuction(
              AuctionParams({
                 borrower:          _borrower,
                 active:            false,
@@ -1122,7 +1126,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             collateral:   0,
             deposit:      0,
             exchangeRate: 1.0 * 1e18
-        });   
+        });
         _assertBucket({
             index:        7388,
             lpBalance:    10 * 1e18, // LP in bucket 7388 diminished when NFT merged and removed
@@ -1199,6 +1203,13 @@ contract ERC721SubsetPoolCollateralTest is ERC721PoolCollateralTest {
         subsetTokenIds[3] = 51;
         subsetTokenIds[4] = 53;
         _pool = _deploySubsetPool(subsetTokenIds);
+
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(1));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(3));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(5));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(51));
+        assertTrue(ERC721Pool(address(_pool)).tokenIdsAllowed(53));
+        assertTrue(!ERC721Pool(address(_pool)).tokenIdsAllowed(1337));
 
         _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
         _mintAndApproveQuoteTokens(_borrower, 100 * 1e18);


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Modify the behavior of tokenIdsAllowed to return true for for collection pool
  * Internalizes the subpool mapping and adds a function that returns true if a pool is a collection pool, this enables external users to verify that their token will work instead of getting a false negative from the mapping.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* isTokenIdAllowed will return a `false` value if the pool is a collection and eligible for deposit, this is a minor inconvenience so long as the user checks `isSubset` first, but this change allows an integrator to check a prospective id against the contract directly.


# Contract size
## Pre Change
```
| Deployment Cost                        | Deployment Size |        |        |          |         |
| 4917690                                | 24487           |        |        |          |         |
```
## Post Change
```
| Deployment Cost                        | Deployment Size |        |        |        |         |
| 4918490                                | 24491           |        |        |        |         |
```


# Gas usage
## Pre Change
```
| Function Name                          | min             | avg    | median | max      | # calls |
| addCollateral                          | 22828           | 230310 | 169039 | 733939   | 8       |
| tokenIdsAllowed                        | 2562            | 2562   | 2562   | 2562     | 5       |
| drawDebt                               | 7304            | 557392 | 319747 | 42501245 | 171     |
```
## Post Change
```
| Function Name                          | min             | avg    | median | max      | # calls |
| addCollateral                          | 22828           | 230495 | 169181 | 734471 | 8       |
| tokenIdsAllowed                        | 537             | 1194   | 708    | 2708   | 77      |
| drawDebt                               | 7304            | 311869 | 319889 | 696148 | 171     |
```

