### PR TITLE
Add unit tests to check deposits and debt limits in pool

### DIFF
--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -8,6 +8,7 @@ import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 import 'src/libraries/helpers/PoolHelper.sol';
 import 'src/interfaces/pool/erc20/IERC20Pool.sol';
 import 'src/libraries/external/PoolCommons.sol';
+import '@std/console.sol';
 
 contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
@@ -1163,6 +1164,219 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         skip(365 days);
 
         // Reverts with PRBMathUD60x18__ExpInputTooBig
+        vm.expectRevert();
+        _updateInterest();
+    }
+
+    function testAccrueInterestNewInterestLimit() external {
+        _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
+
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 1_000_000_000 * 1e18, // 1 billion
+            index:  _i1505_26
+        });
+
+        // draw 80% of liquidity as debt
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     800_000_000 * 1e18,
+            limitIndex:         _i1505_26,
+            collateralToPledge: 1_000_000_000 * 1e18,
+            newLup:             _p1505_26
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  0.80076923076923077 * 1e18,
+                lup:                  _p1505_26,
+                poolSize:             1_000_000_000 * 1e18,
+                pledgedCollateral:    1_000_000_000 * 1e18,
+                encumberedCollateral: 531_979.357254329691641573 * 1e18,
+                poolDebt:             800_769_230.7692307696 * 1e18,
+                actualUtilization:    0,
+                targetUtilization:    1e18,
+                minDebtAmount:        80_076_923.07692307696 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+
+        // update interest rate after each 14 hours
+        uint i = 0;
+        while (i < 171) {
+            // trigger an interest accumulation
+            skip(14 hours);
+
+            _updateInterest();
+
+            unchecked { ++i; }
+        }
+
+        // Pledge some collateral to avoid tu overflow in `(((tu + mau102 - 1e18) / 1e9) ** 2)`
+        _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e24);
+        IERC20Pool(address(_pool)).drawDebt(_borrower, 0, 0, 1_000_000_000 * 1e24);
+
+        skip(14 hours);
+
+        // Update interest rate after each 13 hours
+        while (i < 179) {
+            // trigger an interest accumulation
+            skip(13 hours);
+
+            _updateInterest();
+
+            unchecked { ++i; }
+        }
+
+        skip(13 hours);
+
+        // Revert with Arithmetic overflow in `Maths.wmul(pendingFactor - Maths.WAD, poolState_.debt)` in accrue interest
+        vm.expectRevert();
+        _updateInterest();
+    }
+
+    function testUpdateInterestZeroThresholdPrice() external {
+        _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
+
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 1_000_000_000 * 1e18, // 1 billion
+            index:  _i1505_26
+        });
+
+        // draw 80% of liquidity as debt
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     800_000_000 * 1e18,
+            limitIndex:         _i1505_26,
+            collateralToPledge: 1_000_000_000 * 1e18,
+            newLup:             _p1505_26
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  0.80076923076923077 * 1e18,
+                lup:                  _p1505_26,
+                poolSize:             1_000_000_000 * 1e18,
+                pledgedCollateral:    1_000_000_000 * 1e18,
+                encumberedCollateral: 531_979.357254329691641573 * 1e18,
+                poolDebt:             800_769_230.7692307696 * 1e18,
+                actualUtilization:    0,
+                targetUtilization:    1e18,
+                minDebtAmount:        80_076_923.07692307696 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+
+        // update interest rate after each day
+        uint i = 0;
+        while (i < 104) {
+            // trigger an interest accumulation
+            skip(1 days);
+
+            // check borrower collateralization and pledge more collateral if undercollateralized
+            (uint256 debt, uint256 collateralPledged, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
+            uint256 requiredCollateral = _requiredCollateral(debt, _lupIndex());
+
+            if (requiredCollateral > collateralPledged ) {
+                uint256 collateralToPledge = requiredCollateral - collateralPledged;
+                _mintCollateralAndApproveTokens(_borrower, collateralToPledge);
+
+                // Pledge collateral reverts with `ZeroThresholdPrice()`
+                if (i == 103) {
+                    vm.expectRevert();
+                }
+
+                changePrank(_borrower);
+                IERC20Pool(address(_pool)).drawDebt(_borrower, 0, 0, collateralToPledge);
+            } else {
+                _updateInterest();
+            }
+
+            unchecked { ++i; }
+        }
+    }
+
+    function testUpdateInterestTuLimit() external {
+        _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
+
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 1_000_000_000 * 1e18, // 1 billion
+            index:  _i1505_26
+        });
+
+        // draw 80% of liquidity as debt
+        _drawDebt({
+            from:               _borrower,
+            borrower:           _borrower,
+            amountToBorrow:     800_000_000 * 1e18,
+            limitIndex:         _i1505_26,
+            collateralToPledge: 1_000_000_000 * 1e18,
+            newLup:             _p1505_26
+        });
+
+        _assertPool(
+            PoolParams({
+                htp:                  0.80076923076923077 * 1e18,
+                lup:                  _p1505_26,
+                poolSize:             1_000_000_000 * 1e18,
+                pledgedCollateral:    1_000_000_000 * 1e18,
+                encumberedCollateral: 531_979.357254329691641573 * 1e18,
+                poolDebt:             800_769_230.7692307696 * 1e18,
+                actualUtilization:    0,
+                targetUtilization:    1e18,
+                minDebtAmount:        80_076_923.07692307696 * 1e18,
+                loans:                1,
+                maxBorrower:          _borrower,
+                interestRate:         0.05 * 1e18,
+                interestRateUpdate:   _startTime
+            })
+        );
+
+        // update interest rate after each day
+        uint i = 0;
+        while (i < 237) {
+            // trigger an interest accumulation
+            skip(1 days);
+
+            // stop pledging more collateral to avoid t0Tp becoming 0, i = 103 is the limit where t0tp becomes 0
+            if (i < 100) {
+                // check borrower collateralization and pledge more collateral if undercollateralized
+                (uint256 debt, uint256 collateralPledged, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
+                (uint256 poolDebt,,,) = _pool.debtInfo();
+                uint256 lupIndex = _pool.depositIndex(poolDebt);
+                uint256 requiredCollateral = _requiredCollateral(debt, lupIndex);
+                
+                if (requiredCollateral > collateralPledged) {
+                    uint256 collateralToPledge = requiredCollateral - collateralPledged;
+                    _mintCollateralAndApproveTokens(_borrower, collateralToPledge);
+
+                    changePrank(_borrower);
+                    IERC20Pool(address(_pool)).drawDebt(_borrower, 0, 0, collateralToPledge);
+                }
+
+            } else {
+                _updateInterest();
+            }
+
+            unchecked { ++i; }
+        }
+
+        skip(1 days);
+
+        // Revert with Arithmetic overflow in `(((tu + mau102 - 1e18) / 1e9) ** 2)` in update interest
         vm.expectRevert();
         _updateInterest();
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.18;
 
-import { PRBMath } from "@prb-math/contracts/PRBMathUD60x18.sol";
-
 import { ERC20HelperContract } from './ERC20DSTestPlus.sol';
 
 import 'src/libraries/helpers/PoolHelper.sol';
 import 'src/interfaces/pool/erc20/IERC20Pool.sol';
-import 'src/libraries/external/PoolCommons.sol';
-import '@std/console.sol';
 
 contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
@@ -1353,7 +1349,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
             // stop pledging more collateral to avoid t0Tp becoming 0, i = 103 is the limit where t0tp becomes 0
             if (i < 100) {
-                // check borrower collateralization and pledge more collateral if undercollateralized
+                // check borrower collateralization and pledge more collateral if undercollateralized to avoid `(((tu + mau102 - 1e18) / 1e9) ** 2)` overflow
                 (uint256 debt, uint256 collateralPledged, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
                 (uint256 poolDebt,,,) = _pool.debtInfo();
                 uint256 lupIndex = _pool.depositIndex(poolDebt);


### PR DESCRIPTION
# Description of change
## High level
* Add unit tests to check deposits and debt limits in various situations. Each unit test is written to maximize deposits and pool debt by accruing interest over time. Each test case breaks with different reverts.
* `testAccruePoolInterestRevertDueToExpLimit` reverts with `PRBMathUD60x18__ExpInputTooBig` due to high pool interest rate and 1 year of time lapsed.
* `testAccrueInterestNewInterestLimit` reverts with overflow when `newInterest` is calculated at https://github.com/ajna-finance/contracts/blob/test-exp-limit/src/libraries/external/PoolCommons.sol#L248
* `testUpdateInterestZeroThresholdPrice` reverts with `ZeroThresholdPrice()` when `toDebt` becomes too low compared with collateral pledged.
* `testUpdateInterestTuLimit` reverts with overflow in `(((tu + mau102 - 1e18) / 1e9) ** 2)` due to very high debt.