### PR TITLE
Update assertAuction to use ThresholdPrice from auctionInfo

### DIFF
--- a/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
@@ -178,7 +178,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
                 totalBondEscrowed: 1.104560604152777078 * 1e18,
                 auctionPrice:      52.807937446000777584 * 1e18,
                 debtInAuction:     98.794903846153846199 * 1e18,
-                thresholdPrice:    94.999437626898539235 * 1e18,
+                thresholdPrice:    94.995099852071005961 * 1e18,
                 neutralPrice:      105.615874892001555166 * 1e18
             })
         );
@@ -363,7 +363,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
                 totalBondEscrowed: 11_179.675302295250711919 * 1e18,
                 auctionPrice:      50.449052405478872444 * 1e18,
                 debtInAuction:     999_940.55769230769276876 * 1e18,
-                thresholdPrice:    96.152612442506987001 * 1e18,
+                thresholdPrice:    96.148130547337278151 * 1e18,
                 neutralPrice:      106.897818338005788835 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -150,7 +150,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -261,7 +261,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      8.799359199504876220 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.412284572883088612 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -333,7 +333,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      8.799359199504876220 * 1e18,
                 debtInAuction:     1.446226944275346019 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -369,7 +369,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      14.798699214786891216 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.412212046997139091 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      14.798699214786891216 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.412212046997139091 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -493,7 +493,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.042759438341664008 * 1e18,
                 auctionPrice:      14.798699214786891216 * 1e18,
                 debtInAuction:     4.076551853619286508 * 1e18,
-                thresholdPrice:    4.132604091910177040 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -567,7 +567,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      29.597398429573782432 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.412115346685186095 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );
@@ -670,7 +670,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      35.197436798019505000 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.412091171762431245 * 1e18,
+                thresholdPrice:    9.411970298080049512 * 1e18,
                 neutralPrice:      10.464260567515846957 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -151,7 +151,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -261,7 +261,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      8.982038363413219840 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607688378689587891 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );
@@ -326,7 +326,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      8.982038363413219840 * 1e18,
                 debtInAuction:     0.181853204762687052 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         ); 
@@ -369,7 +369,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      15.105927722931035016 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607614347129428849 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );
@@ -461,7 +461,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      15.105927722931035016 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607614347129428849 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );
@@ -500,7 +500,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.047128646698885501 * 1e18,
                 auctionPrice:      15.105927722931035016 * 1e18,
                 debtInAuction:     4.467355778582383914 * 1e18,
-                thresholdPrice:    2.244862519948070314 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );
@@ -574,7 +574,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      30.211855445862070036 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607515639269910541 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );
@@ -671,7 +671,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      35.928153453652879488 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607490962463487100 * 1e18,
+                thresholdPrice:    9.607367579382098527 * 1e18,
                 neutralPrice:      10.681503928998397483 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -149,7 +149,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.462708682436276194 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -286,7 +286,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.462708682436276194 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -353,7 +353,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.462708682436276194 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -895,7 +895,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     100_096.153846153846200000 * 1e18,
-                thresholdPrice:    20.028374057845207515 * 1e18,
+                thresholdPrice:    20.019230769230769240 * 1e18,
                 neutralPrice:      22.257448812093539488 * 1e18
             })
         );
@@ -958,7 +958,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     80_113.496231380830061171 * 1e18,
-                thresholdPrice:    20.028374057845207515 * 1e18,
+                thresholdPrice:    20.019230769230769240 * 1e18,
                 neutralPrice:      22.257448812093539488 * 1e18
             })
         );
@@ -1021,7 +1021,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     60_085.122173535622545879 * 1e18,
-                thresholdPrice:    20.028374057845207515 * 1e18,
+                thresholdPrice:    20.019230769230769240 * 1e18,
                 neutralPrice:      22.257448812093539488 * 1e18
             })
         );
@@ -1084,7 +1084,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     40_056.748115690415030586 * 1e18,
-                thresholdPrice:    20.028374057845207515 * 1e18,
+                thresholdPrice:    20.019230769230769240 * 1e18,
                 neutralPrice:      22.257448812093539488 * 1e18
             })
         );
@@ -1147,7 +1147,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     20_028.374057845207515293 * 1e18,
-                thresholdPrice:    20.028374057845207515 * 1e18,
+                thresholdPrice:    20.019230769230769240 * 1e18,
                 neutralPrice:      22.257448812093539488 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -185,7 +185,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.354500183821244069 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -277,7 +277,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0.209172983065585793 * 1e18,
                 auctionPrice:      29.416674753697119864 * 1e18,
                 debtInAuction:     18.709000367642488138 * 1e18,
-                thresholdPrice:    9.354629930357136532 * 1e18,
+                thresholdPrice:    9.354500183821244069 * 1e18,
                 neutralPrice:      10.400365099149173069 * 1e18
             })
         );
