### PR TITLE
tweaks to Matt's PR to block adding quote token above auction price

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -159,7 +159,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         _revertIfAuctionClearable(auctions, loans);
 
-        _revertIfAuctionPriceBelow(_priceAt(index_), auctions);
+        _revertIfAuctionPriceBelow(index_, auctions);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -195,7 +195,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         _revertIfAuctionClearable(auctions, loans);
 
-        _revertIfAuctionPriceBelow(_priceAt(toIndex_), auctions);
+        _revertIfAuctionPriceBelow(toIndex_, auctions);
 
         PoolState memory poolState = _accruePoolInterest();
 

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -410,7 +410,6 @@ library KickerActions {
         // record liquidation info
         liquidation_.kicker         = msg.sender;
         liquidation_.kickTime       = uint96(block.timestamp);
-        liquidation_.referencePrice = SafeCast.toUint96(referencePrice_);
         liquidation_.bondSize       = SafeCast.toUint160(bondSize_);
         liquidation_.bondFactor     = SafeCast.toUint96(bondFactor_);
         liquidation_.neutralPrice   = SafeCast.toUint96(neutralPrice_);
@@ -425,10 +424,11 @@ library KickerActions {
             address tail = auctions_.tail;
             auctions_.liquidations[tail].next = borrowerAddress_;
             liquidation_.prev = tail;
-            liquidation_.referencePrice = SafeCast.toUint96(Maths.max(liquidation_.referencePrice, auctions_.liquidations[tail].referencePrice));
+            liquidation_.referencePrice = SafeCast.toUint96(Maths.max(referencePrice_, auctions_.liquidations[tail].referencePrice));
         } else {
             // first auction in queue
             auctions_.head = borrowerAddress_;
+            liquidation_.referencePrice = SafeCast.toUint96(referencePrice_);
         }
         // update liquidation with the new ordering
         auctions_.tail = borrowerAddress_;

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -80,17 +80,17 @@ import { Maths }    from '../internal/Maths.sol';
      *  @notice  Check if provided price is above current auction price.
      *  @notice  Prevents manipulative deposir and arb takes.
      *  @dev     Reverts with `AddAboveAuctionPrice` if price is above head of auction queue.
-     *  @param price_    Price to be compared with current auction price.
+     *  @param index_    Identifies bucket price to be compared with current auction price.
      *  @param auctions_ Auctions data.
      */
     function _revertIfAuctionPriceBelow(
-        uint256 price_,
+        uint256 index_,
         AuctionsState storage auctions_
     ) view {
         address head = auctions_.head;
         if (head != address(0)) {
             uint256 auctionPrice = _auctionPrice(auctions_.liquidations[head].referencePrice, auctions_.liquidations[head].kickTime);
-            if (price_ >= auctionPrice) revert AddAboveAuctionPrice();
+            if (_priceAt(index_) >= auctionPrice) revert AddAboveAuctionPrice();
         }
     }
 


### PR DESCRIPTION
## Description

Code optimization

## Purpose

- Prevent double `SafeCast` and double assignment to struct, reducing gas cost.
- Move `_priceAt` calls into the reverts helper, for tiny reduction in contract size.

## Impact

Reduction in gas cost.

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
