### PR TITLE
Contract size mitigation

### DIFF
--- a/src/ERC721Pool.sol
+++ b/src/ERC721Pool.sol
@@ -344,7 +344,6 @@ contract ERC721Pool is FlashloanablePool, IERC721Pool {
             // Total collateral in buckets meets the requested removal amount, noOfNFTsToRemove_
             _transferFromPoolToAddress(msg.sender, bucketTokenIds, noOfNFTsToRemove_);
         }
-
     }
 
     /**

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.18;
 import { Clone }           from '@clones/Clone.sol';
 import { ReentrancyGuard } from '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import { Multicall }       from '@openzeppelin/contracts/utils/Multicall.sol';
-import { SafeCast }        from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { SafeERC20 }       from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 }          from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -51,6 +50,7 @@ import {
 }                                   from '../interfaces/pool/commons/IPoolInternals.sol';
 
 import {
+    _determineInflatorState,
     _priceAt,
     _roundToScale
 }                               from '../libraries/helpers/PoolHelper.sol';
@@ -688,20 +688,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             emit InterestUpdateFailure();
         }
 
-        // update pool inflator
-        if (poolState_.isNewInterestAccrued) {
-            inflatorState.inflator       = SafeCast.toUint208(poolState_.inflator);
-            inflatorState.inflatorUpdate = SafeCast.toUint48(block.timestamp);
-        // if the debt in the current pool state is 0, also update the inflator and inflatorUpdate fields in inflatorState
-        // slither-disable-next-line incorrect-equality
-        } else if (poolState_.debt == 0) {
-            inflatorState.inflator       = SafeCast.toUint208(Maths.WAD);
-            inflatorState.inflatorUpdate = SafeCast.toUint48(block.timestamp);
-        // if the first loan has just been drawn, update the inflator timestamp
-        // slither-disable-next-line incorrect-equality
-        } else if (inflatorState.inflator == Maths.WAD && inflatorState.inflatorUpdate != block.timestamp){
-            inflatorState.inflatorUpdate = SafeCast.toUint48(block.timestamp);
-        }
+        (uint208 newInflator, bool updateTimestamp) = _determineInflatorState(poolState_, inflatorState);
+        inflatorState.inflator = newInflator;
+        if (updateTimestamp) inflatorState.inflatorUpdate = uint48(block.timestamp);
     }
 
     /**

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -5,9 +5,15 @@ pragma solidity 0.8.18;
 import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 import { PRBMathUD60x18 } from "@prb-math/contracts/PRBMathUD60x18.sol";
 
+import { IERC20 }    from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+
 import { InterestState, EmaState, PoolState, DepositsState } from '../../interfaces/pool/commons/IPoolState.sol';
+import { IERC3156FlashBorrower }                             from '../../interfaces/pool/IERC3156FlashBorrower.sol';
 
 import { _dwatp, _indexOf, MAX_FENWICK_INDEX, MIN_PRICE, MAX_PRICE } from '../helpers/PoolHelper.sol';
+
 
 import { Deposits } from '../internal/Deposits.sol';
 import { Buckets }  from '../internal/Buckets.sol';
@@ -21,6 +27,8 @@ import { Maths }    from '../internal/Maths.sol';
             - pool utilization
  */
 library PoolCommons {
+    using SafeERC20 for IERC20;
+
 
     /*****************/
     /*** Constants ***/
@@ -40,8 +48,17 @@ library PoolCommons {
     /**************/
 
     // See `IPoolEvents` for descriptions
+    event Flashloan(address indexed receiver, address indexed token, uint256 amount);
     event ResetInterestRate(uint256 oldRate, uint256 newRate);
     event UpdateInterestRate(uint256 oldRate, uint256 newRate);
+
+    /**************/
+    /*** Errors ***/
+    /**************/
+
+    // See `IPoolErrors` for descriptions
+    error FlashloanCallbackFailed();
+    error FlashloanIncorrectBalance();
 
     /*************************/
     /*** Local Var Structs ***/
@@ -257,6 +274,36 @@ library PoolCommons {
             // Scale the fenwick tree to update amount of debt owed to lenders
             Deposits.mult(deposits_, accrualIndex, lenderFactor);
         }
+    }
+
+    function flashLoan(
+        IERC3156FlashBorrower receiver_,
+        address token_, 
+        uint256 amount_,
+        bytes calldata data_
+    ) external returns (bool success_) {
+        IERC20 tokenContract = IERC20(token_);
+
+        uint256 initialBalance = tokenContract.balanceOf(address(this));
+
+        tokenContract.safeTransfer(
+            address(receiver_),
+            amount_
+        );
+
+        if (receiver_.onFlashLoan(msg.sender, token_, amount_, 0, data_) != 
+            keccak256("ERC3156FlashBorrower.onFlashLoan")) revert FlashloanCallbackFailed();
+
+        tokenContract.safeTransferFrom(
+            address(receiver_),
+            address(this),
+            amount_
+        );
+
+        if (tokenContract.balanceOf(address(this)) != initialBalance) revert FlashloanIncorrectBalance();
+
+        success_ = true;
+        emit Flashloan(address(receiver_), token_, amount_);
     }
 
     /**************************/

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -4,8 +4,10 @@ pragma solidity 0.8.18;
 
 import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 import { Math }           from '@openzeppelin/contracts/utils/math/Math.sol';
+import { SafeCast }       from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-import { PoolType } from '../../interfaces/pool/IPool.sol';
+import { PoolType }                 from '../../interfaces/pool/IPool.sol';
+import { InflatorState, PoolState } from '../../interfaces/pool/commons/IPoolState.sol';
 
 import { Buckets } from '../internal/Buckets.sol';
 import { Maths }   from '../internal/Maths.sol';
@@ -131,6 +133,35 @@ import { Maths }   from '../internal/Maths.sol';
     ) pure returns (uint256) {
         // current annualized rate divided by 365 (24 hours of interest), capped at 10%
         return Maths.min(Maths.wdiv(interestRate_, 365 * 1e18), 0.1 * 1e18);
+    }
+
+    /**
+     * @notice Determines how the inflator state should be updated
+     * @param  poolState_     State of the pool after updateInterestState was called.
+     * @param  inflatorState_ Old inflator state.
+     * @return newInflator_     New inflator value.
+     * @return updateTimestamp_ `True` if timestamp of last update should be updated.
+     */
+    function _determineInflatorState(
+        PoolState memory poolState_,
+        InflatorState memory inflatorState_
+    ) view returns (uint208 newInflator_, bool updateTimestamp_) {
+        newInflator_ = inflatorState_.inflator;
+
+        // update pool inflator
+        if (poolState_.isNewInterestAccrued) {
+            newInflator_     = SafeCast.toUint208(poolState_.inflator);
+            updateTimestamp_ = true;
+        // if the debt in the current pool state is 0, also update the inflator and inflatorUpdate fields in inflatorState
+        // slither-disable-next-line incorrect-equality
+        } else if (poolState_.debt == 0) {
+            newInflator_     = SafeCast.toUint208(Maths.WAD);
+            updateTimestamp_ = true;
+        // if the first loan has just been drawn, update the inflator timestamp
+        // slither-disable-next-line incorrect-equality
+        } else if (inflatorState_.inflator == Maths.WAD && inflatorState_.inflatorUpdate != block.timestamp){
+            updateTimestamp_ = true;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

Moved inflator state management logic and flashloan implementation to `PoolCommons` and `PoolHelper` libraries, respectively.

## Purpose

`ERC721Pool` contract had exceeded contract size limits.  `develop` branch was at 24,601B  (100.10%), and `first-borrower` at 24,656B  (100.32%).

## Impact

`ERC721Pool` contract size reduced to 24,171B  (98.35%).
Gas cost taking a flashloan increased by ~24%, but still reasonable (median 32959 gas for ERC20 pool).
Gas impact on other pool operations negligible, with ~0.23% increase.


## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
