### PR TITLE
Dust and lenderActions changes

### DIFF
--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -245,11 +245,9 @@ library LenderActions {
         PoolState calldata poolState_,
         MoveQuoteParams calldata params_
     ) external returns (uint256 fromBucketRedeemedLP_, uint256 toBucketLP_, uint256 movedAmount_, uint256 lup_) {
-        if (params_.maxAmountToMove == 0)
-            revert InvalidAmount();
         if (params_.fromIndex == params_.toIndex)
             revert MoveToSameIndex();
-        if (params_.maxAmountToMove != 0 && params_.maxAmountToMove < poolState_.quoteTokenScale)
+        if (params_.maxAmountToMove < poolState_.quoteTokenScale)
             revert DustAmountNotExceeded();
         if (params_.toIndex == 0 || params_.toIndex > MAX_FENWICK_INDEX) 
             revert InvalidIndex();
@@ -830,6 +828,9 @@ library LenderActions {
             removedAmount_ = scaledDepositAvailable;
             unscaledRemovedAmount = unscaledDepositAvailable;
         }
+
+        scaledDepositAvailable -= removedAmount_;
+        if (scaledDepositAvailable != 0 && scaledDepositAvailable < params_.dustLimit) revert DustAmountNotExceeded();
 
         unscaledRemaining_ = unscaledDepositAvailable - unscaledRemovedAmount;
 

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -728,6 +728,16 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         _pool.removeQuoteToken(amount, index);
     }
 
+    function _assertRemoveQuoteDustRevert(
+        address from,
+        uint256 amount,
+        uint256 index
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
+        _pool.removeQuoteToken(amount, index);
+    }
+
     function _assertBorrowAuctionActiveRevert(
         address from,
         uint256 amount,
@@ -798,6 +808,17 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         changePrank(from);
         vm.expectRevert(IPoolErrors.LUPBelowHTP.selector);
         ERC20Pool(address(_pool)).moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max, false);
+    }
+
+    function _assertMoveQuoteDustRevert(
+        address from,
+        uint256 amount,
+        uint256 toIndex,
+        uint256 fromIndex
+    ) internal {
+        changePrank(from);
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
+        _pool.moveQuoteToken(amount, fromIndex, toIndex, type(uint256).max, false);
     }
 
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
@@ -23,8 +23,8 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
     }
 
     function testValidateMoveQuoteTokenInput() external tearDown {
-        // revert on zero amount
-        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        // revert on dust amount if amount is below quote token scale
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
         _pool.moveQuoteToken(0, 1, 2, block.timestamp + 1, false);
         // revert on move to same index
         vm.expectRevert(IPoolErrors.MoveToSameIndex.selector);

--- a/tests/forge/unit/ERC721Pool/ERC721PoolInputValidation.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolInputValidation.t.sol
@@ -28,8 +28,8 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
     }
 
     function testValidateMoveQuoteTokenInput() external tearDown {
-        // revert on zero amount
-        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        // revert on dust amount if amount is below quote token scale
+        vm.expectRevert(IPoolErrors.DustAmountNotExceeded.selector);
         _pool.moveQuoteToken(0, 1, 2, block.timestamp + 1, false);
         // revert on move to same index
         vm.expectRevert(IPoolErrors.MoveToSameIndex.selector);


### PR DESCRIPTION
## Description
* Created `testRemoveQuoteDust` and `testMoveQuoteDust` tests
* added dust limit checks in the following functions (ensuring that the bucket) is not left with deposit after the action):
  * `removeMaxDeposit()`
  * `addQuoteToken()`
  * `moveQuoteToken()`
 
## Purpose
* Resolves `Kirill L-01` (https://github.com/k1rill-fedoseev/audits/blob/master/solo/Ajna.md)

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->
old
```
addQuoteToken                        | 1950            | 252735 | 169787 | 723088 | 944     |
moveQuoteToken                       | 1918            | 149390 | 107324 | 634633 | 41      |
```

new
```
addQuoteToken                        | 1950            | 253720 | 170124 | 723195 | 949     |
moveQuoteToken                       | 1918            | 146633 | 107386 | 634829 | 44      |
```

### size
old
```
  ERC721Pool               -  24,069B  (97.93%)
  ERC20Pool                -  23,360B  (95.05%)
  PositionManager          -  17,801B  (72.43%)
  TakerActions             -  15,866B  (64.56%)
  PositionNFTSVG           -  15,271B  (62.14%)
  PoolInfoUtils            -  14,399B  (58.59%)
  LenderActions            -  10,715B  (43.60%)
  BorrowerActions          -   9,358B  (38.08%)
  SettlerActions           -   9,349B  (38.04%)
  KickerActions            -   9,153B  (37.24%)
  PoolCommons              -   9,089B  (36.98%)
  RewardsManager           -   8,693B  (35.37%)
  PoolInfoUtilsMulticall   -   8,539B  (34.74%)
  ERC721                   -   4,276B  (17.40%)
  ERC721PoolFactory        -   3,742B  (15.23%)
  LPActions                -   2,952B  (12.01%)
  ERC20PoolFactory         -   2,564B  (10.43%)
```

new
```
  ERC721Pool               -  24,069B  (97.93%)
  ERC20Pool                -  23,360B  (95.05%)
  PositionManager          -  17,801B  (72.43%)
  TakerActions             -  15,866B  (64.56%)
  PositionNFTSVG           -  15,271B  (62.14%)
  PoolInfoUtils            -  14,399B  (58.59%)
  LenderActions            -  10,823B  (44.04%)
  BorrowerActions          -   9,358B  (38.08%)
  SettlerActions           -   9,349B  (38.04%)
  KickerActions            -   9,153B  (37.24%)
  PoolCommons              -   9,089B  (36.98%)
  RewardsManager           -   8,693B  (35.37%)
  PoolInfoUtilsMulticall   -   8,539B  (34.74%)
  ERC721                   -   4,276B  (17.40%)
  ERC721PoolFactory        -   3,742B  (15.23%)
  LPActions                -   2,952B  (12.01%)
  ERC20PoolFactory         -   2,564B  (10.43%)
  ERC20                    -   2,114B  (8.60%)
```
## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
