### PR TITLE
PROTOTECH-20: New Borrower Debt overcounted with < 18 decimal Quote Tokens

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -136,6 +136,8 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        // ensure the borrower is not charged for additional debt that they did not receive
+        amountToBorrow_     = _roundToScale(amountToBorrow_, poolState.quoteTokenScale);
         // ensure the borrower is not credited with a fractional amount of collateral smaller than the token scale
         collateralToPledge_ = _roundToScale(collateralToPledge_, _getArgUint256(COLLATERAL_SCALE));
 

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -150,6 +150,9 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
     ) external nonReentrant {
         PoolState memory poolState = _accruePoolInterest();
 
+        // ensure the borrower is not charged for additional debt that they did not receive
+        amountToBorrow_ = _roundToScale(amountToBorrow_, poolState.quoteTokenScale);
+
         DrawDebtResult memory result = BorrowerActions.drawDebt(
             auctions,
             buckets,

--- a/tests/forge/invariants/ERC20Pool/handlers/unbounded/UnboundedBasicERC20PoolHandler.sol
+++ b/tests/forge/invariants/ERC20Pool/handlers/unbounded/UnboundedBasicERC20PoolHandler.sol
@@ -134,13 +134,13 @@ abstract contract UnboundedBasicERC20PoolHandler is UnboundedBasicPoolHandler, B
         (uint256 interestRate, ) = _erc20Pool.interestRateInfo();
 
         try _erc20Pool.drawDebt(_actor, amount_, 7388, collateralToPledge) {
+            // amount is rounded by pool to token scale
+            amount_ = _roundToScale(amount_, _pool.quoteTokenScale());
 
             // **RE10**: Reserves increase by origination fee: max(1 week interest, 0.05% of borrow amount), on draw debt
             increaseInReserves += Maths.wmul(
                 amount_, _borrowFeeRate(interestRate)
             );
-            // rounding in favour of pool goes to reserves
-            increaseInReserves += amount_ - _roundToScale(amount_, _pool.quoteTokenScale());
 
         } catch (bytes memory err) {
             _ensurePoolError(err);

--- a/tests/forge/invariants/ERC721Pool/handlers/unbounded/UnboundedBasicERC721PoolHandler.sol
+++ b/tests/forge/invariants/ERC721Pool/handlers/unbounded/UnboundedBasicERC721PoolHandler.sol
@@ -188,13 +188,13 @@ abstract contract UnboundedBasicERC721PoolHandler is UnboundedBasicPoolHandler, 
         (uint256 kickTimeBefore, , , , uint256 auctionPrice, ) =_poolInfo.auctionStatus(address(_erc721Pool), _actor);
 
         try _erc721Pool.drawDebt(_actor, amount_, 7388, tokenIds) {
+            // amount is rounded by pool to token scale
+            amount_ = _roundToScale(amount_, _pool.quoteTokenScale());
 
             // **RE10**: Reserves increase by origination fee: max(1 week interest, 0.05% of borrow amount), on draw debt
             increaseInReserves += Maths.wmul(
                 amount_, _borrowFeeRate(interestRate)
             );
-            // rounding in favour of pool goes to reserves
-            increaseInReserves += amount_ - _roundToScale(amount_, _pool.quoteTokenScale());
 
             _recordSettleBucket(
                 _actor,

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -692,16 +692,6 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
     }
 
-    function _assertBorrowDustRevert(
-        address from,
-        uint256 amount,
-        uint256 indexLimit
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
-    }
-
     function _assertBorrowInvalidAmountRevert(
         address from,
         uint256 amount,

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -702,6 +702,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
     }
 
+    function _assertBorrowInvalidAmountRevert(
+        address from,
+        uint256 amount,
+        uint256 indexLimit
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
+    }
+
     function _assertBorrowMinDebtRevert(
         address from,
         uint256 amount,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -765,7 +765,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             // ensure illegitimate amounts revert
             if (i < 10) {
                 if (quoteDecimals < 18) {
-                    _assertBorrowDustRevert({
+                    _assertBorrowInvalidAmountRevert({
                         from:       _borrower,
                         amount:     1,
                         indexLimit: bucketId

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -585,17 +585,6 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);        
     }
 
-    function _assertBorrowDustRevert(
-        address from,
-        uint256 amount,
-        uint256 indexLimit
-    ) internal {
-        changePrank(from);
-        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
-        uint256[] memory emptyArray;
-        ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
-    }
-
     function _assertBorrowInvalidAmountRevert(
         address from,
         uint256 amount,

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -596,6 +596,17 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
     }
 
+    function _assertBorrowInvalidAmountRevert(
+        address from,
+        uint256 amount,
+        uint256 indexLimit
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        uint256[] memory emptyArray;
+        ERC721Pool(address(_pool)).drawDebt(from, amount, indexLimit, emptyArray);
+    }
+
     function _assertBorrowMinDebtRevert(
         address from,
         uint256 amount,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -658,7 +658,7 @@ contract ERC721ScaledQuoteTokenBorrowTest is ERC721NDecimalsHelperContract(4) {
 
     function testMinDebtBelowDustLimitCheck() external tearDown {
         // should revert if borrower tries to draw debt below dust limit
-        _assertBorrowDustRevert({
+        _assertBorrowInvalidAmountRevert({
             from:       _borrower,
             amount:     0.00005 * 1e18,
             indexLimit: 2550
@@ -670,7 +670,7 @@ contract ERC721ScaledQuoteTokenBorrowTest is ERC721NDecimalsHelperContract(4) {
         }
 
         // should still revert if borrower tries to draw debt below dust limit
-        _assertBorrowDustRevert({
+        _assertBorrowInvalidAmountRevert({
             from:       _borrower,
             amount:     0.000075 * 1e18,
             indexLimit: 2550


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* See https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/20
  * On draw debt make sure amount is rounded to scale to avoid extra payment from borrower

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* In `ERC20Pool` and `ERC721Pool` `drawDebt` methods round the amount to borrow to quote token scale
* Update invariant tests to follow same approach, round to scale on repay debt instead adding to reserves
* Update unit tests that revert now with `InvalidAmount` (amounts rounded to scale end up as 0)

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,386B  (99.22%)
  ERC20Pool                -  23,614B  (96.08%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,403B  (99.29%)
  ERC20Pool                -  23,631B  (96.15%)
```

# Gas usage
## Pre Change
```
ERC20 | drawDebt                             | 7371            | 255063 | 252879 | 617626 | 495     |
ERC721 | drawDebt                               | 12112           | 319175 | 325668 | 705744 | 175     |
```
## Post Change
```
ERC20 | drawDebt                             | 7584            | 254981 | 253092 | 617839 | 493     |
ERC721 | drawDebt                               | 10764           | 319250 | 325881 | 705914 | 175     |
```

