### PR TITLE
Prototech 45: Revert after instead of on `expiry_`

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -42,7 +42,7 @@ import {
 }                                               from './libraries/helpers/PoolHelper.sol';
 import { 
     _revertIfAuctionClearable,
-    _revertOnExpiry 
+    _revertAfterExpiry 
 }                               from './libraries/helpers/RevertsHelper.sol';
 
 import { Loans }    from './libraries/internal/Loans.sol';
@@ -285,7 +285,7 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
         uint256 index_,
         uint256 expiry_
     ) external override nonReentrant returns (uint256 bucketLP_) {
-        _revertOnExpiry(expiry_);
+        _revertAfterExpiry(expiry_);
         PoolState memory poolState = _accruePoolInterest();
 
         // revert if the dust amount was not exceeded, but round on the scale amount

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -33,7 +33,7 @@ import { _roundToScale }     from './libraries/helpers/PoolHelper.sol';
 
 import {
     _revertIfAuctionClearable,
-    _revertOnExpiry
+    _revertAfterExpiry
 }                               from './libraries/helpers/RevertsHelper.sol';
 
 import { Maths }    from './libraries/internal/Maths.sol';
@@ -301,7 +301,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         uint256 index_,
         uint256 expiry_
     ) external override nonReentrant returns (uint256 bucketLP_) {
-        _revertOnExpiry(expiry_);
+        _revertAfterExpiry(expiry_);
         PoolState memory poolState = _accruePoolInterest();
 
         bucketLP_ = LenderActions.addCollateral(

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -52,7 +52,7 @@ import {
 import {
     _revertIfAuctionDebtLocked,
     _revertIfAuctionClearable,
-    _revertOnExpiry
+    _revertAfterExpiry
 }                               from '../libraries/helpers/RevertsHelper.sol';
 
 import { Buckets }  from '../libraries/internal/Buckets.sol';
@@ -148,7 +148,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 index_,
         uint256 expiry_
     ) external override nonReentrant returns (uint256 bucketLP_) {
-        _revertOnExpiry(expiry_);
+        _revertAfterExpiry(expiry_);
         PoolState memory poolState = _accruePoolInterest();
 
         // round to token precision
@@ -179,7 +179,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 toIndex_,
         uint256 expiry_
     ) external override nonReentrant returns (uint256 fromBucketLP_, uint256 toBucketLP_, uint256 movedAmount_) {
-        _revertOnExpiry(expiry_);
+        _revertAfterExpiry(expiry_);
         PoolState memory poolState = _accruePoolInterest();
 
         _revertIfAuctionDebtLocked(deposits, poolState.t0DebtInAuction, fromIndex_, poolState.inflator);

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -84,7 +84,7 @@ import { Maths }    from '../internal/Maths.sol';
     function _revertOnExpiry(
         uint256 expiry_
     ) view {
-        if (block.timestamp >= expiry_) revert TransactionExpired();
+        if (block.timestamp > expiry_) revert TransactionExpired();
     }
 
     /**

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -81,7 +81,7 @@ import { Maths }    from '../internal/Maths.sol';
      *  @dev    Reverts with `TransactionExpired` if expired.
      *  @param  expiry_ Expiration provided by user when creating the transaction.
      */
-    function _revertOnExpiry(
+    function _revertAfterExpiry(
         uint256 expiry_
     ) view {
         if (block.timestamp > expiry_) revert TransactionExpired();


### PR DESCRIPTION
# Description of change
## High level
* See - https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/45
* Update transaction revert only after expiry time rather than on and after expiry time.