### PR TITLE
Sherlock-104:  `PoolCommons._calculateInterestRate` make decrease rate condition inline with increase condition

### DIFF
--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -294,7 +294,7 @@ library PoolCommons {
         if (4 * (tu - mau102) < (((tu + mau102 - 1e18) / 1e9) ** 2) - 1e18) {
             newInterestRate_ = Maths.wmul(poolState_.rate, INCREASE_COEFFICIENT);
         // decrease rates if 4*(tu-mau) > 1-(tu+mau-1)^2
-        } else if (4 * (tu - mau) > 1e18 - ((tu + mau - 1e18) ** 2) / 1e18) {
+        } else if (4 * (tu - mau) > 1e18 - ((tu + mau - 1e18) / 1e9) ** 2) {
             newInterestRate_ = Maths.wmul(poolState_.rate, DECREASE_COEFFICIENT);
         }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* see https://github.com/sherlock-audit/2023-04-ajna-judging/issues/104
* in `PoolCommons._calculateInterestRate` the condition formula for decreasing interest rate is implemented differently than condition for increasing rate. Condition for increasing rate was changed with  https://github.com/ajna-finance/contracts/commit/23e74852ffde8e32d2f490d5787bf7f899fc6966#diff-f180a783f7f398e0540bb5a9fee461cbec2f970bdd423c904b5e12c6ec69c325R286  to fix an overflow while condition for decreasing wasn't, hence same error can manifest
  * make decrease rate condition in `PoolCommons._calculateInterestRate` at par with increase rate condition, that is from
```Solidity
(4 * (tu - mau) > 1e18 - ((tu + mau - 1e18) ** 2) / 1e18)
```
change to 
```Solidity
(4 * (tu - mau) > 1e18 - ((tu + mau - 1e18) / 1e9) ** 2)
```

# Contract size
## Pre Change
```
PoolCommons              -   9,082B  (36.95%)
```
## Post Change
```
PoolCommons              -   9,086B  (36.97%)
```

# Gas usage
## Pre Change
```
| updateInterest                       | 57081           | 122919 | 112150 | 413480 | 284     |
| updateInterest                         | 138992          | 193642 | 147298 | 417497   | 14      |
```
## Post Change
```
| updateInterest                       | 57081           | 122919 | 112150 | 413480 | 284     |
| updateInterest                         | 138992          | 193642 | 147298 | 417497   | 14      |
```