@@ -478,7 +478,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 90.564949726435836850 * 1e18,
                 auctionPrice:      2.251506213987704828 * 1e18,
                 debtInAuction:     8_100.375358686460903420 * 1e18,
-                thresholdPrice:    8.100712418988636152 * 1e18,
+                thresholdPrice:    8.100375358686460903 * 1e18,
                 neutralPrice:      9.006024855950819304 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -154,7 +154,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -242,7 +242,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2.617475419583478700 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417527901208315548 * 1e18,
+                thresholdPrice:    9.417044136515672180 * 1e18,
                 neutralPrice:      10.469901678333914800 * 1e18
             })
         );
@@ -277,7 +277,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 128.697166052318027786 * 1e18,
                 auctionPrice:      2.617475419583478700 * 1e18,
                 debtInAuction:     7_346.958977412026357603 * 1e18,
-                thresholdPrice:    36.734794887060131788 * 1e18,
+                thresholdPrice:    9.417044136515672180 * 1e18,
                 neutralPrice:      10.469901678333914800 * 1e18
             })
         );
@@ -436,7 +436,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -525,7 +525,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.420576190285556153 * 1e18,
+                thresholdPrice:    9.417044136515672180 * 1e18,
                 neutralPrice:      10.469901678333914800 * 1e18
             })
         );
@@ -697,7 +697,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      1.100512848671229788 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417648846264483444 * 1e18,
+                thresholdPrice:    9.417044136515672180 * 1e18,
                 neutralPrice:      10.469901678333914800 * 1e18
             })
         );
@@ -975,7 +975,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2.617475419583478700 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417527901208315548 * 1e18,
+                thresholdPrice:    9.417044136515672180 * 1e18,
                 neutralPrice:      10.469901678333914800 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -220,7 +220,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.445145395543736188 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -292,7 +292,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      0.910478544213022852 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445778866890769300 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -328,7 +328,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 120.410571209345555877 * 1e18,
                 auctionPrice:      0.910478544213022852 * 1e18,
                 debtInAuction:     8_887.298973552816214298 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -447,7 +447,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.445145395543736188 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -519,7 +519,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      1.338161720906753532 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445724952781695045 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -555,7 +555,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.973544270027428771 * 1e18,
                 auctionPrice:      1.338161720906753532 * 1e18,
                 debtInAuction:     9_810.321944712537091675 * 1e18,
-                thresholdPrice:    9.524584412342269021 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -654,7 +654,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.445145395543736188 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -726,7 +726,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      10.104451796622513460 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445441908757677743 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -762,7 +762,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 134.310867307749930784 * 1e18,
                 auctionPrice:      10.104451796622513460 * 1e18,
                 debtInAuction:     4_068.349646880456528628 * 1e18,
-                thresholdPrice:    8.786932282679171768 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -832,7 +832,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      2_688.293056930299609088 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736188 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -887,7 +887,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      168.018316058143725568 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445210088541969099 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -940,7 +940,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 91.038914432832955568 * 1e18,
                 auctionPrice:      168.018316058143725568 * 1e18,
                 debtInAuction:     8_171.012859715039647158 * 1e18,
-                thresholdPrice:    7.933022193898096744 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -1040,7 +1040,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    9.445145395543736188 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -1112,7 +1112,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      10.104451796622513460 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445441908757677743 * 1e18,
+                thresholdPrice:    9.445145395543736189 * 1e18,
                 neutralPrice:      10.501144753633982848 * 1e18
             })
         );
@@ -1203,7 +1203,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_696.624543676984421888 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636197 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1243,7 +1243,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      4.692225291538286796 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474823131988554412 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1277,7 +1277,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 164.723397202494316334 * 1e18,
                 auctionPrice:      4.692225291538286796 * 1e18,
                 debtInAuction:     5_028.460854599919885110 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1311,7 +1311,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2.633422405934555100 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474904252396877483 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1347,7 +1347,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.753147822166823996 * 1e18,
                 auctionPrice:      2.633422405934555100 * 1e18,
                 debtInAuction:     9_801.820825525375552153 * 1e18,
-                thresholdPrice:    9.609628260318995639 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1395,7 +1395,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 140.784556539184447790 * 1e18,
                 auctionPrice:      2.633422405934555100 * 1e18,
                 debtInAuction:     7_145.761380189146974214 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1585,7 +1585,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 140.784556539184447790 * 1e18,
                 auctionPrice:      2.633422405934555100 * 1e18,
                 debtInAuction:     5_128.384191287040906072 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398  * 1e18
             })
         );
@@ -1687,7 +1687,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_696.624543676984421888 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636197 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1726,7 +1726,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.759881630669866664 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -1759,7 +1759,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.382534258638046113 * 1e18,
                 auctionPrice:      2_777.873809816661136640 * 1e18,
                 debtInAuction:     9_995.146145767066608231 * 1e18,
