### PR TITLE
PROTOTECH-46: Unsafe casts in KickerActions

### DIFF
--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.18;
 
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 import { PoolType } from '../../interfaces/pool/IPool.sol';
 
 import {
@@ -480,10 +482,10 @@ library KickerActions {
         // record liquidation info
         liquidation.kicker       = msg.sender;
         liquidation.kickTime     = uint96(block.timestamp);
-        liquidation.kickMomp     = uint96(momp_);
-        liquidation.bondSize     = uint160(bondSize_);
-        liquidation.bondFactor   = uint96(bondFactor_);
-        liquidation.neutralPrice = uint96(neutralPrice_);
+        liquidation.kickMomp     = uint96(momp_); // cannot exceed max price enforced by _priceAt() function
+        liquidation.bondSize     = SafeCast.toUint160(bondSize_);
+        liquidation.bondFactor   = SafeCast.toUint96(bondFactor_);
+        liquidation.neutralPrice = SafeCast.toUint96(neutralPrice_);
 
         // increment number of active auctions
         ++auctions_.noOfAuctions;


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* See https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/46
* Make sure bond size, bond factor and neutral price can fit in uint160, uint96 and uint96 types
  * use OZ safe cast bond size, bond factor and neutral price

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* Kicker could lose entire bond if bond doesn't fit in uint160 size
* Use safe cast and revert tx

# Gas usage
## Pre Change
```
| kick                                 | 147490          | 221511 | 220012 | 1032365 | 48000   |
| kickWithDeposit                      | 196696          | 274344 | 270489 | 996938  | 8000    |
```
## Post Change
```
| kick                                 | 148286          | 222307 | 220808 | 1033161 | 48000   |
| kickWithDeposit                      | 197492          | 275140 | 271285 | 997734  | 8000    |
```

