### PR TITLE
Sherlock-85: Limit index isn't checked in repayDebt, so user control is void

### DIFF
--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -375,8 +375,6 @@ library BorrowerActions {
             // calculate LUP only if it wasn't calculated in repay action
             if (!vars.repay) result_.newLup = Deposits.getLup(deposits_, result_.poolDebt);
 
-            _revertIfPriceDroppedBelowLimit(result_.newLup, limitIndex_);
-
             uint256 encumberedCollateral = Maths.wdiv(vars.borrowerDebt, result_.newLup);
             if (
                 borrower.t0Debt != 0 && encumberedCollateral == 0 || // case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
@@ -391,6 +389,9 @@ library BorrowerActions {
 
             result_.poolCollateral -= collateralAmountToPull_;
         }
+
+        // check limit price and revert if price dropped below
+        _revertIfPriceDroppedBelowLimit(result_.newLup, limitIndex_);
 
         // update loan state
         Loans.update(

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -551,6 +551,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         ERC20Pool(address(_pool)).repayDebt(from, 0, amount, from, indexLimit);
     }
 
+    function _assertRepayLimitIndexRevert(
+        address from,
+        uint256 amount,
+        uint256 indexLimit
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.LimitIndexExceeded.selector);
+        ERC20Pool(address(_pool)).repayDebt(from, amount, 0, from, indexLimit);
+    }
+
     function _assertRepayNoDebtRevert(
         address from,
         address borrower,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -719,8 +719,13 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             })
         );
 
-        // should revert if LUP is below the limit
-        ( , , , , , uint256 lupIndex ) = _poolUtils.poolPricesInfo(address(_pool));        
+        // should revert if LUP is below the limit when repay or pull collateral
+        ( , , , , , uint256 lupIndex ) = _poolUtils.poolPricesInfo(address(_pool));   
+        _assertRepayLimitIndexRevert({
+            from:       _borrower,
+            amount:     20 * 1e18,
+            indexLimit: lupIndex - 1
+        });     
         _assertPullLimitIndexRevert({
             from:       _borrower,
             amount:     20 * 1e18,

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -637,6 +637,16 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         ERC721Pool(address(_pool)).repayDebt(from, 0, amount, from, indexLimit);
     }
 
+    function _assertRepayLimitIndexRevert(
+        address from,
+        uint256 amount,
+        uint256 indexLimit
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.LimitIndexExceeded.selector);
+        ERC721Pool(address(_pool)).repayDebt(from, amount, 0, from, indexLimit);
+    }
+
     function _assertRepayNoDebtRevert(
         address from,
         address borrower,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -437,7 +437,12 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         });
 
         // should revert if LUP is below the limit
-        ( , , , , , uint256 lupIndex ) = _poolUtils.poolPricesInfo(address(_pool));        
+        ( , , , , , uint256 lupIndex ) = _poolUtils.poolPricesInfo(address(_pool));
+        _assertRepayLimitIndexRevert({
+            from:       _borrower,
+            amount:     20 * 1e18,
+            indexLimit: lupIndex - 1
+        }); 
         _assertPullLimitIndexRevert({
             from:       _borrower,
             amount:     2,


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* see https://github.com/sherlock-audit/2023-04-ajna-judging/issues/85
  * added `_revertIfPriceDroppedBelowLimit` for both `repay` and `pull` logic in `BorrowerActions.repayDebt` function
  * did check only once for both actions (different than suggested in report) in order to save gas when repay and pull at the same time
  * added unit test

<!---
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Contract size
## Pre Change
```
BorrowerActions          -  12,390B  (50.41%)
```
## Post Change
```
BorrowerActions          -  12,390B  (50.41%)
```

# Gas usage 
## Pre Change
```
| repayDebt                            | 576899          | 609055 | 598947 | 757317  | 16002   |
```
## Post Change
```
| repayDebt                            | 587020          | 619176 | 609068 | 767438  | 16002   |
```

