### PR TITLE
Add 1.04 factor in HTP calculations

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -207,7 +207,7 @@ contract PoolInfoUtils {
 
         (, uint256 maxThresholdPrice,) = pool.loansInfo();
 
-        htp_      = Maths.wmul(maxThresholdPrice, COLLATERALIZATION_FACTOR);
+        htp_      = maxThresholdPrice;
         htpIndex_ = htp_ >= MIN_PRICE ? _indexOf(htp_) : MAX_FENWICK_INDEX;
         lupIndex_ = pool.depositIndex(debt);
         lup_      = _priceAt(lupIndex_);

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -19,7 +19,8 @@ import {
     _priceAt,
     _reserveAuctionPrice,
     MAX_FENWICK_INDEX,
-    MIN_PRICE
+    MIN_PRICE,
+    COLLATERALIZATION_FACTOR
 } from './libraries/helpers/PoolHelper.sol';
 
 import { Buckets } from './libraries/internal/Buckets.sol';
@@ -206,7 +207,7 @@ contract PoolInfoUtils {
 
         (, uint256 maxThresholdPrice,) = pool.loansInfo();
 
-        htp_      = Maths.wmul(maxThresholdPrice, 1.04 * 1e18);
+        htp_      = Maths.wmul(maxThresholdPrice, COLLATERALIZATION_FACTOR);
         htpIndex_ = htp_ >= MIN_PRICE ? _indexOf(htp_) : MAX_FENWICK_INDEX;
         lupIndex_ = pool.depositIndex(debt);
         lup_      = _priceAt(lupIndex_);
@@ -495,7 +496,7 @@ contract PoolInfoUtils {
         uint256 debt_,
         uint256 price_
     ) pure returns (uint256 encumberance_) {
-        return price_ != 0 ? Maths.wdiv(Maths.wmul(1.04 * 1e18 , debt_), price_) : 0;
+        return price_ != 0 ? Maths.wdiv(Maths.wmul(COLLATERALIZATION_FACTOR , debt_), price_) : 0;
     }
 
     /**
@@ -515,7 +516,7 @@ contract PoolInfoUtils {
         
         // borrower is undercollateralized when lup at MIN_PRICE
         if (price_ == MIN_PRICE) return 0;
-        return Maths.wdiv(Maths.wmul(collateral_, price_), Maths.wmul(1.04 * 1e18, debt_));
+        return Maths.wdiv(Maths.wmul(collateral_, price_), Maths.wmul(COLLATERALIZATION_FACTOR, debt_));
     }
 
     /**

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -206,7 +206,7 @@ contract PoolInfoUtils {
 
         (, uint256 maxThresholdPrice,) = pool.loansInfo();
 
-        htp_      = maxThresholdPrice;
+        htp_      = Maths.wmul(maxThresholdPrice, 1.04 * 1e18);
         htpIndex_ = htp_ >= MIN_PRICE ? _indexOf(htp_) : MAX_FENWICK_INDEX;
         lupIndex_ = pool.depositIndex(debt);
         lup_      = _priceAt(lupIndex_);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -50,6 +50,7 @@ import {
 }                                   from '../interfaces/pool/commons/IPoolInternals.sol';
 
 import {
+    COLLATERALIZATION_FACTOR,
     _determineInflatorState,
     _priceAt,
     _roundToScale
@@ -940,7 +941,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            Maths.wmul(Maths.wmul(maxLoan.thresholdPrice, inflatorState.inflator), 1.04 * 1e18),
+            Maths.wmul(Maths.wmul(maxLoan.thresholdPrice, inflatorState.inflator), COLLATERALIZATION_FACTOR),
             Loans.noOfLoans(loans)
         );
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -940,7 +940,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            Maths.wmul(maxLoan.thresholdPrice, inflatorState.inflator),
+            Maths.wmul(Maths.wmul(maxLoan.thresholdPrice, inflatorState.inflator), 1.04 * 1e18),
             Loans.noOfLoans(loans)
         );
     }

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -314,7 +314,7 @@ library KickerActions {
         // which will make it harder for kicker to earn a reward and more likely that the kicker is penalized
         _revertIfPriceDroppedBelowLimit(vars.neutralPrice, limitIndex_);
 
-        vars.htp            = Maths.wmul(Loans.getMax(loans_).thresholdPrice, poolState_.inflator);
+        vars.htp            = Maths.wmul(Maths.wmul(Loans.getMax(loans_).thresholdPrice, poolState_.inflator), 1.04 * 1e18);
         vars.referencePrice = Maths.min(Maths.max(vars.htp, vars.neutralPrice), MAX_INFLATED_PRICE);
 
         (vars.bondFactor, vars.bondSize) = _bondParams(

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -26,6 +26,7 @@ import {
 
 import {
     MAX_INFLATED_PRICE,
+    COLLATERALIZATION_FACTOR,
     _bondParams,
     _claimableReserves,
     _isCollateralized,
@@ -314,7 +315,7 @@ library KickerActions {
         // which will make it harder for kicker to earn a reward and more likely that the kicker is penalized
         _revertIfPriceDroppedBelowLimit(vars.neutralPrice, limitIndex_);
 
-        vars.htp            = Maths.wmul(Maths.wmul(Loans.getMax(loans_).thresholdPrice, poolState_.inflator), 1.04 * 1e18);
+        vars.htp            = Maths.wmul(Maths.wmul(Loans.getMax(loans_).thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
         vars.referencePrice = Maths.min(Maths.max(vars.htp, vars.neutralPrice), MAX_INFLATED_PRICE);
 
         (vars.bondFactor, vars.bondSize) = _bondParams(

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -16,7 +16,12 @@ import {
     PoolState
 }                     from '../../interfaces/pool/commons/IPoolState.sol';
 
-import { _depositFeeRate, _priceAt, MAX_FENWICK_INDEX } from '../helpers/PoolHelper.sol';
+import { 
+    _depositFeeRate,
+    _priceAt,
+    MAX_FENWICK_INDEX,
+    COLLATERALIZATION_FACTOR 
+} from '../helpers/PoolHelper.sol';
 
 import { Deposits } from '../internal/Deposits.sol';
 import { Buckets }  from '../internal/Buckets.sol';
@@ -298,7 +303,7 @@ library LenderActions {
 
         // recalculate LUP and HTP
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        vars.htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), 1.04 * 1e18);
+        vars.htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (
@@ -415,7 +420,7 @@ library LenderActions {
 
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
-        uint256 htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), 1.04 * 1e18);
+        uint256 htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
 
         if (
             // check loan book's htp doesn't exceed new lup

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -298,7 +298,7 @@ library LenderActions {
 
         // recalculate LUP and HTP
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        vars.htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
+        vars.htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), 1.04 * 1e18);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (
@@ -415,7 +415,7 @@ library LenderActions {
 
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
-        uint256 htp = Maths.wmul(params_.thresholdPrice, poolState_.inflator);
+        uint256 htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), 1.04 * 1e18);
 
         if (
             // check loan book's htp doesn't exceed new lup

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -246,7 +246,7 @@ library PoolCommons {
 
         // calculate the highest threshold price
         newInflator_ = Maths.wmul(poolState_.inflator, pendingFactor);
-        uint256 htp = Maths.wmul(thresholdPrice_, poolState_.inflator);
+        uint256 htp = Maths.wmul(Maths.wmul(thresholdPrice_, poolState_.inflator), 1.04 * 1e18);
 
         uint256 accrualIndex;
         if (htp > MAX_PRICE)      accrualIndex = 1;                 // if HTP is over the highest price bucket then no buckets earn interest

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -12,8 +12,13 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { InterestState, EmaState, PoolState, DepositsState } from '../../interfaces/pool/commons/IPoolState.sol';
 import { IERC3156FlashBorrower }                             from '../../interfaces/pool/IERC3156FlashBorrower.sol';
 
-import { _dwatp, _indexOf, MAX_FENWICK_INDEX, MIN_PRICE, MAX_PRICE } from '../helpers/PoolHelper.sol';
-
+import { 
+    _dwatp,
+    _indexOf,
+    MAX_FENWICK_INDEX,
+    MIN_PRICE, MAX_PRICE,
+    COLLATERALIZATION_FACTOR 
+} from '../helpers/PoolHelper.sol';
 
 import { Deposits } from '../internal/Deposits.sol';
 import { Buckets }  from '../internal/Buckets.sol';
@@ -246,7 +251,7 @@ library PoolCommons {
 
         // calculate the highest threshold price
         newInflator_ = Maths.wmul(poolState_.inflator, pendingFactor);
-        uint256 htp = Maths.wmul(Maths.wmul(thresholdPrice_, poolState_.inflator), 1.04 * 1e18);
+        uint256 htp = Maths.wmul(Maths.wmul(thresholdPrice_, poolState_.inflator), COLLATERALIZATION_FACTOR);
 
         uint256 accrualIndex;
         if (htp > MAX_PRICE)      accrualIndex = 1;                 // if HTP is over the highest price bucket then no buckets earn interest

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -178,7 +178,13 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 inflator_,
         uint256 t0Debt2ToCollateral_
     ) pure returns (uint256) {
-        return t0Debt_ == 0 ? 0 : Maths.wdiv(Maths.wmul(inflator_, t0Debt2ToCollateral_), t0Debt_);
+        return t0Debt_ == 0 ? 0 : Maths.wdiv(
+            Maths.wmul(
+                Maths.wmul(inflator_, t0Debt2ToCollateral_),
+                COLLATERALIZATION_FACTOR
+            ),
+            t0Debt_
+        );
     }
 
     /**

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -35,6 +35,9 @@ import { Maths }   from '../internal/Maths.sol';
     /// @dev step amounts in basis points. This is a constant across pools at `0.005`, achieved by dividing `WAD` by `10,000`
     int256 constant FLOAT_STEP_INT = 1.005 * 1e18;
 
+    /// @dev collateralization factor used to calculate borrrower HTP/TP/collateralization.
+    uint256 constant COLLATERALIZATION_FACTOR = 1.04 * 1e18;
+
     /**
      *  @notice Calculates the price (`WAD` precision) for a given `Fenwick` index.
      *  @dev    Reverts with `BucketIndexOutOfBounds` if index exceeds maximum constant.
@@ -201,7 +204,7 @@ import { Maths }   from '../internal/Maths.sol';
             collateral_ = (collateral_ / Maths.WAD) * Maths.WAD; // use collateral floor
         }
         
-       return Maths.wmul(collateral_, price_) >= Maths.wmul(1.04 * 1e18, debt_);
+       return Maths.wmul(collateral_, price_) >= Maths.wmul(COLLATERALIZATION_FACTOR, debt_);
     }
 
     /**

--- a/tests/forge/invariants/ERC20Pool/handlers/unbounded/UnboundedBasicERC20PoolHandler.sol
+++ b/tests/forge/invariants/ERC20Pool/handlers/unbounded/UnboundedBasicERC20PoolHandler.sol
@@ -8,7 +8,8 @@ import { PoolInfoUtils }    from 'src/PoolInfoUtils.sol';
 import {
     _borrowFeeRate,
     _depositFeeRate,
-    _roundToScale
+    _roundToScale,
+    COLLATERALIZATION_FACTOR
 }                           from 'src/libraries/helpers/PoolHelper.sol';
 import { Maths }            from "src/libraries/internal/Maths.sol";
 
@@ -126,7 +127,7 @@ abstract contract UnboundedBasicERC20PoolHandler is UnboundedBasicPoolHandler, B
 
         uint256 bucket = depositIndex - 1;
         uint256 price = _poolInfo.indexToPrice(bucket);
-        uint256 collateralToPledge = ((1.04 * 1e18 * amount_ + price / 2) / price) * 101 / 100 + 1;
+        uint256 collateralToPledge = ((COLLATERALIZATION_FACTOR * amount_ + price / 2) / price) * 101 / 100 + 1;
 
         // ensure actor always has amount of collateral to pledge
         _ensureCollateralAmount(_actor, collateralToPledge);

--- a/tests/forge/invariants/ERC721Pool/handlers/unbounded/UnboundedBasicERC721PoolHandler.sol
+++ b/tests/forge/invariants/ERC721Pool/handlers/unbounded/UnboundedBasicERC721PoolHandler.sol
@@ -13,7 +13,8 @@ import {
     _indexOf,
     _roundToScale,
     MIN_PRICE,
-    MAX_PRICE 
+    MAX_PRICE,
+    COLLATERALIZATION_FACTOR
 }                           from 'src/libraries/helpers/PoolHelper.sol';
 import { Maths }            from "src/libraries/internal/Maths.sol";
 
@@ -174,7 +175,7 @@ abstract contract UnboundedBasicERC721PoolHandler is UnboundedBasicPoolHandler, 
         if (bucket > LENDER_MAX_BUCKET_INDEX) return;
 
         // calculates collateral required to borrow <amount_> quote tokens, added 1 for roundup such that 0.8 NFT will become 1
-        uint256 collateralToPledge = Maths.wdiv(Maths.wmul(1.04 * 1e18, amount_), price) / 1e18 + 1;
+        uint256 collateralToPledge = Maths.wdiv(Maths.wmul(COLLATERALIZATION_FACTOR, amount_), price) / 1e18 + 1;
 
         _ensureCollateralAmount(_actor, collateralToPledge);
         uint256[] memory tokenIds = new uint256[](collateralToPledge);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1281,7 +1281,7 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
         changePrank(_borrower);
         uint256 limitIndex = _findLowestIndexPrice(indexes);
         uint256 borrowAmount = Maths.wdiv(mintAmount_, Maths.wad(3));
-        uint256 requiredCollateral = _requiredCollateral(Maths.wdiv(mintAmount_, Maths.wad(3)), limitIndex);
+        uint256 requiredCollateral = _requiredCollateral(borrowAmount, limitIndex);
 
         deal(address(_collateral), _borrower, requiredCollateral);
 
@@ -1314,7 +1314,7 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  Maths.wdiv(debt, requiredCollateral),
+                htp:                  Maths.wdiv(Maths.wmul(debt, COLLATERALIZATION_FACTOR), requiredCollateral),
                 lup:                  _poolUtils.lup(address(_pool)),
                 poolSize:             (49_997.716894977168950000 * 1e18) + (indexes.length * liqAmount_),
                 pledgedCollateral:    requiredCollateral,
@@ -1356,7 +1356,7 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
             (, uint256 deposit, , uint256 lpAccumulator, , uint256 exchangeRate) = _poolUtils.bucketInfo(address(_pool), indexes[i]);
 
             // check that only deposits above the htp earned interest
-            if (indexes[i] <= _poolUtils.priceToIndex(Maths.wdiv(debt, requiredCollateral))) {
+            if (indexes[i] <= _poolUtils.priceToIndex(Maths.wdiv(Maths.wmul(debt, COLLATERALIZATION_FACTOR), requiredCollateral))) {
                 assertGt(deposit, liqAmount_);
                 assertGt(exchangeRate, 1e18);
             } else {

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -1318,7 +1318,7 @@ contract ERC20PoolBorrowFuzzyTest is ERC20FuzzyHelperContract {
                 lup:                  _poolUtils.lup(address(_pool)),
                 poolSize:             (49_997.716894977168950000 * 1e18) + (indexes.length * liqAmount_),
                 pledgedCollateral:    requiredCollateral,
-                encumberedCollateral: Maths.wdiv(Maths.wmul(debt, 1.04 * 1e18), _poolUtils.lup(address(_pool))),
+                encumberedCollateral: Maths.wdiv(Maths.wmul(debt, COLLATERALIZATION_FACTOR), _poolUtils.lup(address(_pool))),
                 poolDebt:             debt,
                 actualUtilization:    poolActualUtilization,
                 targetUtilization:    poolTargetUtilization,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -97,7 +97,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  210.201923076923077020 * 1e18,
+                htp:                  218.610000000000000101 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -196,7 +196,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  400.384615384615384800 * 1e18,
+                htp:                  416.400000000000000192 * 1e18,
                 lup:                  2_951.419442869698640451 * 1e18,  // FIMXE: actual is 2_995.912459898389633881,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -228,7 +228,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  300.384615384615384800 * 1e18,
+                htp:                  312.400000000000000192 * 1e18,
                 lup:                  2_966.176540084047110076 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -291,7 +291,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  80.076923076923076960 * 1e18,
+                htp:                  83.280000000000000038 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -325,7 +325,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         uint256 expectedDebt = 21_020.192307692307702000 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  420.403846153846154040 * 1e18,
+                htp:                  437.220000000000000202 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -359,7 +359,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_046.123595032677924434 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  350.768726583877965407 * 1e18,
+                htp:                  364.799475647233084023 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_019.758489216483593404 * 1e18,
                 pledgedCollateral:    60 * 1e18,
@@ -396,7 +396,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_074.684960840362729425 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  421.493699216807254588 * 1e18,
+                htp:                  438.353447185479544772 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_044.747888604073744487 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -430,7 +430,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_106.147233265508423039 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  422.122944665310168461 * 1e18,
+                htp:                  439.007862451922575199 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_072.276153888476772676 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -461,7 +461,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_140.809985797421809167 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  422.816199715948436183 * 1e18,
+                htp:                  439.728847704586373630 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_102.605614470717226695 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -490,7 +490,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_179.004767688830766408 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  422.816199715948436183 * 1e18,
+                htp:                  439.728847704586373630 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_102.605614470717226695 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -656,7 +656,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -687,7 +687,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  100.096153846153846200 * 1e18,
+                htp:                  104.100000000000000048 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -728,7 +728,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  100.096153846153846200 * 1e18,
+                htp:                  104.100000000000000048 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -788,7 +788,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -816,7 +816,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019228769230769240 * 1e18,
+                htp:                  20.819997920000000010 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -861,7 +861,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  5.004807692307692310 * 1e18,
+                htp:                  5.205000000000000002 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -897,7 +897,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.009615384615384620 * 1e18,
+                htp:                  10.410000000000000005 * 1e18,
                 lup:                  3_010.892022197881557845 * 1e18,
                 poolSize:             49_997.716894977168950000 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -987,8 +987,8 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         assertEq(_collateral.balanceOf(_borrower), 0);
 
         _assertPoolPrices({
-            htp:      210.201923076923077020 * 1e18,
-            htpIndex: 3_083,
+            htp:      218.610000000000000101 * 1e18,
+            htpIndex: 3_075,
             hpb:      3_010.892022197881557845 * 1e18,
             hpbIndex: 2550,
             lup:      2_981.007422784467321543 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolCollateral.t.sol
@@ -88,7 +88,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  210.201923076923077020 * 1e18,
+                htp:                  218.610000000000000101 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             29_998.63013698630137 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -127,7 +127,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  420.980136462780058369 * 1e18,
+                htp:                  437.819341921291260704 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             30_023.122475115992296048 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -163,7 +163,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  2_866.353291138910885986 * 1e18,
+                htp:                  2_981.007422784467321425 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             30_023.122475115992296048 * 1e18,
                 pledgedCollateral:    7.343479566252432930 * 1e18,
@@ -231,7 +231,7 @@ contract ERC20PoolCollateralTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  210.201923076923077020 * 1e18,
+                htp:                  218.610000000000000101 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             29_998.63013698630137 * 1e18,
                 pledgedCollateral:    100 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
@@ -69,7 +69,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  667307692307692308,
+                htp:                  0.694000000000000000 * 1e18,
                 lup:                  1 * 1e18,
                 poolSize:             99.995433789954337900 * 1e18,
                 pledgedCollateral:    75.000000000000000000 * 1e18,
@@ -95,7 +95,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  667307692307692308,
+                htp:                  0.694000000000000000 * 1e18,
                 lup:                  1 * 1e18,
                 poolSize:             99.995433789954337900 * 1e18,
                 pledgedCollateral:    75.000000000000000000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -161,8 +161,8 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
 
         assertEq(hpb,      3_010.892022197881557845 * 1e18);
         assertEq(hpbIndex, 2550);
-        assertEq(htp,      210.201923076923077020 * 1e18);
-        assertEq(htpIndex, 3083);
+        assertEq(htp,      218.610000000000000101 * 1e18);
+        assertEq(htpIndex, 3075);
         assertEq(lup,      2981.007422784467321543 * 1e18);
         assertEq(lupIndex, 2552);
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
@@ -8,7 +8,7 @@ import 'src/interfaces/pool/commons/IPoolErrors.sol';
 
 import 'src/ERC20Pool.sol';
 
-contract ERC20PoolBorrowTest is ERC20HelperContract {
+contract ERC20PooInputValidationTest is ERC20HelperContract {
 
     function testValidateAddQuoteTokenInput() external tearDown {
         // revert on zero amount

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -95,7 +95,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  460.442307692307692520 * 1e18,
+                htp:                  478.860000000000000221 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             109_994.977168949771690000 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -125,7 +125,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  460.475422884660056974 * 1e18,
+                htp:                  478.894439800046459253 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             109_997.791960299722618973 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -210,7 +210,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.663971153846153846 * 1e18,
+                htp:                  0.690530000000000000 * 1e18,
                 lup:                  100.332368143282009890 * 1e18,
                 poolSize:             999.954337899543379 * 1e18,
                 pledgedCollateral:    1_500 * 1e18,
@@ -233,7 +233,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.664020422940018855 * 1e18,
+                htp:                  0.690581239857619609 * 1e18,
                 lup:                  100.332368143282009890 * 1e18,
                 poolSize:             1_000.017155994221264894 * 1e18,
                 pledgedCollateral:    1_500 * 1e18,
@@ -276,7 +276,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  500.480769230769231000 * 1e18,
+                htp:                  520.500000000000000240 * 1e18,
                 lup:                  601.252968524772188572 * 1e18,
                 poolSize:             9_999.54337899543379 * 1e18,
                 pledgedCollateral:    10 * 1e18,
@@ -305,7 +305,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  500.515049909493508659 * 1e18,
+                htp:                  520.535651905873249005 * 1e18,
                 lup:                  601.252968524772188572 * 1e18,
                 poolSize:             10_999.789102664133521092 * 1e18,
                 pledgedCollateral:    10 * 1e18,
@@ -342,7 +342,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // confirm interest rate starts out at 5%
         _assertPool(
             PoolParams({
-                htp:                  1.0009615384615 * 1e18,
+                htp:                  1.040999999999960000 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             9_999.54337899543379 * 1e18,
                 pledgedCollateral:    0.00001 * 1e18,
@@ -371,7 +371,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // show the rate bottoms out at 10 bps
         _assertPool(
             PoolParams({
-                htp:                  1.002309975983935259 * 1e18,
+                htp:                  1.042402375023292669 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             9_999.543379006895126627 * 1e18,
                 pledgedCollateral:    0.00001 * 1e18,
@@ -408,7 +408,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // confirm interest rate starts out at 5%
         _assertPool(
             PoolParams({
-                htp:                  0.000000001000961538 * 1e18,
+                htp:                  0.000000001041000000 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             9_999.54337899543379 * 1e18,
                 pledgedCollateral:    10_000 * 1e18,
@@ -437,7 +437,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // show the rate reset to 10%
         _assertPool(
             PoolParams({
-                htp:                  1028117286,
+                htp:                  1069241977,
                 lup:                  _p1505_26,
                 poolSize:             9_999.543379226256659662 * 1e18,
                 pledgedCollateral:    10_000.0 * 1e18,
@@ -489,7 +489,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  300.288461538461538600 * 1e18,
+                htp:                  312.300000000000000144 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             29_998.63013698630137 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -510,7 +510,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // ensure pendingInflator increases as time passes
         _assertPool(
             PoolParams({
-                htp:                  300.288461538461538600 * 1e18,
+                htp:                  312.300000000000000144 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             29_998.63013698630137 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -580,7 +580,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.009615384615384620 * 1e18,
+                htp:                  10.410000000000000005 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             19_999.08675799086758 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -616,7 +616,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.009615384615384620 * 1e18,
+                htp:                  10.410000000000000005 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             19_999.08675799086758 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -650,7 +650,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.223528890139451939 * 1e18,
+                htp:                  10.632470045745030017 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             20_000.253059806567146479 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -726,7 +726,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  200.192307692307692400 * 1e18,
+                htp:                  208.200000000000000096 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             39_998.17351598173516 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -763,7 +763,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  200.192307692307692400 * 1e18,
+                htp:                  208.200000000000000096 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             39_998.17351598173516 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -797,7 +797,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  200.666923956635192629 * 1e18,
+                htp:                  208.693600914900600334 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_020.333250480026923092 * 1e18,
                 pledgedCollateral:    100 * 1e18,
@@ -835,7 +835,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  200.941998518054562716 * 1e18,
+                htp:                  208.979678458776745225 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_043.293270139495569883 * 1e18,
                 pledgedCollateral:    50_100 * 1e18,
@@ -867,7 +867,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  200.969526704670605713 * 1e18,
+                htp:                  209.008307772857429942 * 1e18,
                 lup:                  327.188250324085203338 * 1e18,
                 poolSize:             40_045.592577350080602020 * 1e18,
                 pledgedCollateral:    50_100 * 1e18,
@@ -913,7 +913,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  948_279_352.226720648210526316 * 1e18,
+                htp:                  986_210_526.315789474138947369 * 1e18,
                 lup:                  999969141.897027226245329498 * 1e18,
                 poolSize:             99_995_433_789_954_337.9 * 1e18,
                 pledgedCollateral:    95_000_000 * 1e18,
@@ -996,7 +996,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // Assert that HTP < LUP, meaning on accual interest should accrue between HTP - LUP
         _assertPool(
             PoolParams({
-                htp:                  0.100096153846153846 * 1e18,
+                htp:                  0.104100000000000000 * 1e18,
                 lup:                  _p9_91,
                 poolSize:             103_995.251141552511416 * 1e18,
                 pledgedCollateral:    1_000 * 1e18,
@@ -1063,7 +1063,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // Assert that HTP < LUP, meaning on accual interest should accrue between HTP - LUP
         _assertPool(
             PoolParams({
-                htp:                  9.008653846153846158 * 1e18,
+                htp:                  9.369000000000000004 * 1e18,
                 lup:                  0.014854015662334135 * 1e18,
                 poolSize:             103_995.251141552511416 * 1e18,
                 pledgedCollateral:    10_001_000.0 * 1e18,
@@ -1131,7 +1131,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.80076923076923077 * 1e18,
+                htp:                  0.832800000000000001 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             999_954_337.899543379 * 1e18,
                 pledgedCollateral:    1_000_000_000 * 1e18,
@@ -1161,7 +1161,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // confirm we hit 400% max rate
         _assertPool(
             PoolParams({
-                htp:                  0.897414066911426240 * 1e18,
+                htp:                  0.933310629587883290 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             1_088_282_545.280982499467572293 * 1e18,
                 pledgedCollateral:    1_000_000_000 * 1e18,
@@ -1222,7 +1222,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.80076923076923077 * 1e18,
+                htp:                  0.832800000000000001 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             999_954_337.899543379000000000 * 1e18,
                 pledgedCollateral:    1_000_000_000 * 1e18,
@@ -1295,7 +1295,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.80076923076923077 * 1e18,
+                htp:                  0.832800000000000001 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             999_954_337.899543379 * 1e18,
                 pledgedCollateral:    1_000_000_000 * 1e18,
@@ -1362,7 +1362,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.80076923076923077 * 1e18,
+                htp:                  0.832800000000000001 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             999_954_337.899543379 * 1e18,
                 pledgedCollateral:    1_000_000_000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -88,7 +88,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.283918269230769235 * 1e18,
+                htp:                  9.655275000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
@@ -213,8 +213,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758 * 1e18,
             collateral:   0,
-            deposit:      2_002.480314013611143267 * 1e18,
-            exchangeRate: 1.001285877823144529 * 1e18
+            deposit:      2_010.338097446880098916 * 1e18,
+            exchangeRate: 1.005214948949419476 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -230,7 +230,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             amount:      1 * 1e18,
             amountAdded: 0.999958904109589041 * 1e18,
             index:       _i9_52,
-            lpAward:     0.998671561665084117 * 1e18,
+            lpAward:     0.999955731278834362 * 1e18,
             newLup:      9.721295865031779605 * 1e18
         });
 
@@ -238,12 +238,12 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758 * 1e18,
             collateral:   0,
-            deposit:      2_002.486667826012234648 * 1e18,
-            exchangeRate: 1.001289054874415909 * 1e18
+            deposit:      2_010.344476191801861046 * 1e18,
+            exchangeRate: 1.005218138467520453 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   27.627772770867411734 * 1e18,
-            claimableReserves :         27.627699679104077180 * 1e18,
+            reserves:                   27.627772770867405734 * 1e18,
+            claimableReserves :         27.627699679104071180 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -283,33 +283,33 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             quoteTokenAmount: 17.598718399009752440 * 1e18,
             bondChange:       0.102293476350866899 * 1e18,
             isReward:         true,
-            lpAwardTaker:     2.232773120787256076 * 1e18,
-            lpAwardKicker:    0.102161784204958471 * 1e18
+            lpAwardTaker:     2.224045908354157413 * 1e18,
+            lpAwardKicker:    0.101762465713975074 * 1e18
         });
 
         _assertLenderLpBalance({
             lender:      _taker,
             index:       _i9_91,
-            lpBalance:   2.232773120787256076 * 1e18,
+            lpBalance:   2.224045908354157413 * 1e18,
             depositTime: _startTime + 100 days + 6.5 hours
         });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_91,
-            lpBalance:   2_000.010837583291716471 * 1e18, // rewarded with LP in bucket
+            lpBalance:   2_000.010438264800733074 * 1e18, // rewarded with LP in bucket
             depositTime: _startTime + 100 days + 6.5 hours
         });
         _assertBucket({
             index:        _i9_91,
-            lpBalance:    2_002.243610704078972547 * 1e18,
+            lpBalance:    2_002.234484173154890487 * 1e18,
             collateral:   2 * 1e18,
-            deposit:      1_984.990242903353349106 * 1e18,
-            exchangeRate: 1.001289054874415909 * 1e18
+            deposit:      1_992.848051269142975504 * 1e18,
+            exchangeRate: 1.005218138467520453 * 1e18
         });
         // reserves should remain the same after arb take
         _assertReserveAuction({
-            reserves:                   27.745855492035466067 * 1e18,
-            claimableReserves :         27.745782417768556436 * 1e18,
+            reserves:                   27.745855492035460073 * 1e18,
+            claimableReserves :         27.745782417768550442 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -423,8 +423,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             exchangeRate: 1.000000000000000001 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   29.177641507437093243 * 1e18,
-            claimableReserves :         29.177543436900138148 * 1e18,
+            reserves:                   29.177641507437087243 * 1e18,
+            claimableReserves :         29.177543436900132148 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -501,8 +501,8 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
             index:        _i1505_26,
             lpBalance:    1_525.676527175958763507 * 1e18,
             collateral:   1.013560945049577072 * 1e18,
-            deposit:      0.000000000000000004 * 1e18,
-            exchangeRate: 1.000000000000000000 * 1e18
+            deposit:      0.000000000000000005 * 1e18,
+            exchangeRate: 1.000000000000000001 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -90,7 +90,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.283918269230769235 * 1e18,
+                htp:                  9.655275000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
@@ -214,8 +214,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             index:        _i9_62,
             lpBalance:    24_998.858447488584475 * 1e18,
             collateral:   0,
-            deposit:      25_080.055384967972924431 * 1e18,
-            exchangeRate: 1.003248025810856400 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1.000000000000000000 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,
@@ -231,7 +231,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             amount:      1 * 1e18,
             amountAdded: 0.999958904109589041 * 1e18,
             index:       _i9_52,
-            lpAward:     0.996718304963012354 * 1e18,
+            lpAward:     0.999955671743685258 * 1e18,
             newLup:      9.721295865031779605 * 1e18
         });
 
@@ -239,12 +239,12 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             index:        _i9_62,
             lpBalance:    24_998.858447488584475 * 1e18,
             collateral:   0,
-            deposit:      25_080.136456477622937583 * 1e18,
-            exchangeRate: 1.003251268819324979 * 1e18
+            deposit:      24_998.939256528387459955 * 1e18,
+            exchangeRate: 1.000003232509195279 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   52.904513396067353834 * 1e18,
-            claimableReserves :         52.904440161068942015 * 1e18,
+            reserves:                   52.904513396067336836 * 1e18,
+            claimableReserves :         52.904440161068925017 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -285,7 +285,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             bondChange:       0.211722980967374082 * 1e18,
             isReward:         true,
             lpAwardTaker:     0,
-            lpAwardKicker:    0.211036843458508666 * 1e18
+            lpAwardKicker:    0.211722296573103563 * 1e18
         });
 
         _assertLenderLpBalance({
@@ -297,20 +297,20 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_62,
-            lpBalance:   24_999.069484332042983666 * 1e18,
+            lpBalance:   24_999.070169785157578563 * 1e18,
             depositTime: _startTime + 250 days + 6.5 hours
         });
         _assertBucket({
             index:        _i9_62,
-            lpBalance:    24_999.069484332042983666 * 1e18,
+            lpBalance:    24_999.070169785157578563 * 1e18,
             collateral:   2 * 1e18,
-            deposit:      25_061.098565112347832991 * 1e18,
-            exchangeRate: 1.003251268819324979 * 1e18
+            deposit:      24_979.901365163112355364 * 1e18,
+            exchangeRate: 1.000003232509195280 * 1e18
         });
         // reserves should remain the same after deposit take
         _assertReserveAuction({
-            reserves:                   52.908881208725969696 * 1e18,
-            claimableReserves :         52.908807992765449243 * 1e18,
+            reserves:                   52.908881208725952697 * 1e18,
+            claimableReserves :         52.908807992765432244 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -431,8 +431,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             exchangeRate: 1.000000000000000001 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   54.465229758885074795 * 1e18,
-            claimableReserves :         54.465131545511623905 * 1e18,
+            reserves:                   54.465229758885057797 * 1e18,
+            claimableReserves :         54.465131545511606907 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -622,8 +622,8 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
             index:        _i10016,
             lpBalance:    999.958904109589041 * 1e18,           // LP balance in arbed bucket is same
             collateral:   0.001951057800006470 * 1e18,          // arbed collateral added to the arbed bucket
-            deposit:      980.416130555022495400 * 1e18,        // quote token amount is diminished in arbed bucket
-            exchangeRate: 1.000000000000000001 * 1e18
+            deposit:      980.416130555022495399 * 1e18,        // quote token amount is diminished in arbed bucket
+            exchangeRate: 1.000000000000000000 * 1e18
         });
         _assertAuction(
             AuctionParams({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -92,7 +92,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.333966346153846158 * 1e18,
+                htp:                  9.707325000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
@@ -182,9 +182,9 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.097846143253778448 * 1e18,
+                htp:                  8.421759988983929586 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_090.532635019443055794 * 1e18,
+                poolSize:             73_090.532635019443083793 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
                 encumberedCollateral: 868.345387306633668354 * 1e18,
                 poolDebt:             8_116.771560618651000629 * 1e18,
@@ -236,8 +236,8 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             locked:    0.211592598652049829 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   27.588925599207944835 * 1e18,
-            claimableReserves :         27.588852508675309816 * 1e18,
+            reserves:                   27.588925599207916836 * 1e18,
+            claimableReserves :         27.588852508675281817 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -430,7 +430,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         2,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 9.333966346153846158 * 1e18
+            maxThresholdPrice: 9.707325000000000004 * 1e18
         });
 
         // kick first loan
@@ -446,7 +446,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 9.462708682436276194 * 1e18
+            maxThresholdPrice: 9.841217029733727242 * 1e18
         });
 
         // kick 2nd loan
@@ -468,11 +468,11 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_105.788429292052721483 * 1e18,
+                poolSize:             73_105.788429292052758482 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
                 encumberedCollateral: 1_009.475328421524777337 * 1e18,
                 poolDebt:             9_435.969553880544732799 * 1e18,
-                actualUtilization:    0.127507068947651280 * 1e18,
+                actualUtilization:    0.517112001843252414 * 1e18,
                 targetUtilization:    0.955532425687922567 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -489,7 +489,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             from:    _lender1,
             amount:  1 * 1e18,
             index:   _i9_91,
-            lpAward: 0.998458369722024471 * 1e18,
+            lpAward: 0.993924947593286866 * 1e18,
             newLup:  9.721295865031779605 * 1e18
         });
 
@@ -497,11 +497,11 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_107.369755748769009210 * 1e18,
+                poolSize:             73_107.387163902795349310 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
                 encumberedCollateral: 1_009.547930285248351849 * 1e18,
                 poolDebt:             9_436.648192532092411327 * 1e18,
-                actualUtilization:    0.061129283123817429 * 1e18,
+                actualUtilization:    0.095694819083490222 * 1e18,
                 targetUtilization:    0.955532425687922567 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -567,7 +567,7 @@ contract ERC20PoolLiquidationKickFuzzyTest is ERC20FuzzyHelperContract {
             (uint256 poolDebt, , , ) = _pool.debtInfo();
             uint256 depositIndex     = _pool.depositIndex(amountToBorrow + poolDebt);
             uint256 price = _poolUtils.indexToPrice(depositIndex);
-            uint256 collateralToPledge = Maths.wdiv(Maths.wmul(amountToBorrow, 1.04 * 1e18), price) * 101 / 100 + 1;
+            uint256 collateralToPledge = Maths.wdiv(Maths.wmul(amountToBorrow, COLLATERALIZATION_FACTOR), price) * 101 / 100 + 1;
 
             _mintCollateralAndApproveTokens(_borrowers[i], collateralToPledge);
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -117,7 +117,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_844.432207828138682757 * 1e18,
                 poolSize:             110_994.931506849315069 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,
@@ -188,7 +188,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_844.432207828138682757 * 1e18,
                 poolSize:             110_994.931506849315069 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,
@@ -318,7 +318,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_844.432207828138682757 * 1e18,
                 poolSize:             110_994.931506849315069 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,
@@ -449,7 +449,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_844.432207828138682757 * 1e18,
                 poolSize:             120_994.474885844748859 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,
@@ -567,7 +567,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  20.019230769230769240 * 1e18,
+                htp:                  20.820000000000000010 * 1e18,
                 lup:                  3_844.432207828138682757 * 1e18,
                 poolSize:             110_994.931506849315069 * 1e18,
                 pledgedCollateral:    5_000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -58,7 +58,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         });
         _borrow({
             from:       _borrower,
-            amount:     19.05 * 1e18,
+            amount:     18.65 * 1e18,
             indexLimit: _i9_91,
             newLup:     9.917184843435912074 * 1e18
         });
@@ -82,15 +82,15 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.534158653846153851 * 1e18,
+                htp:                  9.707325000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             47_997.808219178082192000 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
-                encumberedCollateral: 856.574181632808314357 * 1e18,
-                poolDebt:             8_006.741394230769234461 * 1e18,
+                encumberedCollateral: 856.531347837213447051 * 1e18,
+                poolDebt:             8_006.341009615384619076 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1e18,
-                minDebtAmount:        400.337069711538461723 * 1e18,
+                minDebtAmount:        400.317050480769230954 * 1e18,
                 loans:                2,
                 maxBorrower:          address(_borrower),
                 interestRate:         0.05 * 1e18,
@@ -99,10 +99,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.068317307692307701 * 1e18,
+            borrowerDebt:              18.667932692307692316 * 1e18,
             borrowerCollateral:        2 * 1e18,
-            borrowert0Np:              10.600109996759548181 * 1e18,
-            borrowerCollateralization: 0.980411613609141180 * 1e18
+            borrowert0Np:              10.377535508638612786 * 1e18,
+            borrowerCollateralization: 1.001439208539095951 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower2,
@@ -112,8 +112,8 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             borrowerCollateralization: 1.170228147822941070 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   9.883175052687042461 * 1e18,
-            claimableReserves :         9.883127054878823283 * 1e18,
+            reserves:                   9.882790437302427076 * 1e18,
+            claimableReserves :         9.882742439494207898 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -140,21 +140,21 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             amount:   1_999.935282868211813754 * 1e18,
             index:    _i9_91,
             newLup:   9.721295865031779605 * 1e18,
-            lpRedeem: 1_999.827375411809313515 * 1e18
+            lpRedeem: 1_999.827380807531781086 * 1e18
         });
         _removeLiquidity({
             from:     _lender,
             amount:   4_999.838207170529534384 * 1e18,
             index:    _i9_81,
             newLup:   9.721295865031779605 * 1e18,
-            lpRedeem: 4_999.568438529523283785 * 1e18
+            lpRedeem: 4_999.568452018829452712 * 1e18
         });
         _removeLiquidity({
             from:     _lender,
-            amount:   2_990 * 1e18,
+            amount:   2_980 * 1e18,
             index:    _i9_72,
             newLup:   9.721295865031779605 * 1e18,
-            lpRedeem: 2_989.838673132372185520 * 1e18
+            lpRedeem: 2_979.839220727000051551 * 1e18
         });
 
         // Lender amount to withdraw is restricted by HTP 
@@ -165,13 +165,13 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertBucket({
             index:        _i9_72,
-            lpBalance:    8_009.659043762604983480 * 1e18,
+            lpBalance:    8_019.658496167977117449 * 1e18,
             collateral:   0,
-            deposit:      8_010.091232032797917459 * 1e18,
-            exchangeRate: 1.000053958385473287 * 1e18
+            deposit:      8_020.091202353516607669 * 1e18,
+            exchangeRate: 1.000053955687233597 * 1e18
         });
 
-        skip(16 hours);
+        skip(400 hours);
 
         _assertAuction(
             AuctionParams({
@@ -185,48 +185,48 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.536302992275635967 * 1e18,
+                thresholdPrice:    9.354500183821244069 * 1e18,
                 neutralPrice:      0
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.072605984551271935 * 1e18,
+            borrowerDebt:              18.709000367642488138 * 1e18,
             borrowerCollateral:        2 * 1e18,
-            borrowert0Np:              10.600109996759548181 * 1e18,
-            borrowerCollateralization: 0.980191157704848339 * 1e18
+            borrowert0Np:              10.377535508638612786 * 1e18,
+            borrowerCollateralization: 0.979503487849002840 * 1e18
         });
 
         _kick({
             from:           _lender,
             borrower:       _borrower,
-            debt:           19.072605984551271935 * 1e18,
+            debt:           18.709000367642488138 * 1e18,
             collateral:     2 * 1e18,
-            bond:           0.213238217447629730 * 1e18,
-            transferAmount: 0.213238217447629730 * 1e18
+            bond:           0.209172983065585793 * 1e18,
+            transferAmount: 0.209172983065585793 * 1e18
         });
 
         _assertBucket({
             index:        _i9_72,
-            lpBalance:    8_009.659043762604983480 * 1e18,
+            lpBalance:    8_019.658496167977117449 * 1e18,
             collateral:   0,          
-            deposit:      8_010.656438244246273059 * 1e18,
-            exchangeRate: 1.000124523962404867 * 1e18
+            deposit:      8_034.234589314746482090 * 1e18,
+            exchangeRate: 1.001817545367266480 * 1e18
         });
         _assertAuction(
             AuctionParams({
                 borrower:          _borrower,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          0.213238217447629730 * 1e18,
+                bondSize:          0.209172983065585793 * 1e18,
                 bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp,
-                referencePrice:    10.602494079513784655 * 1e18,
-                totalBondEscrowed: 0.213238217447629730 * 1e18,
-                auctionPrice:      2_714.238484355528871680 * 1e18,
-                debtInAuction:     19.072605984551271935 * 1e18,
-                thresholdPrice:    9.536302992275635967 * 1e18,
-                neutralPrice:      10.602494079513784655 * 1e18
+                referencePrice:    10.400365099149173069 * 1e18,
+                totalBondEscrowed: 0.209172983065585793 * 1e18,
+                auctionPrice:      2_662.493465382188305664 * 1e18,
+                debtInAuction:     18.709000367642488138 * 1e18,
+                thresholdPrice:    9.354500183821244069 * 1e18,
+                neutralPrice:      10.400365099149173069 * 1e18
             })
         );
 
@@ -270,31 +270,31 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          0.213238217447629730 * 1e18,
+                bondSize:          0.209172983065585793 * 1e18,
                 bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp - 3 hours,
-                referencePrice:    10.602494079513784655 * 1e18,
-                totalBondEscrowed: 0.213238217447629730 * 1e18,
-                auctionPrice:      29.988381844457677324 * 1e18,
-                debtInAuction:     19.072605984551271935 * 1e18,
-                thresholdPrice:    9.536435260409064268 * 1e18,
-                neutralPrice:      10.602494079513784655 * 1e18
+                referencePrice:    10.400365099149173069 * 1e18,
+                totalBondEscrowed: 0.209172983065585793 * 1e18,
+                auctionPrice:      29.416674753697119864 * 1e18,
+                debtInAuction:     18.709000367642488138 * 1e18,
+                thresholdPrice:    9.354629930357136532 * 1e18,
+                neutralPrice:      10.400365099149173069 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              19.072870520818128536 * 1e18,
+            borrowerDebt:              18.709259860714273064 * 1e18,
             borrowerCollateral:        2 * 1e18,
-            borrowert0Np:              10.600109996759548181 * 1e18,
-            borrowerCollateralization: 0.980177562682044505 * 1e18
+            borrowert0Np:              10.377535508638612786 * 1e18,
+            borrowerCollateralization: 0.999227114253786894 * 1e18
         });
 
         _take({
             from:            _lender,
             borrower:        _borrower,
             maxCollateral:   2.0 * 1e18,
-            bondChange:      0.213238217447629730 * 1e18,
-            givenAmount:     19.398188023779325106 * 1e18,
+            bondChange:      0.209172983065585793 * 1e18,
+            givenAmount:     19.028375417729999825 * 1e18,
             collateralTaken: 0.646856776880891094 * 1e18,
             isReward:        false
         });
@@ -325,15 +325,15 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         });
         _assertPool(
             PoolParams({
-                htp:                  7.989580407145861718 * 1e18,
+                htp:                  8.325570479144230295 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             38_009.666725806721180539 * 1e18,
+                poolSize:             38_033.245639566817177597 * 1e18,
                 pledgedCollateral:    1_001.353143223119108906 * 1e18,
-                encumberedCollateral: 854.738271398607714479 * 1e18,
-                poolDebt:             7_989.580407145861717463 * 1e18,
-                actualUtilization:    0.195509176991053034 * 1e18,
-                targetUtilization:    0.822077328763715532 * 1e18,
-                minDebtAmount:        798.958040714586171746 * 1e18,
+                encumberedCollateral: 856.425994510867961912 * 1e18,
+                poolDebt:             8_005.356229946375284147 * 1e18,
+                actualUtilization:    0.210612566139746491 * 1e18,
+                targetUtilization:    0.822141283593523235 * 1e18,
+                minDebtAmount:        800.535622994637528415 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.0405 * 1e18,
@@ -343,10 +343,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   8_010.676578662675505263 * 1e18,
+            amount:   8_034.254839833419530359 * 1e18,
             index:    _i9_72,
             newLup:   9.529276179422528643 * 1e18,
-            lpRedeem: 8_009.659043762604983480 * 1e18
+            lpRedeem: 8_019.658496167977117449 * 1e18
         });
         
         _assertBucket({
@@ -359,18 +359,18 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _removeLiquidity({
             from:     _lender,
-            amount:   22_000 * 1e18,
+            amount:   21_000 * 1e18,
             index:    _i9_52,
             newLup:   9.529276179422528643 * 1e18,
-            lpRedeem: 21_999.944687667628067660 * 1e18
+            lpRedeem: 20_999.947069031215483677 * 1e18
         });
 
         _assertBucket({
             index:        _i9_52,
-            lpBalance:    7_998.685449318673302340 * 1e18,
+            lpBalance:    8_998.683067955085886323 * 1e18,
             collateral:   0,          
-            deposit:      7_998.705559639603302741 * 1e18,
-            exchangeRate: 1.000002514203247200 * 1e18
+            deposit:      8_998.705749393805991615 * 1e18,
+            exchangeRate: 1.000002520528676122 * 1e18
         });
 
         _assertRemoveAllLiquidityLupBelowHtpRevert({
@@ -382,15 +382,15 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  7.989580407145861718 * 1e18,
+                htp:                  8.325570479144230295 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
-                poolSize:             7_998.990147144045678219 * 1e18,
+                poolSize:             8_998.990799733397644463 * 1e18,
                 pledgedCollateral:    1_001.353143223119108906 * 1e18,
-                encumberedCollateral: 872.062464536834907097 * 1e18,
-                poolDebt:             7_990.503913730158190391 * 1e18,
-                actualUtilization:    0.195509176991053034 * 1e18,
-                targetUtilization:    0.822077328763715532 * 1e18,
-                minDebtAmount:        799.050391373015819039 * 1e18,
+                encumberedCollateral: 873.784395127733970987 * 1e18,
+                poolDebt:             8_006.281560040228775697 * 1e18,
+                actualUtilization:    0.210612566139746491 * 1e18,
+                targetUtilization:    0.822141283593523235 * 1e18,
+                minDebtAmount:        800.628156004022877570 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.0405 * 1e18,
@@ -399,10 +399,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              7_990.503913730158190391 * 1e18,
+            borrowerDebt:              8_006.281560040228775697 * 1e18,
             borrowerCollateral:        1_000.00 * 1e18,
             borrowert0Np:              8.880722076025322255 * 1e18,
-            borrowerCollateralization: 1.146706848036527502 * 1e18
+            borrowerCollateralization: 1.144447080510994053 * 1e18
         });
 
         // trigger accrual of pool interest that will push the lup back up
@@ -410,15 +410,15 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  7.990503913730158191 * 1e18,
+                htp:                  8.326532822441837927 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
-                poolSize:             7_999.784817415678748744 * 1e18,
+                poolSize:             8_999.787852072874979370 * 1e18,
                 pledgedCollateral:    1_001.353143223119108906 * 1e18,
-                encumberedCollateral: 872.062464536834907097 * 1e18,
-                poolDebt:             7_990.503913730158190391 * 1e18,
-                actualUtilization:    0.522552675292960591 * 1e18,
-                targetUtilization:    0.829008163836671133 * 1e18,
-                minDebtAmount:        799.050391373015819039 * 1e18,
+                encumberedCollateral: 873.784395127733970987 * 1e18,
+                poolDebt:             8_006.281560040228775697 * 1e18,
+                actualUtilization:    0.505203542638556630 * 1e18,
+                targetUtilization:    0.825505559884289307 * 1e18,
+                minDebtAmount:        800.628156004022877570 * 1e18,
                 loans:                1,
                 maxBorrower:          address(_borrower2),
                 interestRate:         0.03645 * 1e18,
@@ -430,10 +430,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_084.412285638162564830 * 1e18,
+            borrowerDebt:              8_100.375358686460903420 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.880722076025322255 * 1e18,
-            borrowerCollateralization: 0
+            borrowerCollateralization: 1.131153206043881494 * 1e18
         });
 
         // kick borrower 2
@@ -443,18 +443,18 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         _assertPool(
             PoolParams({
                 htp:                  0,
-                lup:                  0.000000099836282890 * 1e18,
-                poolSize:             8_082.683609996511125408 * 1e18,
+                lup:                  9.529276179422528643 * 1e18,
+                poolSize:             9_082.718302945104923507 * 1e18,
                 pledgedCollateral:    1_001.353143223119108906 * 1e18,
-                encumberedCollateral: 84_215_763_384.614619914591653924 * 1e18,
-                poolDebt:             8_084.412285638162564830 * 1e18,
-                actualUtilization:    0.998839855833957451 * 1e18,
-                targetUtilization:    0.838521600515825621 * 1e18,
+                encumberedCollateral: 884.053543460678137147 * 1e18,
+                poolDebt:             8_100.375358686460903420 * 1e18,
+                actualUtilization:    0.889607809832559887 * 1e18,
+                targetUtilization:    0.840177303006175138 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.040095 * 1e18,
-                interestRateUpdate:   block.timestamp
+                interestRate:         0.03645 * 1e18,
+                interestRateUpdate:   block.timestamp - 117 days
             })
         );
 
@@ -471,31 +471,31 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 borrower:          _borrower2,
                 active:            true,
                 kicker:            _lender,
-                bondSize:          90.386477144106887514 * 1e18,
+                bondSize:          90.564949726435836850 * 1e18,
                 bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp - 10 hours,
-                referencePrice:    8.988277057079231472 * 1e18,
-                totalBondEscrowed: 90.386477144106887514 * 1e18,
-                auctionPrice:      2.247069264269807868 * 1e18,
-                debtInAuction:     8_084.412285638162564830 * 1e18,
-                thresholdPrice:    8.084782322086612071 * 1e18,
-                neutralPrice:      8.988277057079231472 * 1e18
+                referencePrice:    9.006024855950819304 * 1e18,
+                totalBondEscrowed: 90.564949726435836850 * 1e18,
+                auctionPrice:      2.251506213987704828 * 1e18,
+                debtInAuction:     8_100.375358686460903420 * 1e18,
+                thresholdPrice:    8.100712418988636152 * 1e18,
+                neutralPrice:      9.006024855950819304 * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              8_084.782322086612071679 * 1e18,
+            borrowerDebt:              8_100.712418988636152518 * 1e18,
             borrowerCollateral:        1_000 * 1e18,
             borrowert0Np:              8.880722076025322255 * 1e18,
-            borrowerCollateralization: 0
+            borrowerCollateralization: 1.131106140203037430 * 1e18
         });
 
         _take({
             from:            _lender,
             borrower:        _borrower2,
             maxCollateral:   1_000.0 * 1e18,
-            bondChange:      25.122998125288647552 * 1e18,
-            givenAmount:     2_247.069264269807868000 * 1e18,
+            bondChange:      25.172604731198478139 * 1e18,
+            givenAmount:     2_251.506213987704828000 * 1e18,
             collateralTaken: 1_000 * 1e18,
             isReward:        true
         });
@@ -504,22 +504,22 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  9.529276179422528643 * 1e18,
-                poolSize:             8_083.047814146372012112 * 1e18,
+                poolSize:             9_083.031109529777711575 * 1e18,
                 pledgedCollateral:    1.353143223119108906 * 1e18,
-                encumberedCollateral: 639.854421613507497993 * 1e18,
-                poolDebt:             5_862.836055942092851679 * 1e18,
-                actualUtilization:    0.998839855833957451 * 1e18,
-                targetUtilization:    0.838521600515825621 * 1e18,
+                encumberedCollateral: 641.114167234854983897 * 1e18,
+                poolDebt:             5_874.378809732129803519 * 1e18,
+                actualUtilization:    0.819662267320821453 * 1e18,
+                targetUtilization:    0.840177303006175138 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.040095 * 1e18,
-                interestRateUpdate:   block.timestamp - 10 hours
+                interestRate:         0.03645 * 1e18,
+                interestRateUpdate:   block.timestamp - 117 days - 10 hours
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              5_862.836055942092851679 * 1e18,
+            borrowerDebt:              5_874.378809732129803519 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              0,
             borrowerCollateralization: 0
@@ -535,24 +535,24 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 5_792.415411176588073422 * 1e18
+            settledDebt: 5_792.406276780653057707 * 1e18
         });
 
         _assertPool(
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             2_224.094938954560914482 * 1e18,
+                poolSize:             3_212.543131891302393477 * 1e18,
                 pledgedCollateral:    1.353143223119108906 * 1e18,
                 encumberedCollateral: 0,
                 poolDebt:             0,
-                actualUtilization:    0.998839855833957451 * 1e18,
-                targetUtilization:    0.838521600515825621 * 1e18,
+                actualUtilization:    0.819662267320821453 * 1e18,
+                targetUtilization:    0.840177303006175138 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.040095 * 1e18,
-                interestRateUpdate:   block.timestamp - 10 hours
+                interestRate:         0.032805 * 1e18,
+                interestRateUpdate:   block.timestamp
             })
         );
         _assertBucket({
@@ -578,10 +578,10 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         });
         _assertBucket({
             index:        _i9_52,
-            lpBalance:    7_998.685449318673302340 * 1e18,
+            lpBalance:    8_998.683067955085886323 * 1e18,
             collateral:   0,          
-            deposit:      2_224.094938954560913750 * 1e18,
-            exchangeRate: 0.278057557463271537 * 1e18
+            deposit:      3_212.543131891302393111 * 1e18,
+            exchangeRate: 0.357001475397148280 * 1e18
         });
     }
  }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -89,7 +89,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.333966346153846158 * 1e18,
+                htp:                  9.707325000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,
@@ -202,29 +202,29 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758000 * 1e18,
             collateral:   0,
-            deposit:      2_002.898313131289115657 * 1e18,
-            exchangeRate: 1.001494886925778155 * 1e18
+            deposit:      2_012.033316090796323720 * 1e18,
+            exchangeRate: 1.006062596976766964 * 1e18
         });
         _assertBucket({
             index:        _i9_81,
             lpBalance:    4_999.771689497716895000 * 1e18,
             collateral:   0,
-            deposit:      5_007.245782828222789143 * 1e18,
-            exchangeRate: 1.001494886925778156 * 1e18
+            deposit:      5_030.083290226990809301 * 1e18,
+            exchangeRate: 1.006062596976766965 * 1e18
         });
         _assertBucket({
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0,
-            deposit:      11_015.940722222090136114 * 1e18,
-            exchangeRate: 1.001494886925778155 * 1e18
+            deposit:      11_066.183238499379780461 * 1e18,
+            exchangeRate: 1.006062596976766964 * 1e18
         });
         _assertBucket({
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_036.228914141113945714 * 1e18,
-            exchangeRate: 1.001494886925778156 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1 * 1e18
         });
 
         // skip ahead so take can be called on the loan
@@ -292,29 +292,29 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758000 * 1e18,
             collateral:   0,
-            deposit:      2_002.909690070224960767 * 1e18,
-            exchangeRate: 1.001500575655005404 * 1e18
+            deposit:      2_012.080837484034115925 * 1e18,
+            exchangeRate: 1.006086358758398720 * 1e18
         });
         _assertBucket({
             index:        _i9_81,
             lpBalance:    4_999.771689497716895000 * 1e18,
             collateral:   0,
-            deposit:      5_007.274225175562401917 * 1e18,
-            exchangeRate: 1.001500575655005403 * 1e18
+            deposit:      5_030.202093710085289813 * 1e18,
+            exchangeRate: 1.006086358758398721 * 1e18
         });
         _assertBucket({
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0,
-            deposit:      11_016.003295386237284218 * 1e18,
-            exchangeRate: 1.001500575655005404 * 1e18
+            deposit:      11_066.444606162187637588 * 1e18,
+            exchangeRate: 1.006086358758398720 * 1e18
         });
         _assertBucket({
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_036.371125877812009586 * 1e18,
-            exchangeRate: 1.001500575655005404 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1 * 1e18
         });
 
         // settle should affect first 3 buckets, reducing deposit and incrementing collateral
@@ -331,8 +331,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758000 * 1e18,
             collateral:   0,
-            deposit:      2_002.909690070224960767 * 1e18,
-            exchangeRate: 1.001500575655005404 * 1e18
+            deposit:      2_012.080837484034115925 * 1e18,
+            exchangeRate: 1.006086358758398720 * 1e18
         });
 
         _settle({
@@ -383,25 +383,25 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0,
-            deposit:      10_681.579303051678041845 * 1e18,
-            exchangeRate: 0.971097006242841098 * 1e18
+            deposit:      10_765.975632053571065948 * 1e18,
+            exchangeRate: 0.978769750142070441 * 1e18
         });
         _assertBucket({
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_037.179030360092400426 * 1e18,
-            exchangeRate: 1.001532893309988628 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1.000000000000000000 * 1e18
         });
         _assertPool(
             PoolParams({
-                htp:                  9.466744156482068632 * 1e18,
+                htp:                  9.845413922741351377 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             65_763.373169843881304954 * 1e18,
+                poolSize:             65_763.464216528456910948 * 1e18,
                 pledgedCollateral:    2 * 1e18,
                 encumberedCollateral: 2.025535290651122678 * 1e18,
                 poolDebt:             18.933488312964137265 * 1e18,
-                actualUtilization:    0.001455939239305668 * 1e18,
+                actualUtilization:    0.571142885809255306 * 1e18,
                 targetUtilization:    0.955567693408119411 * 1e18,
                 minDebtAmount:        1.893348831296413727 * 1e18,
                 loans:                1,
@@ -484,29 +484,29 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_91,
             lpBalance:    1_999.908675799086758000 * 1e18,
             collateral:   0,
-            deposit:      2_002.898313131289115657 * 1e18,
-            exchangeRate: 1.001494886925778155 * 1e18
+            deposit:      2_012.033316090796323720 * 1e18,
+            exchangeRate: 1.006062596976766964 * 1e18
         });
         _assertBucket({
             index:        _i9_81,
             lpBalance:    4_999.771689497716895000 * 1e18,
             collateral:   0,
-            deposit:      5_007.245782828222789143 * 1e18,
-            exchangeRate: 1.001494886925778156 * 1e18
+            deposit:      5_030.083290226990809301 * 1e18,
+            exchangeRate: 1.006062596976766965 * 1e18
         });
         _assertBucket({
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0,
-            deposit:      11_015.940722222090136114 * 1e18,
-            exchangeRate: 1.001494886925778155 * 1e18
+            deposit:      11_066.183238499379780461 * 1e18,
+            exchangeRate: 1.006062596976766964 * 1e18
         });
         _assertBucket({
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_036.228914141113945714 * 1e18,
-            exchangeRate: 1.001494886925778156 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1 * 1e18
         });
 
         // settle should work on an kicked auction if 72 hours passed from kick time
@@ -563,37 +563,37 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertBorrower({
             borrower:                  _borrower2,
             borrowerDebt:              0,
-            borrowerCollateral:        40.116563674822801466 * 1e18,
+            borrowerCollateral:        40.159651907487263058 * 1e18,
             borrowert0Np:              0,
             borrowerCollateralization: 1 * 1e18
         });
         _assertBucket({
             index:        _i9_91,
             lpBalance:    1_999.908675799086758000 * 1e18,
-            collateral:   201.970761848998781197 * 1e18,
+            collateral:   202.918500579787987864 * 1e18,
             deposit:      0,
-            exchangeRate: 1.001536421369730981 * 1e18
+            exchangeRate: 1.006236086054551886 * 1e18
         });
         _assertBucket({
             index:        _i9_81,
             lpBalance:    4_999.771689497716895000 * 1e18,
-            collateral:   509.988796841337476694 * 1e18,
+            collateral:   512.381896370250897817 * 1e18,
             deposit:      0,
-            exchangeRate: 1.001536421369730981 * 1e18
+            exchangeRate: 1.006236086054551886 * 1e18
         });
         _assertBucket({
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
-            collateral:   247.923877634840940643 * 1e18,
-            deposit:      8_606.256213749297597987 * 1e18,
-            exchangeRate: 1.001536421369730981 * 1e18
+            collateral:   244.539951142473851261 * 1e18,
+            deposit:      8_690.846315337976774916 * 1e18,
+            exchangeRate: 1.006236086054551886 * 1e18
         });
         _assertBucket({
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_037.267227826185766119 * 1e18,
-            exchangeRate: 1.001536421369730981 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1 * 1e18
         });
         
         // borrower can re-open a loan once their previous loan is fully settled
@@ -697,15 +697,15 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             amount:      100 * 1e18,
             amountAdded: 99.995890410958904100 * 1e18,
             index:       _i9_52,
-            lpAward:     99.845922047420129874 * 1e18,
+            lpAward:     99.995890410958904100 * 1e18,
             newLup:      9.721295865031779605 * 1e18
         });
  
-        _addLiquidity({ 
+        _addLiquidity({
             from:    _lender1, 
             amount:  100 * 1e18, 
             index:   _i9_91, 
-            lpAward: 99.846332389990567383 * 1e18,
+            lpAward: 99.390782962995294778 * 1e18,
             newLup:  9.721295865031779605 * 1e18
         });
 
@@ -748,7 +748,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       _i9_91,
-            lpBalance:   99.846332389990567383 * 1e18,
+            lpBalance:   99.390782962995294778 * 1e18,
             depositTime: _startTime + 100 days + 12.5 hours
         });
 
@@ -767,7 +767,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         // LP forfeited when forgive bad debt should be reflected in BucketBankruptcy event
         vm.expectEmit(true, true, false, true);
-        emit BucketBankruptcy(_i9_91, 2_099.755008189077325383 * 1e18);
+        emit BucketBankruptcy(_i9_91, 2_099.299458762082052778 * 1e18);
         vm.expectEmit(true, true, false, true);
         emit BucketBankruptcy(_i9_81, 4_999.771689497716895000 * 1e18);
         _settle({
@@ -840,16 +840,16 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       _i9_91,
-            lpBalance:   149.665040743606661996 * 1e18,
+            lpBalance:   149.665040743606661995 * 1e18,
             depositTime: _startTime + 100 days + 12.5 hours + 1 hours
         });
         // bucket is healthy again
         _assertBucket({
             index:        _i9_91,
-            lpBalance:    149.665040743606661996 * 1e18,
+            lpBalance:    149.665040743606661995 * 1e18,
             collateral:   4 * 1e18,
-            deposit:      109.996301369863013700 * 1e18,
-            exchangeRate: 1 * 1e18
+            deposit:      109.996301369863013701 * 1e18,
+            exchangeRate: 1.000000000000000001 * 1e18
         });
 
         // when moving to a bucket that was marked insolvent, the deposit time should be the greater between from bucket deposit time and insolvency time + 1
@@ -866,7 +866,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_91,
-            lpBalance:   1_000 * 1e18,
+            lpBalance:   999.999999999999999986 * 1e18,
             depositTime: _startTime + 100 days + 12.5 hours + 1 // _i9_91 bucket insolvency time + 1 (since deposit in _i9_52 from bucket was done before _i9_91 target bucket become insolvent)
         });
 
@@ -876,7 +876,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender,
             index:       _i9_91,
-            lpBalance:   2_000 * 1e18,
+            lpBalance:   1_999.999999999999999972 * 1e18,
             depositTime: _startTime + 100 days + 12.5 hours + 1 hours // time of deposit in _i9_52 from bucket (since deposit in _i9_52 from bucket was done after _i9_91 target bucket become insolvent)
         });
 
@@ -885,8 +885,8 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0 * 1e18,
-            deposit:      9_801.292383308549903532 * 1e18,
-            exchangeRate: 0.891067268303896164 * 1e18
+            deposit:      9_883.914103612419284122 * 1e18,
+            exchangeRate: 0.898578676772754183 * 1e18
         });
 
         _pool.moveQuoteToken(10000000000 * 1e18, _i9_72, _i9_91, type(uint256).max);
@@ -984,7 +984,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             from:    _lender1,
             amount:  100 * 1e18,
             index:   _i9_91,
-            lpAward: 99.846063838315013266 * 1e18,
+            lpAward: 99.390961362762982840 * 1e18,
             newLup:  9.721295865031779605 * 1e18
         });
 
@@ -1002,7 +1002,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       _i9_91,
-            lpBalance:   99.846063838315013266 * 1e18,
+            lpBalance:   99.390961362762982840 * 1e18,
             depositTime: _startTime + 100 days + 10 hours
         });
 
@@ -1016,15 +1016,15 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertBucket({
             index:        _i9_91,
-            lpBalance:    2_099.754739637401771266 * 1e18,
+            lpBalance:    2_099.299637161849740840 * 1e18,
             collateral:   0,
-            deposit:      2_102.905580481183864867 * 1e18,
-            exchangeRate: 1.001500575655005404 * 1e18
+            deposit:      2_112.076727894993020025 * 1e18,
+            exchangeRate: 1.006086358758398721 * 1e18
         });
 
         // LP forfeited when forgive bad debt should be reflected in BucketBankruptcy event
         vm.expectEmit(true, true, false, true);
-        emit BucketBankruptcy(_i9_91, 2_099.754739637401771266 * 1e18);
+        emit BucketBankruptcy(_i9_91, 2_099.299637161849740840 * 1e18);
         _settle({
             from:        _lender,
             borrower:    _borrower2,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -86,7 +86,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.509134615384615389 * 1e18,
+                htp:                  9.889500000000000005 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667000 * 1e18,
                 pledgedCollateral:    1_042 * 1e18,
@@ -166,7 +166,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_082.000000000000000000 * 1e18,
@@ -193,7 +193,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_082.000000000000000000 * 1e18,
@@ -254,8 +254,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.989651241857326201 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   60.554587322829032789 * 1e18,
-            claimableReserves :         60.554504106947284828 * 1e18,
+            reserves:                   60.554587322829041789 * 1e18,
+            claimableReserves :         60.554504106947293828 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -265,9 +265,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.802768832935373870 * 1e18,
+                htp:                  9.154879586252788825 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             83_215.881747961316176813 * 1e18,
+                poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_082.000000000000000000 * 1e18,
                 encumberedCollateral: 2_032.298884574722565768 * 1e18,
                 poolDebt:             18_996.710329927835017232 * 1e18,
@@ -343,9 +343,9 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.803359221076233151 * 1e18,
+                htp:                  9.155493589919282477 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             83_216.980266533218147529 * 1e18,
+                poolSize:             83_216.980266533218143247 * 1e18,
                 pledgedCollateral:    1_042.0 * 1e18,
                 encumberedCollateral: 1_932.130809921545253875 * 1e18,
                 poolDebt:             18_060.399281914251158513 * 1e18,
@@ -393,7 +393,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -420,7 +420,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -481,8 +481,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.989651241857326201 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   60.554587322829032789 * 1e18,
-            claimableReserves :         60.554504106947284828 * 1e18,
+            reserves:                   60.554587322829041789 * 1e18,
+            claimableReserves :         60.554504106947293828 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -492,13 +492,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.154176770377903765 * 1e18,
+                htp:                  9.520343841193019916 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             83_215.881747961316176813 * 1e18,
+                poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
                 encumberedCollateral: 2_032.287284728349016606 * 1e18,
                 poolDebt:             18_996.601901525348298620 * 1e18,
-                actualUtilization:    0.225757284918829265 * 1e18,
+                actualUtilization:    0.353544427325713755 * 1e18,
                 targetUtilization:    0.944118073902160936 * 1e18,
                 minDebtAmount:        1_899.660190152534829862 * 1e18,
                 loans:                1,
@@ -600,7 +600,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -627,7 +627,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -688,8 +688,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.989651241857326201 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   60.554587322829032789 * 1e18,
-            claimableReserves :         60.554504106947284828 * 1e18,
+            reserves:                   60.554587322829041789 * 1e18,
+            claimableReserves :         60.554504106947293828 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -699,13 +699,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.154176770377903765 * 1e18,
+                htp:                  9.520343841193019916 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             83_215.881747961316176813 * 1e18,
+                poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
                 encumberedCollateral: 2_032.226386621120168430 * 1e18,
                 poolDebt:             18_996.032662565740545058 * 1e18,
-                actualUtilization:    0.225757284918829265 * 1e18,
+                actualUtilization:    0.353544427325713755 * 1e18,
                 targetUtilization:    0.944118073902160936 * 1e18,
                 minDebtAmount:        1_899.603266256574054506 * 1e18,
                 loans:                1,
@@ -786,7 +786,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.509134615384615389 * 1e18,
+                htp:                  9.889500000000000005 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             72_996.666666666666667000 * 1e18,
                 pledgedCollateral:    1_042.000000000000000000 * 1e18,
@@ -849,8 +849,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.989651241857326201 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   32.745170254153428997 * 1e18,
-            claimableReserves :         32.745097143666801830 * 1e18,
+            reserves:                   32.745170254153414999 * 1e18,
+            claimableReserves :         32.745097143666787832 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -860,13 +860,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.640293027683069581 * 1e18,
+                htp:                  10.025904748790392364 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_110.486627166698346628 * 1e18,
+                poolSize:             73_110.486627166698360626 * 1e18,
                 pledgedCollateral:    1_042 * 1e18,
                 encumberedCollateral: 1_052.945134138528111945 * 1e18,
                 poolDebt:             9_842.299210198274857970 * 1e18,
-                actualUtilization:    0.132996839511463467 * 1e18,
+                actualUtilization:    0.539376071352046283 * 1e18,
                 targetUtilization:    0.958413284343188833 * 1e18,
                 minDebtAmount:        984.229921019827485797 * 1e18,
                 loans:                1,
@@ -912,13 +912,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.640359057313497386 * 1e18,
+                htp:                  10.025973419606037281 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             73_110.544397798049202892 * 1e18,
+                poolSize:             73_110.546230580506993313 * 1e18,
                 pledgedCollateral:    1_032.0 * 1e18,
                 encumberedCollateral: 876.210891963733856748 * 1e18,
                 poolDebt:             8_190.293577829666641930 * 1e18,
-                actualUtilization:    0.131831746499532612 * 1e18,
+                actualUtilization:    0.539415570795639499 * 1e18,
                 targetUtilization:    0.958414005019059000 * 1e18,
                 minDebtAmount:        819.029357782966664193 * 1e18,
                 loans:                1,  // TODO: is this test still relevant like this?
@@ -986,7 +986,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -1013,7 +1013,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.316642011834319531 * 1e18,
+                htp:                  9.689307692307692312 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -1074,8 +1074,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.989651241857326201 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   60.554587322829032789 * 1e18,
-            claimableReserves :         60.554504106947284828 * 1e18,
+            reserves:                   60.554587322829041789 * 1e18,
+            claimableReserves :         60.554504106947293828 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1085,13 +1085,13 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.154176770377903765 * 1e18,
+                htp:                  9.520343841193019916 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
-                poolSize:             83_215.881747961316176813 * 1e18,
+                poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
                 encumberedCollateral: 2_032.226386621120168430 * 1e18,
                 poolDebt:             18_996.032662565740545058 * 1e18,
-                actualUtilization:    0.225757284918829265 * 1e18,
+                actualUtilization:    0.353544427325713755 * 1e18,
                 targetUtilization:    0.944118073902160936 * 1e18,
                 minDebtAmount:        1_899.603266256574054506 * 1e18,
                 loans:                1,
@@ -1220,8 +1220,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             borrowerCollateralization: 0.986593617011217057 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   32.836144076983077586 * 1e18,
-            claimableReserves :         32.836070966144393628 * 1e18,
+            reserves:                   32.836144076983058586 * 1e18,
+            claimableReserves :         32.836070966144374628 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1365,8 +1365,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
         // reserves should increase after take action
         _assertReserveAuction({
-            reserves:                   32.908673993510215232 * 1e18,
-            claimableReserves :         32.908600882236890211 * 1e18,
+            reserves:                   32.894825757206621409 * 1e18,
+            claimableReserves :         32.894752645919448152 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1413,8 +1413,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
         // reserves should increase after take action
         _assertReserveAuction({
-            reserves:                   32.908673993510215498 * 1e18,
-            claimableReserves :         32.908600882236890477 * 1e18,
+            reserves:                   32.894825757206621675 * 1e18,
+            claimableReserves :         32.894752645919448418 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1434,8 +1434,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             index:        3_696,
             lpBalance:    1_999.908675799086758000 * 1e18,
             collateral:   0,
-            deposit:      2_003.084969724311992270 * 1e18,
-            exchangeRate: 1.001588219484050246 * 1e18
+            deposit:      2_012.644287642503398926 * 1e18,
+            exchangeRate: 1.006368096702379663 * 1e18
         });
 
         _settle({
@@ -1503,8 +1503,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             index:        _i9_72,
             lpBalance:    10_999.497716894977169000 * 1e18,
             collateral:   0,
-            deposit:      10_886.736248589263618301 * 1e18,
-            exchangeRate: 0.989748489321242869 * 1e18
+            deposit:      10_972.770109852986285337 * 1e18,
+            exchangeRate: 0.997570106587600097 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
@@ -1516,8 +1516,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             index:        _i9_62,
             lpBalance:    24_998.858447488584475000 * 1e18,
             collateral:   0,
-            deposit:      25_037.958453410138598371 * 1e18,
-            exchangeRate: 1.001564071655659227 * 1e18
+            deposit:      24_998.858447488584475000 * 1e18,
+            exchangeRate: 1.000000000000000000 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
@@ -1529,8 +1529,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             index:        _i9_52,
             lpBalance:    29_998.630136986301370000 * 1e18,
             collateral:   0,
-            deposit:      30_045.550144092166318045 * 1e18,
-            exchangeRate: 1.001564071655659227 * 1e18
+            deposit:      29_998.630136986301370000 * 1e18,
+            exchangeRate: 1.000000000000000000 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
@@ -1543,8 +1543,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         vm.revertTo(postTakeSnapshot);
 
         _assertReserveAuction({
-            reserves:                   32.908673993510215498 * 1e18,
-            claimableReserves :         32.908600882236890477 * 1e18,
+            reserves:                   32.894825757206621675 * 1e18,
+            claimableReserves :         32.894752645919448418 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1558,8 +1558,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             settledDebt: 4.66826923076923301 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   28.175772733907546282 * 1e18,
-            claimableReserves :         28.175699622634221261 * 1e18,
+            reserves:                   28.161924497603952459 * 1e18,
+            claimableReserves :         28.161851386316779202 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
@@ -1570,7 +1570,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    1,
-            settledDebt: 1_975.731040618697608391 * 1e18
+            settledDebt: 1_985.159817442235291165 * 1e18
         });
 
         _assertAuction(
@@ -1584,14 +1584,14 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 referencePrice:    10.533689623738220398 * 1e18,
                 totalBondEscrowed: 140.784556539184447790 * 1e18,
                 auctionPrice:      2.633422405934555100 * 1e18,
-                debtInAuction:     5_137.943509205232314728 * 1e18,
+                debtInAuction:     5_128.384191287040906072 * 1e18,
                 thresholdPrice:    0,
                 neutralPrice:      10.533689623738220398  * 1e18
             })
         );
         _assertBorrower({
             borrower:                  _borrower2,
-            borrowerDebt:              5_137.943509205232314728 * 1e18,
+            borrowerDebt:              5_128.384191287040906072 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              0,
             borrowerCollateralization: 0
@@ -1607,7 +1607,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    5,
-            settledDebt: 5_067.780263699578770470 * 1e18
+            settledDebt: 5_058.351486876041087696 * 1e18
         });
 
         _assertAuction(
@@ -1704,8 +1704,8 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             locked:    110.164296670852752941 * 1e18
         });
         _assertReserveAuction({
-            reserves:                   32.836144076983077586 * 1e18,
-            claimableReserves :         32.836070966144393628 * 1e18,
+            reserves:                   32.836144076983058586 * 1e18,
+            claimableReserves :         32.836070966144374628 * 1e18,
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -118,7 +118,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.005769230769230772 * 1e18
+            maxThresholdPrice: 6.246000000000000003 * 1e18
         });
 
         // borrower 4 draws debt and becomes loan with highest threshold price in heap
@@ -134,7 +134,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower4,
-            maxThresholdPrice: 14.013461538461538468 * 1e18
+            maxThresholdPrice: 14.574000000000000007 * 1e18
         });
 
         // borrower 4 repays debt, borrower 6 becomes loan with highest threshold price in heap
@@ -150,7 +150,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.005769230769230772 * 1e18
+            maxThresholdPrice: 6.246000000000000003 * 1e18
         });
 
         // borrower 6 repays debt, borrower 5 becomes loan with highest threshold price in heap
@@ -166,7 +166,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower5,
-            maxThresholdPrice: 5.004807692307692310 * 1e18
+            maxThresholdPrice: 5.205000000000000002 * 1e18
         });
 
         // borrower 6 draws more debt and becomes loan with highest threshold price in heap
@@ -182,7 +182,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 12.016346153846153854 * 1e18
+            maxThresholdPrice: 12.497000000000000008 * 1e18
         });
     }
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -8,7 +8,7 @@ import 'src/ERC20Pool.sol';
 import 'src/ERC20PoolFactory.sol';
 
 import 'src/PoolInfoUtils.sol';
-import { MAX_PRICE } from 'src/libraries/helpers/PoolHelper.sol';
+import { MAX_PRICE, COLLATERALIZATION_FACTOR } from 'src/libraries/helpers/PoolHelper.sol';
 
 import 'src/interfaces/pool/IPool.sol';
 import 'src/libraries/internal/Maths.sol';
@@ -986,7 +986,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
     }
 
     function _encumberedCollateral(uint256 debt_, uint256 price_) internal view returns (uint256 encumberance_) {
-        uint256 unscaledEncumberance =  price_ != 0 && debt_ != 0 ? Maths.ceilWdiv(Maths.wmul(debt_, 1.04 * 1e18), price_) : 0;
+        uint256 unscaledEncumberance =  price_ != 0 && debt_ != 0 ? Maths.ceilWdiv(Maths.wmul(debt_, COLLATERALIZATION_FACTOR), price_) : 0;
         encumberance_ = _roundUpToScale(unscaledEncumberance, ERC20Pool(address(_pool)).quoteTokenScale());
     }
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -338,8 +338,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             borrowerCollateralization: 14.533844775739053504 * 1e18
         });
         _assertPoolPrices({
-            htp:      200.192307692307692400 * 1e18,
-            htpIndex: 3093,
+            htp:      208.200000000000000096 * 1e18,
+            htpIndex: 3085,
             hpb:      3_025.946482308870940904 * 1e18,
             hpbIndex: 2549,
             lup:      price,
@@ -348,7 +348,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 200.192307692307692400 * 1e18
+            maxThresholdPrice: 208.200000000000000096 * 1e18
         });
 
         (uint256 poolDebt,,,) = _pool.debtInfo();
@@ -399,8 +399,8 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             borrowerCollateralization: 29.039793496246362170 * 1e18
         });
         _assertPoolPrices({
-            htp:      100.192307692307692400 * 1e18,
-            htpIndex: 3232,
+            htp:      104.200000000000000096 * 1e18,
+            htpIndex: 3224,
             hpb:      3_025.946482308870940904 * 1e18,
             hpbIndex: 2549,
             lup:      price,
@@ -409,7 +409,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 100.192307692307692400 * 1e18
+            maxThresholdPrice: 104.200000000000000096 * 1e18
         });
 
         (poolDebt,,,) = _pool.debtInfo();

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -997,7 +997,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  2_836.057692307692309000 * 1e18,
+                htp:                  2_949.500000000000001360 * 1e18,
                 lup:                  2_995.912459898389633881 * 1e18,
                 poolSize:             89_995.890410958904110000 * 1e18,
                 pledgedCollateral:    5_030.0 * 1e18,
@@ -1034,7 +1034,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  17.997288461538461547 * 1e18,
+                htp:                  18.717180000000000009 * 1e18,
                 lup:                  2_995.912459898389633881 * 1e18,
                 poolSize:             89_995.890410958904110000 * 1e18,
                 pledgedCollateral:    5000.0 * 1e18,
@@ -1525,7 +1525,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.000000029905872487 * 1e18,
+                htp:                  0.000000031102107386 * 1e18,
                 lup:                  14_343_926.246295999585280544 * 1e18,
                 poolSize:             0.000000059751560420 * 1e18,
                 pledgedCollateral:    1 * 1e18,
@@ -1545,7 +1545,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.000000029905872487 * 1e18,
+                htp:                  0.000000031102107386 * 1e18,
                 lup:                  14_343_926.246295999585280544 * 1e18,
                 poolSize:             0.000000059751560420 * 1e18,
                 pledgedCollateral:    1 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolTransferLPs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolTransferLPs.t.sol
@@ -136,18 +136,18 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
             from:      _lender1,
             to:        _lender2,
             indexes:   indexes,
-            lpBalance: 30_000 * 1e18
+            lpBalance: Maths.wmul(30_000 * 1e18, _depositFee())
         });
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
     }
@@ -175,7 +175,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
 
@@ -235,7 +235,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
@@ -247,7 +247,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
@@ -259,7 +259,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[2],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
@@ -282,7 +282,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
             from:      _lender1,
             to:        _lender2,
             indexes:   indexes,
-            lpBalance: 60_000 * 1e18
+            lpBalance: Maths.wmul(60_000 * 1e18, _depositFee())
         });
 
         // check that old token ownership was removed - a new transfer should fail
@@ -303,7 +303,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
@@ -315,7 +315,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
@@ -327,7 +327,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[2],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
     }
@@ -362,7 +362,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       depositIndexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
@@ -374,7 +374,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       depositIndexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
@@ -386,7 +386,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       depositIndexes[2],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
@@ -408,7 +408,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
             from:      _lender1,
             to:        _lender2,
             indexes:   transferIndexes,
-            lpBalance: 40_000 * 1e18
+            lpBalance: Maths.wmul(40_000 * 1e18, _depositFee())
         });
 
         // check that old token ownership was removed - transfer with same indexes should fail
@@ -429,13 +429,13 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       depositIndexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       depositIndexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
         _assertLenderLpBalance({
@@ -453,7 +453,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       depositIndexes[2],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime
         });
     }
@@ -504,37 +504,37 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[0],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[0],
-            lpBalance:   5_000 * 1e18,
+            lpBalance:   Maths.wmul(5_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[1],
-            lpBalance:   20_000 * 1e18,
+            lpBalance:   Maths.wmul(20_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[1],
-            lpBalance:   10_000 * 1e18,
+            lpBalance:   Maths.wmul(10_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[2],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime + 1 hours
         });
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[2],
-            lpBalance:   15_000 * 1e18,
+            lpBalance:   Maths.wmul(15_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
 
@@ -559,7 +559,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
             from:      _lender1,
             to:        _lender2,
             indexes:   indexes,
-            lpBalance: 60_000 * 1e18
+            lpBalance: Maths.wmul(60_000 * 1e18, _depositFee())
         });
 
         // check that old token ownership was removed - transfer with same indexes should fail
@@ -586,7 +586,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[0],
-            lpBalance:   15_000 * 1e18,
+            lpBalance:   Maths.wmul(15_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
         _assertLenderLpBalance({
@@ -598,7 +598,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[1],
-            lpBalance:   30_000 * 1e18,
+            lpBalance:   Maths.wmul(30_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
         _assertLenderLpBalance({
@@ -610,7 +610,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender2,
             index:       indexes[2],
-            lpBalance:   45_000 * 1e18,
+            lpBalance:   Maths.wmul(45_000 * 1e18, _depositFee()),
             depositTime: _startTime + 2 hours
         });
     }
@@ -676,7 +676,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
             from:      _lender1,
             to:        _lender2,
             indexes:   indexes,
-            lpBalance: 60_000 * 1e18
+            lpBalance: 59_997.260273972602740000 * 1e18
         });
     }
 
@@ -836,7 +836,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[0],
-            lpBalance:   4_000 * 1e18,
+            lpBalance:   3_999.543378995433790000 * 1e18,
             depositTime: _startTime
         });
         _assertLenderLpBalance({
@@ -854,7 +854,7 @@ contract ERC20PoolTransferLPTest is ERC20HelperContract {
         _assertLenderLpBalance({
             lender:      _lender1,
             index:       indexes[1],
-            lpBalance:   8_000 * 1e18,
+            lpBalance:   7_999.086757990867580000 * 1e18,
             depositTime: _startTime
         });
         _assertLenderLpBalance({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -774,7 +774,7 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         _mintAndApproveCollateralTokens(_borrower, 52);
     }
 
-    function testBorrowAndRepayWith4DecimalQuote() external tearDown {
+    function testBorrowAndRepayWith4DecimalQuote() external {
 
         // lender deposits 10000 Quote into 3 buckets
         _addInitialLiquidity({
@@ -805,7 +805,7 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
@@ -821,9 +821,9 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         // check initial bucket state
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
 
@@ -856,11 +856,11 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         // check pool state after borrow
         _assertPool(
             PoolParams({
-                htp:                  1_000.961538461538462000 * 1e18,
+                htp:                  1041.000000000000000480 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    Maths.wad(3),
-                encumberedCollateral: 0.997340520100278804 * 1e18,
+                encumberedCollateral: 1.037234140904289956 * 1e18,
                 poolDebt:             3_002.88461538461538600 * 1e18,
                 actualUtilization:    0.000000000000000000 * 1e18,
                 targetUtilization:    1 * 1e18,
@@ -874,9 +874,9 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         // check bucket state after borrow
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
         // check borrower info after borrow
@@ -884,12 +884,11 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             borrower:                  _borrower,
             borrowerDebt:              3_002.884615384615386000 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              1_152.910902143138512881 * 1e18,
-            borrowerCollateralization: 3.007999714779824033 * 1e18
+            borrowert0Np:              1_112.872440604676974401 * 1e18,
+            borrowerCollateralization: 2.892307418057523109 * 1e18
         });
         // pass time to allow interest to accumulate
         skip(10 days);
-
 
         // borrower partially repays half their loan
         _repayDebt({
@@ -911,13 +910,13 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         // check pool state after partial repay
         _assertPool(
             PoolParams({
-                htp:                  502.333658244714424687 * 1e18,
+                htp:                  522.427004574503001674 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_003.498905447098680000 * 1e18,
+                poolSize:             30_002.129042433400069436 * 1e18,
                 pledgedCollateral:    3 * 1e18,
-                encumberedCollateral: 0.500516446164039921 * 1e18,
+                encumberedCollateral: 0.520537104010601517 * 1e18,
                 poolDebt:             1_507.000974734143274062 * 1e18,
-                actualUtilization:    0.100096122026423251 * 1e18,
+                actualUtilization:    0.100100692834315229 * 1e18,
                 targetUtilization:    0.332446840033426268 * 1e18,
                 minDebtAmount:        150.700097473414327406 * 1e18,
                 loans:                1,
@@ -929,18 +928,18 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
         // check bucket state after partial repay
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_001.166301815699560000 * 1e18,
-            exchangeRate: 1.000116630181569956 * 1e18
+            deposit:      10_000.709680811133356479 * 1e18,
+            exchangeRate: 1.000116635507392213 * 1e18
         });
         // check borrower info after partial repay
         _assertBorrower({
             borrower:                  _borrower,
             borrowerDebt:              1_507.000974734143274062 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.993809040625961852 * 1e18
+            borrowert0Np:              557.731729000949159306 * 1e18,
+            borrowerCollateralization: 5.763277923678809473 * 1e18
         });
 
         // pass time to allow additional interest to accumulate
@@ -951,8 +950,8 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             borrower:                  _borrower,
             borrowerDebt:              1_508.860066921599065132 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.986423966420065585 * 1e18
+            borrowert0Np:              557.731729000949159306 * 1e18,
+            borrowerCollateralization: 5.756176890788524601 * 1e18
         });
 
         // mint additional quote to allow borrower to repay their loan plus interest
@@ -1001,11 +1000,11 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             30_005.088767154245370000 * 1e18,
+                poolSize:             30_003.718904596374273953 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
-                actualUtilization:    0.050227555333959397 * 1e18,
+                actualUtilization:    0.050229848666883565 * 1e18,
                 targetUtilization:    0.202597018753257617 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -1018,15 +1017,15 @@ contract ERC721ScaledQuoteTokenBorrowAndRepayTest is ERC721NDecimalsHelperContra
             debtColEma:   1_009_226.137898421530685238 * 1e18,
             lupt0DebtEma: 4_981_446.144217726231751319 * 1e18,
             debtEma:      1_507.002401317220586672 * 1e18,
-            depositEma:   30_003.498902092092525534 * 1e18
+            depositEma:   30_002.129039078394745557 * 1e18
         });
         // check bucket state after fully repay
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_001.696255718081790000 * 1e18,
-            exchangeRate: 1.000169625571808179 * 1e18
+            deposit:      10_001.239634865458091318 * 1e18,
+            exchangeRate: 1.000169633332816715 * 1e18
         });
         // check borrower info after fully repay
         _assertBorrower({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -169,7 +169,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
@@ -185,9 +185,9 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check initial bucket state
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
 
@@ -220,11 +220,11 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check pool state after borrow
         _assertPool(
             PoolParams({
-                htp:                  1_000.961538461538462000 * 1e18,
+                htp:                  1_041.000000000000000480 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    Maths.wad(3),
-                encumberedCollateral: 0.997340520100278804 * 1e18,
+                encumberedCollateral: 1.037234140904289956 * 1e18,
                 poolDebt:             3_002.88461538461538600 * 1e18,
                 actualUtilization:    0.000000000000000000 * 1e18,
                 targetUtilization:    1 * 1e18,
@@ -238,9 +238,9 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check bucket state after borrow
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
         // check borrower info after borrow
@@ -248,8 +248,8 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrower:                  _borrower,
             borrowerDebt:              3_002.884615384615386000 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              1_152.910902143138512881 * 1e18,
-            borrowerCollateralization: 3.007999714779824033 * 1e18
+            borrowert0Np:              1_112.872440604676974401 * 1e18,
+            borrowerCollateralization: 2.892307418057523109 * 1e18
         });
         // pass time to allow interest to accumulate
         skip(10 days);
@@ -274,13 +274,13 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check pool state after partial repay
         _assertPool(
             PoolParams({
-                htp:                  502.333658244714424687 * 1e18,
+                htp:                  522.427004574503001674 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_003.498905447098680000 * 1e18,
+                poolSize:             30_002.129042433400069436 * 1e18,
                 pledgedCollateral:    3 * 1e18,
-                encumberedCollateral: 0.500516446164039921 * 1e18,
+                encumberedCollateral: 0.520537104010601517 * 1e18,
                 poolDebt:             1_507.000974734143274062 * 1e18,
-                actualUtilization:    0.100096122026423251 * 1e18,
+                actualUtilization:    0.100100692834315229 * 1e18,
                 targetUtilization:    0.332446840033426268 * 1e18,
                 minDebtAmount:        150.700097473414327406 * 1e18,
                 loans:                1,
@@ -292,18 +292,18 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         // check bucket state after partial repay
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_001.166301815699560000 * 1e18,
-            exchangeRate: 1.000116630181569956 * 1e18
+            deposit:      10_000.709680811133356479 * 1e18,
+            exchangeRate: 1.000116635507392213 * 1e18
         });
         // check borrower info after partial repay
         _assertBorrower({
             borrower:                  _borrower,
             borrowerDebt:              1_507.000974734143274062 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.993809040625961852 * 1e18
+            borrowert0Np:              557.731729000949159306 * 1e18,
+            borrowerCollateralization: 5.763277923678809473 * 1e18
         });
 
         // pass time to allow additional interest to accumulate
@@ -314,8 +314,8 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             borrower:                  _borrower,
             borrowerDebt:              1_508.860066921599065132 * 1e18,
             borrowerCollateral:        3 * 1e18,
-            borrowert0Np:              577.797569043003579568 * 1e18,
-            borrowerCollateralization: 5.986423966420065585 * 1e18
+            borrowert0Np:              557.731729000949159306 * 1e18,
+            borrowerCollateralization: 5.756176890788524601 * 1e18
         });
 
         // mint additional quote to allow borrower to repay their loan plus interest
@@ -350,11 +350,11 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             30_005.088767154245370000 * 1e18,
+                poolSize:             30_003.718904596374273953 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
-                actualUtilization:    0.050227555333959397 * 1e18,
+                actualUtilization:    0.050229848666883565 * 1e18,
                 targetUtilization:    0.202597018753257617 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -367,15 +367,15 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
             debtColEma:   1_009_226.137898421530685238 * 1e18,
             lupt0DebtEma: 4_981_446.144217726231751319 * 1e18,
             debtEma:      1_507.002401317220586672 * 1e18,
-            depositEma:   30_003.498902092092525534 * 1e18
+            depositEma:   30_002.129039078394745557 * 1e18
         });
         // check bucket state after fully repay
         _assertBucket({
             index:        2550,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_001.696255718081790000 * 1e18,
-            exchangeRate: 1.000169625571808179 * 1e18
+            deposit:      10_001.239634865458091318 * 1e18,
+            exchangeRate: 1.000169633332816715 * 1e18
         });
         // check borrower info after fully repay
         _assertBorrower({
@@ -491,7 +491,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         _assertLoans({
             noOfLoans: 1,
             maxBorrower: _borrower,
-            maxThresholdPrice: 333.653846153846154 * 1e18
+            maxThresholdPrice: 347.000000000000000160 * 1e18
         });
 
         // should revert if LUP is below the limit
@@ -517,7 +517,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         });
         _borrow({
             from:       _borrower2,
-            amount:     3_000 * 1e18,
+            amount:     2_850 * 1e18,
             indexLimit: 3_000,
             newLup:     3_010.892022197881557845 * 1e18
         });
@@ -525,7 +525,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         _assertLoans({
             noOfLoans: 2,
             maxBorrower: _borrower2,
-            maxThresholdPrice: 3_002.884615384615386 * 1e18
+            maxThresholdPrice: 2_966.850000000000001368 * 1e18
         });
 
         // should be able to repay loan if properly specified

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -567,9 +567,9 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        1530,
-            lpBalance:    497_616.252661175041981841 * 1e18,
+            lpBalance:    497_615.796040170475771841 * 1e18,
             collateral:   Maths.wad(1),
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertLenderLpBalance({
@@ -589,9 +589,9 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        1530,
-            lpBalance:    10_000 * 1e18,
+            lpBalance:    9_999.543378995433790000 * 1e18,
             collateral:   0,
-            deposit:      10_000 * 1e18,
+            deposit:      9_999.543378995433790000 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertLenderLpBalance({
@@ -606,10 +606,10 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   10_000 * 1e18,
+            amount:   9_999.543378995433790000 * 1e18,
             index:    1530,
             newLup:   MAX_PRICE,
-            lpRedeem: 10_000 * 1e18
+            lpRedeem: 9_999.543378995433790000 * 1e18
         });
 
         _assertBucket({
@@ -623,12 +623,10 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
     function testMergeOrRemoveERC721Collateral() external {
         for (uint256 i = 3060; i < (3060 + 10); i++) {
-            _addLiquidity({
+            _addInitialLiquidity({
                 from:   _lender,
                 amount: 20 * 1e18,
-                index:  i,
-                newLup: MAX_PRICE,
-                lpAward: 20 * 1e18
+                index:  i
             });
         }
 
@@ -695,8 +693,8 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrower:       _borrower,
             debt:           590.789267398535232526 * 1e18,
             collateral:     2.0 * 1e18,
-            bond:           8.968381880996266239 * 1e18,
-            transferAmount: 8.968381880996266239 * 1e18
+            bond:           6.605224811402125309 * 1e18,
+            transferAmount: 6.605224811402125309 * 1e18
         });
 
         skip(32 hours);
@@ -706,11 +704,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            address(_lender),
-                bondSize:          8.968381880996266239 * 1e18,
+                bondSize:          6.605224811402125309 * 1e18,
                 bondFactor:        0.015180339887498948 * 1e18,
                 kickTime:          block.timestamp - 32 hours,
                 referencePrice:    340.236543104248948639 * 1e18,
-                totalBondEscrowed: 8.968381880996266239 * 1e18,
+                totalBondEscrowed: 6.605224811402125309 * 1e18,
                 auctionPrice:      0.000081118713165342 * 1e18,
                 debtInAuction:     590.789267398535232527 * 1e18,
                 thresholdPrice:    295.453988355164748340 * 1e18,
@@ -919,8 +917,8 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             from:            _lender,
             borrower:        _borrower,
             maxCollateral:   2 * 1e18,
-            bondChange:      0.000001231409637086 * 1e18,
-            givenAmount:     0.000081118713165342 * 1e18,
+            bondChange:      0.000000875438618141 * 1e18,
+            givenAmount:     0.000078301610411710 * 1e18,
             collateralTaken: 1 * 1e18,
             isReward:        true
         });
@@ -972,7 +970,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    11,
-            settledDebt: 106.339800629932799697 * 1e18
+            settledDebt: 102.277919151483596286 * 1e18
         });
 
         _assertBorrower({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -370,7 +370,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
@@ -412,11 +412,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         // check pool state
         _assertPool(
             PoolParams({
-                htp:                  1_000.961538461538462 * 1e18,
+                htp:                  1_041.000000000000000480 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_000 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
                 pledgedCollateral:    Maths.wad(3),
-                encumberedCollateral: 0.997340520100278804 * 1e18,
+                encumberedCollateral: 1.037234140904289956 * 1e18,
                 poolDebt:             3_002.884615384615386 * 1e18,
                 actualUtilization:    0.000000000000000000 * 1e18,
                 targetUtilization:    1 * 1e18,
@@ -434,12 +434,12 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrower:         _borrower,
             amountToRepay:    0,
             amountRepaid:     0,
-            collateralToPull: 2
+            collateralToPull: 1
         });
 
         // check token balances after remove
-        assertEq(_collateral.balanceOf(_borrower),      51);
-        assertEq(_collateral.balanceOf(address(_pool)), 1);
+        assertEq(_collateral.balanceOf(_borrower),      50);
+        assertEq(_collateral.balanceOf(address(_pool)), 2);
 
         assertEq(_quote.balanceOf(address(_pool)), 27_000 * 1e18);
         assertEq(_quote.balanceOf(_borrower),      3_100 * 1e18);
@@ -447,12 +447,12 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         // check pool state
         _assertPool(
             PoolParams({
-                htp:                  3_002.884615384615386000 * 1e18,
+                htp:                  1_561.500000000000000720 * 1e18,
                 lup:                  _priceAt(2550),
-                poolSize:             30_000 * 1e18,
-                pledgedCollateral:    Maths.wad(1),
-                encumberedCollateral: 0.997340520100278804 * 1e18,
-                poolDebt:             3_002.884615384615386 * 1e18,
+                poolSize:             29_998.630136986301370000 * 1e18,
+                pledgedCollateral:    Maths.wad(2),
+                encumberedCollateral: 1.037234140904289956 * 1e18,
+                poolDebt:             3_002.884615384615386000 * 1e18,
                 actualUtilization:    0.000000000000000000 * 1e18,
                 targetUtilization:    1 * 1e18,
                 minDebtAmount:        300.288461538461538600 * 1e18,
@@ -502,14 +502,14 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         // borrower borrows some quote
         _borrow({
             from:       _borrower,
-            amount:     9_000 * 1e18,
+            amount:     8_600 * 1e18,
             indexLimit: 2_551,
             newLup:     _priceAt(2550)
         });
 
         // check collateralization after borrow
         (poolDebt,,,) = _pool.debtInfo();
-        assertEq(_encumberance(poolDebt, _lup()), 2.992021560300836411 * 1e18);
+        assertEq(_encumberance(poolDebt, _lup()), 2.973404537258964540 * 1e18);
 
         // should revert if borrower attempts to pull more collateral than is unencumbered
         _assertPullInsufficientCollateralRevert({
@@ -655,8 +655,8 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrower:                  _borrower,
             borrowerDebt:              150.144230769230769300 * 1e18,
             borrowerCollateral:        2.0 * 1e18,
-            borrowert0Np:              86.468317660735388466 * 1e18,
-            borrowerCollateralization: 3.043424968161510485 * 1e18,
+            borrowert0Np:              83.465433045350773080 * 1e18,
+            borrowerCollateralization: 2.926370161693760082 * 1e18,
             tokenIds:                  borrowerTokenIds
         });
 
@@ -664,11 +664,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         skip(10_000 days);
         _assertPool(
             PoolParams({
-                htp:                  75.072115384615384650 * 1e18,
+                htp:                  78.075000000000000036 * 1e18,
                 lup:                  0.000000099836282890 * 1e18,
-                poolSize:             200.0 * 1e18,
+                poolSize:             199.990867579908675800 * 1e18,
                 pledgedCollateral:    2 * 1e18,
-                encumberedCollateral: 5_917_580_766.197687035371154332 * 1e18,
+                encumberedCollateral: 6_154_283_996.845594516785199193 * 1e18,
                 poolDebt:             590.789267398535232527 * 1e18,
                 actualUtilization:    0,
                 targetUtilization:    1.0 * 1e18,
@@ -682,9 +682,9 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        3061,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      20.0 * 1e18,
+            deposit:      19.999086757990867580 * 1e18,
             exchangeRate: 1.000000000000000000 * 1e18
         });
 
@@ -705,14 +705,14 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 active:            true,
                 kicker:            address(_lender),
                 bondSize:          6.605224811402125309 * 1e18,
-                bondFactor:        0.015180339887498948 * 1e18,
+                bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp - 32 hours,
-                referencePrice:    340.236543104248948639 * 1e18,
+                referencePrice:    328.420757756278243989 * 1e18,
                 totalBondEscrowed: 6.605224811402125309 * 1e18,
-                auctionPrice:      0.000081118713165342 * 1e18,
+                auctionPrice:      0.000078301610411710 * 1e18,
                 debtInAuction:     590.789267398535232527 * 1e18,
                 thresholdPrice:    295.453988355164748340 * 1e18,
-                neutralPrice:      340.236543104248948639 * 1e18
+                neutralPrice:      328.420757756278243989 * 1e18
             })
         );
 
@@ -720,11 +720,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  99836282890,
-                poolSize:             574.548281134908793200 * 1e18,
+                poolSize:             574.539148714817468952 * 1e18,
                 pledgedCollateral:    2 * 1e18,
-                encumberedCollateral: 5_918_769_805.977193435161155568 * 1e18,
+                encumberedCollateral: 6_155_520_598.216281172565197855 * 1e18,
                 poolDebt:             590.907976710329496681 * 1e18,
-                actualUtilization:    0.750721153846153847 * 1e18,
+                actualUtilization:    0.750755434916241346 * 1e18,
                 targetUtilization:    0.328577182109433013 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -738,82 +738,82 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         _updateInterest();
         _assertBucket({
             index:        3060,
-            lpBalance:    20 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0000000000000000000 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3061,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3062,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3063,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3064,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3065,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3066,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3067,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3068,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
             index:        3069,
-            lpBalance:    20.0 * 1e18,
+            lpBalance:    19.999086757990867580 * 1e18,
             collateral:   0.0 * 1e18,
-            deposit:      57.465578391592604940 * 1e18,
-            exchangeRate: 2.873278919579630247 * 1e18
+            deposit:      57.464665200956929022 * 1e18,
+            exchangeRate: 2.873364463904645750 * 1e18
         });
 
         _assertBucket({
@@ -839,18 +839,18 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        3060,
-            lpBalance:    20.308286694556134654 * 1e18,
-            collateral:   0.246630842904997686 * 1e18,
-            deposit:      0.000000000000000144 * 1e18,
-            exchangeRate: 2.873278919579630248 * 1e18
+            lpBalance:    20.225211496821887632 * 1e18,
+            collateral:   0.245629261778504471 * 1e18,
+            deposit:      0.000000000000000149 * 1e18,
+            exchangeRate: 2.873364463904645751 * 1e18
         });
 
         _assertBucket({
             index:        3061,
-            lpBalance:    20.308286694556134655 * 1e18,
-            collateral:   0.247863997119522673 * 1e18,
-            deposit:      0.000000000000000006 * 1e18,
-            exchangeRate: 2.873278919579630248 * 1e18
+            lpBalance:    20.225211496821887632 * 1e18,
+            collateral:   0.246857408087396991 * 1e18,
+            deposit:      0.000000000000000227 * 1e18,
+            exchangeRate: 2.873364463904645751 * 1e18
         });
 
         _assertBucket({
@@ -866,15 +866,15 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            address(_lender),
-                bondSize:          8.968381880996266239 * 1e18,
-                bondFactor:        0.015180339887498948 * 1e18,
+                bondSize:          6.605224811402125309 * 1e18,
+                bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp - 32 hours,
-                referencePrice:    340.236543104248948639 * 1e18,
-                totalBondEscrowed: 8.968381880996266239 * 1e18,
-                auctionPrice:      0.000081118713165342 * 1e18,
-                debtInAuction:     418.511241535551682100 * 1e18,
-                thresholdPrice:    333.103014700636165105 * 1e18,
-                neutralPrice:      340.236543104248948639 * 1e18
+                referencePrice:    328.420757756278243989 * 1e18,
+                totalBondEscrowed: 6.605224811402125309 * 1e18,
+                auctionPrice:      0.000078301610411710 * 1e18,
+                debtInAuction:     418.513981107458710209 * 1e18,
+                thresholdPrice:    332.306488529853590250 * 1e18,
+                neutralPrice:      328.420757756278243989 * 1e18
             })
         );
 
@@ -882,11 +882,11 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  99836282890,
-                poolSize:             402.259048741148234756 * 1e18,
-                pledgedCollateral:    1.256401842870359357 * 1e18,
-                encumberedCollateral: 4_191_975_396.326293274519167147 * 1e18,
-                poolDebt:             418.511241535551682100 * 1e18,
-                actualUtilization:    0.750721153846153847 * 1e18,
+                poolSize:             402.252656406698503718 * 1e18,
+                pledgedCollateral:    1.259421635006264564 * 1e18,
+                encumberedCollateral: 4_359_682_950.449208762774280808 * 1e18,
+                poolDebt:             418.513981107458710209 * 1e18,
+                actualUtilization:    0.750755434916241346 * 1e18,
                 targetUtilization:    0.328577182109433013 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
@@ -902,9 +902,9 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              418.511241535551682100 * 1e18,
-            borrowerCollateral:        1.256401842870359357 * 1e18,
-            borrowert0Np:              97.486777718699640528 * 1e18,
+            borrowerDebt:              418.513981107458710209 * 1e18,
+            borrowerCollateral:        1.259421635006264564 * 1e18,
+            borrowert0Np:              93.876224597051618768 * 1e18,
             borrowerCollateralization: 0,
             tokenIds:                  borrowerTokenIds
         });
@@ -928,9 +928,9 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              418.511161648248153847 * 1e18,
-            borrowerCollateral:        0.256401842870359357 * 1e18,
-            borrowert0Np:              477.697595423190347016 * 1e18,
+            borrowerDebt:              418.513903681286916644 * 1e18,
+            borrowerCollateral:        0.259421635006264564 * 1e18,
+            borrowert0Np:              455.743509574939662401 * 1e18,
             borrowerCollateralization: 0,
             tokenIds:                  borrowerTokenIds
         });
@@ -954,15 +954,15 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 borrower:          _borrower,
                 active:            true,
                 kicker:            address(_lender),
-                bondSize:          8.968383112405903325 * 1e18,
-                bondFactor:        0.015180339887498948 * 1e18,
+                bondSize:          6.605225686840743450 * 1e18,
+                bondFactor:        0.011180339887498948 * 1e18,
                 kickTime:          block.timestamp - (32 hours + 4210 minutes),
-                referencePrice:    340.236543104248948639 * 1e18,
-                totalBondEscrowed: 8.968383112405903325 * 1e18,
+                referencePrice:    328.420757756278243989 * 1e18,
+                totalBondEscrowed: 6.605225686840743450 * 1e18,
                 auctionPrice:      0,
-                debtInAuction:     418.511161648248153847 * 1e18,
-                thresholdPrice:    1_633.038265299714540882 * 1e18,
-                neutralPrice:      340.236543104248948639 * 1e18
+                debtInAuction:     418.513903681286916644 * 1e18,
+                thresholdPrice:    1_614.039492321819633172 * 1e18,
+                neutralPrice:      328.420757756278243989 * 1e18
             })
         );
 
@@ -971,6 +971,13 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             borrower:    _borrower,
             maxDepth:    11,
             settledDebt: 102.277919151483596286 * 1e18
+        });
+
+        _settle({
+            from:        _lender,
+            borrower:    _borrower,
+            maxDepth:    11,
+            settledDebt: 4.062578203586746574 * 1e18
         });
 
         _assertBorrower({
@@ -995,7 +1002,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 bondFactor:        0,
                 kickTime:          0,
                 referencePrice:    0,
-                totalBondEscrowed: 8.968383112405903325 * 1e18,
+                totalBondEscrowed: 6.605225686840743450 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
                 thresholdPrice:    0,
@@ -1005,10 +1012,10 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertBucket({
             index:        3060,
-            lpBalance:    20.308286694556134654 * 1e18,
-            collateral:   0.246630842904997687 * 1e18,
+            lpBalance:    20.225211496821887632 * 1e18,
+            collateral:   0.245629261778504472 * 1e18,
             deposit:      0,
-            exchangeRate: 2.873278919579630252 * 1e18
+            exchangeRate: 2.873364463904645755 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _borrower,
@@ -1086,18 +1093,16 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         assertEq(_collateral.balanceOf(address(_pool)), 0);
 
         // lender deposit quote tokens in bucket 7388 in order to claim and merge settled collateral and to be able to remove entire NFT
-        _addLiquidity({
+        _addInitialLiquidity({
             from:    _lender,
             amount:  10 * 1e18,
-            index:   7388,
-            lpAward: 10 * 1e18, // LP awarded to lender for depositing quote tokens in bucket 7388
-            newLup:  MAX_PRICE
+            index:   7388
         });
 
         _assertLenderLpBalance({
             lender:      _lender,
             index:       7388,
-            lpBalance:   10 * 1e18, // lender now owns LP in bucket 7388 which can be used to merge bucket collateral
+            lpBalance:   9.999392237442922370 * 1e18, // lender now owns LP in bucket 7388 which can be used to merge bucket collateral
             depositTime: _startTime + 10000 days + (32 hours + 4210 minutes)
         });
 
@@ -1129,15 +1134,15 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        7388,
-            lpBalance:    10 * 1e18, // LP in bucket 7388 diminished when NFT merged and removed
+            lpBalance:    9.999392237442922370 * 1e18, // LP in bucket 7388 diminished when NFT merged and removed
             collateral:   0,         // no collateral remaining as it was merged and removed
-            deposit:      10 * 1e18,
+            deposit:      9.999392237442922370 * 1e18,
             exchangeRate: 1 * 1e18
         });
         _assertLenderLpBalance({
             lender:      _lender,
             index:       7388,
-            lpBalance:   10 * 1e18, // lender LP decreased with the amount used to merge NFT
+            lpBalance:   9.999392237442922370 * 1e18, // lender LP decreased with the amount used to merge NFT
             depositTime: _startTime + 10000 days + (32 hours + 4210 minutes)
         });
         _assertLenderLpBalance({
@@ -1149,10 +1154,10 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _removeAllLiquidity({
             from:     _lender,
-            amount:   10 * 1e18,
+            amount:   9.999392237442922370 * 1e18,
             index:    7388,
             newLup:   MAX_PRICE,
-            lpRedeem: 10 * 1e18
+            lpRedeem: 9.999392237442922370 * 1e18
         });
 
         _assertBucket({
@@ -1167,16 +1172,16 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             PoolParams({
                 htp:                  0,
                 lup:                  MAX_PRICE,
-                poolSize:             50.000079544611684526 * 1e18,
+                poolSize:             0,
                 pledgedCollateral:    0,
                 encumberedCollateral: 0,
                 poolDebt:             0,
-                actualUtilization:    0.750721153846153847 * 1e18,
+                actualUtilization:    0.750755434916241347 * 1e18,
                 targetUtilization:    0.328577182109433013 * 1e18,
                 minDebtAmount:        0,
                 loans:                0,
                 maxBorrower:          address(0),
-                interestRate:         0.05445 * 1e18,
+                interestRate:         0.066550000000000000 * 1e18,
                 interestRateUpdate:   block.timestamp
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -99,7 +99,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:   _borrower,
             debt:       10_064.648403565736152554 * 1e18,
             collateral: 2 * 1e18,
-            bond:       152.784783614301553735 * 1e18
+            bond:       112.526190000038609125 * 1e18
         });
         _lenderKick({
             from:       _lender,
@@ -107,17 +107,17 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:   _borrower2,
             debt:       10_064.648403565736152554 * 1e18,
             collateral: 3 * 1e18,
-            bond:       152.784783614301553735 * 1e18
+            bond:       112.526190000038609125 * 1e18
         });
     }
 
     function testSettlePartialDebtSubsetPool() external tearDown {
         _assertBucket({
             index:        2500,
-            lpBalance:    8_000 * 1e18,
+            lpBalance:    7999.634703196347032000 * 1e18,
             collateral:   0,
-            deposit:      13_293.371821008415088000 * 1e18,
-            exchangeRate: 1.661671477626051886 * 1e18
+            deposit:      13293.006524204762122216 * 1e18,
+            exchangeRate: 1.661701692315198699 * 1e18
         });
 
         // the 2 token ids are owned by borrower before settle
@@ -151,8 +151,8 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrower:                  _borrower,
             borrowerDebt:              10_069.704976226041001321 * 1e18,
             borrowerCollateral:        2 * 1e18,
-            borrowert0Np:              2_882.277255357846282204 * 1e18,
-            borrowerCollateralization: 0.767381840478769050 * 1e18
+            borrowert0Np:              2782.181101511692436004 * 1e18,
+            borrowerCollateralization: 0.737867154306508702 * 1e18
         });
 
         // first settle call settles partial borrower debt
@@ -160,24 +160,24 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    1,
-            settledDebt: 2_485.570270210405357279 * 1e18
+            settledDebt: 2485.445445980762364312 * 1e18
         });
 
         // collateral in bucket used to settle auction increased with the amount used to settle debt
         _assertBucket({
             index:        2499,
-            lpBalance:    5_000 * 1e18,
-            collateral:   1.287926464788484107 * 1e18,
+            lpBalance:    4999.748858447488585000 * 1e18,
+            collateral:   1.287861785696232799 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000196645204423177 * 1e18
+            exchangeRate: 1.000196653963394216 * 1e18
         });
         // partial borrower debt is settled, borrower collateral decreased with the amount used to settle debt
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              5_068.721750203925124024 * 1e18,
-            borrowerCollateral:        0.712073535211515893 * 1e18,
-            borrowert0Np:              4_074.953051699645482676 * 1e18,
-            borrowerCollateralization: 0.542781032548108438 * 1e18
+            borrowerDebt:              5068.972897349563013267 * 1e18,
+            borrowerCollateral:        0.712138214303767201 * 1e18,
+            borrowert0Np:              3933.275103347858307094 * 1e18,
+            borrowerCollateralization: 0.521926384043273437 * 1e18
         });
 
         _assertCollateralInvariants();
@@ -199,7 +199,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    1,
-            settledDebt: 2_127.089747762669017517 * 1e18
+            settledDebt: 1_369.922338567221579743 * 1e18
         });
 
         // no token id left in borrower token ids array
@@ -211,14 +211,14 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    20_036.073477395793018984 * 1e18,
-            collateral:   0.712073535211515893 * 1e18,
-            deposit:      30_548.712777641352242710 * 1e18,
-            exchangeRate: 1.661998237353453822 * 1e18
+            lpBalance:    20034.884788261831319325 * 1e18,
+            collateral:   0.712138214303767201 * 1e18,
+            deposit:      30547.093039196991134852 * 1e18,
+            exchangeRate: 1.662028472538971359 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,
-            borrowerDebt:              789.003620205433623214 * 1e18,
+            borrowerDebt:              2_312.680420634460396298 * 1e18,
             borrowerCollateral:        0,
             borrowert0Np:              0,
             borrowerCollateralization: 0
@@ -228,7 +228,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    5,
-            settledDebt: 392.147674334617935204 * 1e18
+            settledDebt: 1_149.439907759708365945 * 1e18
         });
 
         _assertBorrower({
@@ -250,24 +250,24 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    20_036.073477395793018984 * 1e18,
-            collateral:   3.318337971638889847 * 1e18,
-            deposit:      19_690.004181209877611641 * 1e18,
-            exchangeRate: 1.622619083494012841 * 1e18
+            lpBalance:    20_034.884788261831319325 * 1e18,
+            collateral:   3.318402650731141155 * 1e18,
+            deposit:      18164.707642336489729783 * 1e18,
+            exchangeRate: 1.546595793735176658 * 1e18
         });
         _assertBucket({
             index:        2499,
-            lpBalance:    5_000 * 1e18,
-            collateral:   1.287926464788484107 * 1e18,
+            lpBalance:    4999.748858447488585000 * 1e18,
+            collateral:   1.287861785696232799 * 1e18,
             deposit:      0,
-            exchangeRate: 1.000196645204423177 * 1e18
+            exchangeRate: 1.000196653963394216 * 1e18
         });
         _assertBucket({
             index:        7388,
-            lpBalance:    99.984931546150681783 * 1e18,
+            lpBalance:    99.994977208251138039 * 1e18,
             collateral:   0.393735563572626046 * 1e18,
-            deposit:      100.004593064144716734 * 1e18,
-            exchangeRate: 1.000196645204423177 * 1e18
+            deposit:      100.014641577529559813 * 1e18,
+            exchangeRate: 1.000196653963394217 * 1e18
         });
 
         _assertBorrower({
@@ -314,10 +314,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertBucket({
             index:        2500,
-            lpBalance:    15_959.417125063160793398 * 1e18,
+            lpBalance:    15757.677829213243231010 * 1e18,
             collateral:   1.606264436427373954 * 1e18,
-            deposit:      19_690.004181209877611641 * 1e18,
-            exchangeRate: 1.622619083494012841 * 1e18
+            deposit:      18164.707642336489729783 * 1e18,
+            exchangeRate: 1.546595793735176658 * 1e18
         });
         _assertBucket({
             index:        2499,
@@ -328,10 +328,10 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertBucket({
             index:        MAX_FENWICK_INDEX,
-            lpBalance:    99.984931546150681783 * 1e18,
+            lpBalance:    99.994977208251138039 * 1e18,
             collateral:   0.393735563572626046 * 1e18,
-            deposit:      100.004593064144716734 * 1e18,
-            exchangeRate: 1.000196645204423177 * 1e18
+            deposit:      100.014641577529559813 * 1e18,
+            exchangeRate: 1.000196653963394217 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,

--- a/tests/forge/unit/Positions/CodearenaReports.t.sol
+++ b/tests/forge/unit/Positions/CodearenaReports.t.sol
@@ -257,14 +257,14 @@ contract PositionManagerCodeArenaTest is PositionManagerERC20PoolHelperContract 
         // check from and to positions before move
         (uint256 fromLp, uint256 fromDepositTime) = _positionManager.getPositionInfo(tokenId1, mintIndex);
         (uint256 toLp,   uint256 toDepositTime)   = _positionManager.getPositionInfo(tokenId1, moveIndex);
-        assertEq(fromLp, 2_500 * 1e18);
+        assertEq(fromLp, 2_499.885844748858447500 * 1e18);
         assertEq(toLp,   0);
         assertEq(fromDepositTime, block.timestamp);
         assertEq(toDepositTime,   0);
 
         // move liquidity called by testAddress1 owner
         vm.expectEmit(true, true, true, true);
-        emit MoveLiquidity(testAddress1, tokenId1, mintIndex, moveIndex, 2_500 * 1e18, 2_500 * 1e18);
+        emit MoveLiquidity(testAddress1, tokenId1, mintIndex, moveIndex, 2_499.885844748858447500 * 1e18, 2_499.771694710285440276 * 1e18);
         changePrank(address(testAddress1));
         _positionManager.moveLiquidity(address(_pool), tokenId1, mintIndex, moveIndex, block.timestamp + 30);
 
@@ -273,7 +273,7 @@ contract PositionManagerCodeArenaTest is PositionManagerERC20PoolHelperContract 
         (fromLp, fromDepositTime) = _positionManager.getPositionInfo(tokenId1, mintIndex);
         (toLp,   toDepositTime)   = _positionManager.getPositionInfo(tokenId1, moveIndex);
         assertEq(fromLp, 0);
-        assertEq(toLp,   2_500 * 1e18);
+        assertEq(toLp,   2_499.771694710285440276 * 1e18);
         assertEq(fromDepositTime, 0);
         assertEq(toDepositTime,   block.timestamp);
     }
@@ -707,7 +707,7 @@ contract PositionManagerCodeArenaTest is PositionManagerERC20PoolHelperContract 
 
         _assertPool(
             PoolParams({
-                htp:                  9.288923076923076927 * 1e18,
+                htp:                  9.660480000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    1_002.0 * 1e18,
@@ -784,7 +784,7 @@ contract PositionManagerCodeArenaTest is PositionManagerERC20PoolHelperContract 
 
         _assertPool(
             PoolParams({
-                htp:                  9.288923076923076927 * 1e18,
+                htp:                  9.660480000000000004 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_995.981745584954442553 * 1e18,
                 pledgedCollateral:    1_002 * 1e18,

--- a/tests/forge/unit/Rewards/ClaimRewards.t.sol
+++ b/tests/forge/unit/Rewards/ClaimRewards.t.sol
@@ -96,7 +96,7 @@ contract ClaimRewardsOnStakeTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 112.186978951213014722 * 1e18,
+            tokensToBurn: 112.186978951213014663 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -224,11 +224,11 @@ contract ClaimRewardsTest is ClaimRewardsOnStakeTest {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 19 * 1e18,
-            reward:             33.656093685363936645 * 1e18,
+            reward:             33.656093685363936630 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
         uint256 minterOneBalance = _ajnaToken.balanceOf(_minterOne);
-        assertEq(minterOneBalance, 33.656093685363936645 * 1e18);
+        assertEq(minterOneBalance, 33.656093685363936630 * 1e18);
 
         vm.revertTo(claimSnapshot);
 
@@ -253,7 +253,7 @@ contract ClaimRewardsTest is ClaimRewardsOnStakeTest {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 5 * 1e18,
-            reward:             33.656093685363936645 * 1e18,
+            reward:             33.656093685363936630 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
         uint256 minterOneBalance = _ajnaToken.balanceOf(_minterOne);
@@ -297,7 +297,7 @@ contract ClaimRewardsTest is ClaimRewardsOnStakeTest {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             33.656093685363936645 * 1e18,
+            reward:             33.656093685363936630 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
         uint256 minterOneBalance = _ajnaToken.balanceOf(_minterOne);
@@ -319,12 +319,12 @@ contract ClaimRewardsOnUnstakeTest is ClaimRewardsOnStakeTest {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    33.656093685363936645 * 1e18,
+            reward:                    33.656093685363936630 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 5.609348947560656105 * 1e18
         });
         uint256 minterOneBalance = _ajnaToken.balanceOf(_minterOne);
-        assertEq(minterOneBalance, 33.656093685363936645 * 1e18);
+        assertEq(minterOneBalance, 33.656093685363936630 * 1e18);
     }
 
     function testClaimOnUnstakeWithInsufficientFunds() external {

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -727,8 +727,8 @@ contract RewardsManagerTest is RewardsHelperContract {
             index:        _i9_81,
             lpBalance:    5999.726027397260274000 * 1e18,
             collateral:   0,
-            deposit:      2_258.799128242959972962 * 1e18,
-            exchangeRate: 0.376483712410923052 * 1e18
+            deposit:      2_293.069461117449889576 * 1e18,
+            exchangeRate: 0.382195695377811412 * 1e18
         });
 
         /***********************/
@@ -1579,7 +1579,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -1590,7 +1590,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687652965 * 1e18
         });
 
         // burn rewards manager tokens and leave only 5 tokens available
