### PR TITLE
Codearena-217,256: PositionManager allows draining LP balance of other users

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -187,6 +187,11 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
 
             (uint256 lpBalance, uint256 depositTime) = pool.lenderInfo(index, owner);
 
+            // check that specified allowance is at least equal to the lp balance
+            uint256 allowance = pool.lpAllowance(index, address(this), owner);
+
+            if (allowance < lpBalance) revert AllowanceTooLow();
+
             Position memory position = positions[params_.tokenId][index];
 
             // check for previous deposits

--- a/src/interfaces/position/IPositionManagerErrors.sol
+++ b/src/interfaces/position/IPositionManagerErrors.sol
@@ -8,6 +8,11 @@ pragma solidity 0.8.14;
 interface IPositionManagerErrors {
 
     /**
+     * @notice User attempting to memorialize position with an allowance set too low.
+     */
+    error AllowanceTooLow();
+
+    /**
      * @notice User attempting to utilize `LP` from a bankrupt bucket.
      */
     error BucketBankrupt();

--- a/tests/forge/unit/PositionManager.t.sol
+++ b/tests/forge/unit/PositionManager.t.sol
@@ -163,7 +163,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         );
 
         // should revert if access hasn't been granted to transfer LP
-        vm.expectRevert(IPoolErrors.NoAllowance.selector);
+        vm.expectRevert(IPositionManagerErrors.AllowanceTooLow.selector);
         _positionManager.memorializePositions(memorializeParams);
 
         // allow position manager to take ownership of the position

