### PR TITLE
Revert CRA kick if a liquidation awaits settlement

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -406,10 +406,13 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev    update `reserveAuction.latestBurnEventEpoch` and burn event `timestamp` state
      *  @dev    === Reverts on ===
      *  @dev    2 weeks not passed `ReserveAuctionTooSoon()`
+     *  @dev    unsettled liquidation `AuctionNotCleared()`
      *  @dev    === Emit events ===
      *  @dev    - `KickReserveAuction`
      */
     function kickReserveAuction() external override nonReentrant {
+        _revertIfAuctionClearable(auctions, loans);
+
         // start a new claimable reserve auction, passing in relevant parameters such as the current pool size, debt, balance, and inflator value
         KickerActions.kickReserveAuction(
             auctions,

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -778,6 +778,11 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.kickReserveAuction();
     }
 
+    function _assertReserveAuctionUnsettledLiquidation() internal {
+        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        _pool.kickReserveAuction();
+    }
+    
     /**********************/
     /*** Revert asserts ***/
     /**********************/


### PR DESCRIPTION
## Description

Prevent kicking a Claimable Reserve Auction (CRA) if a liquidation auction is pending settlement.

## Purpose

* Several pool actions require actors to settle unsettled liquidations.  CRA auctions should not be kicked if a liquidation is pending settlement, because reserves may be needed to clear bad debt.
* Resolves Kirill audit issue `M-07` (https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)

## Impact

Expect small gas cost in `kickReserveAuction` and increase in contract size.
Specifically, ERC721Pool size increased from 98.97% to 99.02%.
ERC721 unit tests were unchanged, and median gas for the call increased from 64977 to 67372.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