@@ -1598,7 +1598,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         IERC20Token(address(_ajnaToken)).burn(99_999_990.910045863027949943 * 1e18);
 
         uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
-        assertEq(managerBalance, 4.161008608284397087 * 1e18);
+        assertEq(managerBalance, 4.161008608284397092 * 1e18);
 
         // check reward generated are more than manager token balance
         uint256 rewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -1613,7 +1613,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             49.289455286876529748 * 1e18,
+            reward:             49.289455286876529719 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
 
@@ -1662,7 +1662,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 452.070347736384691477 * 1e18,
+            tokensToBurn: 452.070347736384453118 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6000,
             pool:         address(_pool)
@@ -1673,12 +1673,12 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         22.603517386819228170 * 1e18
+            reward:         22.603517386819223250 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 22.603517386819228170 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 22.603517386819223250 * 1e18);
 
         uint256 rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarned, 226.035173868192281719 * 1e18);
+        assertEq(rewardsEarned, 226.035173868192232711 * 1e18);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
 
         /******************************/
@@ -1687,7 +1687,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger second reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 806.644134981218053878 * 1e18,
+            tokensToBurn: 806.210861585628610910 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -1698,13 +1698,13 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         17.728689362241666350 * 1e18
+            reward:         17.707025692462202068 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 40.332206749060894520 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 40.310543079281425318 * 1e18);
 
         // check available rewards
         rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarned, 403.322067490608945398 * 1e18);
