### PR TITLE
Add debt and collateral settled returns in settle function

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -345,7 +345,7 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external override nonReentrant {
+    ) external override nonReentrant returns (uint256 debtSettled_, uint256 collateralSettled_) {
         PoolState memory poolState = _accruePoolInterest();
 
         SettleResult memory result = SettlerActions.settlePoolDebt(
@@ -363,6 +363,9 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
         );
 
         _updatePostSettleState(result, poolState);
+
+        debtSettled_       = Maths.wmul(result.t0DebtSettled, poolState.inflator);
+        collateralSettled_ = result.collateralSettled;
     }
 
     /**

--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -345,7 +345,7 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external override nonReentrant returns (uint256 debtSettled_, uint256 collateralSettled_) {
+    ) external override nonReentrant returns (uint256 collateralSettled_, bool isBorrowerSettled_) {
         PoolState memory poolState = _accruePoolInterest();
 
         SettleResult memory result = SettlerActions.settlePoolDebt(
@@ -364,8 +364,8 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
 
         _updatePostSettleState(result, poolState);
 
-        debtSettled_       = Maths.wmul(result.t0DebtSettled, poolState.inflator);
         collateralSettled_ = result.collateralSettled;
+        isBorrowerSettled_ = (result.debtPostAction == 0);
     }
 
     /**

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -394,7 +394,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external nonReentrant override {
+    ) external nonReentrant override returns (uint256 debtSettled_, uint256 collateralSettled_) {
         PoolState memory poolState = _accruePoolInterest();
 
         SettleParams memory params = SettleParams({
@@ -417,6 +417,9 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
 
         // move token ids from borrower array to pool claimable array if any collateral used to settle bad debt
         _rebalanceTokens(params.borrower, result.collateralRemaining);
+
+        debtSettled_       = Maths.wmul(result.t0DebtSettled, poolState.inflator);
+        collateralSettled_ = result.collateralSettled;
     }
 
     /**

--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -394,7 +394,7 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external nonReentrant override returns (uint256 debtSettled_, uint256 collateralSettled_) {
+    ) external nonReentrant override returns (uint256 collateralSettled_, bool isBorrowerSettled_) {
         PoolState memory poolState = _accruePoolInterest();
 
         SettleParams memory params = SettleParams({
@@ -418,8 +418,8 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
         // move token ids from borrower array to pool claimable array if any collateral used to settle bad debt
         _rebalanceTokens(params.borrower, result.collateralRemaining);
 
-        debtSettled_       = Maths.wmul(result.t0DebtSettled, poolState.inflator);
         collateralSettled_ = result.collateralSettled;
+        isBorrowerSettled_ = (result.debtPostAction == 0);
     }
 
     /**

--- a/src/interfaces/pool/commons/IPoolSettlerActions.sol
+++ b/src/interfaces/pool/commons/IPoolSettlerActions.sol
@@ -11,13 +11,13 @@ interface IPoolSettlerActions {
      *  @notice Called by actors to settle an amount of debt in a completed liquidation.
      *  @param  borrowerAddress_   Address of the auctioned borrower.
      *  @param  maxDepth_          Measured from `HPB`, maximum number of buckets deep to settle debt.
-     *  @return debtSettled_       Amount of debt settled.
      *  @return collateralSettled_ Amount of collateral settled.
+     *  @return isBorrowerSettled_ Is all borrower's debt is settled.
      *  @dev    `maxDepth_` is used to prevent unbounded iteration clearing large liquidations.
      */
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external returns (uint256 debtSettled_, uint256 collateralSettled_);
+    ) external returns (uint256 collateralSettled_, bool isBorrowerSettled_);
 
 }

--- a/src/interfaces/pool/commons/IPoolSettlerActions.sol
+++ b/src/interfaces/pool/commons/IPoolSettlerActions.sol
@@ -9,13 +9,15 @@ interface IPoolSettlerActions {
 
     /**
      *  @notice Called by actors to settle an amount of debt in a completed liquidation.
-     *  @param  borrowerAddress_ Address of the auctioned borrower.
-     *  @param  maxDepth_        Measured from `HPB`, maximum number of buckets deep to settle debt.
+     *  @param  borrowerAddress_   Address of the auctioned borrower.
+     *  @param  maxDepth_          Measured from `HPB`, maximum number of buckets deep to settle debt.
+     *  @return debtSettled_       Amount of debt settled.
+     *  @return collateralSettled_ Amount of collateral settled.
      *  @dev    `maxDepth_` is used to prevent unbounded iteration clearing large liquidations.
      */
     function settle(
         address borrowerAddress_,
         uint256 maxDepth_
-    ) external;
+    ) external returns (uint256 debtSettled_, uint256 collateralSettled_);
 
 }


### PR DESCRIPTION
# Description of change
## High level
* Return `debtSettled_ ` and `collateralSettled_ ` in `settle`

Reasoning:
The `settle` method currently has no return value.  As such, callers do not know whether their call was sufficient to settle auction debt, or if another call is needed to settle against additional buckets.

At a minimum, the method could return a `boolean` indicating whether auction was fully settled.  Better would be to return the amount of debt and collateral settled.