### PR TITLE
Catch interest accrual and update interest overflow

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -575,7 +575,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                     // update total interest earned accumulator with the newly accrued interest
                     reserveAuction.totalInterestEarned += newInterest;
                 } catch {
-                    emit InterestOverflow();
+                    poolState_.isNewInterestAccrued = false;
+                    emit InterestUpdateFailure();
                 }
             }
         }
@@ -683,7 +684,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 lup_
     ) internal {
         try PoolCommons.updateInterestState(interestState, emaState, deposits, poolState_, lup_) {} catch {
-            emit InterestOverflow();
+            emit InterestUpdateFailure();
         }
 
         // update pool inflator

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -561,19 +561,22 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
             // if new interest may have accrued, call accrueInterest function and update inflator and debt fields of poolState_ struct
             if (poolState_.isNewInterestAccrued) {
-                (uint256 newInflator, uint256 newInterest) = PoolCommons.accrueInterest(
+                try PoolCommons.accrueInterest(
                     emaState,
                     deposits,
                     poolState_,
                     Loans.getMax(loans).thresholdPrice,
                     elapsed
-                );
-                poolState_.inflator = newInflator;
-                // After debt owed to lenders has accrued, calculate current debt owed by borrowers
-                poolState_.debt = Maths.wmul(poolState_.t0Debt, poolState_.inflator);
+                ) returns (uint256 newInflator, uint256 newInterest) {
+                    poolState_.inflator = newInflator;
+                    // After debt owed to lenders has accrued, calculate current debt owed by borrowers
+                    poolState_.debt = Maths.wmul(poolState_.t0Debt, poolState_.inflator);
 
-                // update total interest earned accumulator with the newly accrued interest
-                reserveAuction.totalInterestEarned += newInterest;
+                    // update total interest earned accumulator with the newly accrued interest
+                    reserveAuction.totalInterestEarned += newInterest;
+                } catch {
+                    emit InterestOverflow();
+                }
             }
         }
     }
@@ -679,8 +682,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         PoolState memory poolState_,
         uint256 lup_
     ) internal {
-
-        PoolCommons.updateInterestState(interestState, emaState, deposits, poolState_, lup_);
+        try PoolCommons.updateInterestState(interestState, emaState, deposits, poolState_, lup_) {} catch {
+            emit InterestOverflow();
+        }
 
         // update pool inflator
         if (poolState_.isNewInterestAccrued) {

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -367,4 +367,9 @@ interface IPoolEvents {
         uint256 newRate
     );
 
+    /**
+     *  @notice Emitted when interest accural or update interest overflows.
+     */
+    event InterestOverflow();
+
 }

--- a/src/interfaces/pool/commons/IPoolEvents.sol
+++ b/src/interfaces/pool/commons/IPoolEvents.sol
@@ -370,6 +370,6 @@ interface IPoolEvents {
     /**
      *  @notice Emitted when interest accural or update interest overflows.
      */
-    event InterestOverflow();
+    event InterestUpdateFailure();
 
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -1109,7 +1109,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         });
     }
 
-    function testAccruePoolInterestRevertDueToExpLimit() external {
+    function testAccruePoolInterestRevertDueToExpLimit() external tearDown {
         _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
         _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
 
@@ -1181,11 +1181,12 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         skip(365 days * 32);
 
         // Reverts with PRBMathUD60x18__ExpInputTooBig
-        vm.expectRevert();
+        vm.expectEmit(true, true, false, true);
+        emit InterestOverflow();
         _updateInterest();
     }
 
-    function testAccrueInterestNewInterestLimit() external {
+    function testAccrueInterestNewInterestLimit() external tearDown {
         _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
         _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
 
@@ -1253,7 +1254,8 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         skip(13 hours);
 
         // Revert with Arithmetic overflow in `Maths.wmul(pendingFactor - Maths.WAD, poolState_.debt)` in accrue interest
-        vm.expectRevert();
+        vm.expectEmit(true, true, false, true);
+        emit InterestOverflow();
         _updateInterest();
     }
 
@@ -1324,7 +1326,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         }
     }
 
-    function testUpdateInterestTuLimit() external {
+    function testUpdateInterestTuLimit() external tearDown {
         _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
         _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
 
@@ -1394,7 +1396,8 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         skip(1 days);
 
         // Revert with Arithmetic overflow in `(((tu + mau102 - 1e18) / 1e9) ** 2)` in update interest
-        vm.expectRevert();
+        vm.expectEmit(true, true, false, true);
+        emit InterestOverflow();
         _updateInterest();
     }
 }


### PR DESCRIPTION
# Description of change
## High level
* Add try catch for interest accrual and update interest method to avoid pool locking.
* Add tearDown to unit tests where overflow was occurring, so that we know pool can be recovered after such overflows.