-                thresholdPrice:    9.759881630669866664 * 1e18,
+                thresholdPrice:    9.759881630669866665 * 1e18,
                 neutralPrice:      10.851069569596332565 * 1e18
             })
         );
@@ -1824,7 +1824,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_696.624543676984421888 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636197 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1855,7 +1855,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      10.533689623738220400 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474709564583696187 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );
@@ -1874,7 +1874,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      7.448443363859667932 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474758236161951413 * 1e18,
+                thresholdPrice:    9.474417540364636198 * 1e18,
                 neutralPrice:      10.533689623738220398 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -2053,7 +2053,7 @@ contract ERC20PoolLiquidationsLowPriceCollateralTest is ERC20HelperContract {
                 totalBondEscrowed: 8.509085736677607076 * 1e18,
                 auctionPrice:      0 * 1e18,
                 debtInAuction:     761.075765343400230098 * 1e18,
-                thresholdPrice:    0.000015553963016310 * 1e18,
+                thresholdPrice:    0.000015548291115577 * 1e18,
                 neutralPrice:      0.000017286642908996 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -711,7 +711,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605224811402125309 * 1e18,
                 auctionPrice:      0.000078301610411710 * 1e18,
                 debtInAuction:     590.789267398535232527 * 1e18,
-                thresholdPrice:    295.453988355164748340 * 1e18,
+                thresholdPrice:    295.394633699267616263 * 1e18,
                 neutralPrice:      328.420757756278243989 * 1e18
             })
         );
@@ -873,7 +873,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605224811402125309 * 1e18,
                 auctionPrice:      0.000078301610411710 * 1e18,
                 debtInAuction:     418.513981107458710209 * 1e18,
-                thresholdPrice:    332.306488529853590250 * 1e18,
+                thresholdPrice:    295.394633699267616263 * 1e18,
                 neutralPrice:      328.420757756278243989 * 1e18
             })
         );
@@ -961,7 +961,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605225686840743450 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     418.513903681286916644 * 1e18,
-                thresholdPrice:    1_614.039492321819633172 * 1e18,
+                thresholdPrice:    295.394633699267616263 * 1e18,
                 neutralPrice:      328.420757756278243989 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -213,7 +213,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      12.124431596439710012 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905529981921075309 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -255,7 +255,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.076149339066797765 * 1e18,
                 auctionPrice:      12.124431596439710012 * 1e18,
                 debtInAuction:     7.063223505145093670 * 1e18,
-                thresholdPrice:    3.549295445970051290 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -152,7 +152,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -275,7 +275,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -192,7 +192,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 totalBondEscrowed: 111.910902143138508398 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     10_009.615384615384620000 * 1e18,
-                thresholdPrice:    1_669.031171487100626274 * 1e18,
+                thresholdPrice:    1_668.269230769230770000 * 1e18,
                 neutralPrice:      1_854.787401007794957336 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -261,7 +261,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      14.418460319849903168 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905501971177984869 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -329,7 +329,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.082644260707135316 * 1e18,
                 auctionPrice:      14.418460319849903168 * 1e18,
                 debtInAuction:     7.634348553051574639 * 1e18,
-                thresholdPrice:    7.634348553051574639 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -538,7 +538,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3.031107899109927504 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905754070455852115 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -609,7 +609,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.311625180832937747 * 1e18,
                 auctionPrice:      3.031107899109927504 * 1e18,
                 debtInAuction:     15.817069975787312944 * 1e18,
-                thresholdPrice:    0,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -747,7 +747,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737597315 * 1e18,
                 auctionPrice:      0.000000000011027106 * 1e18,
                 debtInAuction:     21.815990418134247758 * 1e18,
-                thresholdPrice:    21.815990418134247758 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );
@@ -780,7 +780,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737597315 * 1e18,
                 auctionPrice:      0.000000000011027106 * 1e18,
                 debtInAuction:     21.815990418134247758 * 1e18,
-                thresholdPrice:    21.815990418134247758 * 1e18,
+                thresholdPrice:    10.905193857752339830 * 1e18,
                 neutralPrice:      12.124431596439710011 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -156,7 +156,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -436,7 +436,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );
@@ -677,7 +677,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                thresholdPrice:    0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -470,8 +470,6 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         (, uint256 lockedBonds) = _pool.kickerInfo(state_.kicker);
         (vars.auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
         (,, vars.auctionDebtInAuction,)  = _pool.debtInfo();
-        // FIXME: replacing this with vars.borrowerThresholdPrice from auctionInfo broke many tests
-        vars.borrowerThresholdPrice = borrowerCollateral > 0 ? borrowerDebt * Maths.WAD / borrowerCollateral : 0;
 
         assertEq(vars.auctionKickTime != 0,     state_.active);
         assertEq(vars.auctionKicker,            state_.kicker);


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

[use auctionInfo thresholdprice instead of recalculating in _assertAuction](https://github.com/ajna-finance/contracts/pull/1003/commits/9d4d182e7b2374a31314913c94930729e0421874)

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
