### PR TITLE
Use bucket price for BPF calculation

### DIFF
--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -27,7 +27,6 @@ import {
 import {
     MAX_INFLATED_PRICE,
     _bondParams,
-    _bpf,
     _claimableReserves,
     _isCollateralized,
     _priceAt,

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -344,6 +344,7 @@ library TakerActions {
 
         vars_ = _prepareTake(
             liquidation,
+            0,
             borrower_.t0Debt,
             borrower_.collateral,
             params_.inflator
@@ -427,6 +428,7 @@ library TakerActions {
 
         vars_= _prepareTake(
             liquidation,
+            _priceAt(params_.index),
             borrower_.t0Debt,
             borrower_.collateral,
             params_.inflator
@@ -436,8 +438,6 @@ library TakerActions {
 
         // revert if no quote tokens in arbed bucket
         if (vars_.unscaledDeposit == 0) revert InsufficientLiquidity();
-
-        vars_.bucketPrice  = _priceAt(params_.index);
 
         // cannot arb with a price lower than the auction price
         if (vars_.auctionPrice > vars_.bucketPrice) revert AuctionPriceGtBucketPrice();
@@ -680,6 +680,7 @@ library TakerActions {
      *  @dev    reverts on:
      *              - loan is not in auction NoAuction()
      *  @param  liquidation_ Liquidation struct holding auction details.
+     *  @param  bucketPrice_ Price of the bucket, or 0 for non-bucket takes.
      *  @param  t0Debt_      Borrower t0 debt.
      *  @param  collateral_  Borrower collateral.
      *  @param  inflator_    The pool's inflator, used to calculate borrower debt.
@@ -687,6 +688,7 @@ library TakerActions {
      */
     function _prepareTake(
         Liquidation memory liquidation_,
+        uint256 bucketPrice_,
         uint256 t0Debt_,
         uint256 collateral_,
         uint256 inflator_
@@ -702,13 +704,14 @@ library TakerActions {
         uint256 neutralPrice = liquidation_.neutralPrice;
 
         vars.auctionPrice = _auctionPrice(liquidation_.referencePrice, kickTime);
+        vars.bucketPrice = bucketPrice_;
         vars.bondFactor   = liquidation_.bondFactor;
         vars.bpf          = _bpf(
             vars.borrowerDebt,
             collateral_,
             neutralPrice,
             liquidation_.bondFactor,
-            vars.auctionPrice
+            bucketPrice_ == 0 ? vars.auctionPrice : bucketPrice_
         );
         vars.factor       = uint256(1e18 - Maths.maxInt(0, vars.bpf));
         vars.kicker       = liquidation_.kicker;

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -376,7 +376,7 @@ import { Maths }   from '../internal/Maths.sol';
      *  @param collateral_   Borrower collateral.
      *  @param neutralPrice_ `NP` of auction.
      *  @param bondFactor_   Factor used to determine bondSize.
-     *  @param auctionPrice_ Auction price at the time of call.
+     *  @param auctionPrice_ Auction price at the time of call or, for bucket takes, bucket price.
      *  @return bpf_         Factor used in determining bond `reward` (positive) or `penalty` (negative).
      */
     function _bpf(

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -281,10 +281,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:            _i9_91,
             collateralArbed:  2 * 1e18,
             quoteTokenAmount: 18.919873153126569032 * 1e18,
-            bondChange:       0.287210105092827748 * 1e18,
+            bondChange:       0.258201596617264198 * 1e18,
             isReward:         true,
             lpAwardTaker:     0.909749138101538138 * 1e18,
-            lpAwardKicker:    0.285719120762723106 * 1e18
+            lpAwardKicker:    0.256861203198864400 * 1e18
         });
 
         _assertLenderLpBalance({
@@ -296,19 +296,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_91,
-            lpBalance:   2_000.285719120762723106 * 1e18, // rewarded with LP in bucket
+            lpBalance:   2_000.256861203198864400 * 1e18, // rewarded with LP in bucket
             depositTime: _startTime + 100 days + 6.5 hours
         });
         _assertBucket({
             index:        _i9_91,
-            lpBalance:    2_001.195468258864261244 * 1e18,
+            lpBalance:    2_001.166610341300402538 * 1e18,
             collateral:   2 * 1e18,
-            deposit:      1_991.804050645641920716 * 1e18,
+            deposit:      1_991.775042137166357167 * 1e18,
             exchangeRate: 1.005218356846837832 * 1e18
         });
         // reserves should remain the same after arb take
         _assertReserveAuction({
-            reserves:                   24.296647707318004709 * 1e18,
+            reserves:                   24.332908342912459160 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -316,7 +316,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              0.902267197572669045 * 1e18,
+            borrowerDebt:              0.909519324691559946 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              0,
             borrowerCollateralization: 0
@@ -332,7 +332,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 referencePrice:    11.249823884323541351 * 1e18,
                 totalBondEscrowed: 0.296536979149981005 * 1e18,
                 auctionPrice:      9.459936576563284516 * 1e18,
-                debtInAuction:     0.902267197572669045 * 1e18,
+                debtInAuction:     0.909519324691559946 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      11.249823884323541351 * 1e18
             })

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -237,8 +237,8 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             index:            _i1505_26,
             collateralArbed:  0.009965031187761219 * 1e18,
             quoteTokenAmount: 14.999999999999999995 * 1e18,
-            bondChange:       0,
-            isReward:         true,
+            bondChange:       0.22770509831248422 * 1e18,
+            isReward:         false,
             lpAwardTaker:     0,
             lpAwardKicker:    0
         });
@@ -248,14 +248,14 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          0.345029692224734546 * 1e18,
+                bondSize:          0.117324593912250326 * 1e18,
                 bondFactor:        0.015180339887498948 * 1e18,
                 kickTime:          block.timestamp - 6 hours,
                 referencePrice:    13.089508376044532178 * 1e18,
-                totalBondEscrowed: 0.345029692224734546 * 1e18,
+                totalBondEscrowed: 0.117324593912250326 * 1e18,
                 auctionPrice:      13.089508376044532180 * 1e18,
-                debtInAuction:     8.014051756262951713 * 1e18,
-                thresholdPrice:    4.027090921445553358 * 1e18,
+                debtInAuction:     8.070978030841072769 * 1e18,
+                thresholdPrice:    4.055696586908858134 * 1e18,
                 neutralPrice:      13.089508376044532178 * 1e18
             })
         );
@@ -275,10 +275,10 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              8.014051756262951713 * 1e18,
+            borrowerDebt:              8.070978030841072769 * 1e18,
             borrowerCollateral:        1.990034968812238781 * 1e18,
-            borrowert0Np:              4.044492274291511923 * 1e18,
-            borrowerCollateralization: 2.462617566100560496 * 1e18
+            borrowert0Np:              4.073221546916370860 * 1e18,
+            borrowerCollateralization: 2.445248215916102640 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _taker,
@@ -305,7 +305,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    5,
-            settledDebt: 6.987894865384582852 * 1e18
+            settledDebt: 7.037532031942566441 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -686,12 +686,12 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:         _borrower2,
             kicker:           _lender,
             index:            2500,
-            collateralArbed:  2.645225595891871889 * 1e18,
-            quoteTokenAmount: 10_220.237430207183199580 * 1e18,
-            bondChange:       155.146677921483848824 * 1e18,
+            collateralArbed:  2.655448316828858737 * 1e18,
+            quoteTokenAmount: 10_259.734490617083440664 * 1e18,
+            bondChange:       0.156330289779736161 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    93.365678971373374698 * 1e18
+            lpAwardKicker:    0.094077964443835904 * 1e18
         });
         _assertCollateralInvariants();
         _assertBorrower({
@@ -722,9 +722,9 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // lender removes collateral
         _assertBucket({
             index:        2500,
-            lpBalance:    8_093.365678971373374698 * 1e18,
-            collateral:   2.645225595891871889 * 1e18,
-            deposit:      3_228.588863672794087920 * 1e18,
+            lpBalance:    8_000.094077964443835904 * 1e18,
+            collateral:   2.655448316828858737 * 1e18,
+            deposit:      3_034.101455631189732489 * 1e18,
             exchangeRate: 1.661709951994811681 * 1e18
         });
         _addLiquidityNoEventCheck({
@@ -734,8 +734,8 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        2569,
-            lpBalance:    10_971.610695426638179656 * 1e18,
-            collateral:   0.354774404108128111 * 1e18,
+            lpBalance:    10_943.614016738084826008 * 1e18,
+            collateral:   0.344551683171141263 * 1e18,
             deposit:      10_000.000000000000000000 * 1e18,
             exchangeRate: 1 * 1e18
         });
@@ -751,14 +751,14 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        2500,
-            lpBalance:    1_942.931652901886597757 * 1e18,
+            lpBalance:    1_825.891126179319554280 * 1e18,
             collateral:   0,
-            deposit:      3_228.588863672794087920 * 1e18,
+            deposit:      3_034.101455631189732489 * 1e18,
             exchangeRate: 1.661709951994811681 * 1e18
         });
         _assertBucket({
             index:        2569,
-            lpBalance:    10_000.000000000000000004 * 1e18,
+            lpBalance:    10_000.000000000000000002 * 1e18,
             collateral:   0,
             deposit:      10_000.000000000000000000 * 1e18,
             exchangeRate: 1 * 1e18
@@ -766,10 +766,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // borrower 2 redeems LP for quote token
         _removeAllLiquidity({
             from:     _borrower2,
-            amount:   971.610695426638179651 * 1e18,
+            amount:   943.614016738084826005 * 1e18,
             index:    2569,
             newLup:   MAX_PRICE,
-            lpRedeem: 971.610695426638179652 * 1e18
+            lpRedeem: 943.614016738084826006 * 1e18
         });
     }
 
@@ -842,12 +842,12 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:         _borrower,
             kicker:           _lender,
             index:            2000,
-            collateralArbed:  0.146369981971725896 * 1e18,
-            quoteTokenAmount: 6_846.697910339464805069 * 1e18,
-            bondChange:       103.935201385981873520 * 1e18,
-            isReward:         true,
+            collateralArbed:  0.147506841889489020 * 1e18,
+            quoteTokenAmount: 6_899.876412641945444064 * 1e18,
+            bondChange:       104.742469125641675010 * 1e18,
+            isReward:         false,
             lpAwardTaker:     0,
-            lpAwardKicker:    103.935201385981873519 * 1e18
+            lpAwardKicker:    0
         });
 
         _assertBorrower({
@@ -866,7 +866,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 bondFactor:        0,
                 kickTime:          0,
                 referencePrice:    0,
-                totalBondEscrowed: 305.569567228603107470 * 1e18,
+                totalBondEscrowed: 200.827098102961432460 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     10_066.670727855240484714 * 1e18,
                 thresholdPrice:    0,
@@ -875,10 +875,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         );
         _assertBucket({
             index:        5476,
-            lpBalance:    0.001343248402621047 * 1e18,
-            collateral:   0.971309980741318100 * 1e18,
+            lpBalance:    0.001341676211148894 * 1e18,
+            collateral:   0.970173120823554976 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000000000000000249 * 1e18
+            exchangeRate: 0.999999999999999776 * 1e18
         });
 
         // bucket take on borrower 2
@@ -887,12 +887,12 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:         _borrower2,
             kicker:           _lender,
             index:            2000,
-            collateralArbed:  0.218524435242978009 * 1e18,
-            quoteTokenAmount: 10_221.841760049014997661 * 1e18,
-            bondChange:       155.171032193774512947 * 1e18,
-            isReward:         true,
+            collateralArbed:  0.220221720903145367 * 1e18,
+            quoteTokenAmount: 10_301.235103043084389243 * 1e18,
+            bondChange:       152.784783614301553735 * 1e18,
+            isReward:         false,
             lpAwardTaker:     0,
-            lpAwardKicker:    155.171032193774512946 * 1e18
+            lpAwardKicker:    0
         });
 
         _assertBorrower({
@@ -911,7 +911,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 bondFactor:        0,
                 kickTime:          0,
                 referencePrice:    0,
-                totalBondEscrowed: 305.569567228603107470 * 1e18,
+                totalBondEscrowed: 48.042314488659878725 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
                 thresholdPrice:    0,
@@ -920,10 +920,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         );
         _assertBucket({
             index:        5557,
-            lpBalance:    0.000721544103807183 * 1e18,
-            collateral:   0.781475564757021991 * 1e18,
+            lpBalance:    0.000719976983201242 * 1e18,
+            collateral:   0.779778279096854633 * 1e18,
             deposit:      0,
-            exchangeRate: 0.999999999999999669 * 1e18
+            exchangeRate: 0.999999999999999438 * 1e18
         });
 
         _assertCollateralInvariants();
@@ -935,9 +935,9 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2000,
-            lpBalance:    60_259.106233579756386465 * 1e18,
-            collateral:   0.364894417214703905 * 1e18,
-            deposit:      43_190.566563191276548531 * 1e18,
+            lpBalance:    60_000 * 1e18,
+            collateral:   0.367728562792634387 * 1e18,
+            deposit:      42_798.888484314970107546 * 1e18,
             exchangeRate: 1.000000000000000001 * 1e18
         });
 
