### PR TITLE
Sherlock-35 Final: Nonce is not incremented, leading to signature replay

### DIFF
--- a/src/base/PermitERC721.sol
+++ b/src/base/PermitERC721.sol
@@ -257,6 +257,21 @@ abstract contract PermitERC721 is ERC721, IPermit {
     }
 
     /**
+     * @notice _approve override to be able to increment the permit nonce
+     * @inheritdoc ERC721
+     */
+    function _approve(
+        address to,
+        uint256 tokenId
+    ) internal virtual override {
+        // increment the permit nonce of this tokenId to ensure it can't be reused
+        _incrementNonce(tokenId);
+
+        // Approve the NFT to the to address
+        super._approve(to, tokenId);
+    }
+
+    /**
      * @notice _transfer override to be able to increment the permit nonce
      * @inheritdoc ERC721
      */

--- a/tests/forge/unit/Positions/PositionManager.t.sol
+++ b/tests/forge/unit/Positions/PositionManager.t.sol
@@ -1330,7 +1330,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         spenderContract.transferFromWithPermit(address(recipientContract), tokenId, deadline, signature);
 
         // check nonces increment with transfer
-        assertEq(_positionManager.nonces(tokenId), 1);
+        assertEq(_positionManager.nonces(tokenId), 2);
 
         // check retrieving token nonces for non existent tokens will revert
         vm.expectRevert(IPermit.NonExistentToken.selector);
@@ -1377,6 +1377,28 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
 
         // check nonces don't change with invalid permits
         assertEq(_positionManager.nonces(tokenId), 0);
+    }
+
+    function testPermitSignatureReplayReverts() external {
+        // generate addresses and set test params
+        (address testMinter, uint256 minterPrivateKey) = makeAddrAndKey("testMinter");
+        address testSpender = makeAddr("spender");
+
+        changePrank(testMinter);
+        uint256 tokenId = _mintNFT(testMinter, testMinter, address(_pool));
+        assertEq(_positionManager.ownerOf(tokenId), testMinter);
+
+        uint256 deadline = block.timestamp + 1 days;
+        bytes memory signature = _getPermitSig(testSpender, tokenId, 0, deadline, minterPrivateKey);
+        
+        _positionManager.permit(testSpender, tokenId, deadline, signature);
+
+        // minter revokes approval
+        _positionManager.approve(address(0), tokenId);
+        
+        // spender tries to get approval with the same signature
+        vm.expectRevert(IPermit.NotAuthorized.selector);
+        _positionManager.permit(testSpender, tokenId, deadline, signature);
     }
 
     /**
@@ -1442,7 +1464,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
         assertEq(_positionManager.ownerOf(tokenId), testMinter);
 
         // check nonces after transfer
-        assertEq(_positionManager.nonces(tokenId), 2);
+        assertEq(_positionManager.nonces(tokenId), 3);
     }
 
     /**


### PR DESCRIPTION
# Description of change
## High level
* Nonce is not incremented in `permit` which allows the user to replay the same signature even after the owner manually revokes his approval after `permit`.
* Fixed with Increment nonces in approve to avoid signature replay.

# Description of bug or vulnerability and solution
* See - https://github.com/sherlock-audit/2023-04-ajna-judging/issues/35
* Fixed with incrementing nonces in approve