### PR TITLE
Prototech 54: Consider checking token id sort order in the pool

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -102,6 +102,9 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         if (noOfTokens != 0) {
             // add subset of tokenIds allowed in the pool
             for (uint256 id = 0; id < noOfTokens;) {
+                // Check that the array of token ids is sorted in ascending order, else revert.
+                if (id < (noOfTokens - 1) && tokenIds_[id] >= tokenIds_[id + 1]) revert TokenIdSubsetInvalid();
+
                 tokenIdsAllowed_[tokenIds_[id]] = true;
 
                 unchecked { ++id; }

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -102,26 +102,8 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
     function getNFTSubsetHash(uint256[] memory tokenIds_) public pure returns (bytes32) {
         if (tokenIds_.length == 0) return ERC721_NON_SUBSET_HASH;
         else {
-            // check the array of token ids is sorted in ascending order
-            // revert if not sorted
-            _checkTokenIdSortOrder(tokenIds_);
-
             // hash the sorted array of tokenIds
             return keccak256(abi.encode(tokenIds_));
-        }
-    }
-
-    /**
-     *  @notice Check that the array of token ids is sorted in ascending order, else revert.
-     *  @dev    The counters are modified in unchecked blocks due to being bounded by array length.
-     *  @param  tokenIds_ The array of token ids to check for sorting.
-     */
-    function _checkTokenIdSortOrder(uint256[] memory tokenIds_) internal pure {
-        for (uint256 i = 0; i < tokenIds_.length - 1; ) {
-            if (tokenIds_[i] >= tokenIds_[i + 1]) revert TokenIdSubsetInvalid();
-            unchecked {
-                ++i;
-            }
         }
     }
 

--- a/src/interfaces/pool/erc721/IERC721PoolErrors.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolErrors.sol
@@ -11,4 +11,9 @@ interface IERC721PoolErrors {
      *  @notice User attempted to add an `NFT` to the pool with a `tokenId` outside of the allowed subset.
      */
     error OnlySubset();
+    
+    /**
+     *  @notice User tried to deploy a pool with an array of `tokenIds` that weren't sorted, or contained duplicates.
+     */
+    error TokenIdSubsetInvalid();
 }

--- a/src/interfaces/pool/erc721/IERC721PoolFactory.sol
+++ b/src/interfaces/pool/erc721/IERC721PoolFactory.sol
@@ -15,9 +15,9 @@ interface IERC721PoolFactory is IPoolFactory {
     /**************/
 
     /**
-     *  @notice User tried to deploy a pool with an array of `tokenIds` that weren't sorted, or contained duplicates.
+     *  @notice User attempted to make pool with non supported `NFT` contract as collateral.
      */
-    error TokenIdSubsetInvalid();
+    error NFTNotSupported();
 
     /**************************/
     /*** External Functions ***/
@@ -38,9 +38,4 @@ interface IERC721PoolFactory is IPoolFactory {
         uint256[] memory tokenIds_,
         uint256 interestRate_
     ) external returns (address pool_);
-
-    /**
-     *  @notice User attempted to make pool with non supported `NFT` contract as collateral.
-     */
-    error NFTNotSupported();
 }

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
@@ -5,10 +5,10 @@ import { ERC721HelperContract }      from './ERC721DSTestPlus.sol';
 import { NFTCollateralToken, TokenWithNDecimals } from '../../utils/Tokens.sol';
 
 import { ERC721Pool }        from 'src/ERC721Pool.sol';
+import { IERC721PoolErrors } from 'src/interfaces/pool/erc721/IERC721PoolErrors.sol';
 import { ERC721PoolFactory } from 'src/ERC721PoolFactory.sol';
 import { IPoolErrors }       from 'src/interfaces/pool/commons/IPoolErrors.sol';
 import { IPoolFactory }      from 'src/interfaces/pool/IPoolFactory.sol';
-import { IERC721PoolFactory } from 'src/interfaces/pool/erc721/IERC721PoolFactory.sol';
 
 contract ERC721PoolFactoryTest is ERC721HelperContract {
     address            internal _NFTCollectionPoolAddress;
@@ -203,7 +203,7 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
     /*** ERC721 Collection Subset Tests ***/
     /**************************************/
 
-    function testGetNFTSubsetHashTokenOrdering() external {
+    function testDeployERC721SubsetPoolWithIncorrectTokenOrdering() external {
         uint256[] memory tokenIdsOne = new uint256[](3);
         tokenIdsOne[0] = 1;
         tokenIdsOne[1] = 70;
@@ -211,22 +211,22 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         uint256[] memory tokenIdsTwo = new uint256[](3);
         tokenIdsTwo[0] = 1;
         tokenIdsTwo[1] = 2;
-        tokenIdsTwo[2] = 3;
+        tokenIdsTwo[2] = 2;
         uint256[] memory tokenIdsThree = new uint256[](3);
         tokenIdsThree[0] = 1;
         tokenIdsThree[1] = 2;
-        tokenIdsThree[2] = 2;
+        tokenIdsThree[2] = 3;
 
-        // check sort order
-        vm.expectRevert(IERC721PoolFactory.TokenIdSubsetInvalid.selector);
-        _factory.getNFTSubsetHash(tokenIdsOne);
+        // should revert if trying to deploy with incorrect token ids order
+        vm.expectRevert(IERC721PoolErrors.TokenIdSubsetInvalid.selector);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsOne, 0.05 * 10**18);
 
-        // check valid subset hash
-        assertEq(_factory.getNFTSubsetHash(tokenIdsTwo), keccak256(abi.encode(tokenIdsTwo)));
+        // should revert if trying to deploy with two same token ids
+        vm.expectRevert(IERC721PoolErrors.TokenIdSubsetInvalid.selector);
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsTwo, 0.05 * 10**18);
 
-        // check for duplicate tokenIds
-        vm.expectRevert(IERC721PoolFactory.TokenIdSubsetInvalid.selector);
-        _factory.getNFTSubsetHash(tokenIdsThree);
+        // ensure pool is deployed with correct token ids order
+        _factory.deployPool(address(_collateral), address(_quote), tokenIdsThree, 0.05 * 10**18);
     }
 
     function testDeployERC721SubsetPoolWithZeroAddress() external {


### PR DESCRIPTION
# Description of change
## High level
* See - https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/54
* Moved sorted token id and duplicate token id checks from `ERC721PoolFactory` to `ERC721Pool` to reduce gas cost for deploying pool.

# Contract size
## Pre Change
ERC721Pool               -  24,386B  (99.22%)
## Post Change
ERC721Pool               -  24,501B  (99.69%)

# Gas usage
## Pre Change
```
| Deployment Cost                                      | Deployment Size |                   |        |                     |         |
| 5660038                                              | 28089           |                   |        |                     |         |
| Function Name                                        | min             | avg               | median | max                 | # calls |
| deployPool                                           | 1039            | 63385769223808816 | 305269 | 8937393460516718777 | 141     |
```
## Post Change
```
| Deployment Cost                                      | Deployment Size |                   |        |                     |         |
| 5643671                                              | 28003           |                   |        |                     |         |
| Function Name                                        | min             | avg               | median | max                 | # calls |
| deployPool                                           | 1039            | 62065232364984430 | 300540 | 8937393460516718777 | 144     |
```