@@ -977,18 +977,18 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // remove lps for both borrower and borrower 2
         _removeAllLiquidity({
             from:     _borrower,
-            amount:   0.001343248402621047 * 1e18,
+            amount:   0.001341676211148893 * 1e18,
             index:    5476,
             newLup:   MAX_PRICE,
-            lpRedeem: 0.001343248402621047 * 1e18
+            lpRedeem: 0.001341676211148894 * 1e18
         });
 
         _removeAllLiquidity({
             from:     _borrower2,
-            amount:   0.000721544103807182 * 1e18,
+            amount:   0.000719976983201241 * 1e18,
             index:    5557,
             newLup:   MAX_PRICE,
-            lpRedeem: 0.000721544103807183 * 1e18
+            lpRedeem: 0.000719976983201242 * 1e18
         });
     }
 }


### PR DESCRIPTION
## Description

Resolve [Sherlock 001-M](https://github.com/sherlock-audit/2023-09-ajna-judging/issues/16) by using bucket price for the BPF calculation.  Contrary to the report, we still wish to use auction price to calculate take flows for `arbTake`, yet use the bucket price to calculate take flows for `depositTake`, as currently implemented.

Change is covered by existing unit tests.

## Purpose

Section 7.4.2 of the whitepaper states the bucket price is used to calculate BPF in a `bucketTake`.  But the code is actually using the auction price.  Resolve the discrepancy by passing bucket price to the `_bpf` function where appropriate.

## Impact

Small gas penalty expected.  No size change to pool contracts.
Gas reports show no noticeable impact to `bucketTake` or `take` operations.
No _new_ invariant test failures, though reproduced the same A8 failure present in `develop` branch.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