+        assertEq(rewardsEarned, 403.105430792814253516 * 1e18);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
 
         /*****************************/
@@ -1714,7 +1714,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger third reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 1_097.906932981315067829 * 1e18,
+            tokensToBurn: 1_097.473661476001950504 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -1722,7 +1722,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         // skip updating exchange rates and check available rewards
         uint256 rewardsEarnedNoUpdate = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarnedNoUpdate, 403.322067490608945398 * 1e18);
+        assertEq(rewardsEarnedNoUpdate, 403.105430792814253516 * 1e18);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
 
         // snapshot calling update exchange rate
@@ -1733,10 +1733,10 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater2,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         14.563139900004842560 * 1e18
+            reward:         14.563139994518658956 * 1e18
         });
 
-        assertEq(_ajnaToken.balanceOf(_updater2), 14.563139900004842560 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater2), 14.563139994518658956 * 1e18);
 
         // check available rewards
         rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -1753,7 +1753,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // triger fourth reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 1_363.211352198574097874 * 1e18,
+            tokensToBurn: 1_362.778083140888837638 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -1761,7 +1761,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         // check rewards earned
         rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarned, 403.322067490608945398 * 1e18);
+        assertEq(rewardsEarned, 403.105430792814253516 * 1e18);
 
         // call update exchange rate
         _updateExchangeRates({
@@ -1774,7 +1774,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         // check rewards earned won't increase since previous update was missed
         rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarned, 403.322067490608945398 * 1e18);
+        assertEq(rewardsEarned, 403.105430792814253516 * 1e18);
 
         /*****************************/
         /*** Fifth Reserve Auction ***/
@@ -1783,7 +1783,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // triger fifth reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 1_604.589489216576018217 * 1e18,
+            tokensToBurn: 1_604.156222509495383981 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -1794,12 +1794,12 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater2,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         12.068906850900079860 * 1e18
+            reward:         12.068906968430323368 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater2), 12.068906850900079860 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater2), 12.068906968430323368 * 1e18);
 
         rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarned, 524.011135999609744045 * 1e18);
