### PR TITLE
Codearena-218: Operator of PositionManager token can't stake into RewardsManager

### DIFF
--- a/src/interfaces/rewards/IRewardsManagerErrors.sol
+++ b/src/interfaces/rewards/IRewardsManagerErrors.sol
@@ -32,6 +32,11 @@ interface IRewardsManagerErrors {
     error NotOwnerOfDeposit();
 
     /**
+     *  @notice User attempted to interact with an `NFT` they aren't the owner or approved of.
+     */
+    error NotOwnerOrApprovedOfDeposit();
+
+    /**
      *  @notice Can't deploy with `Ajna` token address `0x` address.
      */
     error DeployWithZeroAddress();

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -210,20 +210,26 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         assertEq(_ajnaToken.balanceOf(from), fromAjnaBal + reward);
     }
 
-    function _assertNotOwnerOfDepositRevert(address from , uint256 tokenId) internal {
+    function _assertClaimRewardsRevert(address from , uint256 tokenId) internal {
         // check only deposit owner can claim rewards
         changePrank(from);
         uint256 currentBurnEpoch = _pool.currentBurnEpoch();
-        vm.expectRevert(IRewardsManagerErrors.NotOwnerOfDeposit.selector);
+        vm.expectRevert(IRewardsManagerErrors.AlreadyClaimed.selector);
         _rewardsManager.claimRewards(tokenId, currentBurnEpoch);
+    }
+
+    function _assertNotOwnerOfDepositRevert(address from , uint256 tokenId) internal {
+        // check only deposit owner or operator can stake
+        changePrank(from);
+        vm.expectRevert(IRewardsManagerErrors.NotOwnerOrApprovedOfDeposit.selector);
+        _rewardsManager.stake(tokenId);
     }
 
     function _assertNotOwnerOfDepositUnstakeRevert(address from , uint256 tokenId) internal {
         // check only deposit owner can claim rewards
         changePrank(from);
-        uint256 currentBurnEpoch = _pool.currentBurnEpoch();
         vm.expectRevert(IRewardsManagerErrors.NotOwnerOfDeposit.selector);
-        _rewardsManager.claimRewards(tokenId, currentBurnEpoch);
+        _rewardsManager.unstake(tokenId);
     }
 
     function _assertAlreadyClaimedRevert(address from , uint256 tokenId) internal {

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -472,7 +472,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(2, 0),
-            reward:                    78.702220033830716622 * 1e18,
+            reward:                    75.265612882547969705 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 3.436607151282746917 * 1e18
         });
@@ -1209,7 +1209,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdTwo,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    39.906143408239864617 * 1e18,
+            reward:                    33.255119905800315497 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 6.651023502439549120 * 1e18
         });
@@ -1750,7 +1750,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         assertLt(_ajnaToken.balanceOf(_minterOne), tokensToBurn);
 
         // check can't claim rewards twice
-        _assertNotOwnerOfDepositRevert({
+        _assertClaimRewardsRevert({
             from: _minterOne,
             tokenId: tokenIdOne
         });
@@ -1802,12 +1802,6 @@ contract RewardsManagerTest is RewardsHelperContract {
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
-        });
-
-        // check only deposit owner can claim rewards
-        _assertNotOwnerOfDepositRevert({
-            from: _minterTwo,
-            tokenId: tokenIdOne
         });
 
         // check rewards earned in one pool shouldn't be claimable by depositors from another pool


### PR DESCRIPTION
# Description of change
## High level
* Enable the NFT operator to stake NFT on behalf of the owner.
* Removed owner-only check from `claimRewards`. Instead, anyone can call `claimRewards` but the staking rewards will transfer to the owner of NFT and the sender will only get update exchange rate rewards.
* Fixed rewards in `ClaimRewards` event to only account staking rewards and not update exchange rate rewards

# Description of bug or vulnerability and solution
* See - 
 https://github.com/code-423n4/2023-05-ajna-findings/issues/218
* NFT operator can't stake NFT into Rewards Manager.
* Fixed this by enabling only NFT operator and owner to stake NFT.
* Updated `claimRewards` to be called by anyone but the staking rewards will be sent to the owner of NFT.

