### PR TITLE
Bug fix: Recalculate `LUP` after add in to bucket on `moveQuoteToken`

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -306,9 +306,7 @@ library LenderActions {
         Deposits.unscaledAdd(deposits_, params_.toIndex, Maths.wdiv(movedAmount_, vars.toBucketScale));
 
         // recalculate LUP after adding amount in to bucket only if to bucket price is greater than LUP
-        if (vars.toBucketPrice > lup_) {
-            lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        }
+        if (vars.toBucketPrice > lup_) lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -305,8 +305,10 @@ library LenderActions {
 
         Deposits.unscaledAdd(deposits_, params_.toIndex, Maths.wdiv(movedAmount_, vars.toBucketScale));
 
-        // recalculate LUP after adding amount in to bucket
-        lup_ = Deposits.getLup(deposits_, poolState_.debt);
+        // recalculate LUP after adding amount in to bucket only if to bucket price is greater than LUP
+        if (vars.toBucketPrice > lup_) {
+            lup_ = Deposits.getLup(deposits_, poolState_.debt);
+        }
 
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
 

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -49,7 +49,6 @@ library LenderActions {
         uint256 toBucketUnscaledDeposit;    // Amount of unscaled deposit in to bucket.
         uint256 toBucketDeposit;            // Amount of scaled deposit in to bucket.
         uint256 toBucketScale;              // Scale deposit of to bucket.
-        uint256 ptp;                        // [WAD] Pool Threshold Price.
         uint256 htp;                        // [WAD] Highest Threshold Price.
     }
 
@@ -305,6 +304,9 @@ library LenderActions {
         if (toBucketLP_ == 0) revert InsufficientLP();
 
         Deposits.unscaledAdd(deposits_, params_.toIndex, Maths.wdiv(movedAmount_, vars.toBucketScale));
+
+        // recalculate LUP after adding amount in to bucket
+        lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1099,7 +1099,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             toIndex:      4550,
             lpRedeemFrom: amountToMove,
             lpAwardTo:    amountToMove,
-            newLup:       _priceAt(4651)
+            newLup:       0.139445853940958153 * 1e18
         });
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* In `moveQuoteToken` `LUP` is calculated only after remove step and not recalculated after add step, which could result in wrong `LUP` used for calcuating interest state.
* `LUPBelowHTP` was also too restrictive when applied to in between calculated `LUP`
  * Fix should recalculate `LUP` after deposit is added in to bucket (only if to bucket price is greater than LUP). Additional gas required to recalculate `LUP` / traverse Fenwick one more time

# Gas usage
## Pre Change
```
| moveQuoteToken (ERC20)    | 847             | 142852 | 93525  | 632633 | 38      |
```
## Post Change
```
| moveQuoteToken (ERC20)    | 847             | 151597 | 106175 | 654859 | 37      |
```