--- a/tests/forge/unit/Positions/Code4renaReports.sol
+++ b/tests/forge/unit/Positions/Code4renaReports.sol
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.14;
+
+import "forge-std/console.sol";
+
+import {Base64} from "@base64-sol/base64.sol";
+
+import "../PositionManager.t.sol";
+
+contract Code4renaReports is PositionManagerERC20PoolHelperContract {
+
+    /**
+    *  @notice Simulates the effect of the described vulnerability where a user
+    *          can exponentially increase the value of their position by:
+    *          1- only approving the `PositionManager` for a min amount of their position
+    *          2- invoking 'memorializePositions' on their position's respective NFT
+    *          3- repeating these steps until their respective position's Pool lp balance is 0
+    *  @dev    This test case can be implemented and run from the ajna-core/tests/forge directory
+    */
+    function testMemorializePositionsWithMinApproval_report_256() external {
+        uint256 intialLPBalance;
+        uint256 finalLPBalance;
+
+        address testsAddress = makeAddr("testsAddress");
+        uint256 mintAmount = 10000 * 1e18;
+
+        _mintQuoteAndApproveManagerTokens(testsAddress, mintAmount);
+
+        // Call pool contract directly to add quote tokens
+        uint256[] memory indexes = new uint256[](3);
+        indexes[0] = 2550;
+        indexes[1] = 2551;
+        indexes[2] = 2552;
+
+        _addInitialLiquidity({
+            from: testsAddress,
+            amount: 3_000 * 1e18,
+            index: indexes[0]
+        });
+        _addInitialLiquidity({
+            from: testsAddress,
+            amount: 3_000 * 1e18,
+            index: indexes[1]
+        });
+        _addInitialLiquidity({
+            from: testsAddress,
+            amount: 3_000 * 1e18,
+            index: indexes[2]
+        });
+
+        // Mint an NFT to later memorialize existing positions into.
+        uint256 tokenId = _mintNFT(testsAddress, testsAddress, address(_pool));
+
+        // Pool lp balances before.
+        (uint256 poolLPBalanceIndex1, ) = _pool.lenderInfo(
+            indexes[0],
+            testsAddress
+        );
+        (uint256 poolLPBalanceIndex2, ) = _pool.lenderInfo(
+            indexes[1],
+            testsAddress
+        );
+        (uint256 poolLPBalanceIndex3, ) = _pool.lenderInfo(
+            indexes[2],
+            testsAddress
+        );
+
+        console.log("\n Pool lp balances before:");
+        console.log("bucket %s: %s", indexes[0], poolLPBalanceIndex1);
+        console.log("bucket %s: %s", indexes[1], poolLPBalanceIndex2);
+        console.log("bucket %s: %s", indexes[2], poolLPBalanceIndex3);
+
+        intialLPBalance =
+            poolLPBalanceIndex1 +
+            poolLPBalanceIndex2 +
+            poolLPBalanceIndex3;
+
+        // PositionManager lp balances before.
+        (uint256 managerLPBalanceIndex1, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[0]
+        );
+        (uint256 managerLPBalanceIndex2, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[1]
+        );
+        (uint256 managerLPBalanceIndex3, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[2]
+        );
+
+        console.log("\n PositionManger lp balances before:");
+        console.log("bucket %s: %s", indexes[0], managerLPBalanceIndex1);
+        console.log("bucket %s: %s", indexes[1], managerLPBalanceIndex1);
+        console.log("bucket %s: %s", indexes[2], managerLPBalanceIndex1);
+
+        console.log(
+            "\n <--- Repeatedly invoke memorializePositions with a min allowance set for each tx --->"
+        );
+
+        // Approve the PositionManager for only 1 token in each bucket.
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 1 * 1e18;
+        amounts[1] = 1 * 1e18;
+        amounts[2] = 1 * 1e18;
+
+        // Continuosly invoke memorializePositions with the min allowance
+        // until Pool lp balance is 0.
+        while (
+            poolLPBalanceIndex1 != 0 &&
+            poolLPBalanceIndex2 != 0 &&
+            poolLPBalanceIndex3 != 0
+        ) {
+            // Increase manager allowance.
+            _pool.increaseLPAllowance(
+                address(_positionManager),
+                indexes,
+                amounts
+            );
+
+            // Memorialize quote tokens into minted NFT.
+            IPositionManagerOwnerActions.MemorializePositionsParams
+                memory memorializeParams = IPositionManagerOwnerActions
+                    .MemorializePositionsParams(tokenId, indexes);
+            try _positionManager.memorializePositions(memorializeParams) { } catch { }
+
+            // Get new Pool lp balances.
+            (poolLPBalanceIndex1, ) = _pool.lenderInfo(
+                indexes[0],
+                testsAddress
+            );
+            (poolLPBalanceIndex2, ) = _pool.lenderInfo(
+                indexes[1],
+                testsAddress
+            );
+            (poolLPBalanceIndex3, ) = _pool.lenderInfo(
+                indexes[2],
+                testsAddress
+            );
+        }
+
+        // Pool lp balances after.
+        console.log("\n Pool lp balances after:");
+        console.log("bucket %s: %s", indexes[0], poolLPBalanceIndex1);
+        console.log("bucket %s: %s", indexes[1], poolLPBalanceIndex2);
+        console.log("bucket %s: %s", indexes[2], poolLPBalanceIndex3);
+
+        // PositionManager lp balances after.
+        (managerLPBalanceIndex1, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[0]
+        );
+        (managerLPBalanceIndex2, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[1]
+        );
+        (managerLPBalanceIndex3, ) = _positionManager.getPositionInfo(
+            tokenId,
+            indexes[2]
+        );
+
+        console.log("\n PositionManger lp balances after:");
+        console.log("bucket %s: %s", indexes[0], managerLPBalanceIndex1);
+        console.log("bucket %s: %s", indexes[1], managerLPBalanceIndex1);
+        console.log("bucket %s: %s \n", indexes[2], managerLPBalanceIndex1);
+
+        finalLPBalance =
+            managerLPBalanceIndex1 +
+            managerLPBalanceIndex2 +
+            managerLPBalanceIndex3;
+
+        // Assert that the initial and ending balances are equal.
+        assertEq(intialLPBalance, finalLPBalance);
+    }
+
+    function testMemorializePositionsExploitation_report_217() external {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+
+        _mintQuoteAndApproveManagerTokens(alice, 10000 * 1e18);
+        _mintQuoteAndApproveManagerTokens(bob, 10000 * 1e18);
+
+        uint256[] memory indexes = new uint256[](1);
+        indexes[0] = 2550;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 3_000 * 1e18;
+        address[] memory transferors = new address[](1);
+        transferors[0] = address(_positionManager);
+
+        // alice and bob add liquidity
+        _addInitialLiquidity({
+            from:   alice,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+
+        _addInitialLiquidity({
+            from:   bob,
+            amount: amounts[0],
+            index:  indexes[0]
+        });
+        
+        // alice and bob mint NFT
+        uint256 tokenIdAlice = _mintNFT(alice, alice, address(_pool));
+        uint256 tokenIdBob = _mintNFT(bob, bob, address(_pool));
+
+        // Alice
+
+        // alice memorialize params struct
+        IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParamsAlice = IPositionManagerOwnerActions.MemorializePositionsParams(
+            tokenIdAlice, indexes
+        );
+
+        // alice allow position manager to take ownership of the position
+        changePrank(alice);
+        _pool.increaseLPAllowance(address(_positionManager), indexes, amounts);
+        _positionManager.memorializePositions(memorializeParamsAlice);
+
+        // check memorialization success for Alice
+        assertEq(_positionManager.getLP(tokenIdAlice, indexes[0]), 3000 * 1e18);
+
+        // Bob
+
+        // bob memorialize params struct
+        IPositionManagerOwnerActions.MemorializePositionsParams memory memorializeParamsBob = IPositionManagerOwnerActions.MemorializePositionsParams(
+            tokenIdBob, indexes
+        );
+
+        // bob memorialize quote tokens into minted NFT but with allowance of 1000e18 instead of 3000e18
+        uint256[] memory allowanceAmountsBob = new uint256[](1);
+        allowanceAmountsBob[0] = 1_000 * 1e18;
+        changePrank(bob);
+        _pool.increaseLPAllowance(address(_positionManager), indexes, allowanceAmountsBob);
+        vm.expectRevert(IPositionManagerErrors.AllowanceTooLow.selector);
+        _positionManager.memorializePositions(memorializeParamsBob);
+        
+        // check memorialization success for Bob
+        assertEq(_positionManager.getLP(tokenIdBob, indexes[0]), 0); // bob LP balance not inflated
+
+        // bob memorialize one more time to inflate even more LP balance in position manager
+        _pool.increaseLPAllowance(address(_positionManager), indexes, allowanceAmountsBob);
+        vm.expectRevert(IPositionManagerErrors.AllowanceTooLow.selector);
+        _positionManager.memorializePositions(memorializeParamsBob);
+        
+        // check memorialization success for Bob
+        assertEq(_positionManager.getLP(tokenIdBob, indexes[0]), 0); // bob LP balance not inflated
+        
+        // bob cannot redeem as no LP memorialized
+        IPositionManagerOwnerActions.RedeemPositionsParams memory reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
+            tokenIdBob, address(_pool), indexes
+        );
+        _pool.approveLPTransferors(transferors);
+
+        vm.expectRevert(IPositionManagerErrors.RemovePositionFailed.selector);
+        _positionManager.reedemPositions(reedemParams);
+
+        (uint256 lpBalanceBobAfter,) = _pool.lenderInfo(indexes[0], bob);
+        console.log("Balance of Bob: ", lpBalanceBobAfter);
+
+        // alice redeem NFT and get nothing
+        changePrank(alice);
+        reedemParams = IPositionManagerOwnerActions.RedeemPositionsParams(
+            tokenIdAlice, address(_pool), indexes
+        );
+
+        _pool.approveLPTransferors(transferors);
+        _positionManager.reedemPositions(reedemParams);
+
+        (uint256 lpBalanceAliceAfter,) = _pool.lenderInfo(indexes[0], alice);
+        console.log("Balance of Alice: ", lpBalanceAliceAfter);
+
+        // Bob and Alice LP balances are the same as initial 
+        assertEq(lpBalanceBobAfter,   3_000 * 1e18); 
+        assertEq(lpBalanceAliceAfter, 3_000 * 1e18);
+    }
+}


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Reports
https://github.com/code-423n4/2023-05-ajna-findings/issues/108
https://github.com/code-423n4/2023-05-ajna-findings/issues/217
https://github.com/code-423n4/2023-05-ajna-findings/issues/256
https://github.com/code-423n4/2023-05-ajna-findings/issues/223
https://github.com/code-423n4/2023-05-ajna-findings/issues/234
https://github.com/code-423n4/2023-05-ajna-findings/issues/304
* The PositionManager contract should check if the transferred amount is equal to the lpBalance of the user in the pool contract.
* In memorialize positions function revert with `AllowanceTooLow` if allowance lower than LP balance in pool

