### PR TITLE
PROTOTECH-49: Revert if there is no `decimals` method in token contract or decimals are not in range 0 to 18.

### DIFF
--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.18;
 
 import { ClonesWithImmutableArgs } from '@clones/ClonesWithImmutableArgs.sol';
 
-import { IERC20PoolFactory }     from './interfaces/pool/erc20/IERC20PoolFactory.sol';
-import { IPoolFactory }          from './interfaces/pool/IPoolFactory.sol';
-import { IERC20Token, PoolType } from './interfaces/pool/IPool.sol';
+import { IERC20PoolFactory } from './interfaces/pool/erc20/IERC20PoolFactory.sol';
+import { IPoolFactory }      from './interfaces/pool/IPoolFactory.sol';
+import { PoolType }          from './interfaces/pool/IPool.sol';
 
 import { ERC20Pool }    from './ERC20Pool.sol';
 import { PoolDeployer } from './base/PoolDeployer.sol';

--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -43,7 +43,7 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
      *  @dev    - `deployedPoolsList` array
      *  @dev    === Reverts on ===
      *  @dev    - `0x` address provided as quote or collateral `DeployWithZeroAddress()`
-     *  @dev    - quote or collateral lacks `decimals()` method `DecimalNotCompliant()`
+     *  @dev    - quote or collateral lacks `decimals()` method `DecimalsNotCompliant()`
      *  @dev    - pool with provided quote / collateral pair already exists `PoolAlreadyExists()`
      *  @dev    - invalid interest rate provided `PoolInterestRateInvalid()`
      *  @dev    === Emit events ===
@@ -55,8 +55,8 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
         address existingPool = deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_];
         if (existingPool != address(0)) revert IPoolFactory.PoolAlreadyExists(existingPool);
 
-        uint256 quoteTokenScale = 10 ** (18 - _verfiyAndGetTokenDecimals(quote_));
-        uint256 collateralScale = 10 ** (18 - _verfiyAndGetTokenDecimals(collateral_));
+        uint256 quoteTokenScale = _getTokenScale(quote_);
+        uint256 collateralScale = _getTokenScale(collateral_);
 
         bytes memory data = abi.encodePacked(
             PoolType.ERC20,

--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -43,7 +43,7 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
      *  @dev    - `deployedPoolsList` array
      *  @dev    === Reverts on ===
      *  @dev    - `0x` address provided as quote or collateral `DeployWithZeroAddress()`
-     *  @dev    - quote or collateral lacks `decimals()` method `TokenInvalidNoDecimals()`
+     *  @dev    - quote or collateral lacks `decimals()` method `DecimalNotCompliant()`
      *  @dev    - pool with provided quote / collateral pair already exists `PoolAlreadyExists()`
      *  @dev    - invalid interest rate provided `PoolInterestRateInvalid()`
      *  @dev    === Emit events ===
@@ -55,11 +55,8 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
         address existingPool = deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_];
         if (existingPool != address(0)) revert IPoolFactory.PoolAlreadyExists(existingPool);
 
