### PR TITLE
Sherlock-110 (moveQuoteToken continuation): move quote token revert if auction clearable

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -66,7 +66,9 @@
 		- pool inflator and inflatorUpdate state
 
 	reverts on:
+	- block timestamp greater than expiry TransactionExpired()
 	- deposits locked RemoveDepositLockedByAuctionDebt()
+	- head auction not cleared AuctionNotCleared()
 	- LenderActions.moveQuoteToken():
 		- same index MoveToSameIndex()
 		- dust amount DustAmountNotExceeded()

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -250,6 +250,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             toIndex:   _i9_81 
         });
 
+        uint256 snapshot = vm.snapshot();
+        skip(73 hours);
+
+        // lender cannot move funds if auction not cleared
+        _assertMoveDepositAuctionNotClearedRevert({
+            from:      _lender,
+            amount:    10.0 * 1e18,
+            fromIndex: _i9_72,
+            toIndex:   _i9_81 
+        });
+
+        vm.revertTo(snapshot);
+
         // lender can add / remove liquidity in buckets that are not within liquidation debt
         changePrank(_lender1);
         _pool.addQuoteToken(2_000 * 1e18, 5000, block.timestamp + 1 minutes, false);

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1304,6 +1304,17 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max, false);
     }
 
+    function _assertMoveDepositAuctionNotClearedRevert(
+        address from,
+        uint256 amount,
+        uint256 fromIndex,
+        uint256 toIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        _pool.moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max, false);
+    }
+
     function _assertMoveDepositBelowLUPRevert(
         address from,
         uint256 amount,


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* see https://github.com/sherlock-audit/2023-04-ajna-judging/issues/110
  * do not allow moving quote tokens into the pool if there's auction to settle
  * `Pool.moveQuoteToken` revert with `AuctionNotCleared` custom error
  * shrink contract size / improve views gas by reading structs only once from storage
  * unit test for new revert

# Contract size
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,567B  (99.96%)
  ERC20Pool                -  23,850B  (97.04%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,478B  (99.60%)
  ERC20Pool                -  23,761B  (96.68%)
```

# Gas usage
## Pre Change
```
| moveQuoteToken                       | 1918            | 144589 | 106768 | 634238 | 40      |
| moveQuoteToken                         | 41558           | 46707  | 41726  | 66912    | 5       |
```
## Post Change
```
| moveQuoteToken                       | 1918            | 148212 | 107168 | 634633 | 41      |
| moveQuoteToken                         | 45953           | 50286  | 46121  | 67228    | 5       |
```