+        assertEq(rewardsEarned, 523.794500477117487282 * 1e18);
 
         // claim all rewards accrued since deposit
         _claimRewards({
@@ -1808,7 +1808,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
             epochsClaimed:      _epochsClaimedArray(5,0),
-            reward:             524.011135999609744045 * 1e18
+            reward:             523.794500477117487282 * 1e18
         });
         assertEq(_ajnaToken.balanceOf(_minterOne), rewardsEarned);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
@@ -1958,7 +1958,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // borrower takes actions providing reserves enabling reserve auctions
         uint256 firstTokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573752981902 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -1982,7 +1982,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             owner:   _minterTwo,
             tokenId: tokenIdTwo
         });
-        assertEq(_ajnaToken.balanceOf(_minterTwo), 9.852850145141933987 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), 9.848636903826801317 * 1e18);
 
         // calculate rewards earned since exchange rates have been updated
         uint256 idOneRewardsAtOne = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -2006,7 +2006,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // conduct second reserve auction
         uint256 secondTokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 179.671567072721938492 * 1e18,
+            tokensToBurn: 179.637417325199819268 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -2038,11 +2038,11 @@ contract RewardsManagerTest is RewardsHelperContract {
         uint256 idOneRewardsAtTwo = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
         assertLt(idOneRewardsAtTwo, secondTokensToBurn);
         assertGt(idOneRewardsAtTwo, 0);
-        assertEq(idOneRewardsAtTwo, 20.287643735236268524 * 1e18);
+        assertEq(idOneRewardsAtTwo, 20.279092258382791752 * 1e18);
 
         uint256 idTwoRewardsAtTwo = _rewardsManager.calculateRewards(tokenIdTwo, _pool.currentBurnEpoch());
         assertLt(idOneRewardsAtTwo + idTwoRewardsAtTwo, secondTokensToBurn);
-        assertEq(idTwoRewardsAtTwo, 20.261686736574957420 * 1e18);
+        assertEq(idTwoRewardsAtTwo, 20.253146192588418178 * 1e18);
         assertGt(idTwoRewardsAtTwo, 0);
 
         // minter one claims rewards accrued after second auction        
@@ -2052,7 +2052,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokenId:           tokenIdOne,
             minAmountToReceive: 0,
             epochsClaimed:     _epochsClaimedArray(1,1),
-            reward:            20.287643735236268524  * 1e18
+            reward:            20.279092258382791752  * 1e18
         });
 
         assertEq(_ajnaToken.balanceOf(_minterOne), idOneRewardsAtOne + idOneRewardsAtTwo);
