### PR TITLE
Add Helper method for updating post draw/repay debt actions, set optmizer runs to 200

### DIFF
--- a/brownie-config.yml
+++ b/brownie-config.yml
@@ -17,7 +17,7 @@ compiler:
     version: 0.8.18
     optimizer:
       enabled: true
-      runs: 0
+      runs: 200
     remappings:
       - "@ds-math=lib/ds-math/src/"
       - "@openzeppelin/contracts=lib/openzeppelin-contracts/contracts"

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ block_number        = 16_295_000
 fork_block_number   = 16_295_000
 rpc_storage_caching = { chains = ["mainnet"], endpoints = "all" }
 optimizer           = true
-optimizer_runs      = 0
+optimizer_runs      = 200
 fs_permissions      = [{ access = "read-write", path = "./"}]
 
 [fuzz]

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -95,16 +95,16 @@ struct RemoveQuoteParams {
 
 /// @dev Struct used to return result of `BorrowerActions.drawDebt` and `BorrowerActions.repayDebt` actions.
 struct DebtChangeResult {
-    bool    inAuction;             // true if loan still in auction after pledge more collateral, false otherwise
+    bool    inAuction;             // true if loan still in auction after pledge more collateral / repay debt, false otherwise
     uint256 newLup;                // [WAD] new pool LUP after draw debt
-    uint256 poolCollateral;        // [WAD] total amount of collateral in pool after pledge collateral
+    uint256 poolCollateral;        // [WAD] total amount of collateral in pool after pledge / pull collateral
     uint256 poolDebt;              // [WAD] total accrued debt in pool after draw debt
-    uint256 remainingCollateral;   // [WAD] amount of borrower collateral after draw debt (for NFT can be diminished if auction settled)
-    bool    settledAuction;        // true if collateral pledged settles auction
-    uint256 t0DebtInAuctionChange; // [WAD] change of t0 pool debt in auction after pledge collateral
-    uint256 t0PoolDebt;            // [WAD] amount of t0 debt in pool after draw debt
-    uint256 debtPreAction;         // [WAD] The amount of borrower t0 debt before draw debt
-    uint256 debtPostAction;        // [WAD] The amount of borrower t0 debt after draw debt
-    uint256 collateralPreAction;   // [WAD] The amount of borrower collateral before draw debt
-    uint256 collateralPostAction;  // [WAD] The amount of borrower collateral after draw debt
+    uint256 remainingCollateral;   // [WAD] amount of borrower collateral after draw debt / pull collateral (for NFT can be diminished if auction settled)
+    bool    settledAuction;        // true if collateral pledged / repay debt settles auction
+    uint256 t0DebtInAuctionChange; // [WAD] change of t0 pool debt in auction after pledge collateral / repay debt
+    uint256 t0PoolDebt;            // [WAD] amount of t0 debt in pool after draw debt / repay debt
+    uint256 debtPreAction;         // [WAD] The amount of borrower t0 debt before draw debt / repay debt
+    uint256 debtPostAction;        // [WAD] The amount of borrower t0 debt after draw debt / repay debt
+    uint256 collateralPreAction;   // [WAD] The amount of borrower collateral before draw debt / repay debt
+    uint256 collateralPostAction;  // [WAD] The amount of borrower collateral after draw debt / repay debt
 }

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -93,8 +93,8 @@ struct RemoveQuoteParams {
 /*** Loan Management Param Structs ***/
 /*************************************/
 
-/// @dev Struct used to return result of `BorrowerActions.drawDebt` action.
-struct DrawDebtResult {
+/// @dev Struct used to return result of `BorrowerActions.drawDebt` and `BorrowerActions.repayDebt` actions.
+struct DebtChangeResult {
     bool    inAuction;             // true if loan still in auction after pledge more collateral, false otherwise
     uint256 newLup;                // [WAD] new pool LUP after draw debt
     uint256 poolCollateral;        // [WAD] total amount of collateral in pool after pledge collateral
@@ -107,21 +107,4 @@ struct DrawDebtResult {
     uint256 debtPostAction;        // [WAD] The amount of borrower t0 debt after draw debt
     uint256 collateralPreAction;   // [WAD] The amount of borrower collateral before draw debt
     uint256 collateralPostAction;  // [WAD] The amount of borrower collateral after draw debt
-}
-
-/// @dev Struct used to return result of `BorrowerActions.repayDebt` action.
-struct RepayDebtResult {
-    bool    inAuction;             // true if loan still in auction after repay, false otherwise
-    uint256 newLup;                // [WAD] new pool LUP after draw debt
-    uint256 poolCollateral;        // [WAD] total amount of collateral in pool after pull collateral
-    uint256 poolDebt;              // [WAD] total accrued debt in pool after repay debt
-    uint256 remainingCollateral;   // [WAD] amount of borrower collateral after pull collateral
-    bool    settledAuction;        // true if repay debt settles auction
-    uint256 t0DebtInAuctionChange; // [WAD] change of t0 pool debt in auction after repay debt
-    uint256 t0PoolDebt;            // [WAD] amount of t0 debt in pool after repay
-    uint256 quoteTokenToRepay;     // [WAD] quote token amount to be transferred from sender to pool
-    uint256 debtPreAction;         // [WAD] The amount of borrower t0 debt before repay debt
-    uint256 debtPostAction;        // [WAD] The amount of borrower t0 debt after repay debt
-    uint256 collateralPreAction;   // [WAD] The amount of borrower collateral before repay debt
-    uint256 collateralPostAction;  // [WAD] The amount of borrower collateral after repay debt
 }

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -9,11 +9,10 @@ import {
     DepositsState,
     LoansState,
     PoolState
-}                   from '../../interfaces/pool/commons/IPoolState.sol';
+}                    from '../../interfaces/pool/commons/IPoolState.sol';
 import {
-    DrawDebtResult,
-    RepayDebtResult
-}                   from '../../interfaces/pool/commons/IPoolInternals.sol';
+    DebtChangeResult
+}                    from '../../interfaces/pool/commons/IPoolInternals.sol';
 
 import {
     _borrowFeeRate,
@@ -122,7 +121,7 @@ library BorrowerActions {
         uint256 limitIndex_,
         uint256 collateralToPledge_
     ) external returns (
-        DrawDebtResult memory result_
+        DebtChangeResult memory result_
     ) {
         // revert if not enough pool balance to borrow
         if (amountToBorrow_ > maxAvailable_) revert InsufficientLiquidity();
@@ -278,7 +277,8 @@ library BorrowerActions {
         uint256 collateralAmountToPull_,
         uint256 limitIndex_
     ) external returns (
-        RepayDebtResult memory result_
+        DebtChangeResult memory result_,
+        uint256 quoteTokenToRepay_
     ) {
         RepayDebtLocalVars memory vars;
         vars.repay = maxQuoteTokenAmountToRepay_ != 0;
@@ -311,9 +311,10 @@ library BorrowerActions {
                 );
             }
 
-            result_.t0PoolDebt        -= vars.t0RepaidDebt;
-            result_.poolDebt          = Maths.wmul(result_.t0PoolDebt, poolState_.inflator);
-            result_.quoteTokenToRepay = Maths.ceilWmul(vars.t0RepaidDebt,  poolState_.inflator);
+            result_.t0PoolDebt -= vars.t0RepaidDebt;
+            result_.poolDebt   = Maths.wmul(result_.t0PoolDebt, poolState_.inflator);
+
+            quoteTokenToRepay_ = Maths.ceilWmul(vars.t0RepaidDebt,  poolState_.inflator);
 
             vars.borrowerDebt = Maths.wmul(borrower.t0Debt - vars.t0RepaidDebt, poolState_.inflator);
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* Reduce duplicated code by:
  * use same `DebtChangeResult` struct to return result of `BorrowerActions.drawDebt` and `BorrowerActions.repayDebt` (that is instead `RepayDebtResult` and `DrawDebtResult` structs). Return `quoteTokenToRepay_` var on repayDebt` in addition to struct
  * concentrate logic for update state after repay / draw debt in single `Pool._updatePostDebtChangeState` function. Used in `ERC20Pool` and `ERC721Pool` functions for `drawDebt` and `repayDebt`
* Set optimizer runs to 200 as contracts have now enough space

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,350B  (99.08%)
  ERC20Pool                -  23,578B  (95.94%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool         -  24,426B  (99.39%)
  ERC20Pool          -  23,624B  (96.12%)
```

# Gas usage
## Pre Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 122500          | 179774 | 164363 | 745043  | 60004   |
| bucketTake                           | 309224          | 327865 | 327866 | 346507  | 4       |
| drawDebt                             | 253186          | 298177 | 272082 | 812414  | 136003  |
| kick                                 | 149467          | 223488 | 221980 | 1034805 | 48000   |
| kickWithDeposit                      | 199590          | 277221 | 273367 | 1000575 | 8000    |
| moveQuoteToken                       | 272093          | 272093 | 272093 | 272093  | 1       |
| removeQuoteToken                     | 146623          | 171438 | 176084 | 195785  | 4000    |
| repayDebt                            | 586918          | 614064 | 601909 | 757316  | 16002   |
| settle                               | 350544          | 350544 | 350544 | 350544  | 1       |
| take                                 | 81772           | 83349  | 83084  | 315391  | 15998   |
```
## Post Change
```
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 120673          | 177845 | 162532 | 711953  | 60004   |
| bucketTake                           | 307543          | 326184 | 326184 | 344825  | 4       |
| drawDebt                             | 250710          | 295582 | 269534 | 808956  | 136003  |
| kick                                 | 148535          | 222510 | 221011 | 1033120 | 48000   |
| kickWithDeposit                      | 197510          | 275111 | 271257 | 997796  | 8000    |
| moveQuoteToken                       | 277524          | 277524 | 277524 | 277524  | 1       |
| removeQuoteToken                     | 144472          | 168273 | 172636 | 194707  | 4000    |
| repayDebt                            | 584550          | 611697 | 599542 | 754949  | 16002   |
| settle                               | 348772          | 348772 | 348772 | 348772  | 1       |
| take                                 | 80713           | 82316  | 82064  | 313356  | 15998   |
```

