### PR TITLE
Incorrect(Unscaled) deposits are used to check bucket bankruptcy in forgive bad debt

### DIFF
--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -479,10 +479,12 @@ library SettlerActions {
 
             Bucket storage hpbBucket = buckets_[index];
             uint256 bucketLP = hpbBucket.lps;
+
+            uint256 scaledDeposit = Maths.wmul(depositRemaining, scale);
             // If the remaining deposit and resulting bucket collateral is so small that the exchange rate
             // rounds to 0, then bankrupt the bucket.  Note that lhs are WADs, so the
             // quantity is naturally 1e18 times larger than the actual product
-            if (depositRemaining * Maths.WAD + hpbBucket.collateral * _priceAt(index) <= bucketLP) {
+            if (scaledDeposit * Maths.WAD + hpbBucket.collateral * _priceAt(index) <= bucketLP) {
                 // existing LP for the bucket shall become unclaimable
                 hpbBucket.lps            = 0;
                 hpbBucket.bankruptcyTime = block.timestamp;

--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -480,11 +480,10 @@ library SettlerActions {
             Bucket storage hpbBucket = buckets_[index];
             uint256 bucketLP = hpbBucket.lps;
 
-            uint256 scaledDeposit = Maths.wmul(depositRemaining, scale);
             // If the remaining deposit and resulting bucket collateral is so small that the exchange rate
             // rounds to 0, then bankrupt the bucket.  Note that lhs are WADs, so the
             // quantity is naturally 1e18 times larger than the actual product
-            if (scaledDeposit * Maths.WAD + hpbBucket.collateral * _priceAt(index) <= bucketLP) {
+            if (depositRemaining * scale + hpbBucket.collateral * _priceAt(index) <= bucketLP) {
                 // existing LP for the bucket shall become unclaimable
                 hpbBucket.lps            = 0;
                 hpbBucket.bankruptcyTime = block.timestamp;


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
* Fixed bucket bankruptcy check in forgiving bad debt to use `scaled` deposits instead of `unscaled` deposits.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->
* Unscaled deposits were used to check bucket bankruptcy which can lead to wrong bucket bankruptcy even with a reasonable amount of deposits in it.
* Solves for https://github.com/sherlock-audit/2023-09-ajna-judging/issues/25

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, leave _none_. -->
* Small increase in `settle` gas cost.

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [X] Protocol contract size limits have not been exceeded.
- [X] Gas consumption for impacted transactions has been compared with the target branch, and nontrivial changes are cited in the _Impact_ section above.
- [X] Scope labels have been assigned as appropriate.
- [X] Invariant tests have been manually executed as appropriate for the nature of the change.
