### PR TITLE
Claimable Reserve Auction kick timing logic

### DIFF
--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -204,11 +204,10 @@ library KickerActions {
         KickReserveAuctionParams calldata params_
     ) external {
         // retrieve timestamp of latest burn event and last burn timestamp
-        uint256 latestBurnEpoch   = reserveAuction_.latestBurnEventEpoch;
-        uint256 lastBurnTimestamp = reserveAuction_.burnEvents[latestBurnEpoch].timestamp;
+        uint256 latestBurnEpoch = reserveAuction_.latestBurnEventEpoch;
 
-        // check that at least two weeks have passed since the last reserve auction completed, and that the auction was not kicked within the past 72 hours
-        if (block.timestamp < lastBurnTimestamp + 2 weeks || block.timestamp - reserveAuction_.kicked <= 72 hours) {
+        // check that at least two weeks have passed since the last reserve auction completed
+        if (block.timestamp < reserveAuction_.kicked + 2 weeks + 72 hours) {
             revert ReserveAuctionTooSoon();
         }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -218,8 +218,25 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // pass time to allow auction to complete
         skip(48 hours);
 
-        // check that you can't start a new auction unless two weeks have passed
+        // check that you can't start a new auction immediately after the last one finished
         _assertReserveAuctionTooSoon();
+
+        // check that you can't start a new auction two weeks after the last start...
+        skip(2 weeks - 72 hours);
+        _assertReserveAuctionTooSoon();
+
+        // ...or a day later...
+        skip(1 days);
+        _assertReserveAuctionTooSoon();
+
+        // ...but you can start another auction 2 weeks after the last one completed
+        skip(72 hours - 1 days);
+        _kickReserveAuction({
+            from:              _bidder,
+            remainingReserves: 415.792367191826572589 * 1e18,
+            price:             1_000_000_000 * 1e18,
+            epoch:             2
+        });
     }
 
     function testClaimableReserveAuction() external {


### PR DESCRIPTION
## Description

Clean up logic for kicking off claimable reserve auctions (CRAs), bringing implementation in-line with whitepaper, and reducing gas cost.  Expanded an existing unit test to cover some more timing use cases.

## Purpose

Whitepaper states:
```
If two weeks have passed since the completion of the last Claimable Reserve Auction, CRA, any user can kick off a new auction.
```
The code had been checking whether two weeks passed since the _start_ of the last CRA.  It also had some expensive redundant operations. 
* Solves Kirill `L-08`(https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)

## Impact

Expected reduction in gas cost of `kickReserveAuction`.
Analysis revealed small median gas advantage kicking CRAs in ERC20 pools, where tests were unchanged.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
