### PR TITLE
settle event now emits actual debt settled rather than t0 amount

### DIFF
--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -170,7 +170,7 @@ library SettlerActions {
 
         emit Settle(
             params_.borrower,
-            result_.t0DebtSettled
+            Maths.wmul(result_.t0DebtSettled, poolState_.inflator)
         );
 
         // if entire debt was settled then settle auction

--- a/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
@@ -228,7 +228,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
             from:        _attacker,
             borrower:    _attacker,
             maxDepth:    10,
-            settledDebt: 44.575544496415995711 * 1e18
+            settledDebt: 44.577579955878023186 * 1e18
         });
 
         _assertBucket({
@@ -413,7 +413,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
             from:        _attacker,
             borrower:    _attacker,
             maxDepth:    10,
-            settledDebt: 479_190.719215249478234659 * 1e18
+            settledDebt: 479_213.056441751898404364 * 1e18
         });
 
         _assertBucket({
@@ -439,7 +439,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
             from:        _attacker,
             borrower:    _attacker,
             maxDepth:    10,
-            settledDebt: 2_609.098270477324397207 * 1e18
+            settledDebt: 2_609.458188040721145058 * 1e18
         });
 
         _removeAllCollateral({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -904,7 +904,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             from:        _lender1,
             borrower:    _borrower2,
             maxDepth:    1,
-            settledDebt: 20_019.230769230769240000 * 1e18
+            settledDebt: 20_028.374057845207515293 * 1e18
         });
 
         _assertAuction(
@@ -967,7 +967,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             from:        _lender1,
             borrower:    _borrower4,
             maxDepth:    5,
-            settledDebt: 20_019.230769230769240000 * 1e18
+            settledDebt: 20_028.374057845207515293 * 1e18
         });
 
         _assertAuction(
@@ -1030,7 +1030,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             from:        _lender1,
             borrower:    _borrower1,
             maxDepth:    5,
-            settledDebt: 20_019.230769230769240000 * 1e18
+            settledDebt: 20_028.374057845207515293 * 1e18
         });
 
         _assertAuction(
@@ -1093,7 +1093,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             from:        _lender1,
             borrower:    _borrower5,
             maxDepth:    5,
-            settledDebt: 20_019.230769230769240000 * 1e18
+            settledDebt: 20_028.374057845207515293 * 1e18
         });
 
         _assertAuction(
@@ -1152,13 +1152,11 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-
-
         _settle({
             from:        _lender1,
             borrower:    _borrower3,
             maxDepth:    5,
-            settledDebt: 20_019.230769230769240000 * 1e18
+            settledDebt: 20_028.374057845207515293 * 1e18
         });
 
         _assertAuction(

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -535,7 +535,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 5_792.406276780653057707 * 1e18
+            settledDebt: 5_874.378809732129803518 * 1e18
         });
 
         _assertPool(

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -1159,7 +1159,7 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
             from:        actor6,
             borrower:    actor2,
             maxDepth:    2,
-            settledDebt: 56_458_180_321.630022869105202974 * 1e18
+            settledDebt: 59_474_936_428.593370593619524963 * 1e18
         });
 
         // almost all the reserves are used to settle debt

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -339,7 +339,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 7_246.629636396779610400 * 1e18
+            settledDebt: 7_349.714603676187901799 * 1e18
         });
 
         _assertAuction(
@@ -541,7 +541,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 9_288.923076923076927360 * 1e18
+            settledDebt: 9_420.576190285556153618 * 1e18
         });
 
         _assertAuction(
@@ -607,7 +607,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
         });
     }
 
-    function testSettleAuctionReverts() external {
+    function testSettleAuctionReverts() external tearDown {
         // Borrower2 borrows
         _borrow({
             from:       _borrower2,
@@ -774,7 +774,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 8_215.588590626259842303 * 1e18
+            settledDebt: 8_329.440105291957701961 * 1e18
         });
 
         // bucket is insolvent, balances are resetted
@@ -1029,7 +1029,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 6_736.056276265205281160 * 1e18
+            settledDebt: 6_829.316746462954060003 * 1e18
         });
 
         // bucket is insolvent, balances are resetted

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -1442,7 +1442,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 7_048.179573549045611871 * 1e18
+            settledDebt: 7_145.761380189146974213 * 1e18
         });
 
         _assertAuction(
@@ -1555,7 +1555,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    0,
-            settledDebt: 4.66826923076923301 * 1e18
+            settledDebt: 4.732901259602669216 * 1e18
         });
         _assertReserveAuction({
             reserves:                   28.161924497603952459 * 1e18,
@@ -1570,7 +1570,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    1,
-            settledDebt: 1_985.159817442235291165 * 1e18
+            settledDebt: 2_012.644287642503398926 * 1e18
         });
 
         _assertAuction(
@@ -1607,7 +1607,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    5,
-            settledDebt: 5_058.351486876041087696 * 1e18
+            settledDebt: 5_128.384191287040906071 * 1e18
         });
 
         _assertAuction(

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -621,7 +621,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         });
     }
 
