### PR TITLE
Reuse _isCollateralized method in repayment

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -496,7 +496,6 @@ contract PoolInfoUtils {
         uint256 debt_,
         uint256 price_
     ) pure returns (uint256 encumberance_) {
-        // TODO: should use ceilWdiv
         return price_ != 0 ? Maths.wdiv(debt_, price_) : 0;
     }
 

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -496,7 +496,8 @@ contract PoolInfoUtils {
         uint256 debt_,
         uint256 price_
     ) pure returns (uint256 encumberance_) {
-        return price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
+        // TODO: should use ceilWdiv
+        return price_ != 0 ? Maths.wdiv(debt_, price_) : 0;
     }
 
     /**
@@ -511,8 +512,9 @@ contract PoolInfoUtils {
         uint256 collateral_,
         uint256 price_
     ) pure returns (uint256) {
-        uint256 encumbered = _encumberance(debt_, price_);
-        return encumbered != 0 ? Maths.wdiv(collateral_, encumbered) : Maths.WAD;
+        // cannot be undercollateralized if there is no debt
+        if (debt_ == 0) return 1e18;
+        return Maths.wdiv(Maths.wmul(collateral_, price_), debt_);
     }
 
     /**

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -294,14 +294,16 @@ library BorrowerActions {
             uint256 encumberedCollateral = Maths.wdiv(vars.borrowerDebt, result_.newLup);
             if (
                 borrower.t0Debt != 0 && encumberedCollateral == 0 || // case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
-                borrower.collateral < encumberedCollateral ||
-                !_isCollateralized(vars.borrowerDebt, borrower.collateral - encumberedCollateral, result_.newLup, poolState_.poolType)
+                borrower.collateral <= encumberedCollateral ||
+                collateralAmountToPull_ > borrower.collateral
             ) revert InsufficientCollateral();
+
+            borrower.collateral -= collateralAmountToPull_;
+            if (!_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) 
+                revert InsufficientCollateral();
 
             // stamp borrower Np to Tp ratio when pull collateral action
             vars.stampNpTpRatio = true;
-
-            borrower.collateral -= collateralAmountToPull_;
 
             result_.poolCollateral -= collateralAmountToPull_;
         }

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -297,7 +297,6 @@ library BorrowerActions {
 
             // check collateralization
             borrower.collateral -= collateralAmountToPull_;
-            // TODO: handle case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
             if (!_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) 
                 revert InsufficientCollateral();
 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -291,9 +291,11 @@ library BorrowerActions {
             // calculate LUP only if it wasn't calculated in repay action
             if (!vars.repay) result_.newLup = Deposits.getLup(deposits_, result_.poolDebt);
 
+            // prevent underflow
             if (collateralAmountToPull_ > borrower.collateral) 
                 revert InsufficientCollateral();
 
+            // check collateralization
             borrower.collateral -= collateralAmountToPull_;
             // TODO: handle case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
             if (!_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -295,7 +295,7 @@ library BorrowerActions {
             if (
                 borrower.t0Debt != 0 && encumberedCollateral == 0 || // case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
                 borrower.collateral < encumberedCollateral ||
-                borrower.collateral - encumberedCollateral < collateralAmountToPull_
+                !_isCollateralized(vars.borrowerDebt, borrower.collateral - encumberedCollateral, result_.newLup, poolState_.poolType)
             ) revert InsufficientCollateral();
 
             // stamp borrower Np to Tp ratio when pull collateral action

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -291,14 +291,11 @@ library BorrowerActions {
             // calculate LUP only if it wasn't calculated in repay action
             if (!vars.repay) result_.newLup = Deposits.getLup(deposits_, result_.poolDebt);
 
-            uint256 encumberedCollateral = Maths.wdiv(vars.borrowerDebt, result_.newLup);
-            if (
-                borrower.t0Debt != 0 && encumberedCollateral == 0 || // case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
-                borrower.collateral <= encumberedCollateral ||
-                collateralAmountToPull_ > borrower.collateral
-            ) revert InsufficientCollateral();
+            if (collateralAmountToPull_ > borrower.collateral) 
+                revert InsufficientCollateral();
 
             borrower.collateral -= collateralAmountToPull_;
+            // TODO: handle case when small amount of debt at a high LUP results in encumbered collateral calculated as 0
             if (!_isCollateralized(vars.borrowerDebt, borrower.collateral, result_.newLup, poolState_.poolType)) 
                 revert InsufficientCollateral();
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -153,7 +153,7 @@ import { Maths }   from '../internal/Maths.sol';
      *  @param collateral_ Collateral to calculate collateralization for.
      *  @param price_      Price to calculate collateralization for.
      *  @param type_       Type of the pool.
-     *  @return `True` if collateralization calculated is equal or greater than `1`.
+     *  @return `True` if value of collateral exceeds or equals debt.
      */
     function _isCollateralized(
         uint256 debt_,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -933,7 +933,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             borrowerDebt:              500.480769230769231 * 1e18,
             borrowerCollateral:        50 * 1e18,
             borrowert0Np:              11.529109021431385128 * 1e18,
-            borrowerCollateralization: 300.799971477982403259 * 1e18
+            borrowerCollateralization: 300.799971477982403335 * 1e18
         });
 
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -108,7 +108,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
             borrowerDebt:              21_020.192307692307702000 * 1e18,
             borrowerCollateral:        100 * 1e18,
             borrowert0Np:              242.111289450059087705 * 1e18,
