### PR TITLE
Contract size mitigation

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -378,23 +378,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     function withdrawBonds(
         address recipient_,
         uint256 maxAmount_
-    ) external override nonReentrant {
-        uint256 claimable = auctions.kickers[msg.sender].claimable;
-
-        // the amount to claim is constrained by the claimable balance of sender
-        // claiming escrowed bonds is not constraiend by the pool balance
-        maxAmount_ = Maths.min(maxAmount_, claimable);
-
-        // revert if no amount to claim
-        if (maxAmount_ == 0) revert InsufficientLiquidity();
-
-        // decrement total bond escrowed
-        auctions.totalBondEscrowed             -= maxAmount_;
-        auctions.kickers[msg.sender].claimable -= maxAmount_;
-
-        emit BondWithdrawn(msg.sender, recipient_, maxAmount_);
-
-        _transferQuoteToken(recipient_, maxAmount_);
+    ) external override nonReentrant returns (uint256 withdrawnAmount_) {
+        withdrawnAmount_ = KickerActions.withdrawBonds(auctions, recipient_, maxAmount_);
+        _transferQuoteToken(recipient_, withdrawnAmount_);
     }
 
     /*********************************/

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -830,24 +830,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
     /// @inheritdoc IPoolState
     function debtInfo() external view returns (uint256, uint256, uint256, uint256) {
-        uint256 t0Debt   = poolBalances.t0Debt;
-        uint256 inflator = inflatorState.inflator;
-
-        return (
-            Maths.ceilWmul(
-                t0Debt,
-                PoolCommons.pendingInflator(
-                    inflator,
-                    inflatorState.inflatorUpdate,
-                    interestState.interestRate
-                )
-            ),
-            Maths.ceilWmul(t0Debt, inflator),
-            Maths.ceilWmul(poolBalances.t0DebtInAuction, inflator),
-            interestState.t0Debt2ToCollateral
-        );
+        return PoolCommons.debtInfo(poolBalances, inflatorState, interestState);
     }
-
 
     /// @inheritdoc IPoolDerivedState
     function depositUpToIndex(uint256 index_) external view override returns (uint256) {

--- a/src/interfaces/pool/commons/IPoolKickerActions.sol
+++ b/src/interfaces/pool/commons/IPoolKickerActions.sol
@@ -35,11 +35,12 @@ interface IPoolKickerActions {
      *  @notice Called by kickers to withdraw their auction bonds (the amount of quote tokens that are not locked in active auctions).
      *  @param  recipient_ Address to receive claimed bonds amount.
      *  @param  maxAmount_ The max amount to withdraw from auction bonds (`WAD` precision). Constrained by claimable amounts and liquidity.
+     *  @return withdrawnAmount_ The amount withdrawn (`WAD` precision).
      */
     function withdrawBonds(
         address recipient_,
         uint256 maxAmount_
-    ) external;
+    ) external returns (uint256 withdrawnAmount_);
 
     /***********************/
     /*** Reserve Auction ***/


### PR DESCRIPTION
## Description

Moved some things around to get `ERC721Pool` to fit within contract size boundaries.
- Moved `debtInfo` logic into `PoolCommons`, saving 10 bytes.
- Moved `withdrawBonds` into `KickerActions` library, saving 46 bytes (h/t @MikeHathaway)

Since a max amount is passed as a parameter, `withdrawBonds` now returns the actual amount withdrawn, consistent with other methods.

## Purpose

- We cannot deploy if max contract size is exceeded.
- Integrators want actual values returned when they call a method with _uint256.max_.

## Impact

Additional gas consumption:
- median ERC20Pool `debtInfo` cost went from 5784 to 7756
- median ERC20Pool `withdrawBonds` cost went from 10045 to 10784

Considered reverting the `debtInfo` change, but we're still quite close to the size limit.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