@@ -2066,7 +2066,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             epochsClaimed:      _epochsClaimedArray(1,1),
             reward:             idTwoRewardsAtTwo
         });
-        assertEq(_ajnaToken.balanceOf(_minterTwo), 30.114536881716891407 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), 30.101783096415219495 * 1e18);
 
         // check there are no remaining rewards available after claiming
         uint256 remainingRewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -2138,7 +2138,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // auction one
         uint256 tokensToBurnE1 = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 166.619252461054099739 * 1e18,
+            tokensToBurn: 166.619252461054099679 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2148,14 +2148,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         8.330962623052697453 * 1e18
+            reward:         8.330962623052697448 * 1e18
         });
 
         _assertBurn({
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           166.619252461054099739 * 1e18,
+            burned:           166.619252461054099679 * 1e18,
             tokensToBurn:     tokensToBurnE1,
             interest:         6.443638300196908069 * 1e18
         });
@@ -2163,7 +2163,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // auction two
         uint256 tokensToBurnE2 = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 402.024955543581695856 * 1e18,
+            tokensToBurn: 402.024955543581075192 * 1e18,
             borrowAmount: 1_000 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2173,14 +2173,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         11.770285154126329647 * 1e18            
+            reward:         11.770285154126298614 * 1e18            
         });
 
         _assertBurn({
             pool:             address(_pool),
             epoch:            2,
             timestamp:        block.timestamp - 24 hours,
-            burned:           402.024955543581695856 * 1e18,
+            burned:           402.024955543581075192 * 1e18,
             tokensToBurn:     tokensToBurnE2,
             interest:         23.938554168560868287 * 1e18
         });
