### PR TITLE
Codearena-8: no pool validation allows rewards to be drained

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -500,7 +500,7 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
         address pool_,
         bytes32 subsetHash_
     ) external override view returns (bool) {
-        return _isAjnaPool(pool_,subsetHash_);
+        return _isAjnaPool(pool_, subsetHash_);
     }
 
     /// @inheritdoc IPositionManagerDerivedState

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -496,6 +496,14 @@ contract PositionManager is ERC721, PermitERC721, IPositionManager, Multicall, R
     }
 
     /// @inheritdoc IPositionManagerDerivedState
+    function isAjnaPool(
+        address pool_,
+        bytes32 subsetHash_
+    ) external override view returns (bool) {
+        return _isAjnaPool(pool_,subsetHash_);
+    }
+
+    /// @inheritdoc IPositionManagerDerivedState
     function isPositionBucketBankrupt(
         uint256 tokenId_,
         uint256 index_

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -309,8 +309,12 @@ contract RewardsManager is IRewardsManager, ReentrancyGuard {
      */
     function updateBucketExchangeRatesAndClaim(
         address pool_,
+        bytes32 subsetHash_,
         uint256[] calldata indexes_
     ) external override returns (uint256 updateReward) {
+        // revert if trying to update exchange rates for a non Ajna pool
+        if (!positionManager.isAjnaPool(pool_, subsetHash_)) revert NotAjnaPool();
+
         updateReward = _updateBucketExchangeRates(pool_, indexes_);
 
         // transfer rewards to sender

--- a/src/interfaces/position/IPositionManagerDerivedState.sol
+++ b/src/interfaces/position/IPositionManagerDerivedState.sol
@@ -50,9 +50,19 @@ interface IPositionManagerDerivedState {
         uint256 index_
     ) external view returns (uint256, uint256);
 
+    /**
+     *  @notice Checks if a given `pool_` address is an Ajna pool.
+     *  @param  pool_       Address of the `Ajna` pool.
+     *  @param  subsetHash_ Factory's subset hash pool.
+     *  @return isAjnaPool_ `True` if the address to check is an Ajna pool.
+    */
+    function isAjnaPool(
+        address pool_,
+        bytes32 subsetHash_
+    ) external view returns (bool isAjnaPool_);
 
     /**
-     *  @notice Checks if a given `tokenId` has a given position bucket
+     *  @notice Checks if a given `tokenId` has a given position bucket.
      *  @param  tokenId_           Unique `ID` of token.
      *  @param  index_             Index of bucket to check if in position buckets.
      *  @return bucketInPosition_  `True` if tokenId has the position bucket.

--- a/src/interfaces/rewards/IRewardsManagerErrors.sol
+++ b/src/interfaces/rewards/IRewardsManagerErrors.sol
@@ -22,6 +22,11 @@ interface IRewardsManagerErrors {
     error MoveStakedLiquidityInvalid();
 
     /**
+     * @notice User attempted to update exchange rates for a pool that wasn't deployed by an `Ajna` factory.
+     */
+    error NotAjnaPool();
+
+    /**
      *  @notice User attempted to interact with an `NFT` they aren't the owner of.
      */
     error NotOwnerOfDeposit();

--- a/src/interfaces/rewards/IRewardsManagerOwnerActions.sol
+++ b/src/interfaces/rewards/IRewardsManagerOwnerActions.sol
@@ -56,12 +56,14 @@ interface IRewardsManagerOwnerActions {
     /**
      *  @notice Update the exchange rate of a list of buckets.
      *  @dev    Caller can claim `5%` of the rewards that have accumulated to each bucket since the last burn event, if it hasn't already been updated.
-     *  @param  pool_    Address of the pool whose exchange rates are being updated.
-     *  @param  indexes_ List of bucket indexes to be updated.
+     *  @param  pool_       Address of the pool whose exchange rates are being updated.
+     *  @param  subsetHash_ Factory's subset hash pool that dpeloyed the Ajna pool. Used to validate that the `pool_` address is a legit Ajna pool.
+     *  @param  indexes_    List of bucket indexes to be updated.
      *  @return Returns reward amount for updating bucket exchange rates.
      */
     function updateBucketExchangeRatesAndClaim(
         address pool_,
+        bytes32 subsetHash_,
         uint256[] calldata indexes_
     ) external returns (uint256);
 

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -135,7 +135,7 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         changePrank(updater);
         vm.expectEmit(true, true, true, true);
         emit UpdateExchangeRates(updater, pool, indexes, reward);
-        _rewardsManager.updateBucketExchangeRatesAndClaim(pool, indexes);
+        _rewardsManager.updateBucketExchangeRatesAndClaim(pool, keccak256("ERC20_NON_SUBSET_HASH"), indexes);
     }
 
 

--- a/tests/forge/unit/Rewards/RoguePool.sol
+++ b/tests/forge/unit/Rewards/RoguePool.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.14;
+
+import 'src/interfaces/rewards/IRewardsManager.sol';
+import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+contract RoguePool {
+    IRewardsManager immutable rewardsManager;
+    ERC20 immutable ajnaToken;
+
+    uint256 public burnEpoch;
+    uint256 public prevBurnEpoch;
+
+    constructor(IRewardsManager _rewardsManager, ERC20 _ajnaToken) {
+        rewardsManager = _rewardsManager;
+        ajnaToken = _ajnaToken;
+    }
+
+    function reset() external {
+        prevBurnEpoch = 0;
+        burnEpoch = 0;
+    }
+
+    function setBurnEpoch(uint256 newEpoch) external {
+        prevBurnEpoch = burnEpoch;
+        burnEpoch = newEpoch;
+    }
+
+    function currentBurnEpoch() external view returns(uint256) {
+        return burnEpoch;
+    }
+
+    function burnInfo(uint256 epoch) external view returns (uint256 burnBlock_, uint256 totalInterest_, uint256 totalBurned_) {
+        uint256 targetBalance = ajnaToken.balanceOf(address(rewardsManager));
+        burnBlock_ = block.timestamp;
+        if (epoch == burnEpoch - 1) {
+            // overwhelm the reward cap check
+            totalInterest_ = 1 * 1e18;
+            totalBurned_ = targetBalance * 10;
+        }
+    }
+
+    function bucketInfo(uint256) external pure returns(uint256, uint256, uint256, uint256, uint256) {
+        return (0, 0, 0, 100000 * 1e18, 0);
+    }
+
+    function bucketExchangeRate(uint256) external view returns(uint256) {
+        if (prevBurnEpoch == 0)
+            return 1;
+        else
+            return 300000;
+    }
+}


### PR DESCRIPTION

<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* See
https://github.com/code-423n4/2023-05-ajna-findings/issues/8
https://github.com/code-423n4/2023-05-ajna-findings/issues/64
https://github.com/code-423n4/2023-05-ajna-findings/issues/151
https://github.com/code-423n4/2023-05-ajna-findings/issues/207
  * exposed `PositionManager.isAjnaPool` external function to check if an address is a legit pool
  * update `RewardsManager.updateBucketExchangeRatesAndClaim` function to receive subset hash. check if address of pool is a legit Ajna adress by calling `Positionmanager.isAjnaPool`, otherwise revert with `NotAjnaPool` custom error
  * new `NotAjnaPool` custom error
  * unit tests update, POC mitigated


