### PR TITLE
Borrower with threshold price less than `MIN_PRICE` cannot be kicked.

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -513,6 +513,9 @@ contract PoolInfoUtils {
     ) pure returns (uint256) {
         // cannot be undercollateralized if there is no debt
         if (debt_ == 0) return 1e18;
+        
+        // borrower is undercollateralized when lup at MIN_PRICE
+        if (price_ == MIN_PRICE) return 0;
         return Maths.wdiv(Maths.wmul(collateral_, price_), debt_);
     }
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -161,12 +161,17 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 price_,
         uint8 type_
     ) pure returns (bool) {
-        if (type_ == uint8(PoolType.ERC20)) return Maths.wmul(collateral_, price_) >= debt_;
-        else {
+        if (type_ == uint8(PoolType.ERC721)) {
             //slither-disable-next-line divide-before-multiply
-            collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
-            return Maths.wmul(collateral_, price_) >= debt_;
+            collateral_ = (collateral_ / Maths.WAD) * Maths.WAD;
         }
+
+        if (price_ == MIN_PRICE) {
+            // `False` if TP < MIN_PRICE and LUP = MIN_PRICE
+            return debt_ >= Maths.wmul(collateral_, MIN_PRICE);
+        }
+        
+        return Maths.wmul(collateral_, price_) >= debt_;
     }
 
     /**

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -161,14 +161,13 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 price_,
         uint8 type_
     ) pure returns (bool) {
+        // `False` if LUP = MIN_PRICE
+        if (price_ == MIN_PRICE) return false;
+
+        // Use collateral floor for NFT pools
         if (type_ == uint8(PoolType.ERC721)) {
             //slither-disable-next-line divide-before-multiply
             collateral_ = (collateral_ / Maths.WAD) * Maths.WAD;
-        }
-
-        if (price_ == MIN_PRICE) {
-            // `False` if TP < MIN_PRICE and LUP = MIN_PRICE
-            return debt_ >= Maths.wmul(collateral_, MIN_PRICE);
         }
         
         return Maths.wmul(collateral_, price_) >= debt_;

--- a/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
@@ -65,6 +65,8 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
 
         uint256 kickerBondBefore = _getKickerBond(_actor);
 
+        if (borrowerDebt == 0) return;
+
         // ensure actor always has the amount to add for kick
         _ensureQuoteAmount(_actor, borrowerDebt);
 

--- a/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
@@ -20,25 +20,25 @@ contract ERC20PoolBorrowerTPLessThanMinPrice is ERC20HelperContract {
         _mintCollateralAndApproveTokens(_borrower,  100_000 * 1e18);
     }
 
-    function testTpLessThanMinPriceNoKickable() external tearDown {
+    function testTpLessThanMinPriceBorrowerKickable() external tearDown {
         _addInitialLiquidity({
             from:   _lender,
-            amount: 110 * 1e9,
-            index:  MAX_FENWICK_INDEX
+            amount: 1100 * 1e9,
+            index:  2550
         });
 
         // Borrower adds collateral token and borrows
         _pledgeCollateral({
             from:     _borrower,
             borrower: _borrower,
-            amount:   100_000 * 1e18
+            amount:   10 * 1e18
         });
 
         _borrow({
             from:       _borrower,
-            amount:     100 * 1e9,
-            indexLimit: MAX_FENWICK_INDEX,
-            newLup:     MIN_PRICE
+            amount:     990 * 1e9,
+            indexLimit: 2550,
+            newLup:     3_010.892022197881557845 * 1e18
         });
 
         (uint256 debt, uint256 collateral, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
@@ -47,9 +47,8 @@ contract ERC20PoolBorrowerTPLessThanMinPrice is ERC20HelperContract {
         // Ensure borrower tp is less than min price
         assertLt(thresholdPrice, MIN_PRICE);
 
-        // Lender cannot kick borrower with tp less than min price
+        // Lender can kick borrower with tp less than min price
         changePrank(_lender);
-        vm.expectRevert(IPoolErrors.BorrowerOk.selector);
-        _pool.lenderKick(MAX_FENWICK_INDEX, MAX_FENWICK_INDEX);
+        _pool.lenderKick(2550, MAX_FENWICK_INDEX);
     }
 }

--- a/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
@@ -1,0 +1,55 @@
+pragma solidity 0.8.18;
+
+import { ERC20HelperContract, ERC20FuzzyHelperContract } from './ERC20DSTestPlus.sol';
+
+import 'src/libraries/helpers/PoolHelper.sol';
+import 'src/interfaces/pool/commons/IPoolErrors.sol';
+
+contract ERC20PoolBorrowerTPLessThanMinPrice is ERC20HelperContract {
+
+    address internal _borrower;
+    address internal _lender;
+
+    function setUp() external {
+        _startTest();
+
+        _borrower  = makeAddr("borrower");
+        _lender    = makeAddr("lender");
+
+        _mintQuoteAndApproveTokens(_lender,  110 * 1e18);
+        _mintCollateralAndApproveTokens(_borrower,  100_000 * 1e18);
+    }
+
+    function testTpLessThanMinPriceNoKickable() external tearDown {
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 110 * 1e9,
+            index:  MAX_FENWICK_INDEX
+        });
+
+        // Borrower adds collateral token and borrows
+        _pledgeCollateral({
+            from:     _borrower,
+            borrower: _borrower,
+            amount:   100_000 * 1e18
+        });
+
+        _borrow({
+            from:       _borrower,
+            amount:     100 * 1e9,
+            indexLimit: MAX_FENWICK_INDEX,
+            newLup:     MIN_PRICE
+        });
+
+        (uint256 debt, uint256 collateral, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
+        uint256 thresholdPrice = Maths.wdiv(debt, collateral);
+
+        // Ensure borrower tp is less than min price
+        assertLt(thresholdPrice, MIN_PRICE);
+
+        // Lender cannot kick borrower with tp less than min price
+        changePrank(_lender);
+        vm.expectRevert(IPoolErrors.BorrowerOk.selector);
+        _pool.lenderKick(MAX_FENWICK_INDEX, MAX_FENWICK_INDEX);
+    }
+}

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             borrowerDebt:              8_084.412285638162564830 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              9.200228999102245332 * 1e18,
-            borrowerCollateralization: 0.000000012349231999 * 1e18
+            borrowerCollateralization: 0
         });
 
         // kick borrower 2
@@ -508,7 +508,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             borrowerDebt:              8_084.782322086612071679 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              9.200228999102245332 * 1e18,
-            borrowerCollateralization: 0.000000012348666781 * 1e18
+            borrowerCollateralization: 0
         });
 
         _take({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -1099,8 +1099,8 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
         changePrank(actor1);
         _pool.kick(actor6, 7388);
         skip(100 hours);
-        ERC20Pool(address(_pool)).drawDebt(actor1, 1_000_000 * 1e18, 7388, 10_066_231_386_838.450530455239517417 * 1e18);
-        skip(100 days);
+        ERC20Pool(address(_pool)).drawDebt(actor1, 990_000 * 1e18, 7388, 10_066_231_386_838.450530455239517417 * 1e18);
+        skip(200 days);
 
         // another actor kicks borrower 1
         changePrank(actor2);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
@@ -218,11 +218,11 @@ contract ERC20PoolReserveAuctionNoFundsTest is ERC20HelperContract {
         pool.drawDebt(_actor7, 99266, 7388, 999234524847);
 
         // actor 7 draws almost all available quote token
-        pool.drawDebt(_actor7, 98703, 7388, 999234524847);
+        pool.drawDebt(_actor7, 98000, 7388, 999234524847);
         // pool balance decreased by new debt
-        assertEq(_quote.balanceOf(address(pool)), 200);
+        assertEq(_quote.balanceOf(address(pool)), 903);
         // available quote token decreased with new debt
-        assertEq(_availableQuoteToken(), 200);
+        assertEq(_availableQuoteToken(), 903);
 
         vm.warp(block.timestamp + 86400);
 
@@ -231,7 +231,7 @@ contract ERC20PoolReserveAuctionNoFundsTest is ERC20HelperContract {
         pool.updateInterest();
         vm.expectRevert(IPoolErrors.NoReserves.selector);
         pool.kickReserveAuction();
-        assertEq(_quote.balanceOf(address(pool)), 200);
+        assertEq(_quote.balanceOf(address(pool)), 903);
 
         vm.warp(block.timestamp + 86400);
 
@@ -245,8 +245,8 @@ contract ERC20PoolReserveAuctionNoFundsTest is ERC20HelperContract {
         ERC20Pool(address(_pool)).repayDebt(_actor3, type(uint256).max, 0, _actor3, MAX_FENWICK_INDEX);
         ERC20Pool(address(_pool)).repayDebt(_actor7, type(uint256).max, 0, _actor7, MAX_FENWICK_INDEX);
 
-        uint256 initialPoolBalance     = 200784;
-        uint256 initialAvailableAmount = 200784;
+        uint256 initialPoolBalance     = 200788;
+        uint256 initialAvailableAmount = 200788;
 
         assertEq(_quote.balanceOf(address(pool)), initialPoolBalance);
         assertEq(_availableQuoteToken(), initialAvailableAmount);

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -907,7 +907,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrowerDebt:              418.511241535551682100 * 1e18,
             borrowerCollateral:        1.256401842870359357 * 1e18,
             borrowert0Np:              97.486777718699640528 * 1e18,
-            borrowerCollateralization: 0.000000000299715939 * 1e18,
+            borrowerCollateralization: 0,
             tokenIds:                  borrowerTokenIds
         });
 
@@ -933,7 +933,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrowerDebt:              418.511161648248153847 * 1e18,
             borrowerCollateral:        0.256401842870359357 * 1e18,
             borrowert0Np:              477.697595423190347016 * 1e18,
-            borrowerCollateralization: 0.000000000061164932 * 1e18,
+            borrowerCollateralization: 0,
             tokenIds:                  borrowerTokenIds
         });
 

--- a/tests/forge/unit/PoolHelperTest.t.sol
+++ b/tests/forge/unit/PoolHelperTest.t.sol
@@ -139,15 +139,15 @@ contract PoolHelperTest is DSTestPlus {
 
         // undercollateralized at low price
         price = _priceAt(7388); // 0.000000099836282890
-        assertEq(_collateralization(debt, collateral, price), 0.00000000000000013 * 1e18);
+        assertEq(_collateralization(debt, collateral, price), 0);
         assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
         assertEq(_isCollateralized(debt, collateral, price, erc721), false);
 
-        // 130% CR at low price
+        // 0% CR at MIN_PRICE
         collateral = 11_719_186_313.147400474096316788 * 1e18;
-        assertEq(_collateralization(debt, collateral, price), 1.3 * 1e18);
-        assertEq(_isCollateralized(debt, collateral, price, erc20),  true);
-        assertEq(_isCollateralized(debt, collateral, price, erc721), true);
+        assertEq(_collateralization(debt, collateral, price), 0);
+        assertEq(_isCollateralized(debt, collateral, price, erc20),  false);
+        assertEq(_isCollateralized(debt, collateral, price, erc721), false);
     }
 
     /**


### PR DESCRIPTION
## Description
* Borrower with TP less than `MIN_PRICE` cannot be kicked.
* Updated `_isCollateralized` to return `false` if `TP < MIN_PRICE` and `LUP = MIN_PRICE`. 
* Add unit test to check borrower with threshold price less than `MIN_PRICE` cannot be kicked. 

## Purpose
* Borrower with TP less than `MIN_PRICE` cannot be kicked, borrower can misuse this in pool with very less collateral price like (SHIB - BTC)
* Solves the issue discovered in kiril audit M-02 (https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)
```
## [M-02] Positions with threshold price below `MIN_PRICE` cannot be kicked

In order for the borrower’s position to be kicked, it should be under-collateralized with respect to the current LUP.
However, as per the pool constraints, LUP cannot go lower than `MIN_PRICE`. Thus, positions with threshold price
below `MIN_PRICE` can’t ever be kicked, irrespective of kicker or lender actions. Even when `lenderKick` is being used,
the total debt is increased by the deposit amount and starts to exceed the overall deposit in the pool, `LUP` will still
be bounded by the `MIN_PRICE`.

### Recommendation

Allow to kick any position, irrespective of its collateralization, if the `LUP` index ever reaches `MAX_FENWICK_INDEX`.
```
* Solves what we internally have called Dmitrii - 9, an issue discovered by @dmitriia (although not eligible for the Sherlock report) -> 
```
**Summary of the Vulnerability:**
The code outlines a scenario where a borrower can exploit the auction mechanism post-default to incur minimal penalties and unfairly benefit at the expense of the lender (kicker). This is achieved by the borrower exiting the auction early at an artificially high price, avoiding significant taker penalties, and causing collateral damage to the lender. The penalty paid by the borrower is negligible compared to the advantage gained, rendering the penalty almost irrelevant.

** Link an example of the issue: **
https://github.com/ajna-finance/contracts/pull/981/files#diff-e59157bfa5bad910c2f5c2a00cfba7d222f0ad6f1969eb5ab4b2fbd22903b951R212

**Sudo Code Representation of the Attack:**

1. Lender adds liquidity to the pool.

2. Borrower draws a large debt from the pool.

3. Time skip of 100 days.

4. Lender initiates a kick due to default.

5. Borrower exploits the situation by depositing into a high price bucket.

6. Borrower takes from the bucket, reducing their penalty significantly.

7. Borrower removes a large portion of the collateral at an inflated price.

8. Post-removal, the lender's position is significantly weakened, with minimal gains.

9. Borrower ends up with a minor loss in USDC and almost no loss in WETH.

10. Lender gains are marginal compared to the potential loss incurred.

**Analysis:**
- The borrower controls the collateral price, impacting the distribution between borrower and taker. However, when the borrower and taker are the same, the price becomes irrelevant.
- The taker penalty, which should be a deterrent, is reduced to an insignificant amount due to the borrower's control over the collateral price.
- The kicker (lender) faces a substantial loss of bond, while the borrower benefits by virtually eliminating the penalty at a negligible cost.
- The potential for this exploit increases if issue #16 mentioned is fixed, allowing borrowers to execute this strategy more easily and atomically.

This vulnerability creates an imbalance in the protocol, favoring borrowers who default and strategically manipulate the auction process, while significantly disadvantaging lenders who face the brunt of the collateral damage. The protocol needs to address this imbalance to ensure fair and secure interactions between all parties involved.
```

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