-            borrowerCollateralization: 14.181637252165253251 * 1e18
+            borrowerCollateralization: 14.18163725216525325 * 1e18
         });
 
         assertEq(_collateral.balanceOf(_borrower), 50 * 1e18);
@@ -251,7 +251,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
             borrowerDebt:              21_020.192307692307702000 * 1e18,
             borrowerCollateral:        100 * 1e18,
             borrowert0Np:              242.111289450059087705 * 1e18,
-            borrowerCollateralization: 14.181637252165253251 * 1e18
+            borrowerCollateralization: 14.18163725216525325 * 1e18
         });
 
         assertEq(_collateral.balanceOf(collateralReceiver), 0);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -198,7 +198,7 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
         ) = _poolUtils.poolUtilizationInfo(address(_pool));
 
         assertEq(poolMinDebtAmount,     2_102.019230769230770200 * 1e18);
-        assertEq(poolCollateralization, 14.181637252165253251 * 1e18);
+        assertEq(poolCollateralization, 14.18163725216525325 * 1e18);
         assertEq(poolActualUtilization, 0);
         assertEq(poolTargetUtilization, 1 * 1e18);
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -108,7 +108,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,
@@ -379,7 +379,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             borrowerDebt:              19.534779720182741511 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 154.111154569495900146 * 1e18
+            borrowerCollateralization: 154.111154569495905655 * 1e18
         });
 
         // Amount is restricted by the debt in the loan
@@ -509,7 +509,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             borrowerDebt:              4.876337367651467845 * 1e18,
             borrowerCollateral:        1.057176198768911289 * 1e18,
             borrowert0Np:              5.240398686048708221 * 1e18,