@@ -2188,7 +2188,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // auction three
         uint256 tokensToBurnE3 = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 784.128365181429290952 * 1e18,
+            tokensToBurn: 784.128365181427457393 * 1e18,
             borrowAmount: 2_000 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2198,14 +2198,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  19.105170481892383782 * 1e18
+            reward:  19.105170481892325170 * 1e18
         });
 
         _assertBurn({
             pool:             address(_pool),
             epoch:            3,
             timestamp:        block.timestamp - 24 hours,
-            burned:           784.128365181429290952 * 1e18,
+            burned:           784.128365181427457393 * 1e18,
             tokensToBurn:     tokensToBurnE3,
             interest:         52.423542089609182801 * 1e18
         });
@@ -2216,7 +2216,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(3, 0),
-            reward:                    65.344030431785684856 * 1e18,
+            reward:                    65.344030431785552181 * 1e18,
             indexes:                   firstIndexes,   
             updateExchangeRatesReward: 0
         });
@@ -2226,7 +2226,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdTwo,
             claimedArray:              _epochsClaimedArray(3, 0),
-            reward:                    326.720152158928424210 * 1e18,
+            reward:                    326.720152158927660227 * 1e18,
             indexes:                   secondIndexes,
             updateExchangeRatesReward: 0
         });
