### PR TITLE
Code Arena: Consolidate mappings into TokenInfo struct

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -156,7 +156,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
      *  @inheritdoc IPositionManagerOwnerActions
      *  @dev    === Write state ===
      *  @dev    `_nonces`: remove `tokenId` nonce
-     *  @dev    `tokenInfo`: remove `tokenId => TokenINfo` mapping
+     *  @dev    `tokenInfo`: remove `tokenId => TokenInfo` mapping
      *  @dev    === Revert on ===
      *  @dev    - `mayInteract`:
      *  @dev       token id is not a valid / minted id

--- a/src/interfaces/position/IPositionManagerDerivedState.sol
+++ b/src/interfaces/position/IPositionManagerDerivedState.sol
@@ -51,6 +51,15 @@ interface IPositionManagerDerivedState {
     ) external view returns (uint256, uint256);
 
     /**
+     *  @notice Returns the pool address associated with a positions `NFT`.
+     *  @param  tokenId_ The token id of the positions `NFT`.
+     *  @return Pool address associated with the `NFT`.
+     */
+    function poolKey(
+        uint256 tokenId_
+    ) external view returns (address);
+
+    /**
      *  @notice Checks if a given `pool_` address is an Ajna pool.
      *  @param  pool_       Address of the `Ajna` pool.
      *  @param  subsetHash_ Factory's subset hash pool.

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -2,25 +2,35 @@
 
 pragma solidity 0.8.18;
 
+import { EnumerableSet } from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
 /**
  * @title Positions Manager State
  */
 interface IPositionManagerState {
 
     /**
-     * @dev Struct tracking a Position's global state.
-     * @param pool The pool address associated with the position.
-     * @param adjustmentTime The time of last adjustment to the position.
-     */
-    struct TokenInfo {
-        address pool;       // pool address associated with the position
-        uint96 adjustmentTime; // time of last adjustment to the position
+    * @dev Struct holding Position `LP` state.
+    * @param lps         [WAD] position LP.
+    * @param depositTime Deposit time for position
+    */
+    struct Position {
+        uint256 lps;
+        uint256 depositTime;
     }
 
-}
+    /**
+    * @dev Struct tracking a position token info.
+    * @param pool            The pool address associated with the position.
+    * @param adjustmentTime  The time of last adjustment to the position.
+    * @param positionIndexes Mapping tracking indexes to which a position is associated.
+    * @param positions       Mapping tracking a positions state in a bucket index.
+    */
+    struct TokenInfo {
+        address pool;
+        uint96 adjustmentTime;
+        EnumerableSet.UintSet positionIndexes;
+        mapping(uint256 index => Position) positions;
+    }
 
-/// @dev Struct holding Position `LP` state.
-struct Position {
-    uint256 lps;         // [WAD] position LP
-    uint256 depositTime; // deposit time for position
 }

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -8,13 +8,15 @@ pragma solidity 0.8.18;
 interface IPositionManagerState {
 
     /**
-     *  @notice Returns the pool address associated with a positions `NFT`.
-     *  @param  tokenId_ The token id of the positions `NFT`.
-     *  @return Pool address associated with the `NFT`.
+     * @dev Struct tracking a Position's global state.
+     * @param pool The pool address associated with the position.
+     * @param adjustmentTime The time of last adjustment to the position.
      */
-    function poolKey(
-        uint256 tokenId_
-    ) external view returns (address);
+    struct TokenInfo {
+        address pool;       // pool address associated with the position
+        uint96 adjustmentTime; // time of last adjustment to the position
+    }
+
 }
 
 /// @dev Struct holding Position `LP` state.


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Move `adjustmentTime` and `poolKey` into a new packed `TokenInfo` struct for significant gas savings.
* Due to changes in Permit, I deviated from the recommended optimization which included `nonce` in the `TokenInfo` struct. `nonce` is only available within a separate abstract contract.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* https://github.com/code-423n4/2023-05-ajna-findings/blob/main/data/JCN-G.md#multiple-address-mappings-can-be-combined-into-a-single-mapping-of-an-address-to-a-struct-where-appropriate

# Gas usage
Large gas savings in `redeem` and `moveLiquidity`. Modest gas savings in `mint` and `burn`.
## Pre Change
```
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |                                                                                                       
|--------------------------------------------------|-----------------|--------|--------|---------|---------|                                                                                                       
| Deployment Cost                                  | Deployment Size |        |        |         |         |                                                                                                       
| 3872043                                          | 19935           |        |        |         |         |                                                                                                       
| Function Name                                    | min             | avg    | median | max     | # calls |                                                                                                       
| DOMAIN_SEPARATOR                                 | 732             | 732    | 732    | 732     | 9       |                                                                                                       
| PERMIT_TYPEHASH                                  | 426             | 426    | 426    | 426     | 8       |                                                                                                       
| approve(address,uint256)                         | 25302           | 25302  | 25302  | 25302   | 8       |                                                                                                       
| approve(address,uint256)(bool)                   | 2722            | 24579  | 25302  | 25302   | 34      |                                                                                                       
| burn                                             | 1838            | 5460   | 6209   | 11089   | 13      |                                                                                                       
| getLP                                            | 6658            | 9005   | 8260   | 36386   | 229     |                                                                                                       
| getPositionIndexes                               | 1674            | 2364   | 2614   | 3790    | 114     |                                                                                                       
| getPositionIndexesFiltered                       | 8940            | 36545  | 26424  | 79674   | 91      |                                                                                                       
| getPositionInfo                                  | 1047            | 2297   | 1047   | 5047    | 16      |                                                                                                       
| isAjnaPool                                       | 955             | 6473   | 6824   | 10871   | 32      |                                                                                                       
| isIndexInPosition                                | 1060            | 1623   | 1060   | 3060    | 71      |                                                                                                       
| isPositionBucketBankrupt                         | 6928            | 7944   | 8148   | 9716    | 18      |                                                                                                       
| memorializePositions                             | 6459            | 79067  | 73744  | 1154607 | 3071    |                                                                                                       
| mint                                             | 10529           | 92961  | 97764  | 102764  | 76      |                                                                                                       
| moveLiquidity                                    | 5261            | 211862 | 180605 | 689708  | 20      |                                                                                                       
| nonces                                           | 841             | 1817   | 1746   | 2841    | 8       |                                                                                                       
| ownerOf                                          | 836             | 837    | 836    | 882     | 150     |                                                                                                       
| permit                                           | 1290            | 23250  | 17585  | 44417   | 9       |                                                                                                       
| poolKey                                          | 807             | 807    | 807    | 807     | 36      |                                                                                                       
| redeemPositions                                  | 2855            | 48183  | 59992  | 158094  | 29      |                                                                                                       
| safeTransferFrom                                 | 24282           | 36677  | 41715  | 42115   | 7       |                                                                                                       
| tokenURI                                         | 3157            | 468651 | 468651 | 934146  | 2       |                                                                                                       
| transferFrom(address,address,uint256)            | 20623           | 34839  | 42068  | 42068   | 9       |                                                                                                       
| transferFrom(address,address,uint256)(bool)      | 20623           | 29739  | 24548  | 42068   | 57      |                                                                                                       
                                                                                                                                                                      
```


## Post Change
```
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
|--------------------------------------------------|-----------------|--------|--------|---------|---------|                                                                                                                                                                                                                                                                                                                             
| Deployment Cost                                  | Deployment Size |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
| 3881851                                          | 19984           |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
| Function Name                                    | min             | avg    | median | max     | # calls |
| DOMAIN_SEPARATOR                                 | 732             | 732    | 732    | 732     | 9       |
| PERMIT_TYPEHASH                                  | 426             | 426    | 426    | 426     | 8       |
| approve(address,uint256)                         | 2722            | 22570  | 25302  | 25302   | 9       |
| approve(address,uint256)(bool)                   | 25302           | 25302  | 25302  | 25302   | 51      |
| burn                                             | 1838            | 5372   | 5982   | 10862   | 13      |
| getLP                                            | 6658            | 8878   | 8014   | 36386   | 288     |
| getPositionIndexes                               | 1674            | 2254   | 2144   | 3790    | 249     |
| getPositionIndexesFiltered                       | 8940            | 29438  | 26424  | 79674   | 325     |
| getPositionInfo                                  | 1047            | 2297   | 1047   | 5047    | 16      |
| isAjnaPool                                       | 955             | 6503   | 6824   | 10871   | 35      |
| isIndexInPosition                                | 1060            | 1623   | 1060   | 3060    | 71      |
| isPositionBucketBankrupt                         | 6928            | 7944   | 8148   | 9716    | 18      |
| memorializePositions                             | 6459            | 80303  | 73744  | 1154607 | 3089    |
| mint                                             | 10529           | 88970  | 95859  | 100859  | 94      |
| moveLiquidity                                    | 5261            | 201398 | 164810 | 669964  | 20      |
| nonces                                           | 841             | 1817   | 1746   | 2841    | 8       |
| ownerOf                                          | 836             | 836    | 836    | 882     | 186     |
| permit                                           | 1290            | 23250  | 17585  | 44417   | 9       |
| poolKey                                          | 807             | 807    | 807    | 807     | 54      |
| redeemPositions                                  | 2855            | 41116  | 59312  | 142299  | 29      |
| safeTransferFrom                                 | 24320           | 36742  | 41791  | 42191   | 7       |
| tokenURI                                         | 3157            | 468651 | 468651 | 934146  | 2       |
| transferFrom(address,address,uint256)            | 20699           | 32302  | 39819  | 42144   | 13      |
| transferFrom(address,address,uint256)(bool)      | 20699           | 28692  | 24624  | 42144   | 71      |
```