-            borrowerCollateralization: 2.107549546895251001  * 1e18
+            borrowerCollateralization: 2.107549546895251  * 1e18
         });
         _assertLenderLpBalance({
             lender:      _taker,
@@ -679,7 +679,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             borrowerDebt:              19.534528847054102585 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 0.995293609704622699 * 1e18
+            borrowerCollateralization: 0.995293609704622698 * 1e18
         });
 
         // borrower cannot repay amidst auction

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -110,7 +110,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,
@@ -380,7 +380,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             borrowerDebt:              19.940331663853531575 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 150.976799568254654687 * 1e18
+            borrowerCollateralization: 150.976799568254653064 * 1e18
         });
         _assertBucket({
             index:        _i1505_26,
@@ -517,7 +517,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             borrowerDebt:              5.281889311322257910 * 1e18,
             borrowerCollateral:        1.990034968812238781 * 1e18,
             borrowert0Np:              2.954082977863112822 * 1e18,
-            borrowerCollateralization: 3.662651292618643252 * 1e18
+            borrowerCollateralization: 3.662651292618643253 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _taker,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -112,7 +112,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -107,7 +107,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,
@@ -199,7 +199,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             borrowerDebt:              19.272843317722413899 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 0.998794730435100100 * 1e18
+            borrowerCollateralization: 0.998794730435100101 * 1e18
         });
 
         _kick({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -109,7 +109,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -106,7 +106,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerDebt:              19.268509615384615394 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              11.096767433127708186 * 1e18,
-            borrowerCollateralization: 1.009034539679184679 * 1e18
+            borrowerCollateralization: 1.009034539679184678 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -397,7 +397,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             borrowerDebt:              debt,
             borrowerCollateral:        col,
             borrowert0Np:              114.804959297694401926 * 1e18,
-            borrowerCollateralization: 30.207183159927296805 * 1e18
+            borrowerCollateralization: 30.207183159927296803 * 1e18
         });
         _assertPoolPrices({
             htp:      100.173076923076923000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -435,17 +435,18 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
 
         // remove all of the remaining claimable collateral
         uint256 unencumberedCollateral = col - _encumberedCollateral(debt, _lup());
+        uint256 collateralToPull = unencumberedCollateral - 1;
 
         _repayDebtNoLupCheck({
             from:             _borrower,
             borrower:         _borrower,
             amountToRepay:    0,
             amountRepaid:     0,
-            collateralToPull: unencumberedCollateral
+            collateralToPull: collateralToPull
         });
 
-        assertEq(_collateral.balanceOf(address(_pool)),   (50 * 1e18) / ERC20Pool(address(_pool)).collateralScale() - (unencumberedCollateral / ERC20Pool(address(_pool)).collateralScale()));
-        assertEq(_collateral.balanceOf(_borrower), (100 * 1e18) / ERC20Pool(address(_pool)).collateralScale() + (unencumberedCollateral / ERC20Pool(address(_pool)).collateralScale()));
+        assertEq(_collateral.balanceOf(address(_pool)),   (50 * 1e18) / ERC20Pool(address(_pool)).collateralScale() - (collateralToPull / ERC20Pool(address(_pool)).collateralScale()));
+        assertEq(_collateral.balanceOf(_borrower), (100 * 1e18) / ERC20Pool(address(_pool)).collateralScale() + (collateralToPull / ERC20Pool(address(_pool)).collateralScale()));
         assertEq(_quote.balanceOf(address(_pool)),   145_000 * _quotePrecision);
         assertEq(_quote.balanceOf(_borrower), 5_000 * _quotePrecision);
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -433,9 +433,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             depositTime: start
         });
 
-        // remove all of the remaining claimable collateral
-        // FIXME: shouldn't need to subtract 1 to make this work
-        uint256 unencumberedCollateral = col - _encumberedCollateral(debt, _lup()) - 1;
+        // remove all remaining claimable collateral
+        uint256 unencumberedCollateral = col - _encumberedCollateral(debt, _lup());
 
         _repayDebtNoLupCheck({
             from:             _borrower,
@@ -935,7 +934,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
     }
 
     function _encumberedCollateral(uint256 debt_, uint256 price_) internal view returns (uint256 encumberance_) {
-        uint256 unscaledEncumberance =  price_ != 0 && debt_ != 0 ? Maths.wdiv(debt_, price_) : 0;
+        uint256 unscaledEncumberance =  price_ != 0 && debt_ != 0 ? Maths.ceilWdiv(debt_, price_) : 0;
         encumberance_ = _roundUpToScale(unscaledEncumberance, ERC20Pool(address(_pool)).quoteTokenScale());
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -303,7 +303,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrowerDebt:              1_507.000974734143274062 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.993809040625961846 * 1e18
+            borrowerCollateralization: 5.993809040625961852 * 1e18
         });
 
         // pass time to allow additional interest to accumulate
@@ -315,7 +315,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrowerDebt:              1_508.860066921599065132 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.986423966420065589 * 1e18
+            borrowerCollateralization: 5.986423966420065585 * 1e18
         });
 
         // mint additional quote to allow borrower to repay their loan plus interest
@@ -881,7 +881,7 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             borrowerDebt:              1_507.000974734143274062 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.993809040625961846 * 1e18
+            borrowerCollateralization: 5.993809040625961852 * 1e18
         });
 
         // pass time to allow additional interest to accumulate
