### PR TITLE
Ensure exchange rate update is only rewarded when Ajna is burned

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -694,7 +694,7 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
             // retrieve accumulator values used to calculate rewards accrued
             (
                 uint256 curBurnTime,
-                uint256 totalBurned,
+                uint256 totalBurnedInEpoch,
                 uint256 totalInterestEarned
             ) = _getPoolAccumulators(pool_, curBurnEpoch, curBurnEpoch - 1);
 
@@ -708,7 +708,7 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
                         pool_,
                         indexes_[i],
                         curBurnEpoch,
-                        totalBurned,
+                        totalBurnedInEpoch,
                         totalInterestEarned
                     );
 
@@ -716,11 +716,11 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
                     unchecked { ++i; }
                 }
 
-                uint256 rewardsCap            = Maths.wmul(UPDATE_CAP, totalBurned);
+                uint256 rewardsCap            = Maths.wmul(UPDATE_CAP, totalBurnedInEpoch);
                 uint256 rewardsClaimedInEpoch = updateRewardsClaimed[curBurnEpoch];
 
                 // update total tokens claimed for updating bucket exchange rates tracker
-                if (rewardsClaimedInEpoch + updatedRewards_ >= rewardsCap) {
+                if (totalBurnedInEpoch != 0 && (rewardsClaimedInEpoch + updatedRewards_ >= rewardsCap)) {
                     // if update reward is greater than cap, set to remaining difference
                     updatedRewards_ = rewardsCap - rewardsClaimedInEpoch;
                 }

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -505,7 +505,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         skip(2 weeks);
 
-        // first reserve auction happens successfully Staker should receive rewards epoch 0 - 1
+        // second reserve auction is kicked, no take
         _triggerReserveAuctionsNoTake({
             borrower: _borrower,
             borrowAmount: 300 * 1e18,
@@ -521,12 +521,13 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
-
+        
+        // no take has been called on reserveAuction therefore totalBurned is zero. No rewards to distribute
         _updateExchangeRates({
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         3.399661193610840835 * 1e18
+            reward:         0
         });
     }
 
@@ -1690,7 +1691,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokenId: tokenIdOne
         });
 
