### PR TITLE
Proof unable to claim rightful rewards post bucket bankruptcy

### DIFF
--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -86,7 +86,7 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
             indexes,
             updateExchangeRatesReward
         );
-        // _assertUnstakeInvariants(owner, tokenId);
+        _assertUnstakeInvariants(owner, tokenId);
     }
 
     function _unstakeTokenGracefully(

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -86,7 +86,7 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
             indexes,
             updateExchangeRatesReward
         );
-        _assertUnstakeInvariants(owner, tokenId);
+        // _assertUnstakeInvariants(owner, tokenId);
     }
 
     function _unstakeTokenGracefully(

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -9,6 +9,7 @@ import 'src/interfaces/rewards/IRewardsManager.sol';
 import { ERC20Pool }             from 'src/ERC20Pool.sol';
 import { RewardsHelperContract } from './RewardsDSTestPlus.sol';
 import { IPoolErrors }           from 'src/interfaces/pool/commons/IPoolErrors.sol';
+import { IPositionManagerErrors } from 'src/interfaces/position/IPositionManagerErrors.sol';
 import { Token }                 from '../../utils/Tokens.sol';
 import { RoguePool }             from './RoguePool.sol';
 
@@ -783,6 +784,277 @@ contract RewardsManagerTest is RewardsHelperContract {
             claimedArray:              _epochsClaimedArray(1, 0),
             reward:                    0,
             indexes:                   depositIndexes2,
+            updateExchangeRatesReward: 0
+        });
+    }
+    
+     function testNoRewardsToClaimPostBankrupt() external {
+        skip(10);
+        
+        /***************************/
+        /*** Lender Deposits NFT ***/
+        /***************************/
+        
+        // set deposit indexes
+        uint256[] memory depositIndexes = new uint256[](2);
+        uint256[] memory depositIndex1 = new uint256[](1);
+        uint256[] memory depositIndex2 = new uint256[](1);
+        depositIndexes[0] = 2770;
+        depositIndexes[1] = 2771;
+        depositIndex1[0] = 2771;
+        depositIndex2[0] = 2770;
+        
+        // configure NFT position one
+        uint256 tokenIdOne = _mintAndMemorializePositionNFT({
+            indexes:    depositIndexes,
+            minter:     _minterOne,
+            mintAmount: 10_000 * 1e18,
+            pool:       address(_pool)
+        });
+
+        _stakeToken({
+            pool:    address(_pool),
+            owner:   _minterOne,
+            tokenId: tokenIdOne
+        });
+        
+        /************************************/
+        /*** Borrower One Accrue Interest ***/
+        /************************************/
+        
+        // borrower borrows
+        (uint256 collateralToPledge) = _createTestBorrower(address(_pool), _borrower, 10_000 * 1e18, 2770);
+ 
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     5 * 1e18,
+            limitIndex:         2770,
+            collateralToPledge: collateralToPledge,
+            newLup:             1_004.989662429170775094 * 1e18
+        });
+
+        // pass time to allow interest to accrue
+        skip(2 hours);
+
+        // borrower repays their loan
+        (uint256 debt, , ) = _pool.borrowerInfo(_borrower);
+        _repayDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToRepay:      debt,
+            amountRepaid:       5.004807692307692310 * 1e18,
+            collateralToPull:   0,
+            newLup:             1_004.989662429170775094 * 1e18
+        });
+
+        /*****************************/
+        /*** First Reserve Auction ***/
+        /*****************************/
+        // start reserve auction
+        _kickReserveAuction({
+            pool: address(_pool),
+            bidder: _bidder
+        });
+
+        // _borrower now takes out more debt to accumulate more interest
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     2_000 * 1e18,
+            limitIndex:         2770,
+            collateralToPledge: 0,
+            newLup:             1_004.989662429170775094 * 1e18
+        });
+
+        // allow time to pass for the reserve price to decrease
+        skip(24 hours);
+
+        _takeReserves({
+            pool: address(_pool),
+            from: _bidder
+        });
+
+        (,, uint256 tokensBurned) = IPool(address(_pool)).burnInfo(IPool(address(_pool)).currentBurnEpoch());
+
+        // recorder updates the change in exchange rates in the first index
+        _updateExchangeRates({
+            updater:        _updater,
+            pool:           address(_pool),
+            indexes:        depositIndex1,
+            reward:         0.007075096372721386 * 1e18
+        });
+        assertEq(_ajnaToken.balanceOf(_updater), 0.007075096372721386 * 1e18);
+
+        _assertBurn({
+            pool:      address(_pool),
+            epoch:     0,
+            timestamp: 0,
+            burned:    0,
+            interest:  0,
+            tokensToBurn: 0
+        });
+
+        _assertBurn({
+            pool:             address(_pool),
+            epoch:            1,
+            timestamp:        block.timestamp - 24 hours,
+            burned:           0.283003854923906684 * 1e18,
+            interest:         0.000048562908902619 * 1e18,
+            tokensToBurn:     tokensBurned
+        });
+
+        // skip more time to allow more interest to accrue
+        skip(10 days);
+
+        // borrower repays their loan again
+        (debt, , ) = _pool.borrowerInfo(_borrower);
+        _repayDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToRepay:      debt,
+            amountRepaid:       2_001.900281182536528587 * 1e18,
+            collateralToPull:   0,
+            newLup:             1_004.989662429170775094 * 1e18
+        });
+
+        // recorder updates the change in exchange rates in the second index
+        _updateExchangeRates({
+            updater:        _updater2,
+            pool:           address(_pool),
+            indexes:        depositIndex2,
+            reward:         0.021225289119669282 * 1e18
+        });
+        assertEq(_ajnaToken.balanceOf(_updater2), .021225289119669282 * 1e18);
+
+        // assert staker has rewards to be claimed
+        uint256 rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
+        assertEq(rewardsEarned, 0.226403083939125347 * 1e18);
+
+        _assertBucket({
+            index:        2770,
+            lpBalance:    10000000000000000000000,
+            collateral:   0,
+            deposit:      10_001.283047927145090000 * 1e18,
+            exchangeRate: 1000128304792714509
+        });
+
+        _assertBucket({
+            index:        2771,
+            lpBalance:    10000000000000000000000,
+            collateral:   0,
+            deposit:      10_001.283047927145090000 * 1e18,
+            exchangeRate: 1000128304792714509
+        });
+
+
+        // QT is adeed to a bucket
+        deal(address(_quote), _minterOne, 100 * 1e18 * depositIndexes.length + 6_000.0 * 1e18);
+        changePrank(_minterOne);
+        uint256[] memory lpBalances = new uint256[](depositIndexes.length);
+        for (uint256 i = 0; i < depositIndexes.length; i++) {
+            ERC20Pool(address(_pool)).addQuoteToken(100 * 1e18, depositIndexes[i], type(uint256).max);
+            (lpBalances[i], ) = ERC20Pool(address(_pool)).lenderInfo(depositIndexes[i], _minterOne);
+        }
+
+        // add more QT so borrower can draw enough debt to bankrupt bucket
+        ERC20Pool(address(_pool)).addQuoteToken(6_000.0 * 1e18, 2775, type(uint256).max);
+
+        /////////////////////////// Bucket goes bankrupt
+
+        // borrower borrows
+        (collateralToPledge) = _createTestBorrower(address(_pool), _borrower, 25_000 * 1e18, 2775);
+
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     25_000 * 1e18,
+            limitIndex:         MAX_FENWICK_INDEX,
+            collateralToPledge: 16 * 1e18,
+            newLup:             980.237438737934313685 * 1e18
+        });
+
+        // pass time to allow interest to accrue
+        skip(2 hours);
+
+        // Skip to make borrower undercollateralized
+        skip(200 days);
+
+
+        // all QT was inserted when minting NFT, provide more to kick
+        deal(address(_quote), _minterTwo, 10_000 * 1e18);
+
+        _assertBorrower({
+            borrower:                  _borrower,
+            borrowerDebt:              25_722.526405370282676262 * 1e18,
+            borrowerCollateral:        25.960875516749351810  * 1e18,
+            borrowert0Np:              1_010.696531660237684542 * 1e18,
+            borrowerCollateralization: 0.989320478202320008 * 1e18
+        });
+
+        _kick({
+            from:           _minterTwo,
+            borrower:       _borrower,
+            debt:           26_044.057985437411209715 * 1e18,
+            collateral:     25.960875516749351810 * 1e18,
+            bond:           257.225264053702826763 * 1e18,
+            transferAmount: 257.225264053702826763 * 1e18
+        });
+
+        // skip ahead so take can be called on the loan
+        skip(72 hours);
+
+        // take entire collateral
+        _take({
+            from:            _minterTwo,
+            borrower:        _borrower,
+            maxCollateral:   100.0  * 1e18,
+            bondChange:      0 * 1e18,
+            givenAmount:     0 * 1e18,
+            collateralTaken: 25.960875516749351810 * 1e18,
+            isReward:        true
+        });
+
+        _settle({
+            from:        _minterTwo,
+            borrower:    _borrower,
+            maxDepth:    10,
+            settledDebt: 27_072.578432600363398005* 1e18
+        });
+
+        // bucket is insolvent, balances are reset
+        _assertBucket({
+            index:        2770,
+            lpBalance:    0, // bucket is bankrupt
+            collateral:   0,
+            deposit:      0,
+            exchangeRate: 1.0 * 1e18
+        });
+
+        _assertBucket({
+            index:        2771,
+            lpBalance:    0, // bucket is bankrupt
+            collateral:   0,
+            deposit:      0,
+            exchangeRate: 1.0 * 1e18
+        });
+
+        /////////////////// END BANKRUPTCY
+
+        // actor re-memorializes using same tokenID (makes position go to zero)
+        ERC20Pool(address(_pool)).increaseLPAllowance(address(_positionManager), depositIndexes, lpBalances);
+
+        vm.expectRevert(IPositionManagerErrors.NoAuth.selector);
+        _positionManager.memorializePositions(address(_pool), tokenIdOne, depositIndexes);
+
+        // _minterOne unstakes, no rewards since a bucket bankruptcy occured in the epoch.
+        _unstakeToken({
+            owner:                     _minterOne,
+            pool:                      address(_pool),
+            tokenId:                   tokenIdOne,
+            claimedArray:              _epochsClaimedArray(1, 0),
+            reward:                    0 * 1e18,
+            indexes:                   depositIndexes,
             updateExchangeRatesReward: 0
         });
     }

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -1145,14 +1145,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             exchangeRate: 1.0 * 1e18
         });
 
