### PR TITLE
Invariants Improvements: Add `LUPBelowHTP` revert in `_ensurePositionManagerError` and renamed Position and Rewards regression contract

### DIFF
--- a/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedBasePositionHandler.sol
+++ b/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedBasePositionHandler.sol
@@ -82,7 +82,8 @@ abstract contract UnboundedBasePositionHandler is Test {
             err == keccak256(abi.encodeWithSignature("MoveToSameIndex()")) ||
             err == keccak256(abi.encodeWithSignature("RemoveDepositLockedByAuctionDebt()")) ||
             err == keccak256(abi.encodeWithSignature("DustAmountNotExceeded()")) ||
-            err == keccak256(abi.encodeWithSignature("InvalidIndex()")),
+            err == keccak256(abi.encodeWithSignature("InvalidIndex()")) ||
+            err == keccak256(abi.encodeWithSignature("LUPBelowHTP()")),
             "Unexpected revert error"
         );
     }

--- a/tests/forge/regression/PositionAndRewards/RegressionTestPositionManager.t.sol
+++ b/tests/forge/regression/PositionAndRewards/RegressionTestPositionManager.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.18;
 
 import { ERC20PoolPositionsInvariants } from "../../invariants/PositionsAndRewards/ERC20PoolPositionsInvariants.t.sol";
 
-contract RegressionPositionManager is ERC20PoolPositionsInvariants { 
+contract RegressionTestPositionManager is ERC20PoolPositionsInvariants { 
 
     function setUp() public override { 
         super.setUp();

--- a/tests/forge/regression/PositionAndRewards/RegressionTestRewardsManager.t.sol
+++ b/tests/forge/regression/PositionAndRewards/RegressionTestRewardsManager.t.sol
@@ -6,7 +6,7 @@ import { PoolInfoUtils }     from 'src/PoolInfoUtils.sol';
 
 import '@std/console.sol';
 
-contract RegressionRewardsManager is RewardsInvariants {
+contract RegressionTestRewardsManager is RewardsInvariants {
 
     function setUp() public override { 
         super.setUp();


### PR DESCRIPTION
# Description of change
## High level
* Add `LUPBelowHTP` revert in `_ensurePositionManagerError`.
* Renamed  `RegressionPositionManager` to `RegressionTestPositionManager` and  `RegressionRewardsManager` to `RegressionTestRewardsManager` to avoid regression test runs in invariants and unit tests.
