### PR TITLE
Group all mappings in TokenInfo struct

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -13,7 +13,6 @@ import { IPool }                        from './interfaces/pool/IPool.sol';
 import { IPositionManager }             from './interfaces/position/IPositionManager.sol';
 import { IPositionManagerOwnerActions } from './interfaces/position/IPositionManagerOwnerActions.sol';
 import { IPositionManagerDerivedState } from './interfaces/position/IPositionManagerDerivedState.sol';
-import { Position }                     from './interfaces/position/IPositionManagerState.sol';
 
 import { ERC20PoolFactory }  from './ERC20PoolFactory.sol';
 import { ERC721PoolFactory } from './ERC721PoolFactory.sol';
@@ -39,7 +38,6 @@ import { PositionNFTSVG } from './libraries/external/PositionNFTSVG.sol';
  *          - `burn` positions `NFT`
  */
 contract PositionManager is PermitERC721, IPositionManager, Multicall, ReentrancyGuard {
-
     using EnumerableSet for EnumerableSet.UintSet;
     using SafeERC20     for ERC20;
 
@@ -54,12 +52,8 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
     /*** State Variables ***/
     /***********************/
 
-    /// @dev Mapping tracking a positions state in a bucket index.
-    mapping(uint256 tokenId => mapping(uint256 index => Position)) internal positions;
-    /// @dev Mapping tracking indexes to which a position is associated.
-    mapping(uint256 tokenId => EnumerableSet.UintSet)              internal positionIndexes;
-    /// @dev Mapping tracking information about a position.
-    mapping(uint256 tokenId => TokenInfo)                          internal tokenInfo;
+    /// @dev Mapping tracking information of position tokens minted.
+    mapping(uint256 tokenId => TokenInfo) internal positionTokens;
 
     /// @dev Id of the next token that will be minted. Skips `0`.
     uint176 private _nextId = 1;
@@ -116,7 +110,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         if (!_isApprovedOrOwner(msg.sender, tokenId_)) revert NoAuth();
 
         // revert if the token id is not minted for given pool address
-        if (pool_ != tokenInfo[tokenId_].pool) revert WrongPool();
+        if (pool_ != positionTokens[tokenId_].pool) revert WrongPool();
 
         _;
     }
@@ -129,7 +123,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
     modifier recordAdjustmentTime(uint256 tokenId_) {
         _;
 
-        tokenInfo[tokenId_].adjustmentTime = uint96(block.timestamp);
+        positionTokens[tokenId_].adjustmentTime = uint96(block.timestamp);
     }
 
     /*******************/