@@ -893,7 +893,7 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             borrowerDebt:              1_508.860066921599065132 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.986423966420065589 * 1e18
+            borrowerCollateralization: 5.986423966420065585 * 1e18
         });
 
         // mint additional quote to allow borrower to repay their loan plus interest

--- a/tests/forge/unit/ERC721Pool/ERC721PoolInterest.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolInterest.t.sol
@@ -153,7 +153,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             borrowerDebt:              expectedDebt,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              1_902.683561057818747541 * 1e18,
-            borrowerCollateralization: 1.800750077529217167 * 1e18
+            borrowerCollateralization: 1.800750077529217166 * 1e18
         });
 
         _assertLenderInterest(liquidityAdded, 10.004595693661100000 * 1e18);
@@ -555,7 +555,7 @@ contract ERC721PoolSubsetInterestTest is ERC721PoolInterestTest {
             borrowerDebt:              expectedDebt,
             borrowerCollateral:        4 * 1e18,
             borrowert0Np:              1_419.869894115524642215 * 1e18,
-            borrowerCollateralization: 2.404169939255701731 * 1e18
+            borrowerCollateralization: 2.404169939255701732 * 1e18
         });
 
         _assertLenderInterest(liquidityAdded, 25.779680075333500000 * 1e18);

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -136,7 +136,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             borrowerDebt:              15.014423076923076930 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.981531649793150539 * 1e18
+            borrowerCollateralization: 1.981531649793150538 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
@@ -186,7 +186,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             borrowerDebt:              17.218727143819483943 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.727860269914713433 * 1e18
+            borrowerCollateralization: 1.727860269914713432 * 1e18
         });
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -129,7 +129,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
             borrowerDebt:              15.014423076923076930 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.981531649793150539 * 1e18
+            borrowerCollateralization: 1.981531649793150538 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
@@ -222,7 +222,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
             borrowerDebt:              17.218727143819483943 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.727860269914713433 * 1e18
+            borrowerCollateralization: 1.727860269914713432 * 1e18
         });
         _assertKicker({
             kicker:    _lender,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -100,7 +100,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             borrowerDebt:              5_004.807692307692310000 * 1e18,
             borrowerCollateral:        2 * 1e18,
             borrowert0Np:              2_882.277255357846282204 * 1e18,
-            borrowerCollateralization: 1.543977154129479546 * 1e18
+            borrowerCollateralization: 1.543977154129479545 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,
@@ -169,7 +169,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             borrowerDebt:              5_007.093514461301878824 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              1_921.518170238564188136 * 1e18,
-            borrowerCollateralization: 2.314908454001357886 * 1e18
+            borrowerCollateralization: 2.314908454001357885 * 1e18
         });
 
         assertEq(_quote.balanceOf(address(_pool)), 6_151.949363681600046878 * 1e18); // increased by bonds size

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -134,7 +134,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerDebt:              15.014423076923076930 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.981531649793150539 * 1e18
+            borrowerCollateralization: 1.981531649793150538 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 47_000 * 1e18);
@@ -211,7 +211,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerDebt:              17.218727143819483943 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.727860269914713433 * 1e18
+            borrowerCollateralization: 1.727860269914713432 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 46_999.654970307775265454 * 1e18);
@@ -490,7 +490,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             borrowerDebt:              17.218727143819483943 * 1e18,
             borrowerCollateral:        3 * 1e18,
             borrowert0Np:              5.764554510715692564 * 1e18,
-            borrowerCollateralization: 1.727860269914713433 * 1e18
+            borrowerCollateralization: 1.727860269914713432 * 1e18
         });
 
         assertEq(_quote.balanceOf(_lender), 46_999.654970307775265454 * 1e18);

