### PR TITLE
Low-lying fruit

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -454,7 +454,6 @@ contract PoolInfoUtils {
             bucketCollateral,
             bucketDeposit,
             lp_,
-            bucketDeposit,
             _priceAt(index_)
         );
     }

--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -324,7 +324,6 @@ contract PositionManager is PermitERC721, IPositionManager, ReentrancyGuard {
             vars.bucketCollateral,
             vars.bucketDeposit,
             vars.fromLP,
-            vars.bucketDeposit,
             _priceAt(fromIndex_)
         );
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.18;
 import { Clone }           from '@clones/Clone.sol';
 import { ReentrancyGuard } from '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import { Multicall }       from '@openzeppelin/contracts/utils/Multicall.sol';
+import { SafeCast }        from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { SafeERC20 }       from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 }          from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -684,13 +685,13 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         // update pool inflator
         if (poolState_.isNewInterestAccrued) {
-            inflatorState.inflator       = uint208(poolState_.inflator);
-            inflatorState.inflatorUpdate = uint48(block.timestamp);
+            inflatorState.inflator       = SafeCast.toUint208(poolState_.inflator);
+            inflatorState.inflatorUpdate = SafeCast.toUint48(block.timestamp);
         // if the debt in the current pool state is 0, also update the inflator and inflatorUpdate fields in inflatorState
         // slither-disable-next-line incorrect-equality
         } else if (poolState_.debt == 0) {
-            inflatorState.inflator       = uint208(Maths.WAD);
-            inflatorState.inflatorUpdate = uint48(block.timestamp);
+            inflatorState.inflator       = SafeCast.toUint208(Maths.WAD);
+            inflatorState.inflatorUpdate = SafeCast.toUint48(block.timestamp);
         }
     }
 

