### PR TITLE
Sherlock-88: In `moveQuoteToken` ensure pool debt is less than deposits (if deposit fee applied)

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -311,7 +311,18 @@ library LenderActions {
         vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
-        if (params_.fromIndex < params_.toIndex && vars.htp > lup_) revert LUPBelowHTP();
+        if (
+            params_.fromIndex < params_.toIndex
+            &&
+            (
+                // check loan book's htp doesn't exceed new lup
+                vars.htp > lup_
+                ||
+                // ensure that pool debt < deposits after move
+                // this can happen if deposit fee is applied when moving amount
+                (poolState_.debt != 0 && poolState_.debt > Deposits.treeSum(deposits_))
+            )
+        ) revert LUPBelowHTP();
 
         // update lender and bucket LP balance in from bucket
         vars.fromBucketRemainingLP = vars.fromBucketLP - fromBucketRedeemedLP_;

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -722,6 +722,17 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).drawDebt(from, amount, indexLimit, 0);
     }
 
+    function _assertLupBelowHTPRevert(
+        address from,
+        uint256 amount,
+        uint256 fromIndex,
+        uint256 toIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.LUPBelowHTP.selector);
+        ERC20Pool(address(_pool)).moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max);
+    }
+
 }
 
 abstract contract ERC20HelperContract is ERC20DSTestPlus {

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -21,8 +21,8 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
         _lender    = makeAddr("lender");
         _lender1   = makeAddr("bidder");
 
-        _mintCollateralAndApproveTokens(_borrower,  100 * 1e18);
-        _mintCollateralAndApproveTokens(_borrower2,  200 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,   5_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower2,  5_000 * 1e18);
 
         _mintQuoteAndApproveTokens(_lender,   200_000 * 1e18);
         _mintQuoteAndApproveTokens(_lender1,  200_000 * 1e18);
@@ -910,6 +910,150 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
             index:       2777,
             lpBalance:   15_000 * 1e18,
             depositTime: _startTime
+        });
+    }
+
+    function testPoolMoveQuoteTokenRevertOnHTPLUP() external {
+
+        _addLiquidity({
+            from:    _lender,
+            amount:  40_000 * 1e18,
+            index:   2549,
+            lpAward: 40_000 * 1e18,
+            newLup:  MAX_PRICE
+        });
+        _addLiquidity({
+            from:    _lender,
+            amount:  10_000 * 1e18,
+            index:   2550,
+            lpAward: 10_000 * 1e18,
+            newLup:  MAX_PRICE
+        });   
+        _addLiquidity({   
+            from:    _lender,
+            amount:  20_000 * 1e18,
+            index:   2551,
+            lpAward: 20_000 * 1e18,
+            newLup:  MAX_PRICE
+        });
+
+        _addLiquidity({   
+            from:    _lender,
+            amount:  20_000 * 1e18,
+            index:   2540,
+            lpAward: 20_000 * 1e18,
+            newLup:  MAX_PRICE
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2549,
+            lpBalance:   40_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2540,
+            lpBalance:   20_000 * 1e18,
+            depositTime: _startTime
+        });
+        _assertLenderLpBalance({
+            lender:      _lender,
+            index:       2552,
+            lpBalance:   0,
+            depositTime: 0
+        });
+
+        uint256 snapshot = vm.snapshot();
+
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     89_000 * 1e18,
+            limitIndex:         7_388,
+            collateralToPledge: 30 * 1e18,
+            newLup:             2_995.912459898389633881 * 1e18
+        });
+
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              89_085.576923076923118000 * 1e18,
+            borrowerCollateral:        30.0 * 1e18,
+            borrowert0Np:              3_117.995192307692309130 * 1e18,
+            borrowerCollateralization: 1.008888047888587643 * 1e18
+        });
+
+        _drawDebt({
+            from:               _borrower2,
+            borrower:           _borrower2,
+            amountToBorrow:     900 * 1e18,
+            limitIndex:         7_388,
+            collateralToPledge: 5_000 * 1e18,
+            newLup:             2_995.912459898389633881 * 1e18
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  2_969.519230769230770600 * 1e18,
+                lup:                  2_995.912459898389633881 * 1e18,
+                poolSize:             90_000.000000000000000000 * 1e18,
+                pledgedCollateral:    5_030.0 * 1e18,
+                encumberedCollateral: 30.036405773600046352 * 1e18,
+                poolDebt:             89_986.442307692307733800 * 1e18,
+                actualUtilization:    0 * 1e18,
+                targetUtilization:    1.0 * 1e18,
+                minDebtAmount:        4_499.322115384615386690 * 1e18,
+                loans:                2,
+                maxBorrower:          _borrower,
+                interestRate:         0.050000000000000000 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+
+        // ensure htp > lup to fire error
+        _assertLupBelowHTPRevert({
+            from:         _lender,
+            fromIndex:    2549,
+            toIndex:      3000,
+            amount:       40_000 * 1e18
+        });
+
+        vm.revertTo(snapshot);
+
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     89_913 * 1e18,
+            limitIndex:         7_388,
+            collateralToPledge: 5_000 * 1e18,
+            newLup:             2_995.912459898389633881 * 1e18
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  17.999890961538461547 * 1e18,
+                lup:                  2_995.912459898389633881 * 1e18,
+                poolSize:             90_000.000000000000000000 * 1e18,
+                pledgedCollateral:    5000.0 * 1e18,
+                encumberedCollateral: 30.040749191565083066 * 1e18,
+                poolDebt:             89_999.454807692307733806 * 1e18,
+                actualUtilization:    0 * 1e18,
+                targetUtilization:    1.0 * 1e18,
+                minDebtAmount:        8_999.945480769230773381 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.050000000000000000 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+
+        skip(50 days);
+
+        // htp > lup && debt > deposit
+        _assertLupBelowHTPRevert({
+            from:         _lender,
+            fromIndex:    2549,
+            toIndex:      3000,
+            amount:       40_000 * 1e18
         });
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* see https://github.com/sherlock-audit/2023-04-ajna-judging/issues/88
* `moveQuoteToken` doesn't check if pool debt is not less than deposits
  * in `removeQuoteToken` after removing amount from deposit we revert if `HTP` > `LUP` or pool debt exceeds deposits
  * in `moveQuoteToken` we revert if `HTP` > `LUP` but don't check if pool debt exceeds deposits (unlikely but there's a chance when unutilized deposit fee is applied)
  * fixed by checking that, after move quote token, the pool debt doesn't exceed deposits

# Contract size
## Pre Change
```
 LenderActions            -  10,603B  (43.14%)
```
## Post Change
```
LenderActions            -  10,635B  (43.27%)
```

# Gas usage
## Pre Change
```
| moveQuoteToken                       | 847             | 143618 | 102184 | 632650 | 24      |
| moveQuoteToken                         | 40229           | 40326  | 40330  | 40417    | 4       |
```
## Post Change
```
| moveQuoteToken                       | 847             | 137806 | 102184 | 632831 | 24      |
| moveQuoteToken                         | 40229           | 40326  | 40330  | 40417    | 4       |
```

