### PR TITLE
addQuoteToken - return amount added

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -153,7 +153,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 amount_,
         uint256 index_,
         uint256 expiry_
-    ) external override nonReentrant returns (uint256 bucketLP_) {
+    ) external override nonReentrant returns (uint256 bucketLP_, uint256 addedAmount_) {
         _revertAfterExpiry(expiry_);
 
         _revertIfAuctionClearable(auctions, loans);
@@ -164,7 +164,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         amount_ = _roundToScale(amount_, poolState.quoteTokenScale);
 
         uint256 newLup;
-        (bucketLP_, newLup) = LenderActions.addQuoteToken(
+        (bucketLP_, addedAmount_, newLup) = LenderActions.addQuoteToken(
             buckets,
             deposits,
             poolState,

--- a/src/interfaces/pool/commons/IPoolLenderActions.sol
+++ b/src/interfaces/pool/commons/IPoolLenderActions.sol
@@ -17,12 +17,13 @@ interface IPoolLenderActions {
      *  @param  index_            The index of the bucket to which the quote tokens will be added.
      *  @param  expiry_           Timestamp after which this transaction will revert, preventing inclusion in a block with unfavorable price.
      *  @return bucketLP_         The amount of `LP` changed for the added quote tokens (`WAD` precision).
+     *  @return addedAmount_      The amount of quote token added (`WAD` precision).
      */
     function addQuoteToken(
         uint256 amount_,
         uint256 index_,
         uint256 expiry_
-    ) external returns (uint256 bucketLP_);
+    ) external returns (uint256 bucketLP_, uint256 addedAmount_);
 
     /**
      *  @notice Called by lenders to move an amount of credit from a specified price bucket to another specified price bucket.

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -163,7 +163,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectEmit(true, true, false, true);
         emit AddQuoteToken(from, index, amountAdded, lpAward, newLup);
         _assertQuoteTokenTransferEvent(from, address(_pool), amount);
-        _pool.addQuoteToken(amount, index, type(uint256).max);
+        (uint256 returnLpAward, uint256 returnedAmountAdded) = _pool.addQuoteToken(amount, index, type(uint256).max);
+        assertEq(returnLpAward, lpAward);
+        assertEq(returnedAmountAdded, amountAdded);
 
         // Add for tearDown
         lenders.add(from);


### PR DESCRIPTION
## Description

`moveQuoteToken` and `removeQuoteToken` return the amount moved/removed.  `addQuoteToken` did not.  Adding an `amountAdded_` return value illuminates the amount of liquidity added, which will change due to token precision and the deposit fee.

## Purpose

Help integrators understand how much liquidity was added with respect to deposit fee.

## Impact

`ERC721Pool` contract size increased by 12 bytes (98.04% to 98.09%).
No noticable change in gas consumption was observed.


## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
