### PR TITLE
Memorialize borrower threshold price on kick 

### DIFF
--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -413,6 +413,7 @@ struct Liquidation {
     address next;           // next liquidated borrower in auctions queue
     uint160 bondSize;       // [WAD] liquidation bond size
     uint96  neutralPrice;   // [WAD] Neutral Price when liquidation was started
+    uint256 thresholdPrice; // [WAD] Threshold Price when liquidation was started
 }
 
 /// @dev Struct holding kicker state.

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -27,7 +27,6 @@ import {
 import {
     MAX_INFLATED_PRICE,
     _bondParams,
-    _bpf,
     _claimableReserves,
     _isCollateralized,
     _priceAt,
@@ -333,6 +332,9 @@ library KickerActions {
             vars.referencePrice,
             vars.neutralPrice
         );
+
+        // store borrower Threshold price
+        liquidation.thresholdPrice = Maths.wdiv(vars.borrowerDebt, vars.borrowerCollateral);
 
         // update escrowed bonds balances and get the difference needed to cover bond (after using any kick claimable funds if any)
         kickResult_.amountToCoverBond = _updateEscrowedBonds(auctions_, vars.bondSize);

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -61,6 +61,7 @@ library KickerActions {
         uint256 referencePrice;     // [WAD] used to calculate auction start price
         uint256 bondFactor;         // [WAD] bond factor of kicked auction
         uint256 bondSize;           // [WAD] bond size of kicked auction
+        uint256 thresholdPrice;     // [WAD] borrower threshold price at kick time
     }
 
     /// @dev Struct used for `lenderKick` function local vars.
@@ -322,6 +323,8 @@ library KickerActions {
             borrower.npTpRatio
         );
 
+        vars.thresholdPrice = Maths.wdiv(vars.borrowerDebt, vars.borrowerCollateral);
+
         // record liquidation info
         _recordAuction(
             auctions_,
@@ -330,11 +333,9 @@ library KickerActions {
             vars.bondSize,
             vars.bondFactor,
             vars.referencePrice,
-            vars.neutralPrice
+            vars.neutralPrice,
+            vars.thresholdPrice
         );
-
-        // store borrower Threshold price
-        liquidation.thresholdPrice = Maths.wdiv(vars.borrowerDebt, vars.borrowerCollateral);
 
         // update escrowed bonds balances and get the difference needed to cover bond (after using any kick claimable funds if any)
         kickResult_.amountToCoverBond = _updateEscrowedBonds(auctions_, vars.bondSize);
@@ -402,7 +403,8 @@ library KickerActions {
         uint256 bondSize_,
         uint256 bondFactor_,
         uint256 referencePrice_,
-        uint256 neutralPrice_
+        uint256 neutralPrice_,
+        uint256 thresholdPrice_
     ) internal {
         // record liquidation info
         liquidation_.kicker         = msg.sender;
@@ -411,6 +413,7 @@ library KickerActions {
         liquidation_.bondSize       = SafeCast.toUint160(bondSize_);
         liquidation_.bondFactor     = SafeCast.toUint96(bondFactor_);
         liquidation_.neutralPrice   = SafeCast.toUint96(neutralPrice_);
+        liquidation_.thresholdPrice = thresholdPrice_;
 
         // increment number of active auctions
         ++auctions_.noOfAuctions;

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -394,6 +394,7 @@ library KickerActions {
      *  @param  bondFactor_      Bond factor of the newly kicked auction.
      *  @param  referencePrice_  Used to calculate auction start price.
      *  @param  neutralPrice_    Current pool `Neutral Price`.
+     *  @param  thresholdPrice_  Borrower threshold price.
      */
     function _recordAuction(
         AuctionsState storage auctions_,

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -345,7 +345,6 @@ library TakerActions {
         vars_ = _prepareTake(
             liquidation,
             borrower_.t0Debt,
-            borrower_.collateral,
             params_.inflator
         );
 
@@ -428,7 +427,6 @@ library TakerActions {
         vars_= _prepareTake(
             liquidation,
             borrower_.t0Debt,
-            borrower_.collateral,
             params_.inflator
         );
 
@@ -681,14 +679,12 @@ library TakerActions {
      *              - loan is not in auction NoAuction()
      *  @param  liquidation_ Liquidation struct holding auction details.
      *  @param  t0Debt_      Borrower t0 debt.
-     *  @param  collateral_  Borrower collateral.
      *  @param  inflator_    The pool's inflator, used to calculate borrower debt.
      *  @return vars         The prepared vars for take action.
      */
     function _prepareTake(
         Liquidation memory liquidation_,
         uint256 t0Debt_,
-        uint256 collateral_,
         uint256 inflator_
     ) internal view returns (TakeLocalVars memory vars) {
 
@@ -704,8 +700,7 @@ library TakerActions {
         vars.auctionPrice = _auctionPrice(liquidation_.referencePrice, kickTime);
         vars.bondFactor   = liquidation_.bondFactor;
         vars.bpf          = _bpf(
-            vars.borrowerDebt,
-            collateral_,
+            liquidation_.thresholdPrice,
             neutralPrice,
             liquidation_.bondFactor,
             vars.auctionPrice

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -385,7 +385,7 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 auctionPrice_
     ) pure returns (int256) {
         int256 sign;
-        if (int256(thresholdPrice_) < int256(neutralPrice_)) {
+        if (thresholdPrice_ < neutralPrice_) {
             // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
             sign = Maths.minInt(
                 1e18,

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -372,24 +372,20 @@ import { Maths }   from '../internal/Maths.sol';
     /**
      *  @notice Calculates bond penalty factor.
      *  @dev    Called in kick and take.
-     *  @param debt_         Borrower debt.
-     *  @param collateral_   Borrower collateral.
-     *  @param neutralPrice_ `NP` of auction.
-     *  @param bondFactor_   Factor used to determine bondSize.
-     *  @param auctionPrice_ Auction price at the time of call.
-     *  @return bpf_         Factor used in determining bond `reward` (positive) or `penalty` (negative).
+     *  @param thresholdPrice_ Borrower tp at time of kick.
+     *  @param neutralPrice_   `NP` of auction.
+     *  @param bondFactor_     Factor used to determine bondSize.
+     *  @param auctionPrice_   Auction price at the time of call.
+     *  @return bpf_           Factor used in determining bond `reward` (positive) or `penalty` (negative).
      */
     function _bpf(
-        uint256 debt_,
-        uint256 collateral_,
+        uint256 thresholdPrice_,
         uint256 neutralPrice_,
         uint256 bondFactor_,
         uint256 auctionPrice_
     ) pure returns (int256) {
-        int256 thresholdPrice = int256(Maths.wdiv(debt_, collateral_));
-
         int256 sign;
-        if (thresholdPrice < int256(neutralPrice_)) {
+        if (int256(thresholdPrice_) < int256(neutralPrice_)) {
             // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
             sign = Maths.minInt(
                 1e18,
@@ -397,7 +393,7 @@ import { Maths }   from '../internal/Maths.sol';
                     -1 * 1e18,
                     PRBMathSD59x18.div(
                         int256(neutralPrice_) - int256(auctionPrice_),
-                        int256(neutralPrice_) - thresholdPrice
+                        int256(neutralPrice_) - int256(thresholdPrice_)
                     )
                 )
             );

--- a/tests/forge/unit/Auctions.t.sol
+++ b/tests/forge/unit/Auctions.t.sol
@@ -14,13 +14,14 @@ contract AuctionsTest is DSTestPlus {
         uint256 collateral = 1000 * 1e18;
         uint256 neutralPrice = 15 * 1e18;
         uint256 bondFactor = 0.1 *  1e18;
+        uint256 thresholdPrice = Maths.wdiv(debt, collateral);
 
-        assertEq(_bpf(debt, collateral, neutralPrice, bondFactor, price),             0.1 * 1e18);
-        assertEq(_bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, price),      0.083333333333333333 * 1e18);
-        assertEq(_bpf(debt, collateral, neutralPrice, bondFactor, 9.5 * 1e18),        0.1 * 1e18);
-        assertEq(_bpf(9000 * 1e18, collateral, neutralPrice, bondFactor, 9.5 * 1e18), 0.091666666666666667 * 1e18);
-        assertEq(_bpf(9000 * 1e18, collateral, 10 * 1e18, bondFactor, 10.5 * 1e18),   -0.05 * 1e18);
-        assertEq(_bpf(debt, collateral, 5 * 1e18, bondFactor, 10.5 * 1e18),           -0.1 * 1e18);
+        assertEq(_bpf(Maths.wdiv(debt, collateral), neutralPrice, bondFactor, price),             0.1 * 1e18);
+        assertEq(_bpf(Maths.wdiv(9000 * 1e18, collateral), neutralPrice, bondFactor, price),      0.083333333333333333 * 1e18);
+        assertEq(_bpf(Maths.wdiv(debt, collateral), neutralPrice, bondFactor, 9.5 * 1e18),        0.1 * 1e18);
+        assertEq(_bpf(Maths.wdiv(9000 * 1e18, collateral), neutralPrice, bondFactor, 9.5 * 1e18), 0.091666666666666667 * 1e18);
+        assertEq(_bpf(Maths.wdiv(9000 * 1e18, collateral), 10 * 1e18, bondFactor, 10.5 * 1e18),   -0.05 * 1e18);
+        assertEq(_bpf(Maths.wdiv(debt, collateral), 5 * 1e18, bondFactor, 10.5 * 1e18),           -0.1 * 1e18);
     }
 
     /**

--- a/tests/forge/unit/Auctions.t.sol
+++ b/tests/forge/unit/Auctions.t.sol
@@ -14,7 +14,6 @@ contract AuctionsTest is DSTestPlus {
         uint256 collateral = 1000 * 1e18;
         uint256 neutralPrice = 15 * 1e18;
         uint256 bondFactor = 0.1 *  1e18;
-        uint256 thresholdPrice = Maths.wdiv(debt, collateral);
 
         assertEq(_bpf(Maths.wdiv(debt, collateral), neutralPrice, bondFactor, price),             0.1 * 1e18);
         assertEq(_bpf(Maths.wdiv(9000 * 1e18, collateral), neutralPrice, bondFactor, price),      0.083333333333333333 * 1e18);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -281,10 +281,10 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:            _i9_91,
             collateralArbed:  2 * 1e18,
             quoteTokenAmount: 18.919873153126569032 * 1e18,
-            bondChange:       0.258201596617264198 * 1e18,
+            bondChange:       0.258144802096036104 * 1e18,
             isReward:         true,
             lpAwardTaker:     0.909749138101538138 * 1e18,
-            lpAwardKicker:    0.256861203198864400 * 1e18
+            lpAwardKicker:    0.256804703513158056 * 1e18
         });
 
         _assertLenderLpBalance({
@@ -296,19 +296,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_91,
-            lpBalance:   2_000.256861203198864400 * 1e18, // rewarded with LP in bucket
+            lpBalance:   2_000.256804703513158056 * 1e18, // rewarded with LP in bucket
             depositTime: _startTime + 100 days + 6.5 hours
         });
         _assertBucket({
             index:        _i9_91,
-            lpBalance:    2_001.166610341300402538 * 1e18,
+            lpBalance:    2_001.166553841614696194 * 1e18,
             collateral:   2 * 1e18,
-            deposit:      1_991.775042137166357167 * 1e18,
+            deposit:      1_991.774985342645129073 * 1e18,
             exchangeRate: 1.005218356846837832 * 1e18
         });
         // reserves should remain the same after arb take
         _assertReserveAuction({
-            reserves:                   24.332908342912459160 * 1e18,
+            reserves:                   24.332979336063994265 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
@@ -316,7 +316,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              0.909519324691559946 * 1e18,
+            borrowerDebt:              0.909533523321866957 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              0,
             borrowerCollateralization: 0
@@ -332,7 +332,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 referencePrice:    11.249823884323541351 * 1e18,
                 totalBondEscrowed: 0.296536979149981005 * 1e18,
                 auctionPrice:      9.459936576563284516 * 1e18,
-                debtInAuction:     0.909519324691559946 * 1e18,
+                debtInAuction:     0.909533523321866957 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      11.249823884323541351 * 1e18
             })

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -743,7 +743,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:            _lender,
             borrower:        _borrower2,
             maxCollateral:   577 * 1e18,
-            bondChange:      27.337468146252670459 * 1e18,
+            bondChange:      27.331814713911545819 * 1e18,
             givenAmount:     6_281.628773838729840580 * 1e18,
             collateralTaken: 577 * 1e18,
             isReward:        true
@@ -755,23 +755,23 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          176.453206233100261662 * 1e18,
+                bondSize:          176.447552800759137022 * 1e18,
                 bondFactor:        0.015180339887498948 * 1e18,
                 kickTime:          block.timestamp - 22000 seconds,
                 referencePrice:    11.314108592233961587 * 1e18,
-                totalBondEscrowed: 176.453206233100261662 * 1e18,
+                totalBondEscrowed: 176.447552800759137022 * 1e18,
                 auctionPrice:      10.886704980656377540 * 1e18,
-                debtInAuction:     3_653.993019025148320626 * 1e18,
-                thresholdPrice:    8.638281368853778535 * 1e18,
+                debtInAuction:     3_653.994432383233602314 * 1e18,
+                thresholdPrice:    8.638284710125847759 * 1e18,
                 neutralPrice:      11.314108592233961587 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              3_653.993019025148320626 * 1e18,
+            borrowerDebt:              3_653.994432383233602314 * 1e18,
             borrowerCollateral:        423.000000000000000000 * 1e18,
-            borrowert0Np:              9.813927120521769770 * 1e18,
-            borrowerCollateralization: 1.136655711572588218 * 1e18
+            borrowert0Np:              9.813930916531551927 * 1e18,
+            borrowerCollateralization: 1.136655271916324406 * 1e18
         });
     }
 
@@ -1129,9 +1129,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:            _lender,
             borrower:        _borrower2,
             maxCollateral:   1_001 * 1e18,
-            bondChange:      43.529168844258845077 * 1e18,
-            givenAmount:     10_002.172770738542860841 * 1e18,
-            collateralTaken: 918.751154597329341626 * 1e18,
+            bondChange:      43.520176912520187399 * 1e18,
+            givenAmount:     10_002.175062202988939757 * 1e18,
+            collateralTaken: 918.751365080156804231 * 1e18,
             isReward:        true
         });
 
@@ -1145,7 +1145,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 bondFactor:        0,
                 kickTime:          0,
                 referencePrice:    0,
-                totalBondEscrowed: 192.644906931106436280 * 1e18,
+                totalBondEscrowed: 192.635914999367778602 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
                 thresholdPrice:    0,
@@ -1155,7 +1155,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         _assertBorrower({
             borrower:                  _borrower2,
             borrowerDebt:              0,
-            borrowerCollateral:        81.248845402670658374 * 1e18,
+            borrowerCollateral:        81.248634919843195769 * 1e18,
             borrowert0Np:              0,
             borrowerCollateralization: 1 * 1e18
         });

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -686,12 +686,12 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:         _borrower2,
             kicker:           _lender,
             index:            2500,
-            collateralArbed:  2.655448316828858737 * 1e18,
-            quoteTokenAmount: 10_259.734490617083440664 * 1e18,
-            bondChange:       0.156330289779736161 * 1e18,
+            collateralArbed:  2.655448319814158671 * 1e18,
+            quoteTokenAmount: 10_259.734502151250575171 * 1e18,
+            bondChange:       0.156285028574074978 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    0.094077964443835904 * 1e18
+            lpAwardKicker:    0.094050726714648058 * 1e18
         });
         _assertCollateralInvariants();
         _assertBorrower({
@@ -722,9 +722,9 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // lender removes collateral
         _assertBucket({
             index:        2500,
-            lpBalance:    8_000.094077964443835904 * 1e18,
-            collateral:   2.655448316828858737 * 1e18,
-            deposit:      3_034.101455631189732489 * 1e18,
+            lpBalance:    8_000.094050726714648058 * 1e18,
+            collateral:   2.655448319814158671 * 1e18,
+            deposit:      3_034.101398835816938926 * 1e18,
             exchangeRate: 1.661709951994811681 * 1e18
         });
         _addLiquidityNoEventCheck({
@@ -734,10 +734,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        2569,
-            lpBalance:    10_943.614016738084826008 * 1e18,
-            collateral:   0.344551683171141263 * 1e18,
+            lpBalance:    10_943.614008562327749549 * 1e18,
+            collateral:   0.344551680185841329 * 1e18,
             deposit:      10_000.000000000000000000 * 1e18,
-            exchangeRate: 1 * 1e18
+            exchangeRate: 1.000000000000000001 * 1e18
         });
         removalIndexes[0] = 2500;
         removalIndexes[1] = 2569;
@@ -751,25 +751,25 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        2500,
-            lpBalance:    1_825.891126179319554280 * 1e18,
+            lpBalance:    1_825.891092000446926490 * 1e18,
             collateral:   0,
-            deposit:      3_034.101455631189732489 * 1e18,
+            deposit:      3_034.101398835816938926 * 1e18,
             exchangeRate: 1.661709951994811681 * 1e18
         });
         _assertBucket({
             index:        2569,
-            lpBalance:    10_000.000000000000000002 * 1e18,
+            lpBalance:    9_999.999999999999999995 * 1e18,
             collateral:   0,
             deposit:      10_000.000000000000000000 * 1e18,
-            exchangeRate: 1 * 1e18
+            exchangeRate: 1.000000000000000001 * 1e18
         });
         // borrower 2 redeems LP for quote token
         _removeAllLiquidity({
             from:     _borrower2,
-            amount:   943.614016738084826005 * 1e18,
+            amount:   943.614008562327749554 * 1e18,
             index:    2569,
             newLup:   MAX_PRICE,
-            lpRedeem: 943.614016738084826006 * 1e18
+            lpRedeem: 943.614008562327749554 * 1e18
         });
     }
 


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
* Memorialize borrower threshold price at the time of kick to calculate bpf.
## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->
* The kicker penalty was getting reduced with subsequent takes due to a decrease in threshold price with each take. To avoid this situation, threshold price is stored at the time of kick and the same used to calculate bpf
* Solves the issue discovered in Sherlock audit -> https://github.com/sherlock-audit/2023-09-ajna-judging/issues/69

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->
Small increase in gas cost of kicks and takes functions

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