@@ -2460,7 +2460,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger ajna burns
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2472,7 +2472,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             54.218400815564182718 * 1e18,
+            reward:             54.218400815564182684 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1, 0)
         });
 

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -347,7 +347,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool),
-            tokensToBurn: 98.578910573753041506 * 1e18
+            tokensToBurn: 98.578910573752981902 * 1e18
         });
 
         // call update exchange rate to enable claiming rewards
@@ -355,7 +355,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687649225 * 1e18
         });
 
         // check only deposit owner can claim rewards
@@ -370,7 +370,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:              _minterOne,
             tokenId:           tokenId,
             minAmountToReceive: 0,
-            reward:            49.289455286876529748 * 1e18,
+            reward:            49.289455286876492297 * 1e18,
             epochsClaimed:     _epochsClaimedArray(1, 0)
         });
 
@@ -387,13 +387,13 @@ contract RewardsManagerTest is RewardsHelperContract {
             burnEvent:     1,
             rewardsEarned: 0
         });
-        assertEq(_ajnaToken.balanceOf(_minterOne), 49.289455286876529748 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterOne), 49.289455286876492297 * 1e18);
 
         _assertBurn({
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           98.578910573753041506 * 1e18,
+            burned:           98.578910573752981902 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -440,7 +440,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // first reserve auction happens successfully -> epoch 1
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2_555,
             pool:         address(_pool)
@@ -451,14 +451,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687652965 * 1e18
         });
 
         _assertBurn({
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           98.578910573753041506 * 1e18,
+            burned:           98.578910573753041447 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -469,7 +469,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool),
-            tokensToBurn: 169.956275403543598295 * 1e18
+            tokensToBurn: 169.956275403543493749 * 1e18
         });
 
         // check owner can withdraw the NFT and rewards will be automatically claimed
