### PR TITLE
Prototech 19 - enforcing claimable collateral dust limit

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -326,6 +326,7 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
         (removedAmount_, redeemedLP_) = LenderActions.removeMaxCollateral(
             buckets,
             deposits,
+            _bucketCollateralDust(index_),
             maxAmount_,
             index_
         );

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -520,12 +520,14 @@ library LenderActions {
      *  @dev    === Reverts on ===
      *  @dev    not enough collateral `InsufficientCollateral()`
      *  @dev    no claim `NoClaim()`
+     *  @dev    leaves less than dust limit in bucket `DustAmountNotExceeded()`
      *  @return Amount of collateral that was removed.
      *  @return Amount of LP redeemed for removed collateral amount.
      */
     function removeMaxCollateral(
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
+        uint256 dustLimit_,
         uint256 maxAmount_,
         uint256 index_
     ) external returns (uint256, uint256) {
@@ -535,6 +537,7 @@ library LenderActions {
         return _removeMaxCollateral(
             buckets_,
             deposits_,
+            dustLimit_,
             maxAmount_,
             index_
         );
@@ -572,6 +575,7 @@ library LenderActions {
             (collateralRemoved, ) = _removeMaxCollateral(
                 buckets_,
                 deposits_,
+                1,
                 collateralRemaining,
                 fromIndex
             );
@@ -613,6 +617,7 @@ library LenderActions {
      *  @dev    === Reverts on ===
      *  @dev    not enough collateral `InsufficientCollateral()`
      *  @dev    no claim `NoClaim()`
+     *  @dev    leaves less than dust limit in bucket `DustAmountNotExceeded()`
      *  @dev    === Emit events ===
      *  @dev    - `BucketBankruptcy`
      *  @return collateralAmount_ Amount of collateral that was removed.
@@ -621,6 +626,7 @@ library LenderActions {
     function _removeMaxCollateral(
         mapping(uint256 => Bucket) storage buckets_,
         DepositsState storage deposits_,
+        uint256 dustLimit_,
         uint256 maxAmount_,
         uint256 index_
     ) internal returns (uint256 collateralAmount_, uint256 lpAmount_) {
@@ -673,6 +679,7 @@ library LenderActions {
 
         collateralAmount_ = Maths.min(bucketCollateral, collateralAmount_);
         bucketCollateral  -= collateralAmount_;
+        if (bucketCollateral != 0 && bucketCollateral < dustLimit_) revert DustAmountNotExceeded();
         bucket.collateral = bucketCollateral;
 
         // check if bucket healthy after collateral remove - set bankruptcy if collateral and deposit are 0 but there's still LP

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -575,7 +575,7 @@ library LenderActions {
             (collateralRemoved, ) = _removeMaxCollateral(
                 buckets_,
                 deposits_,
-                1,
+                1,                   // dust limit is same as collateral scale
                 collateralRemaining,
                 fromIndex
             );


### PR DESCRIPTION
# Description of change
## High level
In fungible pools with non-18-decimal collateral, and low-priced buckets below index 3900, revert if a `removeCollateral` call would leave less than the dust limit.

# Description of bug or vulnerability and solution
* Because bucket price factors into the exchange rate, buckets with low prices are given dust limits higher than the minimum transferable amount of collateral (limited by collateral token decimals).  https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/19 identified an issue where rounding of the input value does not implicitly enforce this dust limit.
* To address this, `removeCollateral` shall revert if the operation leaves behind a nonzero amount of collateral smaller than the dust limit for the bucket.

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,448B  (99.48%)
  ERC20Pool                -  23,840B  (97.00%)
  LenderActions            -  10,028B  (40.80%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,448B  (99.48%)
  ERC20Pool                -  23,864B  (97.10%)
  LenderActions            -  10,136B  (41.24%)
```

# Gas usage
`test-load` does not exercise `removeCollateral`, so `test-with-gas-report` was used.
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 716             | 164099 | 145991 | 398673 | 29      |
| addQuoteToken                        | 714             | 261012 | 189985 | 711369 | 721     |
| moveQuoteToken                       | 692             | 136842 | 119863 | 630360 | 38      |
| removeCollateral                     | 3901            | 58509  | 60611  | 156085 | 67      |
| removeQuoteToken                     | 3943            | 65916  | 59032  | 612015 | 407     |

## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 716             | 164202 | 146120 | 398673 | 29      |
| addQuoteToken                        | 714             | 260331 | 189985 | 711369 | 734     |
| moveQuoteToken                       | 692             | 136842 | 119863 | 630360 | 38      |
| removeCollateral                     | 3901            | 59211  | 61032  | 156507 | 67      |
| removeQuoteToken                     | 3943            | 65669  | 59032  | 612015 | 414     |
