### PR TITLE
Sherlock-31 Final: EIP 4494 compliance

### DIFF
--- a/src/base/PermitERC721.sol
+++ b/src/base/PermitERC721.sol
@@ -34,6 +34,15 @@ interface IPermit {
     /*** External Functions ***/
     /**************************/
 
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+
+    /**
+    *  @notice Allows to retrieve current nonce for token.
+    *  @param  tokenId token id
+    *  @return current token nonce
+    */
+    function nonces(uint256 tokenId) external view returns (uint256);
+
     /**
     *  @notice `EIP-4494` permit to approve by way of owner signature.
     */
@@ -154,6 +163,19 @@ abstract contract PermitERC721 is ERC721, IPermit {
 
         // approve the spender for accessing the tokenId
         _approve(spender_, tokenId_);
+    }
+
+    /**
+     *  @notice Query if a contract implements an interface.
+     *  @param  interfaceId The interface identifier.
+     *  @return `true` if the contract implements `interfaceId` and `interfaceId` is not 0xffffffff, `false` otherwise
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IPermit).interfaceId || // 0x5604e225
+            super.supportsInterface(interfaceId);
     }
 
     /**************************/


### PR DESCRIPTION
# Description of change
## High level
* The `PermitERC721` and `PositionManager` contracts do not satisfy the requirements of the `EIP-4494` standard. Specifically, they lack the implementation of the IERC165 interface and do not indicate support for the 0x5604e225 interface. These discrepancies, mark the contracts as non-compliant with the EIP-4494 standard, which could lead to potential interoperability issues. https://github.com/sherlock-audit/2023-04-ajna-judging/issues/31
* Add `supportsInterface` for EIP-4494 compliance