### PR TITLE
Sherlock-44: assert owners of position NFT in unstake / emergencyUnstake before and after action taken

### DIFF
--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -7,8 +7,8 @@ import 'src/PositionManager.sol';
 
 import 'src/interfaces/rewards/IRewardsManager.sol';
 import 'src/interfaces/position/IPositionManager.sol';
-
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 
 import { Token }               from '../../utils/Tokens.sol';
 import { Strings }             from '@openzeppelin/contracts/utils/Strings.sol';
@@ -98,6 +98,8 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         uint256[] memory indexes,
         uint256 updateExchangeRatesReward
     ) internal {
+        // token owner is Rewards manager
+        assertEq(ERC721(address(_positionManager)).ownerOf(tokenId), address(_rewardsManager));
 
         // when the token is unstaked updateExchangeRates emits
         vm.expectEmit(true, true, true, true);
@@ -114,6 +116,9 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         emit Unstake(owner, address(pool), tokenId);
         _rewardsManager.unstake(tokenId);
 
+        // token owner is staker
+        assertEq(ERC721(address(_positionManager)).ownerOf(tokenId), owner);
+
         // check exchange rates were updated
         uint256 updateEpoch = IPool(pool).currentBurnEpoch();
         _assertBucketsUpdated(pool, indexes, updateEpoch);
@@ -124,10 +129,16 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         address pool,
         uint256 tokenId
     ) internal {
-        // when the token is unstaked in emergency mode then no cliam event is emitted
+        // token owner is Rewards manager
+        assertEq(ERC721(address(_positionManager)).ownerOf(tokenId), address(_rewardsManager));
+
+        // when the token is unstaked in emergency mode then no claim event is emitted
         vm.expectEmit(true, true, true, true);
         emit Unstake(owner, address(pool), tokenId);
         _rewardsManager.emergencyUnstake(tokenId);
+
+        // token owner is staker
+        assertEq(ERC721(address(_positionManager)).ownerOf(tokenId), owner);
     }
 
     function _updateExchangeRates(


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* proof of https://github.com/sherlock-audit/2023-04-ajna-judging/issues/44 is not valid report
  * assert `RewardsManager` is owner of position NFT before `unstake` / `emergencyUnstake`
  * assert staker is owner of position NFT after `unstake` / `emergencyUnstake`