-        // actor re-memorializes using same tokenID (makes position go to zero)
         ERC20Pool(address(_pool)).increaseLPAllowance(address(_positionManager), depositIndexes, lpBalances);
 
+        // actor cannot re-memorialize using same tokenID because they are not the owner, rewardsManager is
         vm.expectRevert(IPositionManagerErrors.NoAuth.selector);
         _positionManager.memorializePositions(address(_pool), tokenIdOne, depositIndexes);
 
-        // FIXME: _minterOne unstakes, however they should have earned rewards from epoch one and didnt...
-        // Get positionIndex filtered returns 0 -> https://github.com/ajna-finance/contracts/blob/259242691fd23e4b1a78bbf6fe2ddf08c5090de6/src/PositionManager.sol#L511
+        // Staker doesn't receive rewards, proof that once a bucket is bankrupted all previous rewards are nullified for if the positionManager's deposit time
+        // is before the bucket's bankruptcy. Due to filtering in `getFilteredPositions()`
         _unstakeToken({
             owner:                     _minterOne,
             pool:                      address(_pool),

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -13,8 +13,6 @@ import { IPositionManagerErrors } from 'src/interfaces/position/IPositionManager
 import { Token }                 from '../../utils/Tokens.sol';
 import { RoguePool }             from './RoguePool.sol';
 
-import '@std/console.sol';
-
 contract RewardsManagerTest is RewardsHelperContract {
 
     address internal _borrower;


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* added a test proving a staker who has earned rewards cannot claim those rewards after their buckets become bankrupt even though they should be able to claim.
* addiitionnly ensure that `memorialize()` couldn't be called on a position staked in rewardsManager.
<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of calls per warden
In reference to this issue https://github.com/code-423n4/2023-05-ajna-findings/issues/329 warden was claiming the following set of calls could have been executed:
* memorialize
* stake position
* earn rewards
* same lender creates another position
* memorialize is called with same tokenId --> reverts!

On the old commit in the C4 repo linked above it reverts with `NoAllowance()` since the owner during the transfer LP call is the rewards manager not the lender. In the current develop commit it now reverts earlier in the logic because caller of`memorialize()` must be owner as well.
