### PR TITLE
RC9 suggested improvements

### DIFF
--- a/src/ERC20Pool.sol
+++ b/src/ERC20Pool.sol
@@ -221,12 +221,13 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
             limitIndex_
         );
 
-        emit RepayDebt(borrowerAddress_, result.quoteTokenToRepay, collateralAmountToPull_, result.newLup);
-
+        amountRepaid_        = result.quoteTokenToRepay;
         // update in memory pool state struct
         poolState.debt       = result.poolDebt;
         poolState.t0Debt     = result.t0PoolDebt;
         poolState.collateral = result.poolCollateral;
+
+        emit RepayDebt(borrowerAddress_, amountRepaid_, collateralAmountToPull_, result.newLup);
 
         // adjust t0Debt2ToCollateral ratio
         _updateT0Debt2ToCollateral(
@@ -239,12 +240,12 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
         // update pool interest rate state
         _updateInterestState(poolState, result.newLup);
 
-        if (result.quoteTokenToRepay != 0) {
+        if (amountRepaid_ != 0) {
             // update pool balances t0 debt state
             poolBalances.t0Debt = poolState.t0Debt;
 
             // move amount to repay from sender to pool
-            _transferQuoteTokenFrom(msg.sender, result.quoteTokenToRepay);
+            _transferQuoteTokenFrom(msg.sender, amountRepaid_);
         }
         if (collateralAmountToPull_ != 0) {
             // update pool balances pledged collateral state
@@ -253,8 +254,6 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
             // move collateral from pool to address specified as collateral receiver
             _transferCollateral(collateralReceiver_, collateralAmountToPull_);
         }
-
-        amountRepaid_ = result.quoteTokenToRepay;
     }
 
     /*********************************/
@@ -404,19 +403,19 @@ contract ERC20Pool is FlashloanablePool, IERC20Pool {
 
         _updatePostTakeState(result, poolState);
 
-        _transferCollateral(callee_, result.collateralAmount);
+        collateralTaken_ = result.collateralAmount;
+
+        _transferCollateral(callee_, collateralTaken_);
 
         if (data_.length != 0) {
             IERC20Taker(callee_).atomicSwapCallback(
-                result.collateralAmount / collateralTokenScale,
+                collateralTaken_ / collateralTokenScale,
                 result.quoteTokenAmount / poolState.quoteTokenScale,
                 data_
             );
         }
 
         _transferQuoteTokenFrom(msg.sender, result.quoteTokenAmount);
-
-        collateralTaken_ = result.collateralAmount;
     }
 
     /**

--- a/src/base/FlashloanablePool.sol
+++ b/src/base/FlashloanablePool.sol
@@ -24,16 +24,18 @@ abstract contract FlashloanablePool is Pool {
      *  @param  token_    Address of the `ERC20` token caller wants to borrow.
      *  @param  amount_   The denormalized amount (dependent upon token precision) of tokens to borrow.
      *  @param  data_     User-defined calldata passed to the receiver.
-     *  @return success_  `True` if flashloan was successful.
+     *  @return `True` if flashloan was successful.
      */
     function flashLoan(
         IERC3156FlashBorrower receiver_,
         address token_,
         uint256 amount_,
         bytes calldata data_
-    ) external virtual override nonReentrant returns (bool success_) {
+    ) external virtual override nonReentrant returns (bool) {
         if (!_isFlashloanSupported(token_)) revert FlashloanUnavailableForToken();
-        success_ = PoolCommons.flashLoan(receiver_, token_, amount_, data_);
+        PoolCommons.flashLoan(receiver_, token_, amount_, data_);
+        // if flashLoan call didn't revert then flashloan was successful
+        return true;
     }
 
     /**

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -363,7 +363,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         poolBalances.t0DebtInAuction = poolState.t0DebtInAuction;
 
         // update pool interest rate state
-        _updateInterestState(poolState, Deposits.getLup(deposits, poolState.debt));
+        _updateInterestState(poolState, result.lup);
 
         // transfer from kicker to pool the difference to cover bond
         if (result.amountToCoverBond != 0) _transferQuoteTokenFrom(msg.sender, result.amountToCoverBond);

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -545,10 +545,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             // Calculate prior pool debt
             poolState_.debt = Maths.wmul(poolState_.t0Debt, poolState_.inflator);
 
-	        // calculate elapsed time since inflator was last updated
+            // calculate elapsed time since inflator was last updated
             uint256 elapsed = block.timestamp - inflatorState.inflatorUpdate;
 
-	        // set isNewInterestAccrued field to true if elapsed time is not 0, indicating that new interest may have accrued
+            // set isNewInterestAccrued field to true if elapsed time is not 0, indicating that new interest may have accrued
             poolState_.isNewInterestAccrued = elapsed != 0;
 
             // if new interest may have accrued, call accrueInterest function and update inflator and debt fields of poolState_ struct

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -617,7 +617,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         PoolState memory poolState_
     ) internal {
         // update in memory pool state struct
-        poolState_.debt            -= Maths.wmul(result_.t0DebtSettled, poolState_.inflator);
+        poolState_.debt            -= result_.debtSettled;
         poolState_.t0Debt          -= result_.t0DebtSettled;
         poolState_.t0DebtInAuction -= result_.t0DebtSettled;
         poolState_.collateral      -= result_.collateralSettled;

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -52,6 +52,7 @@ import {
 import {
     COLLATERALIZATION_FACTOR,
     _determineInflatorState,
+    _htp,
     _priceAt,
     _roundToScale
 }                               from '../libraries/helpers/PoolHelper.sol';
@@ -918,7 +919,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            Maths.wmul(Maths.wmul(maxLoan.thresholdPrice, inflatorState.inflator), COLLATERALIZATION_FACTOR),
+            _htp(maxLoan.thresholdPrice, inflatorState.inflator),
             Loans.noOfLoans(loans)
         );
     }

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -34,6 +34,7 @@ struct SettleResult {
     uint256 collateralRemaining; // [WAD] The amount of borrower collateral left after settle
     uint256 collateralSettled;   // [WAD] The amount of borrower collateral settled
     uint256 t0DebtSettled;       // [WAD] The amount of t0 debt settled
+    uint256 debtSettled;         // [WAD] The amount of actual debt settled
 }
 
 /// @dev Struct used to return result of `TakerAction.take` and `TakerAction.bucketTake` actions.

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -120,7 +120,7 @@ library BorrowerActions {
         if (amountToBorrow_ > maxAvailable_) revert InsufficientLiquidity();
 
         // revert if borrower is in auction
-        if(_inAuction(auctions_, borrowerAddress_)) revert AuctionActive();
+        if (_inAuction(auctions_, borrowerAddress_)) revert AuctionActive();
 
         DrawDebtLocalVars memory vars;
         vars.pledge = collateralToPledge_ != 0;
@@ -239,7 +239,7 @@ library BorrowerActions {
         // revert if no amount to pull or repay
         if (!vars.repay && !vars.pull) revert InvalidAmount();
 
-        if(_inAuction(auctions_, borrowerAddress_)) revert AuctionActive();
+        if (_inAuction(auctions_, borrowerAddress_)) revert AuctionActive();
 
         Borrower memory borrower = loans_.borrowers[borrowerAddress_];
 

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -105,7 +105,7 @@ library KickerActions {
 
     /**
      *  @notice See `IPoolKickerActions` for descriptions.
-     *  @return The `KickResult` struct result of the kick action.
+     *  @return kickResult_ The `KickResult` struct result of the kick action.
      */
     function kick(
         AuctionsState storage auctions_,
@@ -115,17 +115,20 @@ library KickerActions {
         address borrowerAddress_,
         uint256 limitIndex_
     ) external returns (
-        KickResult memory
+        KickResult memory kickResult_
     ) {
-        return _kick(
+        uint256 curLup = Deposits.getLup(deposits_, poolState_.debt);
+
+        kickResult_ = _kick(
             auctions_,
-            deposits_,
             loans_,
             poolState_,
             borrowerAddress_,
             limitIndex_,
-            0
+            curLup // proposed LUP is the current pool LUP
         );
+        // return current LUP in pool
+        kickResult_.lup = curLup;
     }
 
     /**
@@ -151,7 +154,8 @@ library KickerActions {
         vars.bucketPrice = _priceAt(index_);
 
         // revert if the bucket price is below current LUP
-        if (vars.bucketPrice < Deposits.getLup(deposits_, poolState_.debt)) revert PriceBelowLUP();
+        uint256 curLup = Deposits.getLup(deposits_, poolState_.debt);
+        if (vars.bucketPrice < curLup) revert PriceBelowLUP();
 
         Bucket storage bucket = buckets_[index_];
         Lender storage lender = bucket.lenders[msg.sender];
@@ -175,16 +179,21 @@ library KickerActions {
         // revert if no entitled amount
         if (vars.entitledAmount == 0) revert InsufficientLiquidity();
 
+        // add amount to remove to pool debt in order to calculate proposed LUP
+        // this simulates LUP movement with additional debt
+        uint256 proposedLup =  Deposits.getLup(deposits_, poolState_.debt + vars.entitledAmount);
+
         // kick top borrower
         kickResult_ = _kick(
             auctions_,
-            deposits_,
             loans_,
             poolState_,
             Loans.getMax(loans_).borrower,
             limitIndex_,
-            vars.entitledAmount
+            proposedLup
         );
+        // return current LUP in pool
+        kickResult_.lup = curLup;
     }
 
     /*************************/
@@ -285,22 +294,20 @@ library KickerActions {
      *  @dev    === Emit events ===
      *  @dev    - `Kick`
      *  @param  auctions_        Struct for pool auctions state.
-     *  @param  deposits_        Struct for pool deposits state.
      *  @param  loans_           Struct for pool loans state.
      *  @param  poolState_       Current state of the pool.
      *  @param  borrowerAddress_ Address of the borrower to kick.
      *  @param  limitIndex_      Index of the lower bound of `NP` tolerated when kicking the auction.
-     *  @param  additionalDebt_  Additional debt to be used when calculating proposed `LUP`.
+     *  @param  proposedLup_     Proposed `LUP` in pool.
      *  @return kickResult_      The `KickResult` struct result of the kick action.
      */
     function _kick(
         AuctionsState storage auctions_,
-        DepositsState storage deposits_,
         LoansState    storage loans_,
         PoolState calldata poolState_,
         address borrowerAddress_,
         uint256 limitIndex_,
-        uint256 additionalDebt_
+        uint256 proposedLup_
     ) internal returns (
         KickResult memory kickResult_
     ) {
@@ -313,18 +320,13 @@ library KickerActions {
         kickResult_.t0KickedDebt        = borrower.t0Debt;
         kickResult_.collateralPreAction = borrower.collateral;
 
-        // add amount to remove to pool debt in order to calculate proposed LUP
-        // for regular kick this is the currrent LUP in pool
-        // for provisional kick this simulates LUP movement with additional debt
-        kickResult_.lup = Deposits.getLup(deposits_, poolState_.debt + additionalDebt_);
-
         KickLocalVars memory vars;
         vars.borrowerDebt       = Maths.wmul(kickResult_.t0KickedDebt, poolState_.inflator);
         vars.borrowerCollateral = kickResult_.collateralPreAction;
         vars.borrowerNpTpRatio  = borrower.npTpRatio;
 
         // revert if kick on a collateralized borrower
-        if (_isCollateralized(vars.borrowerDebt, vars.borrowerCollateral, kickResult_.lup, poolState_.poolType)) {
+        if (_isCollateralized(vars.borrowerDebt, vars.borrowerCollateral, proposedLup_, poolState_.poolType)) {
             revert BorrowerOk();
         }
 

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -29,6 +29,7 @@ import {
     COLLATERALIZATION_FACTOR,
     _bondParams,
     _claimableReserves,
+    _htp,
     _isCollateralized,
     _priceAt,
     _reserveAuctionPrice
@@ -341,7 +342,7 @@ library KickerActions {
         // which will make it harder for kicker to earn a reward and more likely that the kicker is penalized
         _revertIfPriceDroppedBelowLimit(vars.neutralPrice, limitIndex_);
 
-        vars.htp            = Maths.wmul(Maths.wmul(Loans.getMax(loans_).thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
+        vars.htp            = _htp(Loans.getMax(loans_).thresholdPrice, poolState_.inflator);
         vars.referencePrice = Maths.min(Maths.max(vars.htp, vars.neutralPrice), MAX_INFLATED_PRICE);
 
         (vars.bondFactor, vars.bondSize) = _bondParams(

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -171,10 +171,9 @@ library LenderActions {
         uint256 bucketScale           = Deposits.scale(deposits_, params_.index);
         uint256 bucketDeposit         = Maths.wmul(bucketScale, unscaledBucketDeposit);
         uint256 bucketPrice           = _priceAt(params_.index);
-        addedAmount_                  = params_.amount;
 
-        // charge deposit fee
-        addedAmount_ = Maths.wmul(addedAmount_, Maths.WAD - _depositFeeRate(poolState_.rate));
+        // calculate added amount charging deposit fee
+        addedAmount_ = Maths.wmul(params_.amount, Maths.WAD - _depositFeeRate(poolState_.rate));
 
         bucketLP_ = Buckets.quoteTokensToLP(
             bucket.collateral,

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -18,6 +18,7 @@ import {
 
 import { 
     _depositFeeRate,
+    _htp,
     _priceAt,
     MAX_FENWICK_INDEX,
     COLLATERALIZATION_FACTOR 
@@ -302,7 +303,7 @@ library LenderActions {
 
         // recalculate LUP and HTP
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        vars.htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
+        vars.htp = _htp(params_.thresholdPrice, poolState_.inflator);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (
@@ -419,7 +420,7 @@ library LenderActions {
 
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
-        uint256 htp = Maths.wmul(Maths.wmul(params_.thresholdPrice, poolState_.inflator), COLLATERALIZATION_FACTOR);
+        uint256 htp = _htp(params_.thresholdPrice, poolState_.inflator);
 
         if (
             // check loan book's htp doesn't exceed new lup

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -288,12 +288,22 @@ library PoolCommons {
         }
     }
 
+    /**
+     *  @notice Executes a flashloan from current pool.
+     *  @dev    === Reverts on ===
+     *  @dev    - `FlashloanCallbackFailed()` if receiver is not an `ERC3156FlashBorrower`
+     *  @dev    - `FlashloanIncorrectBalance()` if pool balance after flashloan is different than initial balance
+     *  @param  receiver_ Address of the contract which implements the appropriate interface to receive tokens.
+     *  @param  token_    Address of the `ERC20` token caller wants to borrow.
+     *  @param  amount_   The denormalized amount (dependent upon token precision) of tokens to borrow.
+     *  @param  data_     User-defined calldata passed to the receiver.
+     */
     function flashLoan(
         IERC3156FlashBorrower receiver_,
         address token_, 
         uint256 amount_,
         bytes calldata data_
-    ) external returns (bool success_) {
+    ) external {
         IERC20 tokenContract = IERC20(token_);
 
         uint256 initialBalance = tokenContract.balanceOf(address(this));
@@ -314,7 +324,6 @@ library PoolCommons {
 
         if (tokenContract.balanceOf(address(this)) != initialBalance) revert FlashloanIncorrectBalance();
 
-        success_ = true;
         emit Flashloan(address(receiver_), token_, amount_);
     }
 

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -21,6 +21,7 @@ import { IERC3156FlashBorrower }                             from '../../interfa
 
 import { 
     _dwatp,
+    _htp,
     _indexOf,
     MAX_FENWICK_INDEX,
     MIN_PRICE, MAX_PRICE,
@@ -258,7 +259,7 @@ library PoolCommons {
 
         // calculate the highest threshold price
         newInflator_ = Maths.wmul(poolState_.inflator, pendingFactor);
-        uint256 htp = Maths.wmul(Maths.wmul(thresholdPrice_, poolState_.inflator), COLLATERALIZATION_FACTOR);
+        uint256 htp  = _htp(thresholdPrice_, poolState_.inflator);
 
         uint256 accrualIndex;
         if (htp > MAX_PRICE)      accrualIndex = 1;                 // if HTP is over the highest price bucket then no buckets earn interest

--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -167,11 +167,9 @@ library SettlerActions {
 
         // complete result struct with debt settled
         result_.t0DebtSettled -= borrower.t0Debt;
+        result_.debtSettled   = Maths.wmul(result_.t0DebtSettled, poolState_.inflator);
 
-        emit Settle(
-            params_.borrower,
-            Maths.wmul(result_.t0DebtSettled, poolState_.inflator)
-        );
+        emit Settle(params_.borrower, result_.debtSettled);
 
         // if entire debt was settled then settle auction
         if (borrower.t0Debt == 0) {

--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -146,7 +146,7 @@ library SettlerActions {
                 uint256 t0ReserveSettleAmount = Maths.min(Maths.floorWdiv(assets - liabilities, poolState_.inflator), borrower.t0Debt);
 
                 // if the settlement phase of 144 hours has not ended, settle up to the borrower reserve limit
-                if((block.timestamp - kickTime < 144 hours) && (Deposits.treeSum(deposits_) > 0)) {
+                if ((block.timestamp - kickTime < 144 hours) && (Deposits.treeSum(deposits_) > 0)) {
                     t0ReserveSettleAmount = Maths.min(t0ReserveSettleAmount, borrower.t0ReserveSettleAmount);
                     borrower.t0ReserveSettleAmount -= t0ReserveSettleAmount;
                 }
@@ -300,12 +300,12 @@ library SettlerActions {
             auctions_.head = address(0);
             auctions_.tail = address(0);
         }
-        else if(auctions_.head == borrower_) {
+        else if (auctions_.head == borrower_) {
             // liquidation is the head
             auctions_.liquidations[liquidation.next].prev = address(0);
             auctions_.head = liquidation.next;
         }
-        else if(auctions_.tail == borrower_) {
+        else if (auctions_.tail == borrower_) {
             // liquidation is the tail
             auctions_.liquidations[liquidation.prev].next = address(0);
             auctions_.tail = liquidation.prev;

--- a/src/libraries/external/SettlerActions.sol
+++ b/src/libraries/external/SettlerActions.sol
@@ -132,11 +132,12 @@ library SettlerActions {
 
         if (borrower.t0Debt != 0 && borrower.collateral == 0) {
             // 2. settle debt with pool reserves
-            uint256 assets = Maths.floorWmul(poolState_.t0Debt - result_.t0DebtSettled + borrower.t0Debt, poolState_.inflator) + params_.poolBalance;
+            uint256 assets   = Maths.floorWmul(poolState_.t0Debt - result_.t0DebtSettled + borrower.t0Debt, poolState_.inflator) + params_.poolBalance;
+            uint256 deposits = Deposits.treeSum(deposits_);
 
             uint256 liabilities =
                 // require 1.0 + 1e-9 deposit buffer (extra margin) for deposits
-                Maths.wmul(DEPOSIT_BUFFER, Deposits.treeSum(deposits_)) +
+                Maths.wmul(DEPOSIT_BUFFER, deposits) +
                 auctions_.totalBondEscrowed +
                 reserveAuction_.unclaimed;
 
@@ -146,7 +147,7 @@ library SettlerActions {
                 uint256 t0ReserveSettleAmount = Maths.min(Maths.floorWdiv(assets - liabilities, poolState_.inflator), borrower.t0Debt);
 
                 // if the settlement phase of 144 hours has not ended, settle up to the borrower reserve limit
-                if ((block.timestamp - kickTime < 144 hours) && (Deposits.treeSum(deposits_) > 0)) {
+                if (deposits > 0 && block.timestamp - kickTime < 144 hours) {
                     t0ReserveSettleAmount = Maths.min(t0ReserveSettleAmount, borrower.t0ReserveSettleAmount);
                     borrower.t0ReserveSettleAmount -= t0ReserveSettleAmount;
                 }

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -340,9 +340,6 @@ library TakerActions {
     ) internal returns (TakeLocalVars memory vars_) {
         Liquidation storage liquidation = auctions_.liquidations[params_.borrower];
 
-        // Auction may not be taken in the same block it was kicked
-        if (liquidation.kickTime == block.timestamp) revert AuctionNotTakeable();
-
         vars_ = _prepareTake(
             liquidation,
             0,
@@ -422,9 +419,6 @@ library TakerActions {
         BucketTakeParams memory params_
     ) internal returns (TakeLocalVars memory vars_) {
         Liquidation storage liquidation = auctions_.liquidations[params_.borrower];
-
-        // Auction may not be taken in the same block it was kicked
-        if (liquidation.kickTime == block.timestamp) revert AuctionNotTakeable();
 
         vars_= _prepareTake(
             liquidation,
@@ -693,6 +687,8 @@ library TakerActions {
 
         uint256 kickTime = liquidation_.kickTime;
         if (kickTime == 0) revert NoAuction();
+        // Auction may not be taken in the same block it was kicked
+        if (kickTime == block.timestamp) revert AuctionNotTakeable();
 
         vars.t0BorrowerDebt = t0Debt_;
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -168,6 +168,21 @@ import { Maths }   from '../internal/Maths.sol';
     }
 
     /**
+     *  @notice Calculates `HTP` price.
+     *  @param  thresholdPrice_ Threshold price.
+     *  @param  inflator_       Pool's inflator.
+     */
+    function _htp(
+        uint256 thresholdPrice_,
+        uint256 inflator_
+    ) pure returns (uint256) {
+        return Maths.wmul(
+            Maths.wmul(thresholdPrice_, inflator_),
+            COLLATERALIZATION_FACTOR
+        );
+    }
+
+    /**
      *  @notice Calculates debt-weighted average threshold price.
      *  @param  t0Debt_              Pool debt owed by borrowers in `t0` terms.
      *  @param  inflator_            Pool's borrower inflator.

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -385,6 +385,11 @@ import { Maths }   from '../internal/Maths.sol';
     /*** Auction Utilities ***/
     /*************************/
 
+    /// @dev max bond factor.
+    uint256 constant MIN_BOND_FACTOR = 0.005 * 1e18;
+    /// @dev max NP / TP ratio.
+    uint256 constant MAX_NP_TP_RATIO = 0.03 * 1e18;
+
     /**
      *  @notice Calculates auction price.
      *  @param  referencePrice_ Recorded at kick, used to calculate start price.
@@ -459,10 +464,10 @@ import { Maths }   from '../internal/Maths.sol';
         // bondFactor = max(min(0.03,(((NP/TP_ratio)-1)/10)),0.005)
         bondFactor_ = Maths.max(
             Maths.min(
-                0.03 * 1e18,
+                MAX_NP_TP_RATIO,
                 (npTpRatio_ - 1e18) / 10
             ),
-            0.005 * 1e18
+            MIN_BOND_FACTOR
         );
 
         bondSize_ = Maths.wmul(bondFactor_,  borrowerDebt_);


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

Suggested code improvements in different areas / for different PRs since Sherlock audit commit

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

### In changes for initial audit
- `take` and `bucketTake` were prevented in same block as when auction was kicked. The check was added in both functions. Proposed improvement is to have the check done in the same place (that is `_prepareTake` function) and save a warm access from storage (100 gas) as `liquidation.kickTime` is already loaded https://github.com/ajna-finance/contracts/pull/1005/commits/1cb0f8dbbee9d98d3a53ac026e25d3e9c87660fb
- repaid amount and collateral taken are now returned from `Pool.repayDebt` and `Pool.take` functions. For `ERC721` the collateral taken was calculated twice as `result.collateralAmount / 1e18`. Commit https://github.com/ajna-finance/contracts/pull/1005/commits/6ac8b9a494348077aeee6428949dbabe1dcdadec read from result struct in local var and reuse them, resulting in minor gas saving (5 gas for one `DIV` opcode) and minor contract size reduction
- `borrower.npTpRatio` was introduced to hold the neutral price / threshold price ration of a loan. When kicking this is accessed twice, once for neutral price calculation and 2nd time for determining bond params. Both time the value is read from storage. Improvement to read only once (and save 100 gas when kick) suggested in commit https://github.com/ajna-finance/contracts/pull/1005/commits/95d30ef2b0d5bedf32118b7e10b4234f9f1b1e35

### In changes for fix review / rc9 candidate
- Audit finding `hypothetical lup was used to calculate interest rate in lenderKick which could lead to incorrect interest rate calculations` was fixed by computing `LUP` inside `Pool.lenderKick` function . This was unnecessary as `LUP` was already calculated. Commit https://github.com/ajna-finance/contracts/pull/1005/commits/0b3305d37e39874f5d14624fe0893989e77c79bc adds the improvement which result in substantial gas cost reduction and slightly reduction of contract size
- settle debt emitted in `Settle` event was in terms of `t0` debt which was misleading. Event was changed to emit current debt settled. Commit https://github.com/ajna-finance/contracts/pull/1005/commits/98c895c3fb1a972279a415810d2e704a0787ac28 suggest improvement of calculating the current debt settled only once (instead doing same calculation in Pool contract) and return it in `SettleResult.debtSettled`
- the new way of using part of reserves to settle auction implies reading pool deposits from Fenwick tree. However this was done twice, first time for calculating pool liabilities and second time for making sure pool deposits are greater than 0. https://github.com/ajna-finance/contracts/pull/1005/commits/673949b1af0ec546b350bd9a5df3ccefa759b054 reads deposits in local var only once and reuse for both places. Further gas improvement can be done by changing `deposits > 0` to `deposits != 0`
- when calculating `HTP` the `1.04` collateralization factor is now taken into account. This is done in several places in code, making it harder to maintain (and slightly increasing pool contract size). Commit https://github.com/ajna-finance/contracts/pull/1005/commits/5a229c23f0eaa8bc0264ebd30a02e63b98d9eeff#diff-b8a3c7e9053439915e5f4dc0ecc997ebfa0e8197de2ca64c1a83531c24333a7a introduce the `PoolHelper._htp` free function to be used when calculating price

### Minor impact changes
- code style https://github.com/ajna-finance/contracts/pull/1005/commits/9772b44a43c68b0864ec6f73b91e6906099e8592
- cosmetic flashloan code changes https://github.com/ajna-finance/contracts/pull/1005/commits/448c5e94c853d2988a100fb34227f41706e9f7c1
- remove unnecessary line https://github.com/ajna-finance/contracts/pull/1005/commits/49f5a15639658bef31c62d04c23fc4f104302445

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

### Contract sizes:
Slightly reduction of contract size due to removing duped code

post changes
```
| Contract                      | Size (kB) | Margin (kB) |
|-------------------------------|-----------|-------------|
| ERC20Pool                     | 23.609    | 0.967       |
| ERC721Pool                    | 24.344    | 0.232       |
```
current
```
| Contract                      | Size (kB) | Margin (kB) |
|-------------------------------|-----------|-------------|
| ERC20Pool                     | 23.797    | 0.779       |
| ERC721Pool                    | 24.535    | 0.041       |
```

###  Gas consumption
No significant gains but for `lenderKick` as https://github.com/ajna-finance/contracts/pull/1005/commits/0b3305d37e39874f5d14624fe0893989e77c79bc removes one Fenwick traversal

post changes
```
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |         |         |
|--------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 112628          | 170974 | 154491 | 725641  | 60004   |
| bucketTake                           | 369501          | 392597 | 392597 | 415694  | 4       |
| drawDebt                             | 254839          | 296525 | 273264 | 764643  | 136003  |
| kick                                 | 145460          | 220168 | 218736 | 1025534 | 48000   |
| lenderKick                           | 190937          | 268945 | 264977 | 969677  | 8000    |
| moveQuoteToken                       | 286039          | 286039 | 286039 | 286039  | 1       |
| removeQuoteToken                     | 162058          | 178720 | 178581 | 198217  | 4000    |
| repayDebt                            | 594419          | 626697 | 616557 | 774746  | 16002   |
| settle                               | 984473          | 984473 | 984473 | 984473  | 1       |
| take                                 | 69288           | 70590  | 69985  | 305127  | 15998   |
```

current
```
| src/ERC20Pool.sol:ERC20Pool contract |                 |        |        |         |         |
|--------------------------------------|-----------------|--------|--------|---------|---------|
| Function Name                        | min             | avg    | median | max     | # calls |
| addQuoteToken                        | 112636          | 170979 | 154499 | 725600  | 60004   |
| bucketTake                           | 369567          | 392663 | 392663 | 415760  | 4       |
| drawDebt                             | 254839          | 296522 | 273264 | 764594  | 136003  |
| kick                                 | 145532          | 220259 | 218827 | 1025576 | 48000   |
| lenderKick                           | 213016          | 291024 | 287056 | 991937  | 8000    |
| moveQuoteToken                       | 285945          | 285945 | 285945 | 285945  | 1       |
| removeQuoteToken                     | 161964          | 178626 | 178487 | 198123  | 4000    |
| repayDebt                            | 594404          | 626682 | 616542 | 774731  | 16002   |
| settle                               | 984677          | 984677 | 984677 | 984677  | 1       |
| take                                 | 69396           | 70698  | 70092  | 305195  | 15998   |
```
## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
