### PR TITLE
`updateRewardsClaimed()` and `rewardsClaimed()` become inaccurate once rewardsManager is out of ajna

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -828,43 +828,43 @@ contract RewardsManager is IRewardsManager {
     }
 }
 
-    /**********************/
-    /** Rewards Utilities */
-    /**********************/
+/**********************/
+/** Rewards Utilities */
+/**********************/
 
-    /**
-     *  @notice Retrieve the total ajna tokens burned and total interest earned over a given epoch.
-     *  @param  pool_   Address of the `Ajna` pool to retrieve accumulators of.
-     *  @param  epoch_  time window used to identify time between Ajna burn events (kickReserve and takeReserve actions).
-     *  @return currentBurnTime_ timestamp of the latest burn event.
-     *  @return tokensBurned_    total `Ajna` tokens burned in epoch.
-     *  @return interestEarned_  total interest earned in epoch.
-     */
-    function _getEpochInfo(
-        address pool_,
-        uint256 epoch_
-    ) view returns (uint256 currentBurnTime_, uint256 tokensBurned_, uint256 interestEarned_) {
+/**
+*  @notice Retrieve the total ajna tokens burned and total interest earned over a given epoch.
+*  @param  pool_   Address of the `Ajna` pool to retrieve accumulators of.
+*  @param  epoch_  time window used to identify time between Ajna burn events (kickReserve and takeReserve actions).
+*  @return currentBurnTime_ timestamp of the latest burn event.
+*  @return tokensBurned_    total `Ajna` tokens burned in epoch.
+*  @return interestEarned_  total interest earned in epoch.
+*/
+function _getEpochInfo(
+    address pool_,
+    uint256 epoch_
+) view returns (uint256 currentBurnTime_, uint256 tokensBurned_, uint256 interestEarned_) {
 
-        // 0 epoch won't have any ajna burned or interest associated with it
-        if (epoch_ != 0) {
+    // 0 epoch won't have any ajna burned or interest associated with it
+    if (epoch_ != 0) {
 
-            uint256 totalInterestLatest;
-            uint256 totalBurnedLatest;
+        uint256 totalInterestLatest;
+        uint256 totalBurnedLatest;
 
-            (
-                currentBurnTime_,
-                totalInterestLatest,
-                totalBurnedLatest
-            ) = IPool(pool_).burnInfo(epoch_);
+        (
+            currentBurnTime_,
+            totalInterestLatest,
+            totalBurnedLatest
+        ) = IPool(pool_).burnInfo(epoch_);
 
-            (
-                ,
-                uint256 totalInterestPrev,
-                uint256 totalBurnedPrev
-            ) = IPool(pool_).burnInfo(epoch_ - 1);
+        (
+            ,
+            uint256 totalInterestPrev,
+            uint256 totalBurnedPrev
+        ) = IPool(pool_).burnInfo(epoch_ - 1);
 
-            // calculate total tokens burned and interest earned in epoch
-            tokensBurned_   = totalBurnedLatest   != 0 ? totalBurnedLatest   - totalBurnedPrev   : 0;
-            interestEarned_ = totalInterestLatest != 0 ? totalInterestLatest - totalInterestPrev : 0;
-        }
+        // calculate total tokens burned and interest earned in epoch
+        tokensBurned_   = totalBurnedLatest   != 0 ? totalBurnedLatest   - totalBurnedPrev   : 0;
+        interestEarned_ = totalInterestLatest != 0 ? totalInterestLatest - totalInterestPrev : 0;
     }
+}

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -347,7 +347,7 @@ contract RewardsManager is IRewardsManager {
         uint256 epoch = lastClaimedEpoch;
 
         // iterate through all burn periods to calculate and claim rewards
-        while (epoch <= epochToClaim_ && rewards_ <= maxReward_) {
+        while (epoch < epochToClaim_ && rewards_ <= maxReward_) {
             uint256 nextEpochRewards = _calculateNextEpochRewards(
                 tokenId_,
                 epoch,

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -2212,8 +2212,7 @@ contract RewardsManagerTest is RewardsHelperContract {
                 (, , uint256 lastInteractionEpoch) = _rewardsManager.getStakeInfo(randomNfts[j]);
 
                 // select random epoch to claim reward
-                uint256 epochToClaim = lastInteractionEpoch < _pool.currentBurnEpoch() ? randomInRange(lastInteractionEpoch + 1, _pool.currentBurnEpoch()) : lastInteractionEpoch; 
- 
+                uint256 epochToClaim = lastInteractionEpoch < _pool.currentBurnEpoch() ? randomInRange(lastInteractionEpoch + 1, _pool.currentBurnEpoch()) : lastInteractionEpoch;  
                 uint256 rewardsEarned = _rewardsManager.calculateRewards(randomNfts[j], epochToClaim);
                 assertGt(rewardsEarned, 0);
 

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -991,12 +991,15 @@ contract RewardsManagerTest is RewardsHelperContract {
         uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
         assertEq(managerBalance, 5 * 1e18);
 
-        // check reward generated are more than manager token balance
+        // check reward generated is equal to the manager token balance
         uint256 rewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertGt(rewards, managerBalance);
+        assertEq(rewards, managerBalance);
 
         // claimRewards should revert when user tries to claim more rewards than available in manager
         _assertClaimRewardsInsufficientLiquidityRevert(_minterOne, tokenIdOne, managerBalance + 1);
+
+        uint256 minterOneBal = _ajnaToken.balanceOf(address(_minterOne));
+        assertEq(minterOneBal, 0);
 
         // claimRewards should claim all available ajna token in manager
         _claimRewards({
@@ -1004,13 +1007,16 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             40.899541369720500568 * 1e18,
+            reward:             5.0 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
 
         // manager balance should be zero after all ajna tokens are claimed
         managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
         assertEq(managerBalance, 0);
+
+        minterOneBal = _ajnaToken.balanceOf(address(_minterOne));
+        assertEq(minterOneBal, 5.0 * 1e18);
     }
 
     function testMultiPeriodRewardsSingleClaim() external {
@@ -1792,14 +1798,31 @@ contract RewardsManagerTest is RewardsHelperContract {
         uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
         assertEq(managerBalance, 5 * 1e18);
 
-        // check reward generated are more than manager token balance
+        // check reward generated is equal to manager token balance
         uint256 rewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertGt(rewards, managerBalance);
+        assertEq(rewards, managerBalance);
 
-        // should revert when rewards are more than token balance
-        _assertUnstakeInsufficientLiquidityRevert(_minterOne, tokenIdOne);
+        uint256 minterOneBal = _ajnaToken.balanceOf(_minterOne);
+        assertEq(minterOneBal, 0);
+
+        // since rewards can never exceed the contract's balance, unstake works cleanly
+        _unstakeToken({
+            owner:                     _minterOne,
+            pool:                      address(_pool),
+            tokenId:                   tokenIdOne,
+            claimedArray:              _epochsClaimedArray(1, 0),
+            reward:                    5.000000000000000000 * 1e18,
+            indexes:                   depositIndexes,   
+            updateExchangeRatesReward: 0
+        });
+
+        minterOneBal = _ajnaToken.balanceOf(address(_minterOne));
+        assertEq(minterOneBal, 5 * 1e18);
 
         vm.revertTo(snapshot);
+
+        minterOneBal = _ajnaToken.balanceOf(address(_minterOne));
+        assertEq(minterOneBal, 0);
 
         // test when enough tokens in rewards manager contracts
         // _minterOne unstakes staked position
@@ -2049,17 +2072,18 @@ contract RewardsManagerTest is RewardsHelperContract {
         for (uint256 i = 0; i < deposits; ++i) {
 
             tokenIds[i] = _mintAndMemorializePositionNFT({
-                indexes: depositIndexes,
-                minter: minters[i],
+                indexes:    depositIndexes,
+                minter:     minters[i],
                 mintAmount: 1_000_000_000 * 1e18,
-                pool: address(_pool)
+                pool:       address(_pool)
             });
             tokenIdToMinter[tokenIds[i]] = minters[i];
             _stakeToken(address(_pool), minters[i], tokenIds[i]);
         }
 
         uint256 updaterBalance = _ajnaToken.balanceOf(_updater);
-
+        
+        // track the balances of each minter
         for (uint i = 0; i < deposits; i++) {
             minterToBalance[minters[i]] = _ajnaToken.balanceOf(minters[i]);
         }
@@ -2080,7 +2104,6 @@ contract RewardsManagerTest is RewardsHelperContract {
             assertEq(_ajnaToken.balanceOf(_updater), updaterBalance);
 
             changePrank(_updater);
-            assertEq(_ajnaToken.balanceOf(_updater), updaterBalance);
             _rewardsManager.updateBucketExchangeRatesAndClaim(
                 address(_pool), keccak256("ERC20_NON_SUBSET_HASH"), depositIndexes
             );
@@ -2104,11 +2127,11 @@ contract RewardsManagerTest is RewardsHelperContract {
 
                 // select random epoch to claim reward
                 uint256 epochToClaim = lastInteractionEpoch < _pool.currentBurnEpoch() ? randomInRange(lastInteractionEpoch + 1, _pool.currentBurnEpoch()) : lastInteractionEpoch; 
-                
+ 
                 uint256 rewardsEarned = _rewardsManager.calculateRewards(randomNfts[j], epochToClaim);
                 assertGt(rewardsEarned, 0);
 
-                _rewardsManager.claimRewards(randomNfts[j], _pool.currentBurnEpoch(), 0);
+                _rewardsManager.claimRewards(randomNfts[j], epochToClaim, 0);
 
                 // ensure user gets reward
                 assertGt(_ajnaToken.balanceOf(minterAddress), minterToBalance[minterAddress]);

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -2044,18 +2044,38 @@ contract RewardsManagerTest is RewardsHelperContract {
         assertEq(_rewardsManager.updateRewardsClaimed(_pool.currentBurnEpoch()), 0);
 
         // call update exchange rate to enable claiming rewards
-        // updater should earn 4.089954136972050057 ajna tokens but rewardsManager contract only has 3 remaining ajna tokens
-        // balance of updater is restricted to 3 ajna tokens
+        // updater should earn 4.089954136972050057 ajna tokens but rewardsManager contract only has 3
+        // updater rewards are restricted to 3 ajna tokens
         _updateExchangeRates({
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  3.0 * 1e18 // this event matches what is rewarded
+            reward:  3.0 * 1e18 // updater rewards are restricted to 3 ajna tokens
         });
 
         // The rewards claimed by updater should match the `updateRewardsClaimed` accumulator
         assertEq(_rewardsManager.updateRewardsClaimed(_pool.currentBurnEpoch()), _ajnaToken.balanceOf(_updater));
 
+        assertEq(_ajnaToken.balanceOf(address(_rewardsManager)), 0);
+        deal(address(_ajna), address(_rewardsManager), 5 * 1e18);
+        assertEq(_ajnaToken.balanceOf(address(_rewardsManager)), 5 * 1e18);
+
+        assertEq(_ajnaToken.balanceOf(_minterOne), 0);
+        assertEq(_rewardsManager.rewardsClaimed(_pool.currentBurnEpoch()), 0);
+
+        // claim rewards accrued since deposit
+        // claimer should earn 40.899541369720500568 * 1e18 ajna tokens but rewardsManager contract only has 5
+        _claimRewards({
+            pool:               address(_pool),
+            from:               _minterOne,
+            tokenId:            tokenId,
+            minAmountToReceive: 0,
+            reward:             5.0 * 1e18, // claimer rewards are restricted to 5 ajna tokens
+            epochsClaimed:      _epochsClaimedArray(1, 0)
+        });
+
+        // The rewards claimed should match the `rewardsClaimed` accumulator
+        assertEq(_rewardsManager.rewardsClaimed(_pool.currentBurnEpoch()), _ajnaToken.balanceOf(_minterOne)); 
     }
 
     /********************/


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* removed ajna balance restriction from `_transferAjnaRewards()`
* applied the ajna balance restriction on the rewarded amount in a new `enforceRewards()` method at a lower level in the logic flow. By applying the restriction at this depth `updateRewardsClaimed()` and `rewardsClaimed()` are altered properly across all calls against the contract.
* re-applied a ajna balance check inside `_calculateAndClaimAllRewards()` in the event `unstake()` is called and the caller should receive rewards for updating exchange rates and staking rewards
* added a `maxAmount_` argument to `_calculateAndClaimStakingRewards()` in order to ensure the amounts reduced from the `rewardsClaimed()` accumulator were accurate.
* SIDE EFFECT OF CHANGE: `calculateRewards()` now provides an accurate rewards calculation restricted by the ajna balance of the contract at the time the call is made.

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
There is a discrepancy in the `rewardsManger.sol` contract's reward accumulators and events when we apply the ajna balance restriction to the amount of rewards transferred to the updaters and staking claimers.
* `rewardsClaimed()` - was greater than the amount claimed by caller
* `updateRewardsClaimed()` - was greater than the amount claimed by caller
* `ClaimedRewards` event - was emitting a greater value then was actually claimed


# Contract size
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>

# Gas usage
## Pre Change
<PASTE_OUTPUT_HERE>
## Post Change
<PASTE_OUTPUT_HERE>