--- a/tests/forge/unit/PoolHelperTest.t.sol
+++ b/tests/forge/unit/PoolHelperTest.t.sol
@@ -93,10 +93,10 @@ contract PoolHelperTest is DSTestPlus {
         uint256 price      = 1_001.6501589292607751220 * 1e18;
         uint256 collateral = 10.98202093218880245 * 1e18;
 
-        // FIXME: _collateralization and _isCollateralized do not agree at 100% CR
         assertEq(_collateralization(debt, collateral, price),        1 * 1e18);
-        // assertEq(_isCollateralized(debt, collateral, price, erc20),  true);
-        // assertEq(_isCollateralized(debt, collateral, price, erc721), true);
+        // due to rounding error, _collateralization and _isCollateralized do not agree at 100% CR
+        assertEq(_isCollateralized(debt, collateral + 1, price, erc20),  true);
+        assertEq(_isCollateralized(debt, 11 * 1e18, price, erc721), true);
 
         assertEq(_collateralization(0, collateral, price),        Maths.WAD);
         assertEq(_isCollateralized(0, collateral, price, erc20),  true);
@@ -119,16 +119,35 @@ contract PoolHelperTest is DSTestPlus {
         debt       = 5_000_000_000 * 1e18;
         price      = _priceAt(1); // 999969141.897027226245329498
         collateral = 1 * 1e18;
-        assertEq(_collateralization(debt, collateral, price),        0.199993828379405445 * 1e18);
+        assertEq(_collateralization(debt, collateral, price), 0.199993828379405445 * 1e18);
         assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
         assertEq(_isCollateralized(debt, collateral, price, erc721), false);
 
         // undercollateralized with tiny amount of high-priced collateral
         debt       = 33_000_000_000 * 1e18;
         collateral = 6;
-        assertEq(_collateralization(debt, collateral, price),        0 * 1e18);
+        assertEq(_collateralization(debt, collateral, price), 0 * 1e18);
         assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
         assertEq(_isCollateralized(debt, collateral, price, erc721), false);
+
+        // 130% CR at high price
+        debt       = 900 * 1e18;
+        collateral = 0.000001170036105095 * 1e18;
+        assertEq(_collateralization(debt, collateral, price), 1.300000000000430128 * 1e18);
+        assertEq(_isCollateralized(debt, collateral, price, erc20), true);
+        assertEq(_isCollateralized(debt, 1e18, price, erc721),      true);
+
+        // undercollateralized at low price
+        price = _priceAt(7388); // 0.000000099836282890
+        assertEq(_collateralization(debt, collateral, price), 0.00000000000000013 * 1e18);
+        assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
+        assertEq(_isCollateralized(debt, collateral, price, erc721), false);
+
+        // 130% CR at low price
+        collateral = 11_719_186_313.147400474096316788 * 1e18;
+        assertEq(_collateralization(debt, collateral, price), 1.3 * 1e18);
+        assertEq(_isCollateralized(debt, collateral, price, erc20),  true);
+        assertEq(_isCollateralized(debt, collateral, price, erc721), true);
     }
 
     /**

--- a/tests/forge/unit/PoolHelperTest.t.sol
+++ b/tests/forge/unit/PoolHelperTest.t.sol
@@ -86,15 +86,49 @@ contract PoolHelperTest is DSTestPlus {
      *  @notice Tests loan/pool collateralization for varying values of debt, collateral and lup
      */
     function testCollateralization() external {
-        uint256 debt  = 11_000.143012091382543917 * 1e18;
-        uint256 price = 1_001.6501589292607751220 * 1e18;
+        uint8   erc20      = uint8(PoolType.ERC20);
+        uint8   erc721     = uint8(PoolType.ERC721);
+
+        uint256 debt       = 11_000.143012091382543917 * 1e18;
+        uint256 price      = 1_001.6501589292607751220 * 1e18;
         uint256 collateral = 10.98202093218880245 * 1e18;
 
-        assertEq(_collateralization(debt, collateral, price),   1 * 1e18);
-        assertEq(_collateralization(0, collateral, price),      Maths.WAD);
-        assertEq(_collateralization(debt, collateral, 0),       Maths.WAD);
-        assertEq(_collateralization(0, collateral, 0),          Maths.WAD);
-        assertEq(_collateralization(debt, 0, price),            0);
+        // FIXME: _collateralization and _isCollateralized do not agree at 100% CR
+        assertEq(_collateralization(debt, collateral, price),        1 * 1e18);
+        // assertEq(_isCollateralized(debt, collateral, price, erc20),  true);
+        // assertEq(_isCollateralized(debt, collateral, price, erc721), true);
+
+        assertEq(_collateralization(0, collateral, price),        Maths.WAD);
+        assertEq(_isCollateralized(0, collateral, price, erc20),  true);
+        assertEq(_isCollateralized(0, collateral, price, erc721), true);
+
+        // if collateral is not worth anything, no amount of debt can be collateralized
+        assertEq(_collateralization(debt, collateral, 0),        0);
+        assertEq(_isCollateralized(debt, collateral, 0, erc20),  false);
+        assertEq(_isCollateralized(debt, collateral, 0, erc721), false);
+
+        assertEq(_collateralization(0, collateral, 0),        Maths.WAD);
+        assertEq(_isCollateralized(0, collateral, 0, erc20),  true);
+        assertEq(_isCollateralized(0, collateral, 0, erc721), true);
+
+        assertEq(_collateralization(debt, 0, price),        0);
+        assertEq(_isCollateralized(debt, 0, price, erc20),  false);
+        assertEq(_isCollateralized(debt, 0, price, erc721), false);
+
+        // undercollateralized with single unit of collateral at high price
+        debt       = 5_000_000_000 * 1e18;
+        price      = _priceAt(1); // 999969141.897027226245329498
+        collateral = 1 * 1e18;
+        assertEq(_collateralization(debt, collateral, price),        0.199993828379405445 * 1e18);
+        assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
+        assertEq(_isCollateralized(debt, collateral, price, erc721), false);
+
+        // undercollateralized with tiny amount of high-priced collateral
+        debt       = 33_000_000_000 * 1e18;
+        collateral = 6;
+        assertEq(_collateralization(debt, collateral, price),        0 * 1e18);
+        assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
+        assertEq(_isCollateralized(debt, collateral, price, erc721), false);
     }
 
     /**


### PR DESCRIPTION
# Description of change
## High level
Reuse `_isCollateralized` method in repayment.  Reusing this code will allow us to more easily change the collateralization requirement / threshold price.  Expanded unit tests for `PoolHelper._isCollateralized` and `PoolInfoUtils._collateralization` methods.


# Description of bug or vulnerability and solution
No bug/vulnerability.

# Contract size
Contract sizes practically unaffected.
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,069B  (97.93%)
  ERC20Pool                -  23,360B  (95.05%)
  PoolInfoUtils            -  13,288B  (54.07%)
  BorrowerActions          -   9,358B  (38.08%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,069B  (97.93%)
  ERC20Pool                -  23,360B  (95.05%)
  PoolInfoUtils            -  13,258B  (53.94%)
  BorrowerActions          -   9,346B  (38.03%)
```

# Gas usage
There was a slight increase in cost to `repayDebt`.
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 1553            | 162421 | 144126 | 400771 | 34      |
| addQuoteToken                        | 1950            | 256226 | 171180 | 723088 | 919     |
| bucketCollateralDust                 | 1152            | 1834   | 1152   | 3099   | 17      |
| bucketExchangeRate                   | 14696           | 17243  | 16006  | 33332  | 865     |
| bucketInfo                           | 4571            | 7238   | 6206   | 42027  | 3283    |
| bucketTake                           | 8165            | 111835 | 107046 | 357768 | 34      |
| drawDebt                             | 7442            | 243934 | 229841 | 592550 | 504     |
| kick                                 | 6878            | 477983 | 572805 | 713526 | 55      |
| kickReserveAuction                   | 4090            | 48187  | 51755  | 100698 | 105     |
| kickerInfo                           | 1304            | 2332   | 1304   | 5304   | 140     |
| moveQuoteToken                       | 1918            | 151323 | 107324 | 634633 | 41      |
| removeCollateral                     | 4412            | 57217  | 58408  | 157370 | 100     |
| removeQuoteToken                     | 4698            | 70245  | 63688  | 621261 | 405     |
| repayDebt                            | 9853            | 191633 | 120664 | 589911 | 296     |
| settle                               | 11765           | 202099 | 170123 | 510561 | 58      |
| take                                 | 9159            | 185511 | 184787 | 570795 | 42      |
| takeReserves                         | 6714            | 113862 | 140256 | 153184 | 60      |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |          |         |
|----------------------------------------|-----------------|--------|--------|----------|---------|
| Function Name                          | min             | avg    | median | max      | # calls |
| addCollateral                          | 23601           | 894551 | 303067 | 6193522  | 9       |
| addQuoteToken                          | 43467           | 280023 | 215624 | 682428   | 183     |
| bucketInfo                             | 4148            | 9476   | 7181   | 39239    | 111522  |
| bucketTake                             | 98327           | 193479 | 136773 | 508779   | 13      |
| bucketTokenIds                         | 1279            | 1279   | 1279   | 1279     | 120     |
| drawDebt                               | 12207           | 694581 | 302620 | 66535639 | 166     |
| kick                                   | 6878            | 517649 | 565965 | 783665   | 13      |
| kickReserveAuction                     | 6912            | 57451  | 64977  | 104077   | 8       |
| kickerInfo                             | 1326            | 2468   | 1326   | 5326     | 42      |
| moveQuoteToken                         | 45953           | 53109  | 46131  | 67228    | 6       |
| removeCollateral                       | 3779            | 112208 | 66745  | 926760   | 21      |
| removeQuoteToken                       | 4830            | 62850  | 59734  | 182722   | 140     |
| repayDebt                              | 8354            | 543587 | 117424 | 42863028 | 118     |
| settle                                 | 108920          | 332643 | 268003 | 714682   | 15      |
| take                                   | 12144           | 311693 | 382145 | 706382   | 13      |
| takeReserves                           | 4449            | 82426  | 63969  | 164783   | 8       |

## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 1553            | 162405 | 144126 | 400771 | 34      |
| addQuoteToken                        | 1950            | 253806 | 170017 | 723088 | 942     |
| bucketCollateralDust                 | 1152            | 1948   | 1152   | 3099   | 17      |
| bucketExchangeRate                   | 14696           | 17207  | 16006  | 33332  | 928     |
| bucketInfo                           | 4571            | 7172   | 6206   | 46561  | 3980    |
| bucketTake                           | 8165            | 113178 | 108059 | 398012 | 34      |
| drawDebt                             | 7442            | 244350 | 230546 | 592550 | 515     |
| kick                                 | 6878            | 483024 | 572805 | 713526 | 54      |
| kickReserveAuction                   | 4090            | 44417  | 51755  | 100698 | 129     |
| kickerInfo                           | 1304            | 2332   | 1304   | 5304   | 140     |
| moveQuoteToken                       | 1918            | 148419 | 107324 | 634633 | 41      |
| removeCollateral                     | 4412            | 56894  | 58408  | 157370 | 103     |
| removeQuoteToken                     | 4698            | 70373  | 63688  | 621261 | 403     |
| repayDebt                            | 9853            | 193967 | 126946 | 589911 | 307     |
| settle                               | 11765           | 206109 | 176798 | 451449 | 58      |
| take                                 | 9159            | 184352 | 184787 | 570795 | 42      |
| takeReserves                         | 6714            | 106542 | 135626 | 153184 | 72      |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |         |         |
|----------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                          | min             | avg    | median | max     | # calls |
| addCollateral                          | 23601           | 571551 | 303067 | 3286525 | 9       |
| addQuoteToken                          | 43467           | 280023 | 215624 | 682428  | 183     |
| bucketInfo                             | 4148            | 9476   | 7181   | 39239   | 111522  |
| bucketTake                             | 98327           | 193479 | 136773 | 508779  | 13      |
| bucketTokenIds                         | 1279            | 1279   | 1279   | 1279    | 65      |
| drawDebt                               | 12207           | 300847 | 302620 | 1175788 | 166     |
| kick                                   | 6878            | 517649 | 565965 | 783665  | 13      |
| kickReserveAuction                     | 6912            | 57451  | 64977  | 104077  | 8       |
| kickerInfo                             | 1326            | 2468   | 1326   | 5326    | 42      |
| moveQuoteToken                         | 45953           | 53109  | 46131  | 67228   | 6       |
| removeCollateral                       | 3779            | 88802  | 66745  | 435224  | 21      |
| removeQuoteToken                       | 4830            | 62850  | 59734  | 182722  | 140     |
| repayDebt                              | 8354            | 187537 | 117597 | 835920  | 118     |
| settle                                 | 108920          | 332643 | 268003 | 714682  | 15      |
| take                                   | 12144           | 311693 | 382145 | 706382  | 13      |
| takeReserves                           | 4449            | 82426  | 63969  | 164783  | 8       |