@@ -478,9 +478,9 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(2, 0),
-            reward:                    88.547005943261232824 * 1e18,
+            reward:                    88.547005943261175327 * 1e18,
             indexes:                   depositIndexes,
-            updateExchangeRatesReward: 3.568868241489518460 * 1e18
+            updateExchangeRatesReward: 3.568868241489513235 * 1e18
         });
     }
 
@@ -515,7 +515,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // first reserve auction happens successfully Staker should receive rewards epoch 0 - 1
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower: _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex: 2555,
             pool: address(_pool)
@@ -526,7 +526,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687652965 * 1e18
         });
 
         skip(2 weeks);
@@ -543,7 +543,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - (2 weeks + 26 weeks + 24 hours),
-            burned:           98.578910573753041506 * 1e18,
+            burned:           98.578910573753041447 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -2259,7 +2259,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2270,7 +2270,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687652965 * 1e18
         });
 
         // _minterOne unstakes staked position
@@ -2279,7 +2279,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    49.289455286876529748 * 1e18,
+            reward:                    49.289455286876529719 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 0
         });
@@ -2373,7 +2373,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573753041447 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2384,7 +2384,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687652965 * 1e18
         });
 
         // check owner can withdraw the NFT and rewards will be automatically claimed
@@ -2398,7 +2398,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         IERC20Token(address(_ajnaToken)).burn(99_999_990.910045863027949943 * 1e18);
 
         uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
-        assertEq(managerBalance, 4.161008608284397087 * 1e18);
+        assertEq(managerBalance, 4.161008608284397092 * 1e18);
 
         // check reward generated are more than manager token balance
         uint256 rewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -2416,13 +2416,13 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                       address(_pool),
             tokenId:                    tokenIdOne,
             claimedArray:               _epochsClaimedArray(1, 0),
-            reward:                     49.289455286876529748 * 1e18,
+            reward:                     49.289455286876529719 * 1e18,
             indexes:                    depositIndexes,
             updateExchangeRatesReward:  0
         });
 
         assertEq(PositionManager(address(_positionManager)).ownerOf(tokenIdOne), _minterOne);
-        assertEq(_ajnaToken.balanceOf(_minterOne), 49.289455286876529748 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterOne), 49.289455286876529719 * 1e18);
         assertLt(_ajnaToken.balanceOf(_minterOne), tokensToBurn);
 
         // check can't claim rewards twice
@@ -2531,7 +2531,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041506 * 1e18,
+            tokensToBurn: 98.578910573752981902 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -2560,9 +2560,9 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _minterOne,
             pool:    address(_pool),
             indexes: firstIndexes,
-            reward:  4.928945528687652970 * 1e18
+            reward:  4.928945528687649225 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_minterOne), 4.928945528687652970 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterOne), 4.928945528687649225 * 1e18);
 
         // check owner in pool with accrued interest can properly claim rewards
         _claimRewards({
@@ -2570,7 +2570,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             49.289455286876529748 * 1e18,
+            reward:             49.289455286876492297 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1, 0)
         });
         assertLt(_ajnaToken.balanceOf(_minterOne), tokensToBurn);
@@ -2617,7 +2617,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 452.070347736384691477 * 1e18,
+            tokensToBurn: 452.070347736384453118 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6000,
             pool:         address(_pool)
@@ -2628,12 +2628,12 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         22.603517386819228170 * 1e18
+            reward:         22.603517386819223250 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 22.603517386819228170 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 22.603517386819223250 * 1e18);
 
         uint256 rewardsEarnedFirstEpoch = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
-        assertEq(rewardsEarnedFirstEpoch, 226.035173868192281719 * 1e18);
+        assertEq(rewardsEarnedFirstEpoch, 226.035173868192232711 * 1e18);
 
         uint256 snapshot = vm.snapshot();
 
@@ -2677,7 +2677,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger second reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 806.644134981218053878 * 1e18,
+            tokensToBurn: 806.210861585628610910 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -2688,10 +2688,10 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         17.728689362241666350 * 1e18
+            reward:         17.707025692462202068 * 1e18
         });
 
-        uint256 totalRewardEarned = 403.322067490608945398 * 1e18;
+        uint256 totalRewardEarned = 403.105430792814253516 * 1e18;
 
         // claim rewards for second epoch
         _claimRewards({
@@ -2700,7 +2700,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
             epochsClaimed:      _epochsClaimedArray(1, 1),
-            reward:             177.286893622416663679 * 1e18
+            reward:             177.070256924622020805 * 1e18
         });
 
         // ensure total rewards earned are same with and without unstake between epochs
@@ -2716,7 +2716,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger second reserve auction
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 806.644134981218053878 * 1e18,
+            tokensToBurn: 806.210861585628610910 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6_000,
             pool:         address(_pool)
@@ -2727,7 +2727,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         17.728689362241666350 * 1e18
+            reward:         17.707025692462202068 * 1e18
         });
 
         // check available rewards

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -1524,7 +1524,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         (uint256 interestRate, ) = _pool.interestRateInfo();
         uint256 newInterestRate = Maths.wmul(interestRate, 1.1 * 10**18); // interest rate multipled by increase coefficient
         uint256 expectedDebt = Maths.wmul(borrowAmount, _borrowFeeRate(newInterestRate) + Maths.WAD);
-        requiredCollateral_ = Maths.wdiv(expectedDebt, _poolUtils.indexToPrice(indexPrice));
+        requiredCollateral_ = Maths.wdiv(Maths.wmul(expectedDebt, COLLATERALIZATION_FACTOR), _poolUtils.indexToPrice(indexPrice));
     }
 
     // calculate the fee that will be charged a borrower


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
* Add `1.04` collateralization factor in `HTP` calculations.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->
* Incorrect `HTP` can lead to a situation where `TP > LUP` but `LUP > HTP` but remove/moveQuoteToken is not reverted with `LUPBelowHTP` although the borrower is kickable.

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