-        uint256 tokensToBurn = _triggerReserveAuctions({
+        _triggerReserveAuctions({
             borrower:     _borrower,
             tokensToBurn: 81.799378162662704349 * 1e18,
             borrowAmount: 300 * 1e18,
@@ -1705,12 +1706,6 @@ contract RewardsManagerTest is RewardsHelperContract {
             indexes: depositIndexes,
             reward:  4.089968908133134138 * 1e18
         });
-
-        // check owner can withdraw the NFT and rewards will be automatically claimed
-
-        uint256 snapshot = vm.snapshot();
-
-        // claimed rewards amount is greater than available tokens in rewards manager contract
 
         // burn rewards manager tokens and leave only 5 tokens available
         changePrank(address(_rewardsManager));
@@ -1764,7 +1759,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  3.395081241453374356 * 1e18
+            reward:  0
         });
 
         // allow time to pass for the reserve price to decrease

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -1759,7 +1759,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         ERC20Pool(address(_pool)).kickReserveAuction();
 
         // exchange rate is updated even though no ajna tokens are burned in epoch?
-        // should this we allow this to occur
+        // should this we allow this to occur??
         _updateExchangeRates({
             updater: _updater,
             pool:    address(_pool),
@@ -1783,7 +1783,8 @@ contract RewardsManagerTest is RewardsHelperContract {
         });
 
         // stake nft
-        // reverts here because totalBurned = 0 (takes haven't burned any ajna)
+        // reverts here because totalBurned = 0 for Epoch 2 (takes haven't burned any ajna)
+        // causes the update cap to be zero which then causes overflow
         _stakeToken({
             pool:    address(_pool),
             owner:   _minterTwo,

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -8,6 +8,8 @@ import 'src/interfaces/rewards/IRewardsManager.sol';
 
 import { ERC20Pool }           from 'src/ERC20Pool.sol';
 import { RewardsHelperContract }   from './RewardsDSTestPlus.sol';
+import { IPoolErrors }         from 'src/interfaces/pool/commons/IPoolErrors.sol';
+import { Token }               from '../../utils/Tokens.sol';
 
 contract RewardsManagerTest is RewardsHelperContract {
 
@@ -52,7 +54,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         _updater     = makeAddr("updater");
         _updater2    = makeAddr("updater2");
 
-        _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  1_000 * 1e18);
         _mintQuoteAndApproveTokens(_borrower,   200_000 * 1e18);
 
         _mintCollateralAndApproveTokens(_borrower2,  1_000 * 1e18);
@@ -1660,6 +1662,132 @@ contract RewardsManagerTest is RewardsHelperContract {
             reward:                    286.756084406079436885 * 1e18,
             indexes:                   secondIndexes,
             updateExchangeRatesReward: 0
+        });
+    }
+
+    function testWithdrawClaimAndRestake() external {
+        skip(10);
+
+        // configure NFT position
+        uint256[] memory depositIndexes = new uint256[](5);
+        depositIndexes[0] = 2550;
+        depositIndexes[1] = 2551;
+        depositIndexes[2] = 2552;
+        depositIndexes[3] = 2553;
+        depositIndexes[4] = 2555;
+
+        uint256 tokenIdOne = _mintAndMemorializePositionNFT({
+            indexes:    depositIndexes,
+            minter:     _minterOne,
+            mintAmount: 1_000 * 1e18,
+            pool:       address(_pool)
+        });
+
+        // stake nft
+        _stakeToken({
+            pool:    address(_pool),
+            owner:   _minterOne,
+            tokenId: tokenIdOne
+        });
+
+        uint256 tokensToBurn = _triggerReserveAuctions({
+            borrower:     _borrower,
+            tokensToBurn: 81.799378162662704349 * 1e18,
+            borrowAmount: 300 * 1e18,
+            limitIndex:   2555,
+            pool:         address(_pool)
+        });
+
+        // call update exchange rate to enable claiming rewards
+        _updateExchangeRates({
+            updater: _updater,
+            pool:    address(_pool),
+            indexes: depositIndexes,
+            reward:  4.089968908133134138 * 1e18
+        });
+
+        // check owner can withdraw the NFT and rewards will be automatically claimed
+
+        uint256 snapshot = vm.snapshot();
+
+        // claimed rewards amount is greater than available tokens in rewards manager contract
+
+        // burn rewards manager tokens and leave only 5 tokens available
+        changePrank(address(_rewardsManager));
+        IERC20Token(address(_ajnaToken)).burn(99_999_990.978586345404952410 * 1e18);
+
+        uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
+        assertEq(managerBalance, 4.931444746461913452 * 1e18);
+
+        // _minterOne unstakes staked position
+        _unstakeToken({
+            owner:                     _minterOne,
+            pool:                      address(_pool),
+            tokenId:                   tokenIdOne,
+            claimedArray:              _epochsClaimedArray(1, 0),
+            reward:                    40.899689081331351737 * 1e18,
+            indexes:                   depositIndexes,
+            updateExchangeRatesReward: 0
+        });
+
+        // borrower drawsDebt from the pool
+        Token collateral = Token(ERC20Pool(address(_pool)).collateralAddress());
+        Token quote = Token(ERC20Pool(address(_pool)).quoteTokenAddress());
+        deal(address(quote), _borrower, 300 * 1e18);
+
+        // approve tokens
+        collateral.approve(address(_pool), type(uint256).max);
+        quote.approve(address(_pool), type(uint256).max);
+
+        changePrank(_borrower);
+        uint256 collateralToPledge = _requiredCollateral(300 * 1e18, 2555);
+        deal(address(collateral), _borrower, collateralToPledge);
+        ERC20Pool(address(_pool)).drawDebt(_borrower, 300 * 1e18, 2555, collateralToPledge);
+
+        // allow time to pass for interest to accumulate
+        skip(26 weeks);
+
+        // borrower repays some of their debt, providing reserves to be claimed
+        // don't pull any collateral, as such functionality is unrelated to reserve auctions
+        ERC20Pool(address(_pool)).repayDebt(_borrower, 300 * 1e18, 0, _borrower, MAX_FENWICK_INDEX);
+
+        // start reserve auction
+        changePrank(_bidder);
+        _ajnaToken.approve(address(_pool), type(uint256).max);
+        (,, uint256 tokensBurned_) = IPool(_pool).burnInfo(IPool(_pool).currentBurnEpoch());
+
+        ERC20Pool(address(_pool)).kickReserveAuction();
+
+        // exchange rate is updated even though no ajna tokens are burned in epoch?
+        // should this we allow this to occur
+        _updateExchangeRates({
+            updater: _updater,
+            pool:    address(_pool),
+            indexes: depositIndexes,
+            reward:  3.395081241453374356 * 1e18
+        });
+
+        // allow time to pass for the reserve price to decrease
+        skip(72 hours);
+
+        // take reserves is called with 0 ajna being burned due to very low price and low take amount
+        ERC20Pool(address(_pool)).takeReserves(612);
+
+        (,, tokensBurned_) = IPool(_pool).burnInfo(IPool(_pool).currentBurnEpoch());
+
+        uint256 tokenIdTwo = _mintAndMemorializePositionNFT({
+            indexes:    depositIndexes,
+            minter:     _minterTwo,
+            mintAmount: 1_000 * 1e18,
+            pool:       address(_pool)
+        });
+
+        // stake nft
+        // reverts here because totalBurned = 0 (takes haven't burned any ajna)
+        _stakeToken({
+            pool:    address(_pool),
+            owner:   _minterTwo,
+            tokenId: tokenIdTwo
         });
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* This change alters the `_getPoolAccumulators()` -> `getEpochInfo()`. The result is a method that only returns ajna burned and interest earned over one Epoch versus a specified window of Epochs. Additionally, if passed the first epoch, epoch 0 the method returns 0 for all return values.
  * In the code this method was never used to get info over more than one epoch so that added feature went unutilized. However, it would be nice to have such a method for UIs.
* Additionally, moved where `_getPoolAccumulators()` was called in order to simplify branching logic. Rewarded and non-rewarded updates are now separated earlier in the logic.
* ajna rewards is now only awarded to exchange rate updaters if Ajna has been burned in the epoch.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* `_getPoolAccumulators()` was returning incorrect burn amount values when attempting to retrieve data about one Epoch.
* This scenario occurred when a reserve auction (E2) was kicked without a `takeReserve()` call and the epoch prior (E1) had burned Ajna. When `getPoolAccumulators()` was called, it showed that the kicked auction (E2) had burned Ajna associated with it when it did not.
* When the above occurred the rewards were provided to the exchange rate updater even though no burned ajna was associated with the epoch.

# Contract size
## Pre Change
```
RewardsManager           -   9,644B  (39.24%)
```
## Post Change
```
  RewardsManager           -   9,677B  (39.37%)
```

# Gas usage
## Pre Change
```
| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Deployment Cost                                | Deployment Size |         |         |         |         |
| 1953583                                        | 10053           |         |         |         |         |
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 33708           | 48590   | 36027   | 163831  | 85      |
| claimRewards                                   | 523             | 101547  | 84560   | 393064  | 88      |
| getBucketStateStakeInfo                        | 660             | 2658    | 2660    | 2660    | 81279   |
| getStakeInfo                                   | 694             | 694     | 694     | 694     | 114     |
| moveStakedLiquidity                            | 1828645         | 1971949 | 1971949 | 2115253 | 2       |
| stake                                          | 118764          | 390538  | 435331  | 892271  | 32      |
| unstake                                        | 78573           | 176225  | 141226  | 398616  | 13      |
| updateBucketExchangeRatesAndClaim              | 9614            | 258881  | 176062  | 537409  | 35      |
```
## Post Change
```
| src/RewardsManager.sol:RewardsManager contract |                 |         |         |         |         |
|------------------------------------------------|-----------------|---------|---------|---------|---------|
| Deployment Cost                                | Deployment Size |         |         |         |         |
| 1960190                                        | 10086           |         |         |         |         |
| Function Name                                  | min             | avg     | median  | max     | # calls |
| calculateRewards                               | 33795           | 46225   | 36114   | 164092  | 151     |
| claimRewards                                   | 523             | 114908  | 118251  | 393377  | 154     |
| getBucketStateStakeInfo                        | 660             | 2658    | 2660    | 2660    | 88668   |
| getStakeInfo                                   | 694             | 694     | 694     | 694     | 200     |
| moveStakedLiquidity                            | 1828896         | 1972152 | 1972152 | 2115409 | 2       |
| stake                                          | 118889          | 310918  | 168183  | 892428  | 51      |
| unstake                                        | 78699           | 172746  | 141340  | 398813  | 14      |
| updateBucketExchangeRatesAndClaim              | 9771            | 261226  | 211236  | 537501  | 33      |
```

