### PR TITLE
Readable order of operations

### DIFF
--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -281,7 +281,7 @@ library PoolCommons {
         if (poolState_.debt != 0) {
             // calculate meaningful actual utilization for interest rate update
             mau    = int256(_utilization(debtEma_, depositEma_));
-            mau102 = mau * PERCENT_102 / 1e18;
+            mau102 = (mau * PERCENT_102) / 1e18;
         }
 
         // calculate target utilization

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -418,7 +418,7 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 collateral_,
         uint256 momp_
     ) pure returns (uint256 bondFactor_, uint256 bondSize_) {
-        uint256 thresholdPrice = (borrowerDebt_  * Maths.WAD) / collateral_;
+        uint256 thresholdPrice = (borrowerDebt_ * Maths.WAD) / collateral_;
 
         // bondFactor = min(30%, max(1%, (MOMP - thresholdPrice) / MOMP))
         if (thresholdPrice >= momp_) {

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -418,7 +418,7 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 collateral_,
         uint256 momp_
     ) pure returns (uint256 bondFactor_, uint256 bondSize_) {
-        uint256 thresholdPrice = borrowerDebt_  * Maths.WAD / collateral_;
+        uint256 thresholdPrice = (borrowerDebt_  * Maths.WAD) / collateral_;
 
         // bondFactor = min(30%, max(1%, (MOMP - thresholdPrice) / MOMP))
         if (thresholdPrice >= momp_) {


### PR DESCRIPTION
- make readable / explicit order of operations where `a * b / c` -> `(a * b) / c`