@@ -171,11 +165,11 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_
     ) external override mayInteract(pool_, tokenId_) {
         // revert if trying to burn an positions token that still has liquidity
-        if (positionIndexes[tokenId_].length() != 0) revert LiquidityNotRemoved();
+        if (positionTokens[tokenId_].positionIndexes.length() != 0) revert LiquidityNotRemoved();
 
         // remove permit nonces and pool mapping for burned token
         delete _nonces[tokenId_];
-        delete tokenInfo[tokenId_];
+        delete positionTokens[tokenId_];
 
         _burn(tokenId_);
 
@@ -205,16 +199,17 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256[] calldata indexes_
     ) external mayInteract(pool_, tokenId_) override {
-        EnumerableSet.UintSet storage positionIndex = positionIndexes[tokenId_];
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
+        EnumerableSet.UintSet storage positionIndexes = tokenInfo.positionIndexes;
 
         IPool   pool  = IPool(pool_);
         address owner = ownerOf(tokenId_);
+
         LendersBucketLocalVars memory vars;
 
         // local vars used in for loop for reduced gas
         uint256 index;
         uint256 indexesLength = indexes_.length;
-        mapping(uint256 => Position) storage _position = positions[tokenId_];
 
         // loop through all bucket indexes and memorialize lp balance and deposit time to the Position.
         for (uint256 i = 0; i < indexesLength; ) {
@@ -222,7 +217,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
 
             // record bucket index at which a position has added liquidity
             // slither-disable-next-line unused-return
-            positionIndex.add(index);
+            positionIndexes.add(index);
 
             (vars.lpBalance, vars.depositTime) = pool.lenderInfo(index, owner);
 
@@ -231,7 +226,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
 
             if (vars.allowance < vars.lpBalance) revert AllowanceTooLow();
 
-            Position memory position = _position[index];
+            Position memory position = tokenInfo.positions[index];
 
             // check for previous deposits
             if (position.depositTime != 0) {
@@ -248,7 +243,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
             position.depositTime = vars.depositTime;
 
             // save position in storage
-            _position[index] = position;
+            tokenInfo.positions[index] = position;
 
             unchecked { ++i; }
         }
@@ -280,7 +275,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         tokenId_ = _nextId++;
 
         // record which pool the tokenId was minted in
-        tokenInfo[tokenId_].pool = pool_;
+        positionTokens[tokenId_].pool = pool_;
 
         _mint(recipient_, tokenId_);
 
@@ -315,7 +310,8 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 toIndex_,
         uint256 expiry_
     ) external override nonReentrant mayInteract(pool_, tokenId_) recordAdjustmentTime(tokenId_) {
-        Position storage fromPosition = positions[tokenId_][fromIndex_];
+        TokenInfo storage tokenInfo    = positionTokens[tokenId_];
+        Position  storage fromPosition = tokenInfo.positions[fromIndex_];
 
         MoveLiquidityLocalVars memory vars;
         vars.fromDepositTime = fromPosition.depositTime;
@@ -359,19 +355,19 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
             expiry_
         );
 
-        EnumerableSet.UintSet storage positionIndex = positionIndexes[tokenId_];
+        EnumerableSet.UintSet storage positionIndexes = tokenInfo.positionIndexes;
 
         // 1. update FROM memorialized position
-        if (!positionIndex.remove(fromIndex_)) revert RemovePositionFailed(); // revert if FROM position is not in memorialized indexes
+        if (!positionIndexes.remove(fromIndex_)) revert RemovePositionFailed(); // revert if FROM position is not in memorialized indexes
         if (vars.fromLP != vars.lpbAmountFrom) revert RemovePositionFailed(); // bucket has collateral and quote therefore LP is not redeemable for full quote token amount
 
-        delete positions[tokenId_][fromIndex_]; // remove memorialized FROM position
+        delete tokenInfo.positions[fromIndex_]; // remove memorialized FROM position
 
         // 2. update TO memorialized position
         // slither-disable-next-line unused-return
-        positionIndex.add(toIndex_); // record the TO memorialized position
+        positionIndexes.add(toIndex_); // record the TO memorialized position
 
-        Position storage toPosition = positions[tokenId_][toIndex_];
+        Position storage toPosition = tokenInfo.positions[toIndex_];
         vars.toDepositTime = toPosition.depositTime;
 
         // reset LP in TO memorialized position if bucket went bankrupt after memorialization
@@ -419,7 +415,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256[] calldata indexes_
     ) external override mayInteract(pool_, tokenId_) recordAdjustmentTime(tokenId_) {
-        EnumerableSet.UintSet storage positionIndex = positionIndexes[tokenId_];
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
 
         IPool pool = IPool(pool_);
 
@@ -427,13 +423,12 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 index;
         uint256 indexesLength = indexes_.length;
         uint256[] memory lpAmounts = new uint256[](indexesLength);
-        mapping(uint256 => Position) storage _position = positions[tokenId_];
 
         // retrieve LP amounts from each bucket index associated with token id
         for (uint256 i = 0; i < indexesLength; ) {
             index = indexes_[i];
 
-            Position memory position = _position[index];
+            Position memory position = tokenInfo.positions[index];
 
             if (position.lps == 0 || position.depositTime == 0) revert RemovePositionFailed();
 
@@ -441,12 +436,12 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
             if (_bucketBankruptAfterDeposit(pool, index, position.depositTime)) revert BucketBankrupt();
 
             // remove bucket index at which a position has added liquidity
-            if (!positionIndex.remove(index)) revert RemovePositionFailed();
+            if (!tokenInfo.positionIndexes.remove(index)) revert RemovePositionFailed();
 
             lpAmounts[i] = position.lps;
 
             // remove LP tracked by position manager at bucket index
-            delete _position[index];
+            delete tokenInfo.positions[index];
 
             unchecked { ++i; }
         }
@@ -478,7 +473,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
     ) internal override {
         // burning is not constrained by any redeem action
         if (to_ != address(0)) {
-            TokenInfo storage token = tokenInfo[tokenId_];
+            TokenInfo storage token = positionTokens[tokenId_];
             // revert transfer in case token positions were redeem in the last transfer lock period
             if (block.timestamp - token.adjustmentTime <= TRANSFER_LOCK_PERIOD) revert TransferLocked();
 
@@ -539,30 +534,32 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256 index_
     ) external override view returns (uint256) {
-        Position memory position = positions[tokenId_][index_];
-        return _bucketBankruptAfterDeposit(IPool(tokenInfo[tokenId_].pool), index_, position.depositTime) ? 0 : position.lps;
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
+        Position memory position = tokenInfo.positions[index_];
+        return _bucketBankruptAfterDeposit(IPool(tokenInfo.pool), index_, position.depositTime) ? 0 : position.lps;
     }
 
     /// @inheritdoc IPositionManagerDerivedState
     function getPositionIndexes(
         uint256 tokenId_
     ) external view override returns (uint256[] memory) {
-        return positionIndexes[tokenId_].values();
+        return positionTokens[tokenId_].positionIndexes.values();
     }
 
     /// @inheritdoc IPositionManagerDerivedState
     function getPositionIndexesFiltered(
         uint256 tokenId_
     ) external view override returns (uint256[] memory filteredIndexes_) {
-        uint256[] memory indexes = positionIndexes[tokenId_].values();
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
+        uint256[] memory indexes = tokenInfo.positionIndexes.values();
         uint256 indexesLength = indexes.length;
 
         // filter out bankrupt buckets
         filteredIndexes_ = new uint256[](indexesLength);
         uint256 filteredIndexesLength = 0;
-        IPool pool = IPool(tokenInfo[tokenId_].pool);
+        IPool pool = IPool(tokenInfo.pool);
         for (uint256 i = 0; i < indexesLength; ) {
-            if (!_bucketBankruptAfterDeposit(pool, indexes[i], positions[tokenId_][indexes[i]].depositTime)) {
+            if (!_bucketBankruptAfterDeposit(pool, indexes[i], tokenInfo.positions[indexes[i]].depositTime)) {
                 filteredIndexes_[filteredIndexesLength++] = indexes[i];
             }
             unchecked { ++i; }
@@ -577,7 +574,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256 index_
     ) external view override returns (uint256, uint256) {
-        Position memory position = positions[tokenId_][index_];
+        Position memory position = positionTokens[tokenId_].positions[index_];
         return (
             position.lps,
             position.depositTime
@@ -586,7 +583,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
 
     /// @inheritdoc IPositionManagerDerivedState
     function poolKey(uint256 tokenId_) external view override returns (address) {
-        return tokenInfo[tokenId_].pool;
+        return positionTokens[tokenId_].pool;
     }
 
     /// @inheritdoc IPositionManagerDerivedState
@@ -602,7 +599,8 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256 index_
     ) external view override returns (bool) {
-        return _bucketBankruptAfterDeposit(IPool(tokenInfo[tokenId_].pool), index_, positions[tokenId_][index_].depositTime);
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
+        return _bucketBankruptAfterDeposit(IPool(tokenInfo.pool), index_, tokenInfo.positions[index_].depositTime);
     }
 
     /// @inheritdoc IPositionManagerDerivedState
@@ -610,7 +608,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
         uint256 tokenId_,
         uint256 index_
     ) external override view returns (bool) {
-        return positionIndexes[tokenId_].contains(index_);
+        return positionTokens[tokenId_].positionIndexes.contains(index_);
     }
 
     /**
@@ -621,7 +619,8 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
     ) public view override returns (string memory) {
         if (!_exists(tokenId_)) revert NoToken();
 
-        address pool = tokenInfo[tokenId_].pool;
+        TokenInfo storage tokenInfo = positionTokens[tokenId_];
+        address pool = tokenInfo.pool;
 
         address collateralTokenAddress = IPool(pool).collateralAddress();
         address quoteTokenAddress      = IPool(pool).quoteTokenAddress();
@@ -632,7 +631,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
             tokenId:               tokenId_,
             pool:                  pool,
             owner:                 ownerOf(tokenId_),
-            indexes:               positionIndexes[tokenId_].values()
+            indexes:               tokenInfo.positionIndexes.values()
         });
 
         return PositionNFTSVG.constructTokenURI(params);

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -182,8 +182,8 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
      *  @dev    - `lenderInfo()`: get lender position in bucket
      *  @dev    - `transferLP()`: transfer `LP` ownership to `PositionManager` contract
      *  @dev    === Write state ===
-     *  @dev    `positionIndexes`: add bucket index
-     *  @dev    `positions`: update `tokenId => bucket id` position
+     *  @dev    `TokenInfo.positionIndexes`: add bucket index
+     *  @dev    `TokenInfo.positions`: update `tokenId => bucket id` position
      *  @dev    === Revert on ===
      *  @dev    - `mayInteract`:
      *  @dev       token id is not a valid / minted id
@@ -288,10 +288,10 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
      *  @dev    `bucketInfo()`: get from bucket info
      *  @dev    `moveQuoteToken()`: move liquidity between buckets
      *  @dev    === Write state ===
-     *  @dev    `positionIndexes`: remove from bucket index
-     *  @dev    `positionIndexes`: add to bucket index
-     *  @dev    `positions`: update from bucket position
-     *  @dev    `positions`: update to bucket position
+     *  @dev    `TokenInfo.positionIndexes`: remove from bucket index
+     *  @dev    `TokenInfo.positionIndexes`: add to bucket index
+     *  @dev    `TokenInfo.positions`: update from bucket position
+     *  @dev    `TokenInfo.positions`: update to bucket position
      *  @dev    === Revert on ===
      *  @dev    - `mayInteract`:
      *  @dev      token id is not a valid / minted id

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -10,6 +10,16 @@ import { EnumerableSet } from '@openzeppelin/contracts/utils/structs/EnumerableS
 interface IPositionManagerState {
 
     /**
+    * @dev Struct holding Position `LP` state.
+    * @param lps         [WAD] position LP.
+    * @param depositTime Deposit time for position
+    */
+    struct Position {
+        uint256 lps;
+        uint256 depositTime;
+    }
+
+    /**
     * @dev Struct tracking a position token info.
     * @param pool            The pool address associated with the position.
     * @param adjustmentTime  The time of last adjustment to the position.
@@ -21,16 +31,6 @@ interface IPositionManagerState {
         uint96 adjustmentTime;
         EnumerableSet.UintSet positionIndexes;
         mapping(uint256 index => Position) positions;
-    }
-
-    /**
-    * @dev Struct holding Position `LP` state.
-    * @param lps         [WAD] position LP.
-    * @param depositTime Deposit time for position
-    */
-    struct Position {
-        uint256 lps;
-        uint256 depositTime;
     }
 
 }

--- a/src/interfaces/position/IPositionManagerState.sol
+++ b/src/interfaces/position/IPositionManagerState.sol
@@ -2,25 +2,35 @@
 
 pragma solidity 0.8.18;
 
+import { EnumerableSet } from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
 /**
  * @title Positions Manager State
  */
 interface IPositionManagerState {
 
     /**
-     * @dev Struct tracking a Position's global state.
-     * @param pool The pool address associated with the position.
-     * @param adjustmentTime The time of last adjustment to the position.
-     */
+    * @dev Struct tracking a position token info.
+    * @param pool            The pool address associated with the position.
+    * @param adjustmentTime  The time of last adjustment to the position.
+    * @param positionIndexes Mapping tracking indexes to which a position is associated.
+    * @param positions       Mapping tracking a positions state in a bucket index.
+    */
     struct TokenInfo {
-        address pool;       // pool address associated with the position
-        uint96 adjustmentTime; // time of last adjustment to the position
+        address pool;
+        uint96 adjustmentTime;
+        EnumerableSet.UintSet positionIndexes;
+        mapping(uint256 index => Position) positions;
     }
 
-}
+    /**
+    * @dev Struct holding Position `LP` state.
+    * @param lps         [WAD] position LP.
+    * @param depositTime Deposit time for position
+    */
+    struct Position {
+        uint256 lps;
+        uint256 depositTime;
+    }
 
-/// @dev Struct holding Position `LP` state.
-struct Position {
-    uint256 lps;         // [WAD] position LP
-    uint256 depositTime; // deposit time for position
 }


### PR DESCRIPTION
 - minor gas savings, better code readability

gas pre change:
```
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
|--------------------------------------------------|-----------------|--------|--------|---------|---------|                                                                                                                                                                                                                                                                                                                             
| Deployment Cost                                  | Deployment Size |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
| 3881851                                          | 19984           |        |        |         |         |                                                                                                                                                                                                                                                                                                                             
| Function Name                                    | min             | avg    | median | max     | # calls |
| DOMAIN_SEPARATOR                                 | 732             | 732    | 732    | 732     | 9       |
| PERMIT_TYPEHASH                                  | 426             | 426    | 426    | 426     | 8       |
| approve(address,uint256)                         | 2722            | 22570  | 25302  | 25302   | 9       |
| approve(address,uint256)(bool)                   | 25302           | 25302  | 25302  | 25302   | 51      |
| burn                                             | 1838            | 5372   | 5982   | 10862   | 13      |
| getLP                                            | 6658            | 8878   | 8014   | 36386   | 288     |
| getPositionIndexes                               | 1674            | 2254   | 2144   | 3790    | 249     |
| getPositionIndexesFiltered                       | 8940            | 29438  | 26424  | 79674   | 325     |
| getPositionInfo                                  | 1047            | 2297   | 1047   | 5047    | 16      |
| isAjnaPool                                       | 955             | 6503   | 6824   | 10871   | 35      |
| isIndexInPosition                                | 1060            | 1623   | 1060   | 3060    | 71      |
| isPositionBucketBankrupt                         | 6928            | 7944   | 8148   | 9716    | 18      |
| memorializePositions                             | 6459            | 80303  | 73744  | 1154607 | 3089    |
| mint                                             | 10529           | 88970  | 95859  | 100859  | 94      |
| moveLiquidity                                    | 5261            | 201398 | 164810 | 669964  | 20      |
| nonces                                           | 841             | 1817   | 1746   | 2841    | 8       |
| ownerOf                                          | 836             | 836    | 836    | 882     | 186     |
| permit                                           | 1290            | 23250  | 17585  | 44417   | 9       |
| poolKey                                          | 807             | 807    | 807    | 807     | 54      |
| redeemPositions                                  | 2855            | 41116  | 59312  | 142299  | 29      |
| safeTransferFrom                                 | 24320           | 36742  | 41791  | 42191   | 7       |
| tokenURI                                         | 3157            | 468651 | 468651 | 934146  | 2       |
| transferFrom(address,address,uint256)            | 20699           | 32302  | 39819  | 42144   | 13      |
| transferFrom(address,address,uint256)(bool)      | 20699           | 28692  | 24624  | 42144   | 71      |
```

gas post change
```
| src/PositionManager.sol:PositionManager contract |                 |        |        |         |         |
|--------------------------------------------------|-----------------|--------|--------|---------|---------|
| Deployment Cost                                  | Deployment Size |        |        |         |         |
| 3880451                                          | 19977           |        |        |         |         |
| Function Name                                    | min             | avg    | median | max     | # calls |
| DOMAIN_SEPARATOR                                 | 732             | 732    | 732    | 732     | 9       |
| PERMIT_TYPEHASH                                  | 426             | 426    | 426    | 426     | 8       |
| approve(address,uint256)                         | 25302           | 25587  | 25302  | 27302   | 14      |
| approve(address,uint256)(bool)                   | 2722            | 25240  | 25302  | 27302   | 74      |
| burn                                             | 1838            | 5497   | 6303   | 11183   | 13      |
| getLP                                            | 6588            | 10996  | 8190   | 36316   | 423     |
| getPositionIndexes                               | 1680            | 3008   | 2150   | 14620   | 418     |
| getPositionIndexesFiltered                       | 8810            | 28366  | 26150  | 78896   | 584     |
| getPositionInfo                                  | 1053            | 2303   | 1053   | 5053    | 16      |
| isAjnaPool                                       | 955             | 7465   | 6824   | 20824   | 48      |
| isIndexInPosition                                | 1066            | 1629   | 1066   | 3066    | 71      |
| isPositionBucketBankrupt                         | 6900            | 7916   | 8120   | 9688    | 18      |
| memorializePositions                             | 6459            | 84262  | 73687  | 1154681 | 3120    |
| mint                                             | 10528           | 88656  | 95859  | 100859  | 125     |
| moveLiquidity                                    | 5261            | 201277 | 164645 | 669758  | 20      |
| nonces                                           | 841             | 1817   | 1746   | 2841    | 8       |
| ownerOf                                          | 836             | 836    | 836    | 882     | 246     |
| permit                                           | 1290            | 23250  | 17585  | 44417   | 9       |
| poolKey                                          | 807             | 1099   | 807    | 2807    | 82      |
| redeemPositions                                  | 2855            | 41081  | 59272  | 142273  | 29      |
| safeTransferFrom                                 | 24320           | 36742  | 41791  | 42191   | 7       |
| tokenURI                                         | 3157            | 468625 | 468625 | 934094  | 2       |
| transferFrom(address,address,uint256)            | 20699           | 31296  | 30208  | 42144   | 26      |
| transferFrom(address,address,uint256)(bool)      | 20699           | 31984  | 30208  | 42144   | 90      |
```