### PR TITLE
Bug fix: Kick auctioned loan reverts due to divide by 0

### DIFF
--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -372,6 +372,10 @@ library KickerActions {
     ) internal returns (
         KickResult memory kickResult_
     ) {
+        Liquidation storage liquidation = auctions_.liquidations[borrowerAddress_];
+        // revert if liquidation is active
+        if (liquidation.kickTime != 0) revert AuctionActive();
+
         Borrower storage borrower = loans_.borrowers[borrowerAddress_];
 
         kickResult_.debtPreAction       = borrower.t0Debt;
@@ -417,6 +421,7 @@ library KickerActions {
         // record liquidation info
         _recordAuction(
             auctions_,
+            liquidation,
             borrowerAddress_,
             vars.bondSize,
             vars.bondFactor,
@@ -486,6 +491,7 @@ library KickerActions {
      *  @dev    increment auctions count accumulator
      *  @dev    updates auction queue state
      *  @param  auctions_        Struct for pool auctions state.
+     *  @param  liquidation_     Struct for current auction state.
      *  @param  borrowerAddress_ Address of the borrower that is kicked.
      *  @param  bondSize_        Bond size to cover newly kicked auction.
      *  @param  bondFactor_      Bond factor of the newly kicked auction.
@@ -494,22 +500,20 @@ library KickerActions {
      */
     function _recordAuction(
         AuctionsState storage auctions_,
+        Liquidation storage liquidation_,
         address borrowerAddress_,
         uint256 bondSize_,
         uint256 bondFactor_,
         uint256 momp_,
         uint256 neutralPrice_
     ) internal {
-        Liquidation storage liquidation = auctions_.liquidations[borrowerAddress_];
-        if (liquidation.kickTime != 0) revert AuctionActive();
-
         // record liquidation info
-        liquidation.kicker       = msg.sender;
-        liquidation.kickTime     = uint96(block.timestamp);
-        liquidation.kickMomp     = uint96(momp_); // cannot exceed max price enforced by _priceAt() function
-        liquidation.bondSize     = SafeCast.toUint160(bondSize_);
-        liquidation.bondFactor   = SafeCast.toUint96(bondFactor_);
-        liquidation.neutralPrice = SafeCast.toUint96(neutralPrice_);
+        liquidation_.kicker       = msg.sender;
+        liquidation_.kickTime     = uint96(block.timestamp);
+        liquidation_.kickMomp     = uint96(momp_); // cannot exceed max price enforced by _priceAt() function
+        liquidation_.bondSize     = SafeCast.toUint160(bondSize_);
+        liquidation_.bondFactor   = SafeCast.toUint96(bondFactor_);
+        liquidation_.neutralPrice = SafeCast.toUint96(neutralPrice_);
 
         // increment number of active auctions
         ++auctions_.noOfAuctions;
@@ -518,7 +522,7 @@ library KickerActions {
         if (auctions_.head != address(0)) {
             // other auctions in queue, liquidation doesn't exist or overwriting.
             auctions_.liquidations[auctions_.tail].next = borrowerAddress_;
-            liquidation.prev = auctions_.tail;
+            liquidation_.prev = auctions_.tail;
         } else {
             // first auction in queue
             auctions_.head = borrowerAddress_;

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -1790,7 +1790,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         });
 
         // trigger ajna burns
-        uint256 tokensToBurn = _triggerReserveAuctions({
+        _triggerReserveAuctions({
             borrower:     _borrower,
             tokensToBurn: 81.799082739441001952 * 1e18,
             borrowAmount: 300 * 1e18,


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Kick fails on calculating bonds for unsettled auctions with 0 collateral and bad debt
  * move requirement for auction to not be active when kick enters (from `_recordAuction` function) to prevent calculating bonds for loan in auction
  * add unit test


# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
 KickerActions            -  10,570B  (43.01%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
KickerActions            -  10,574B  (43.02%)
```

# Gas usage
## Pre Change
```
| kick                                 | 148570          | 222591 | 221092 | 1033445 | 48000   |
| kickWithDeposit                      | 198027          | 275674 | 271820 | 998189  | 8000    |
```
## Post Change
```
| kick                                 | 148581          | 222602 | 221103 | 1033456 | 48000   |
| kickWithDeposit                      | 198038          | 275685 | 271831 | 998200  | 8000    |
```