-        // quote and collateral tokens must have decimals() method or pool is invalid
-        if (!hasDecimalsMethod(quote_) || !hasDecimalsMethod(collateral_)) revert IPoolFactory.TokenInvalidNoDecimals();
-
-        uint256 quoteTokenScale = 10 ** (18 - IERC20Token(quote_).decimals());
-        uint256 collateralScale = 10 ** (18 - IERC20Token(collateral_).decimals());
+        uint256 quoteTokenScale = 10 ** (18 - _verfiyAndGetTokenDecimals(quote_));
+        uint256 collateralScale = 10 ** (18 - _verfiyAndGetTokenDecimals(collateral_));
 
         bytes memory data = abi.encodePacked(
             PoolType.ERC20,

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -45,7 +45,7 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
      *  @dev    - `deployedPoolsList` array
      *  @dev    === Reverts on ===
      *  @dev    - `0x` address provided as quote or collateral `DeployWithZeroAddress()`
-     *  @dev    - quote lacks `decimals()` method `DecimalNotCompliant()`
+     *  @dev    - quote lacks `decimals()` method `DecimalsNotCompliant()`
      *  @dev    - pool with provided quote / collateral pair already exists `PoolAlreadyExists()`
      *  @dev    - invalid interest rate provided `PoolInterestRateInvalid()`
      *  @dev    - not supported `NFT` provided `NFTNotSupported()`
@@ -60,7 +60,7 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
         address existingPool = deployedPools[subsetHash][collateral_][quote_];
         if (existingPool != address(0)) revert IPoolFactory.PoolAlreadyExists(existingPool);
 
-        uint256 quoteTokenScale = 10 ** (18 - _verfiyAndGetTokenDecimals(quote_));
+        uint256 quoteTokenScale = _getTokenScale(quote_);
 
         try IERC165(collateral_).supportsInterface(0x80ac58cd) returns (bool supportsERC721Interface) {
             if (!supportsERC721Interface) revert NFTNotSupported();

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -45,7 +45,7 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
      *  @dev    - `deployedPoolsList` array
      *  @dev    === Reverts on ===
      *  @dev    - `0x` address provided as quote or collateral `DeployWithZeroAddress()`
-     *  @dev    - quote lacks `decimals()` method `TokenInvalidNoDecimals()`
+     *  @dev    - quote lacks `decimals()` method `DecimalNotCompliant()`
      *  @dev    - pool with provided quote / collateral pair already exists `PoolAlreadyExists()`
      *  @dev    - invalid interest rate provided `PoolInterestRateInvalid()`
      *  @dev    - not supported `NFT` provided `NFTNotSupported()`
@@ -60,10 +60,7 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
         address existingPool = deployedPools[subsetHash][collateral_][quote_];
         if (existingPool != address(0)) revert IPoolFactory.PoolAlreadyExists(existingPool);
 
-        // quote token must have decimals() method or pool is invalid
-        if (!hasDecimalsMethod(quote_)) revert IPoolFactory.TokenInvalidNoDecimals();
-
-        uint256 quoteTokenScale = 10**(18 - IERC20Token(quote_).decimals());
+        uint256 quoteTokenScale = 10 ** (18 - _verfiyAndGetTokenDecimals(quote_));
 
         try IERC165(collateral_).supportsInterface(0x80ac58cd) returns (bool supportsERC721Interface) {
             if (!supportsERC721Interface) revert NFTNotSupported();

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -5,9 +5,9 @@ pragma solidity 0.8.18;
 import { ClonesWithImmutableArgs } from '@clones/ClonesWithImmutableArgs.sol';
 import { IERC165 }                 from '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 
-import { IERC721PoolFactory }    from './interfaces/pool/erc721/IERC721PoolFactory.sol';
-import { IPoolFactory }          from './interfaces/pool/IPoolFactory.sol';
-import { IERC20Token, PoolType } from './interfaces/pool/IPool.sol';
+import { IERC721PoolFactory } from './interfaces/pool/erc721/IERC721PoolFactory.sol';
+import { IPoolFactory }       from './interfaces/pool/IPoolFactory.sol';
+import { PoolType }           from './interfaces/pool/IPool.sol';
 
 import { ERC721Pool }   from './ERC721Pool.sol';
 import { PoolDeployer } from './base/PoolDeployer.sol';

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.18;
 
 import { IPoolFactory } from '../interfaces/pool/IPoolFactory.sol';
+import { IERC20Token }  from '../interfaces/pool/IPool.sol';
 
 /**
  *  @title  Pool Deployer base contract
@@ -45,6 +46,27 @@ abstract contract PoolDeployer {
         _;
     }
 
+    /*********************************/
+    /*** Internal Helper Functions ***/
+    /*********************************/
+
+    /**
+     * @notice Checks token compliance and returns token decimals
+     * @dev    Reverts with `DecimalNotCompliant` if token decimals are more than 18 or token contract lacks `decimals` method
+     * @param  token_    Address of token
+     * @return decimals_ Token decimals 
+     */
+    function _verfiyAndGetTokenDecimals(address token_) internal view returns (uint256 decimals_) {
+        try IERC20Token(token_).decimals() returns (uint8 tokenDecimals_) {
+            // revert if token decimals is more than 18
+            if (tokenDecimals_ > 18) revert IPoolFactory.DecimalNotCompliant();
+            decimals_ = tokenDecimals_;
+        } catch {
+            // revert if token contract lack `decimals` method
+            revert IPoolFactory.DecimalNotCompliant();
+        }
+    }
+
     /*******************************/
     /*** External View Functions ***/
     /*******************************/
@@ -65,10 +87,5 @@ abstract contract PoolDeployer {
      */
     function getNumberOfDeployedPools() external view returns (uint256) {
         return deployedPoolsList.length;
-    }
-
-    function hasDecimalsMethod(address contract_) internal view returns (bool methodExists_) {
-        // 0x313ce567 = bytes4(keccak256("decimals()""))
-        (methodExists_,) = contract_.staticcall(abi.encodePacked(bytes4(0x313ce567)));
     }
 }

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -51,19 +51,21 @@ abstract contract PoolDeployer {
     /*********************************/
 
     /**
-     * @notice Checks token compliance and returns token decimals
-     * @dev    Reverts with `DecimalNotCompliant` if token decimals are more than 18 or token contract lacks `decimals` method
-     * @param  token_    Address of token
-     * @return decimals_ Token decimals 
+     * @notice Calculates `ERC20` token scale based on token decimals.
+     * @dev    Reverts with `DecimalsNotCompliant` if token decimals are more than 18 or token contract lacks `decimals` method.
+     * @param  token_  `ERC20` token address.
+     * @return scale_  Calculated token scale. 
      */
-    function _verfiyAndGetTokenDecimals(address token_) internal view returns (uint256 decimals_) {
+    function _getTokenScale(address token_) internal view returns (uint256 scale_) {
         try IERC20Token(token_).decimals() returns (uint8 tokenDecimals_) {
             // revert if token decimals is more than 18
-            if (tokenDecimals_ > 18) revert IPoolFactory.DecimalNotCompliant();
-            decimals_ = tokenDecimals_;
+            if (tokenDecimals_ > 18) revert IPoolFactory.DecimalsNotCompliant();
+
+            // scale calculated at pool precision (18)
+            scale_ = 10 ** (18 - tokenDecimals_);
         } catch {
             // revert if token contract lack `decimals` method
-            revert IPoolFactory.DecimalNotCompliant();
+            revert IPoolFactory.DecimalsNotCompliant();
         }
     }
 

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -24,7 +24,7 @@ interface IPoolFactory {
     /**
      *  @notice Can't deploy with token that has no decimals method or decimals greater than 18
      */
-    error DecimalNotCompliant();
+    error DecimalsNotCompliant();
 
     /**
      *  @notice Pool with this combination of quote and collateral already exists.

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -22,9 +22,9 @@ interface IPoolFactory {
     error DeployWithZeroAddress();
 
     /**
-     *  @notice Can't deploy with token that has no decimals method
+     *  @notice Can't deploy with token that has no decimals method or decimals greater than 18
      */
-    error TokenInvalidNoDecimals();
+    error DecimalNotCompliant();
 
     /**
      *  @notice Pool with this combination of quote and collateral already exists.

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -494,13 +494,13 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
     }
 
-    function _assertTokenInvalidNoDecimals(
+    function _assertTokenDecimalsNotCompliant(
         address poolFactory,
         address collateral,
         address quote,
         uint256 interestRate
     ) internal {
-        vm.expectRevert(IPoolFactory.DecimalNotCompliant.selector);
+        vm.expectRevert(IPoolFactory.DecimalsNotCompliant.selector);
         ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
     }
 

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -500,7 +500,7 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         address quote,
         uint256 interestRate
     ) internal {
-        vm.expectRevert(IPoolFactory.TokenInvalidNoDecimals.selector);
+        vm.expectRevert(IPoolFactory.DecimalNotCompliant.selector);
         ERC20PoolFactory(poolFactory).deployPool(collateral, quote, interestRate);
     }
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.18;
 
 import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
-import { Token } from '../../utils/Tokens.sol';
-import { ERC20NoDecimals } from '../../utils/ContractERC20NoDecimals.sol';
+import { Token, TokenWithNDecimals } from '../../utils/Tokens.sol';
+import { ERC20NoDecimals }           from '../../utils/ContractERC20NoDecimals.sol';
 
 import { ERC20Pool }        from 'src/ERC20Pool.sol';
 import { ERC20PoolFactory } from 'src/ERC20PoolFactory.sol';
@@ -42,12 +42,12 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         });
     }
 
-    function testDeployERC20PoolWithNoDecimals() external {
+    function testDeployERC20PoolWithNoncompliantDecimals() external {
 
         ERC20NoDecimals noDecToken = new ERC20NoDecimals("NoDec", "ND");
 
         // should revert if trying to deploy with token that doesn't have decimals() method
-        _assertTokenInvalidNoDecimals({
+        _assertTokenDecimalsNotCompliant({
             poolFactory:  address(_poolFactory),
             collateral:   address(_collateral),
             quote:        address(noDecToken),
@@ -55,10 +55,25 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         });
 
         // should revert if trying to deploy with token that doesn't have decimals() method
-        _assertTokenInvalidNoDecimals({
+        _assertTokenDecimalsNotCompliant({
             poolFactory:  address(_poolFactory),
             collateral:   address(noDecToken),
             quote:        address(_quote),
+            interestRate: 0.05 * 10**18
+        });
+
+        // should revert if trying to deploy with token with more than 18 decimals
+        TokenWithNDecimals nonCompliantToken = new TokenWithNDecimals("NonCompliant", "NC", 19);
+        _assertTokenDecimalsNotCompliant({
+            poolFactory:  address(_poolFactory),
+            collateral:   address(nonCompliantToken),
+            quote:        address(_quote),
+            interestRate: 0.05 * 10**18
+        });
+        _assertTokenDecimalsNotCompliant({
+            poolFactory:  address(_poolFactory),
+            collateral:   address(_collateral),
+            quote:        address(nonCompliantToken),
             interestRate: 0.05 * 10**18
         });
     }

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -487,7 +487,7 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         uint256 interestRate
     ) internal {
         uint256[] memory tokenIds;
-        vm.expectRevert(IPoolFactory.TokenInvalidNoDecimals.selector);
+        vm.expectRevert(IPoolFactory.DecimalNotCompliant.selector);
         ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -480,14 +480,14 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
     }
 
-    function _assertTokenInvalidNoDecimals(
+    function _assertTokenDecimalsNotCompliant(
         address poolFactory,
         address collateral,
         address quote,
         uint256 interestRate
     ) internal {
         uint256[] memory tokenIds;
-        vm.expectRevert(IPoolFactory.DecimalNotCompliant.selector);
+        vm.expectRevert(IPoolFactory.DecimalsNotCompliant.selector);
         ERC721PoolFactory(poolFactory).deployPool(collateral, quote, tokenIds, interestRate);
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
@@ -112,15 +112,24 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         assertEq(_factory.getNumberOfDeployedPools(), 3);
     }
 
-    function testDeployERC721PoolWithNoDecimals() external {
+    function testDeployERC721PoolWithNoncompliantDecimals() external {
 
         ERC20NoDecimals noDecToken = new ERC20NoDecimals("NoDec", "ND");
 
         // should revert if trying to deploy with token that doesn't have decimals() method
-        _assertTokenInvalidNoDecimals({
+        _assertTokenDecimalsNotCompliant({
             poolFactory:  address(_poolFactory),
             collateral:   address(_collateral),
             quote:        address(noDecToken),
+            interestRate: 0.05 * 10**18
+        });
+
+        // should revert if trying to deploy with token with more than 18 decimals
+        TokenWithNDecimals nonCompliantToken = new TokenWithNDecimals("NonCompliant", "NC", 19);
+        _assertTokenDecimalsNotCompliant({
+            poolFactory:  address(_poolFactory),
+            collateral:   address(_collateral),
+            quote:        address(nonCompliantToken),
             interestRate: 0.05 * 10**18
         });
     }


### PR DESCRIPTION
# Description of change
## High level
* See - https://github.com/Fixed-Point-Solutions/prototech-ajna-audit/issues/49
* Add revert `DecimalsNotCompliant` in `deployPool` method if token contract has no `decimals` method or `decimals < 18`
* Add `_getTokenScale` helper function to calculate token scale (instead having logic to calculate scale in 3 places)