-    function testMergeOrRemoveERC721Collateral() external {
+    function testMergeOrRemoveERC721Collateral() external tearDown {
         for (uint256 i = 3060; i < (3060 + 10); i++) {
             _addInitialLiquidity({
                 from:   _lender,
@@ -970,14 +970,14 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    11,
-            settledDebt: 102.277919151483596286 * 1e18
+            settledDebt: 402.720322053719854868 * 1e18
         });
 
         _settle({
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    11,
-            settledDebt: 4.062578203586746574 * 1e18
+            settledDebt: 15.996442009087794242 * 1e18
         });
 
         _assertBorrower({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -305,7 +305,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    5,
-            settledDebt: 6.158815317027324956 * 1e18
+            settledDebt: 7.065836620069259061 * 1e18
         });
         _assertBorrower({
             borrower:                  _borrower,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -209,7 +209,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    1,
-            settledDebt: 5_004.807692307692310000 * 1e18
+            settledDebt: 5_007.093514461301878823 * 1e18
         });
 
         _assertAuction(
@@ -242,7 +242,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    5,
-            settledDebt: 5_004.807692307692310000 * 1e18
+            settledDebt: 5_007.093514461301878823 * 1e18
         });
 
         _assertPool(

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -160,7 +160,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    1,
-            settledDebt: 2485.445445980762364312 * 1e18
+            settledDebt: 5_000.732078876477988054 * 1e18
         });
 
         // collateral in bucket used to settle auction increased with the amount used to settle debt
@@ -199,7 +199,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    1,
-            settledDebt: 1_369.922338567221579743 * 1e18
+            settledDebt: 2_756.292476715102616970 * 1e18
         });
 
         // no token id left in borrower token ids array
@@ -228,7 +228,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    5,
-            settledDebt: 1_149.439907759708365945 * 1e18
+            settledDebt: 2_312.680420634460396297 * 1e18
         });
 
         _assertBorrower({
@@ -245,7 +245,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    1,
-            settledDebt: 5_004.807692307692310000 * 1e18
+            settledDebt: 10_069.704976226041001321 * 1e18
         });
 
         _assertBucket({
@@ -421,7 +421,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    2,
-            settledDebt: 1_860.895155634793071933 * 1e18
+            settledDebt: 3_744.885235439616158161 * 1e18
         });
         _assertBucket({
             index:        2500,
@@ -456,7 +456,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower2,
             maxDepth:    2,
-            settledDebt: 5_004.80769230769231 * 1e18
+            settledDebt: 10_071.72831655001594162 * 1e18
         });
 
         _assertBucket({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -625,7 +625,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    10,
-            settledDebt: 13.791494531146433229 * 1e18
+            settledDebt: 15.817069975787312943 * 1e18
         });
 
         _assertAuction(
@@ -798,7 +798,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             from:        _lender,
             borrower:    _borrower,
             maxDepth:    10,
-            settledDebt: 19.018269230759725285 * 1e18
+            settledDebt: 21.818209514195374228 * 1e18
         });
     }
 

--- a/tests/forge/unit/Positions/CodearenaReports.t.sol
+++ b/tests/forge/unit/Positions/CodearenaReports.t.sol
@@ -163,7 +163,7 @@ contract PositionManagerCodeArenaTest is PositionManagerERC20PoolHelperContract 
             from:        testMinter,
             borrower:    testBorrowerTwo,
             maxDepth:    10,
-            settledDebt: 5_678.605678397318135315 * 1e18
+            settledDebt: 5_757.196206294532254049 * 1e18
         });
 
         // bucket is insolvent, balances are reset

--- a/tests/forge/unit/Positions/PositionManager.t.sol
+++ b/tests/forge/unit/Positions/PositionManager.t.sol
@@ -943,7 +943,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             from:        testMinter,
             borrower:    testBorrowerTwo,
             maxDepth:    10,
-            settledDebt: 6_736.056276265205281160 * 1e18
+            settledDebt: 6_829.316746462954060003 * 1e18
         });
 
         // bucket is insolvent, balances are reset
@@ -2882,7 +2882,7 @@ contract PositionManagerERC20PoolTest is PositionManagerERC20PoolHelperContract 
             from:        testMinter,
             borrower:    testBorrowerTwo,
             maxDepth:    10,
-            settledDebt: 6_736.056276265205281160 * 1e18
+            settledDebt: 6_829.316746462954060003 * 1e18
         });
 
         // bucket is insolvent, balances are reset

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -560,7 +560,7 @@ contract RewardsManagerTest is RewardsHelperContract {
     // two lenders stake their positions in the pool
     // staker one bucket bankrupt, staker two bucket active
     // interest accrued to both buckets, but staker one receives no rewards
-    function testClaimRewardsBankruptBucket() external {
+    function testClaimRewardsBankruptBucket() external tearDown {
 
         address[] memory transferors = new address[](1);
         transferors[0] = address(_positionManager);
@@ -710,7 +710,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:        _minterTwo,
             borrower:    _borrower2,
             maxDepth:    10,
-            settledDebt: 5_678.605678397318135315 * 1e18
+            settledDebt: 5_757.196206294532254049 * 1e18
         });
 
         // bucket is insolvent, balances are reset
@@ -787,7 +787,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         });
     }
     
-    function testNoRewardsToClaimPostBankrupt() external {
+    function testNoRewardsToClaimPostBankrupt() external tearDown {
         skip(10);
         
         /***************************/
@@ -1122,7 +1122,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:        _minterTwo,
             borrower:    _borrower,
             maxDepth:    10,
-            settledDebt: 24_911.288118205001229953 * 1e18
+            settledDebt: 25_665.876911373608528229 * 1e18
         });
 
         // bucket is insolvent, balances are reset


### PR DESCRIPTION
## Description

Emit settled debt in actual amount rather than t0 amount.
Also added some `tearDown` modifiers where missing from affected unit tests.

## Purpose

All other auction events emit amounts in actual terms.  This was brought to our attention by BlockAnalytica.

## Impact

No change in pool contract sizes.  Tiny gas cost for the multiplication.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
