### PR TITLE
Invariant fix: round up quote tokens calculated from rewarded LP (bec…

### DIFF
--- a/tests/forge/regression/PositionAndRewards/RegressionTestERC721PoolRewardsManager.t.sol
+++ b/tests/forge/regression/PositionAndRewards/RegressionTestERC721PoolRewardsManager.t.sol
@@ -77,7 +77,8 @@ contract RegressionTestERC721PoolRewardsManager is ERC721PoolRewardsInvariants {
     
     /**
         Test was failing due to rounding error converting LP to quote token.
-        Fixed by updating UnboundedLiquidationPoolHandler._bucketTake to handle such error.
+        Fixed in invariant logic by rounding up when calculating quote tokens from rewarded LP.
+        (opposite of TakerActions implementation which rounds down when calculating rewarded LP from quote tokens).
      */
     function test_regression_failure_rewards_overflow() external {
         _erc721poolrewardsHandler.takeAuction(8916353616233254, 57649844002245701248730112897897147833956884330328914675231893131196499, 2, 1018952559902734233814512249);


### PR DESCRIPTION
…ause LP rewarded are calculated in bucketTake as rewarded quote tokens -> LP rounded down)

## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