--- a/src/base/PoolDeployer.sol
+++ b/src/base/PoolDeployer.sol
@@ -77,6 +77,7 @@ abstract contract PoolDeployer {
      * @notice Returns the list of all deployed pools.
      * @dev    This function is used by integrations to access deployed pools.
      * @dev    Each factory implementation maintains its own list of deployed pools.
+     * @dev    This method should only be used by off-chain integrations.
      * @return List of all deployed pools.
      */
     function getDeployedPoolsList() external view returns (address[] memory) {

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.18;
 
 import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 import { Math }           from '@openzeppelin/contracts/utils/math/Math.sol';
+import { SafeCast }       from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import { PoolType } from '../../interfaces/pool/IPool.sol';
 
@@ -569,14 +570,14 @@ library TakerActions {
     ) internal {
         if (vars.isRewarded) {
             // take is below neutralPrice, Kicker is rewarded
-            liquidation_.bondSize                 += uint160(vars.bondChange);
+            liquidation_.bondSize                 += SafeCast.toUint160(vars.bondChange);
             auctions_.kickers[vars.kicker].locked += vars.bondChange;
             auctions_.totalBondEscrowed           += vars.bondChange;
         } else {
             // take is above neutralPrice, Kicker is penalized
             vars.bondChange = Maths.min(liquidation_.bondSize, vars.bondChange);
 
-            liquidation_.bondSize                 -= uint160(vars.bondChange);
+            liquidation_.bondSize                 -= SafeCast.toUint160(vars.bondChange);
             auctions_.kickers[vars.kicker].locked -= vars.bondChange;
             auctions_.totalBondEscrowed           -= vars.bondChange;
         }
@@ -653,7 +654,7 @@ library TakerActions {
             // take is above neutralPrice, Kicker is penalized
             vars.bondChange = Maths.min(liquidation_.bondSize, vars.bondChange);
 
-            liquidation_.bondSize -= uint160(vars.bondChange);
+            liquidation_.bondSize -= SafeCast.toUint160(vars.bondChange);
 
             auctions_.kickers[vars.kicker].locked -= vars.bondChange;
             auctions_.totalBondEscrowed           -= vars.bondChange;

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -226,7 +226,6 @@ import { Maths }   from '../internal/Maths.sol';
      *  @param  bucketCollateral_ Amount of collateral in bucket.
      *  @param  deposit_          Current bucket deposit (quote tokens). Used to calculate bucket's exchange rate / `LP`.
      *  @param  lenderLPBalance_  The amount of `LP` to calculate quote token amount for.
-     *  @param  maxQuoteToken_    The max quote token amount to calculate `LP` for.
      *  @param  bucketPrice_      Bucket's price.
      *  @return quoteTokenAmount_ Amount of quote tokens calculated for the given `LP` amount, capped at available bucket deposit.
      */
@@ -235,7 +234,6 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 bucketCollateral_,
         uint256 deposit_,
         uint256 lenderLPBalance_,
-        uint256 maxQuoteToken_,
         uint256 bucketPrice_
     ) pure returns (uint256 quoteTokenAmount_) {
         quoteTokenAmount_ = Buckets.lpToQuoteTokens(
@@ -247,8 +245,7 @@ import { Maths }   from '../internal/Maths.sol';
             Math.Rounding.Down
         );
 
-        if (quoteTokenAmount_ > deposit_)       quoteTokenAmount_ = deposit_;
-        if (quoteTokenAmount_ > maxQuoteToken_) quoteTokenAmount_ = maxQuoteToken_;
+        if (quoteTokenAmount_ > deposit_) quoteTokenAmount_ = deposit_;
     }
 
     /**

--- a/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedPositionPoolHandler.sol
+++ b/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedPositionPoolHandler.sol
@@ -233,7 +233,6 @@ abstract contract UnboundedPositionPoolHandler is UnboundedBasePositionHandler, 
             bucketCollateral,
             bucketDeposit,
             lp,
-            bucketDeposit,
             _priceAt(index)
         );
     }

--- a/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedRewardsPoolHandler.sol
+++ b/tests/forge/invariants/PositionsAndRewards/handlers/unbounded/UnboundedRewardsPoolHandler.sol
@@ -8,7 +8,6 @@ import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import { IPositionManagerOwnerActions } from 'src/interfaces/position/IPositionManagerOwnerActions.sol';
 import { 
     _depositFeeRate,
-    _lpToQuoteToken,
     _priceAt
     }                                   from 'src/libraries/helpers/PoolHelper.sol';
 import { Maths }                        from "src/libraries/internal/Maths.sol";

--- a/tests/forge/unit/Auctions.t.sol
+++ b/tests/forge/unit/Auctions.t.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.18;
 
 import '../utils/DSTestPlus.sol';
+import '../utils/AuctionQueueInstance.sol';
 
 contract AuctionsTest is DSTestPlus {
-
     /**
      *  @notice Tests bond penalty/reward factor calculation for varying parameters
      */
@@ -103,5 +103,57 @@ contract AuctionsTest is DSTestPlus {
         assertEq(_claimableReserves(debt, 11_000 * 1e18, 11_000 * 1e18, reserveAuctionUnclaimed, 0),                       0);
         assertEq(_claimableReserves(debt, poolSize, 11_000 * 1e18, 10_895 * 1e18, quoteTokenBalance),                      0);
     }
+}
 
+contract AuctionQueueTest is DSTestPlus {
+    AuctionQueueInstance private _auctions;
+
+    function setUp() public {
+       _auctions = new AuctionQueueInstance();
+    }
+
+    function testAuctionsQueueAddRemove() external {
+        address b1 = makeAddr("b1");
+        address b2 = makeAddr("b2");
+        address b3 = makeAddr("b3");
+        assertEq(_auctions.count(), 0);
+
+        _auctions.add(b1);
+        assertEq(_auctions.count(), 1);
+        _auctions.add(b2);
+        assertEq(_auctions.count(), 2);
+        _auctions.add(b3);
+        assertEq(_auctions.count(), 3);
+
+        _auctions.remove(b2);
+        assertEq(_auctions.count(), 2);
+        _auctions.remove(b1);
+        assertEq(_auctions.count(), 1);
+        _auctions.remove(b3);
+        assertEq(_auctions.count(), 0);
+    }
+
+    function testAuctionsQueueRemoveOnlyAuction() external {
+        address b1 = makeAddr("b1");
+        address b2 = makeAddr("b2");
+        address b3 = makeAddr("b3");
+
+        // add and remove the only auction on the queue
+        _auctions.add(b1);
+        assertEq(_auctions.count(), 1);
+        _auctions.remove(b1);
+        assertEq(_auctions.count(), 0);
+
+        // add new auctions
+        _auctions.add(b2);
+        assertEq(_auctions.count(), 1);
+        _auctions.add(b3);
+        assertEq(_auctions.count(), 2);
+
+        // remove new auctions
+        _auctions.remove(b2);
+        assertEq(_auctions.count(), 1);
+        _auctions.remove(b3);
+        assertEq(_auctions.count(), 0);
+    }
 }

--- a/tests/forge/unit/FenwickTree.t.sol
+++ b/tests/forge/unit/FenwickTree.t.sol
@@ -152,6 +152,24 @@ contract FenwickTreeTest is DSTestPlus {
         assertEq(_tree.valueAt(3_700), 0);
     }
 
+    function testFenwickOutOfBoundsBehavior() external {
+        uint depositAmount = 3 * 1e18;
+
+        // set up a tree with 100 deposit in each bucket
+        for (uint256 i; i < MAX_FENWICK_INDEX; i++) {
+            _tree.add(i, depositAmount);
+        }
+
+        // try sum of bottom bucket
+        assertEq(_tree.prefixSum(0), depositAmount);
+        assertEq(_tree.prefixSum(1), 2 * depositAmount);
+
+        // try a prefixSum above SIZE
+        assertEq(_tree.prefixSum(MAX_INDEX + 1), depositAmount * MAX_FENWICK_INDEX);
+        // CAUTION: this will cause infinite loop
+        // assertEq(_tree.prefixSum(8192 + 1), depositAmount * MAX_FENWICK_INDEX);
+    }
+
     /**
      *  @notice Fuzz tests additions and scaling values, testing findSum.
      */

--- a/tests/forge/unit/Heap.t.sol
+++ b/tests/forge/unit/Heap.t.sol
@@ -231,6 +231,42 @@ contract HeapTest is DSTestPlus {
         assertEq(_loans.getTotalTps(),    7);
     }
 
+    function testHeapZeroInsertion() public {
+        address b1 = makeAddr("b1");
+        address b2 = makeAddr("b2");
+        address b3 = makeAddr("b3");
+
+        _loans.upsertTp(b1, 0);
+        assertEq(_loans.getMaxTp(),       0);
+        assertEq(_loans.getMaxBorrower(), b1);
+        assertEq(_loans.getTotalTps(),    2);
+
+        _loans.upsertTp(b2, 153 * 1e18);
+        assertEq(_loans.getMaxTp(),       153 * 1e18);
+        assertEq(_loans.getMaxBorrower(), b2);
+        assertEq(_loans.getTotalTps(),    3);
+
+        _loans.removeTp(b2);
+        assertEq(_loans.getMaxTp(),       0);
+        assertEq(_loans.getMaxBorrower(), b1);
+        assertEq(_loans.getTotalTps(),    2);
+
+        _loans.upsertTp(b3, 2_007 * 1e18);
+        assertEq(_loans.getMaxTp(),       2_007 * 1e18);
+        assertEq(_loans.getMaxBorrower(), b3);
+        assertEq(_loans.getTotalTps(),    3);
+
+        _loans.removeTp(b1);
+        assertEq(_loans.getMaxTp(),       2_007 * 1e18);
+        assertEq(_loans.getMaxBorrower(), b3);
+        assertEq(_loans.getTotalTps(),    2);
+
+        _loans.removeTp(b3);
+        assertEq(_loans.getMaxBorrower(), address(0));
+        assertEq(_loans.getMaxTp(),       0);
+        assertEq(_loans.getTotalTps(),    1);
+    }
+
     function testLoadHeapFuzzy(uint256 inserts_, uint256 seed_) public {
 
         // test adding different TPs

--- a/tests/forge/utils/AuctionQueueInstance.sol
+++ b/tests/forge/utils/AuctionQueueInstance.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+import './DSTestPlus.sol';
+
+import {
+    AuctionsState,
+    Borrower,
+    Bucket,
+    DepositsState,
+    LoansState,
+    PoolState,
+    ReserveAuctionState
+}                         from 'src/interfaces/pool/commons/IPoolState.sol';
+import { SettleParams }   from 'src/interfaces/pool/commons/IPoolInternals.sol';
+import { PoolType }       from 'src/interfaces/pool/IPool.sol';
+
+import { Buckets }        from 'src/libraries/internal/Buckets.sol';
+import { Deposits }       from 'src/libraries/internal/Deposits.sol';
+import { Loans }          from 'src/libraries/internal/Loans.sol';
+import { Maths }          from 'src/libraries/internal/Maths.sol';
+
+import { KickerActions }  from 'src/libraries/external/KickerActions.sol';
+import { SettlerActions } from 'src/libraries/external/SettlerActions.sol';
+
+import { _indexOf }       from 'src/libraries/helpers/PoolHelper.sol';
+
+contract AuctionQueueInstance is DSTestPlus {
+    AuctionsState              private _auctions;
+    mapping(uint256 => Bucket) private _buckets;
+    DepositsState              private _deposits;
+    LoansState                 private _loans;
+    PoolState                  private _poolState;
+    ReserveAuctionState        private _reserveAuction;
+
+    uint256 private constant LOAN_SIZE =   100 * 1e18;
+    uint256 private constant TP        =     5 * 1e18;
+    uint256 private constant LUP       =     4 * 1e18;
+    uint256 private constant LUP_INDEX = 3_878;
+    address private          _lender;
+
+    constructor() {
+        Loans.init(_loans);
+        _poolState.inflator        = 1 * 1e18;
+        // _poolState.rate            = 0.05 * 1e18;
+        _poolState.poolType        = uint8(PoolType.ERC20);
+        _poolState.quoteTokenScale = 18;
+        _lender                    = makeAddr("lender");
+        skip(1);
+    }
+
+    function add(address loan) external {
+        _mockDraw(loan);
+        KickerActions.kick(
+            _auctions,
+            _deposits,
+            _loans,
+            _poolState,
+            loan,
+            7_388
+        );
+    }
+
+    function remove(address loan) external {
+        _mockSettle(loan);
+        SettlerActions.settlePoolDebt(
+            _auctions,
+            _buckets,
+            _deposits,
+            _loans,
+            _reserveAuction,
+            _poolState,
+            SettleParams({
+                borrower:    loan,
+                poolBalance: type(uint256).max,
+                bucketDepth: 1
+            })
+        );
+    }
+
+    function count() external view returns (uint256 count_) {
+        return _auctions.noOfAuctions;
+    }
+
+    function _mockDraw(address loan) internal {
+        // add debt and collateral to PoolState
+        uint256 pledge        =  Maths.wdiv(LOAN_SIZE, TP);
+        _poolState.debt       += LOAN_SIZE;
+        _poolState.collateral += pledge;
+
+        // create Deposits with single Bucket at LUP
+        Deposits.unscaledAdd(_deposits, LUP_INDEX, LOAN_SIZE);
+        Bucket storage bucket =  _buckets[LUP_INDEX];
+        bucket.lps            += LOAN_SIZE;
+        Buckets.addLenderLP(bucket, 0, _lender, LOAN_SIZE);
+
+        // add Borrower to Loans
+        Borrower memory borrower;
+        borrower.t0Debt = LOAN_SIZE;
+        borrower.collateral = pledge;
+        borrower.npTpRatio = 1 * 1e18;
+        Loans.update(_loans, borrower, loan, _poolState.rate, false, false);
+    }
+
+    function _mockSettle(address loan) internal {
+        // remove debt and collateral from PoolState
+        uint256 pull = Maths.wdiv(LOAN_SIZE, TP);
+        _poolState.debt       -= LOAN_SIZE;
+        _poolState.collateral -= pull;
+
+        // remove Borrower from Loans
+        Borrower memory borrower;
+        borrower.t0Debt     = 0;
+        borrower.collateral = 0;
+        Loans.update(_loans, borrower, loan, _poolState.rate, false, false);
+
+        // remove liquidity from LUP
+        Deposits.unscaledRemove(_deposits, LUP_INDEX, LOAN_SIZE);
+        Bucket storage bucket =  _buckets[LUP_INDEX];
+        bucket.lps            -= LOAN_SIZE;
+    }
+}


### PR DESCRIPTION
# Description of change
## High level
Resolved some low-severity issues brought up in Kirill and Sherlock audits.  Added some unit tests to disprove issues brought up in Sherlock audit.

# Description of bug or vulnerability and solution
**Kirill L-05** - Removed redundant parameters and logic from `_lpToQuoteToken` method (https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)
**Kirill L-07** - Added comment explaining `getDeployedPoolsList` method is not for onchain use (https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)
**Sherlock [007-M](https://github.com/sherlock-audit/2023-09-ajna-judging/issues/46)** - Added `SafeCast`s where appropriate to revert upon overflow.
**Sherlock [54](https://github.com/sherlock-audit/2023-09-ajna-judging/issues/54) and [60](https://github.com/sherlock-audit/2023-09-ajna-judging/issues/60)** - Added unit tests to prove invalid, including implementing test harness for auction queue.

# Contract size
Small increase in contract size from including `SafeCast` in `Pool` baseclass and `TakerActions` library.
## Pre Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,069B  (97.93%)
  ERC20Pool                -  23,360B  (95.05%)
  PositionManager          -  17,885B  (72.77%)
  TakerActions             -  15,866B  (64.56%)
```
## Post Change
```
============ Deployment Bytecode Sizes ============
  ERC721Pool               -  24,323B  (98.97%)
  ERC20Pool                -  23,614B  (96.08%)
  PositionManager          -  17,882B  (72.76%)
  TakerActions             -  16,001B  (65.11%)
```

# Gas usage
`SafeCast` induced a small gas penalty in interest-accruing transactions.
## Pre Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 1553            | 162395 | 144126 | 400771 | 34      |
| addQuoteToken                        | 1950            | 257429 | 171180 | 723088 | 903     |
| bucketTake                           | 8165            | 111714 | 107028 | 357178 | 34      |
| drawDebt                             | 7442            | 244655 | 230546 | 592550 | 521     |
| kick                                 | 6878            | 470667 | 572805 | 713526 | 56      |
| kickReserveAuction                   | 4090            | 43454  | 51755  | 100698 | 137     |
| kickerInfo                           | 1304            | 2332   | 1304   | 5304   | 140     |
| moveQuoteToken                       | 1918            | 141585 | 107168 | 634633 | 41      |
| removeCollateral                     | 4412            | 57127  | 58408  | 157370 | 103     |
| removeQuoteToken                     | 4698            | 70563  | 64360  | 621261 | 391     |
| repayDebt                            | 9853            | 194590 | 128398 | 589911 | 311     |
| settle                               | 11765           | 203393 | 170589 | 507761 | 60      |
| take                                 | 9159            | 185238 | 184787 | 579429 | 42      |
| takeReserves                         | 6714            | 104616 | 115461 | 153184 | 76      |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |          |         |
|----------------------------------------|-----------------|--------|--------|----------|---------|
| Function Name                          | min             | avg    | median | max      | # calls |
| addCollateral                          | 23601           | 268358 | 303067 | 738259   | 9       |
| addQuoteToken                          | 43467           | 279826 | 215624 | 682428   | 185     |
| bucketTake                             | 98327           | 193479 | 136773 | 508779   | 13      |
| drawDebt                               | 12207           | 362950 | 302620 | 11484930 | 166     |
| kick                                   | 6878            | 517649 | 565965 | 783665   | 13      |
| kickReserveAuction                     | 6912            | 57451  | 64977  | 104077   | 8       |
| kickerInfo                             | 1326            | 2468   | 1326   | 5326     | 42      |
| moveQuoteToken                         | 45953           | 53109  | 46131  | 67228    | 6       |
| removeCollateral                       | 3779            | 72163  | 66745  | 167878   | 21      |
| removeQuoteToken                       | 4830            | 62755  | 59002  | 182722   | 142     |
| repayDebt                              | 8354            | 243817 | 117597 | 7476997  | 118     |
| settle                                 | 108920          | 332643 | 268003 | 714682   | 15      |
| take                                   | 12144           | 311693 | 382145 | 706382   | 13      |
| takeReserves                           | 4449            | 82426  | 63969  | 164783   | 8       |

## Post Change
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |        |         |
|--------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                        | min             | avg    | median | max    | # calls |
| addCollateral                        | 1553            | 162836 | 144673 | 401305 | 34      |
| addQuoteToken                        | 1950            | 254785 | 170564 | 723622 | 928     |
| bucketTake                           | 8165            | 113071 | 107028 | 398194 | 34      |
| drawDebt                             | 7442            | 244631 | 230546 | 592550 | 509     |
| kick                                 | 6878            | 511407 | 573339 | 714060 | 50      |
| kickReserveAuction                   | 4090            | 44945  | 51755  | 100698 | 125     |
| kickerInfo                           | 1304            | 2332   | 1304   | 5304   | 140     |
| moveQuoteToken                       | 1918            | 141744 | 107168 | 635167 | 41      |
| removeCollateral                     | 4412            | 57244  | 58955  | 157904 | 103     |
| removeQuoteToken                     | 4698            | 70866  | 64324  | 621795 | 397     |
| repayDebt                            | 9853            | 194232 | 127384 | 590445 | 305     |
| settle                               | 11765           | 214023 | 199993 | 437278 | 54      |
| take                                 | 9159            | 184991 | 185391 | 579097 | 42      |
| takeReserves                         | 6714            | 107588 | 140256 | 153184 | 70      |

| src/ERC721Pool.sol:ERC721Pool contract |                 |        |        |        |         |
|----------------------------------------|-----------------|--------|--------|--------|---------|
| Function Name                          | min             | avg    | median | max    | # calls |
| addCollateral                          | 23601           | 251198 | 303614 | 738793 | 9       |
| addQuoteToken                          | 43467           | 280581 | 216171 | 682962 | 184     |
| bucketTake                             | 98327           | 193601 | 136846 | 509313 | 13      |
| drawDebt                               | 12207           | 297778 | 302620 | 685792 | 166     |
| kick                                   | 6878            | 518068 | 566499 | 784199 | 13      |
| kickReserveAuction                     | 6912            | 57451  | 64977  | 104077 | 8       |
| kickerInfo                             | 1326            | 2468   | 1326   | 5326   | 42      |
| moveQuoteToken                         | 45953           | 53255  | 46131  | 67666  | 6       |
| removeCollateral                       | 3779            | 71534  | 66745  | 168305 | 21      |
| removeQuoteToken                       | 4830            | 63237  | 59519  | 183256 | 141     |
| repayDebt                              | 8354            | 185133 | 117597 | 643012 | 118     |
| settle                                 | 108920          | 333008 | 268537 | 715216 | 15      |
| take                                   | 12144           | 312014 | 382752 | 706986 | 13      |
| takeReserves                           | 4449            | 82426  | 63969  | 164783 | 8       |

