### PR TITLE
Fixed RewardsManager exchangeRate emit

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -611,7 +611,7 @@ contract RewardsManager is IRewardsManager {
         ) = _getEpochInfo(pool_, curBurnEpoch);
 
         // Update exchange rates without reward if first epoch or if the epoch does not have burned tokens associated with it
-        if (curBurnEpoch == 0 || totalBurnedInEpoch == 0) {
+        if (totalBurnedInEpoch == 0) {
             uint256 noOfIndexes = indexes_.length;
 
             for (uint256 i = 0; i < noOfIndexes; ) {

--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -657,6 +657,9 @@ contract RewardsManager is IRewardsManager {
 
                 // accumulate the full amount of additional rewards
                 updateRewardsClaimed[curBurnEpoch] += updatedRewards_;
+            } else {
+                // block.timestamp is greater than curBurnTime + UPDATE_PERIOD do not emit UpdateExchangeRates
+                return 0;
             }
         }
 

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -101,9 +101,11 @@ abstract contract RewardsDSTestPlus is IRewardsManagerEvents, ERC20HelperContrac
         // token owner is Rewards manager
         assertEq(ERC721(address(_positionManager)).ownerOf(tokenId), address(_rewardsManager));
 
-        // when the token is unstaked updateExchangeRates emits
-        vm.expectEmit(true, true, true, true);
-        emit UpdateExchangeRates(owner, pool, indexes, updateExchangeRatesReward);
+        if (updateExchangeRatesReward != 0) {
+            // when the token is unstaked updateExchangeRates emits
+            vm.expectEmit(true, true, true, true);
+            emit UpdateExchangeRates(owner, pool, indexes, updateExchangeRatesReward);
+        }
 
         if (claimedArray.length != 0) {
             // when the token is unstaked claimRewards emits

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -406,9 +406,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         );
         assertEq(updateRewards, 0);
 
-        // check unstake will only emit Unstake and UpdateExchangeRate events
-        vm.expectEmit(true, true, true, true);
-        emit UpdateExchangeRates(_minterOne, address(_pool), depositIndexes, 0);
+        // check unstake will only emit Unstake event since block.timestamp > curBurnTime + UPDATE_PERIOD
         vm.expectEmit(true, true, true, true);
         emit Unstake(_minterOne, address(_pool), tokenId);
         _rewardsManager.unstake(tokenId);
@@ -1158,7 +1156,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             claimedArray:              _epochsClaimedArray(2, 0),
             reward:                    0 * 1e18,
             indexes:                   depositIndexes,
-            updateExchangeRatesReward: 0
+            updateExchangeRatesReward: 0 // updateExchangeRates is not emitted
         });
     }
 


### PR DESCRIPTION
<!---
No need to add special tag
src/ & non src/ changes you need the following (that apply):
-->
# Description of change
## High level
* updated `RewardsManager.sol` `emit updatedExchangeRates` event so it only emits when the rates have been updated.
* Cleaned up `testUpdateExchangeRatesAndClaimRewards` test
<!---j
Add the `Status: Needs Auditor Approval` tags
CHANGES IN /SRC DIR:
- renaming (not retyping or resizing) of variables & methods
- reordering and moving of functions in files
- lite moving of functions accross files
- comments

src/ changes you need the following (that apply):
-->

# Description of bug or vulnerability and solution
* `updatedExchangeRates` event would be incorrectly emitted when `block.timestamp > curBurnTime + UPDATE_PERIOD` and no bucket exchange rates were updated.
* originally pointed out by Kurt during a solo audit: 
```
If curBurnEpoch != 0, totalBurnedInEpoch != 0, and block.timestamp > curBurnTime + UPDATE_PERIOD, no exchange rate updates are actually done but the full list of indexes is still emitted in this event, which is arguably misleading.

Comments on the event are ambiguous as to whether this is intended behavior:

https://github.com/ajna-finance/contracts/blob/a2557591bb44ef02cfc0aee14c38e31ec66ad523/src/interfaces/rewards/IRewardsManagerEvents.sol#L54

Is the goal just to log the argument passed to this function, or to log the list of indexes that actually had their exchange rates updated?
```
# Contract size
## Pre Change
```
  RewardsManager           -   8,685B  (35.34%)
```
## Post Change
```
  RewardsManager           -   8,693B  (35.37%)
```

# Gas usage
## Pre Change
```
| src/RewardsManager.sol:RewardsManager contract |                 |        |        |         |         |
|------------------------------------------------|-----------------|--------|--------|---------|---------|
| Deployment Cost                                | Deployment Size |        |        |         |         |
| 1739497                                        | 9103            |        |        |         |         |
| Function Name                                  | min             | avg    | median | max     | # calls |
| calculateRewards                               | 30303           | 45795  | 38287  | 168513  | 312     |
| claimRewards                                   | 699             | 128358 | 108437 | 557955  | 320     |
| emergencyUnstake                               | 9898            | 36943  | 27596  | 97196   | 20      |
| getBucketStateStakeInfo                        | 882             | 4657   | 4882   | 4882    | 266005  |
| getStakeInfo                                   | 748             | 748    | 748    | 748     | 411     |
| isBucketUpdated                                | 726             | 726    | 726    | 726     | 254     |
| stake                                          | 157128          | 534557 | 614621 | 1152570 | 83      |
| unstake                                        | 542             | 188087 | 123475 | 587232  | 25      |
| updateBucketExchangeRatesAndClaim              | 4408            | 243435 | 187258 | 557592  | 65      |
```
## Post Change
```
| src/RewardsManager.sol:RewardsManager contract |                 |        |        |         |         |
|------------------------------------------------|-----------------|--------|--------|---------|---------|
| Deployment Cost                                | Deployment Size |        |        |         |         |
| 1741097                                        | 9111            |        |        |         |         |
| Function Name                                  | min             | avg    | median | max     | # calls |
| calculateRewards                               | 30303           | 83673  | 69344  | 168513  | 23      |
| claimRewards                                   | 699             | 226925 | 142603 | 557941  | 31      |
| emergencyUnstake                               | 9898            | 36943  | 27596  | 97196   | 20      |
| getBucketStateStakeInfo                        | 882             | 4657   | 4882   | 4882    | 266005  |
| getStakeInfo                                   | 748             | 748    | 748    | 748     | 110     |
| isBucketUpdated                                | 726             | 726    | 726    | 726     | 254     |
| stake                                          | 157112          | 575807 | 614601 | 1152550 | 71      |
| unstake                                        | 542             | 187840 | 123464 | 587218  | 25      |
| updateBucketExchangeRatesAndClaim              | 4408            | 272448 | 318942 | 557578  | 41      |
```

