### PR TITLE
Resolve Kiril [L-02] Some unit tests are not properly executed

### DIFF
--- a/tests/forge/unit/PoolHelperTest.t.sol
+++ b/tests/forge/unit/PoolHelperTest.t.sol
@@ -11,62 +11,65 @@ contract PoolHelperTest is DSTestPlus {
      *  @notice Tests fenwick index calculation from varying bucket prices
      */
     function testPriceToIndex() external {
-        _assertBucketPriceOutOfBoundsRevert(2_000_000_000 * 10**18);
-        _assertBucketPriceOutOfBoundsRevert(1_004_968_987.606512354182109772 * 10**18);
-        assertEq(_indexOf(1_004_968_987.606512354182109771 * 10**18), 0);
-        assertEq(_indexOf(4_669_863.090889329544038534 * 1e18),       1077);
-        assertEq(_indexOf(49_910.043670274810022205 * 1e18),          1987);
-        assertEq(_indexOf(21_699.795273870723549803 * 1e18),          2154);
-        assertEq(_indexOf(2_000.221618840727700609 * 1e18),           2632);
-        assertEq(_indexOf(146.575625611106531706 * 1e18),             3156);
-        assertEq(_indexOf(145.846393642892072537 * 1e18),             3157);
-        assertEq(_indexOf(100.332368143282009890 * 1e18),             3232);
-        assertEq(_indexOf(5.263790124045347667 * 1e18),               3823);
-        assertEq(_indexOf(1.646668492116543299 * 1e18),               4056);
-        assertEq(_indexOf(1.315628874808846999 * 1e18),               4101);
-        assertEq(_indexOf(1.051140132040790557 * 1e18),               4146);
-        assertEq(_indexOf(1 * 1e18),                                  4156);
-        assertEq(_indexOf(0.951347940696068854 * 1e18),               4166);
-        assertEq(_indexOf(0.463902261297398000 * 1e18),               4310);
-        assertEq(_indexOf(0.006856528811048429 * 1e18),               5155);
-        assertEq(_indexOf(0.006822416727411372 * 1e18),               5156);
-        assertEq(_indexOf(0.002144924036174487 * 1e18),               5388);
-        assertEq(_indexOf(0.000046545370002462 * 1e18),               6156);
-        assertEq(_indexOf(0.000009917388865689 * 1e18),               6466);
-        assertEq(_indexOf(99_836_282_890),                            7388);
-        _assertBucketPriceOutOfBoundsRevert(99_836_282_889);
-        _assertBucketPriceOutOfBoundsRevert(1);
-        _assertBucketPriceOutOfBoundsRevert(0);
+        assertEq(_indexOf(4_669_863.090889329544038534 * 1e18), 1077);
+        assertEq(_indexOf(49_910.043670274810022205 * 1e18),    1987);
+        assertEq(_indexOf(21_699.795273870723549803 * 1e18),    2154);
+        assertEq(_indexOf(2_000.221618840727700609 * 1e18),     2632);
+        assertEq(_indexOf(146.575625611106531706 * 1e18),       3156);
+        assertEq(_indexOf(145.846393642892072537 * 1e18),       3157);
+        assertEq(_indexOf(100.332368143282009890 * 1e18),       3232);
+        assertEq(_indexOf(5.263790124045347667 * 1e18),         3823);
+        assertEq(_indexOf(1.646668492116543299 * 1e18),         4056);
+        assertEq(_indexOf(1.315628874808846999 * 1e18),         4101);
+        assertEq(_indexOf(1.051140132040790557 * 1e18),         4146);
+        assertEq(_indexOf(1 * 1e18),                            4156);
+        assertEq(_indexOf(0.951347940696068854 * 1e18),         4166);
+        assertEq(_indexOf(0.463902261297398000 * 1e18),         4310);
+        assertEq(_indexOf(0.006856528811048429 * 1e18),         5155);
+        assertEq(_indexOf(0.006822416727411372 * 1e18),         5156);
+        assertEq(_indexOf(0.002144924036174487 * 1e18),         5388);
+        assertEq(_indexOf(0.000046545370002462 * 1e18),         6156);
+        assertEq(_indexOf(0.000009917388865689 * 1e18),         6466);
+        assertEq(_indexOf(99_836_282_890),                      7388);
+    }
+
+    function testPriceToIndexRevertOnPriceGtMaxPrice() external {
+        _assertBucketPriceOutOfBoundsRevert(MAX_PRICE + 1);
+    }
+
+    function testPriceToIndexRevertOnPriceLtMinPrice() external {
+        _assertBucketPriceOutOfBoundsRevert(MIN_PRICE - 1);
     }
 
     /**
      *  @notice Tests bucket price calculation from varying fenwick index
      */
     function testIndexToPrice() external {
-        assertEq(                  _priceAt(0),    1_004_968_987.606512354182109771 * 10**18);
-        assertEq(                  _priceAt(1077), 4_669_863.090889329544038534 * 1e18);
-        assertEq(                  _priceAt(1987), 49_910.043670274810022205 * 1e18);
-        assertEq(                  _priceAt(2154), 21_699.795273870723549803 * 1e18);
-        assertEq(                  _priceAt(2632), 2_000.221618840727700609 * 1e18);
-        assertEq(                  _priceAt(3156), 146.575625611106531706 * 1e18);
-        assertEq(                  _priceAt(3157), 145.846393642892072537 * 1e18);
-        assertEq(                  _priceAt(3232), 100.332368143282009890 * 1e18);
-        assertEq(                  _priceAt(3823), 5.263790124045347667 * 1e18);
-        assertEq(                  _priceAt(4056), 1.646668492116543299 * 1e18);
-        assertEq(                  _priceAt(4101), 1.315628874808846999 * 1e18);
-        assertEq(                  _priceAt(4146), 1.051140132040790557 * 1e18);
-        assertEq(                  _priceAt(4156), 1 * 1e18);
-        assertEq(                  _priceAt(4166), 0.951347940696068854 * 1e18);
-        assertEq(                  _priceAt(4310), 0.463902261297391185 * 1e18);
-        assertEq(                  _priceAt(5155), 0.006856528811048429 * 1e18);
-        assertEq(                  _priceAt(5156), 0.006822416727411372 * 1e18);
-        assertEq(                  _priceAt(5388), 0.002144924036174487 * 1e18);
-        assertEq(                  _priceAt(6156), 0.000046545370002462 * 1e18);
-        assertEq(                  _priceAt(6466), 0.000009917388865689 * 1e18);
-        assertEq(                  _priceAt(7388), 99_836_282_890);
-        _assertBucketIndexOutOfBoundsRevert(7389);
-        _assertBucketIndexOutOfBoundsRevert(8191);
-        _assertBucketIndexOutOfBoundsRevert(9999);
+        assertEq(_priceAt(0),    1_004_968_987.606512354182109771 * 10**18);
+        assertEq(_priceAt(1077), 4_669_863.090889329544038534 * 1e18);
+        assertEq(_priceAt(1987), 49_910.043670274810022205 * 1e18);
+        assertEq(_priceAt(2154), 21_699.795273870723549803 * 1e18);
+        assertEq(_priceAt(2632), 2_000.221618840727700609 * 1e18);
+        assertEq(_priceAt(3156), 146.575625611106531706 * 1e18);
+        assertEq(_priceAt(3157), 145.846393642892072537 * 1e18);
+        assertEq(_priceAt(3232), 100.332368143282009890 * 1e18);
+        assertEq(_priceAt(3823), 5.263790124045347667 * 1e18);
+        assertEq(_priceAt(4056), 1.646668492116543299 * 1e18);
+        assertEq(_priceAt(4101), 1.315628874808846999 * 1e18);
+        assertEq(_priceAt(4146), 1.051140132040790557 * 1e18);
+        assertEq(_priceAt(4156), 1 * 1e18);
+        assertEq(_priceAt(4166), 0.951347940696068854 * 1e18);
+        assertEq(_priceAt(4310), 0.463902261297391185 * 1e18);
+        assertEq(_priceAt(5155), 0.006856528811048429 * 1e18);
+        assertEq(_priceAt(5156), 0.006822416727411372 * 1e18);
+        assertEq(_priceAt(5388), 0.002144924036174487 * 1e18);
+        assertEq(_priceAt(6156), 0.000046545370002462 * 1e18);
+        assertEq(_priceAt(6466), 0.000009917388865689 * 1e18);
+        assertEq(_priceAt(7388), 99_836_282_890);
+    }
+
+    function testIndexToPriceRevertOnIndexGtMaxIndex() external {
+        _assertBucketIndexOutOfBoundsRevert(MAX_FENWICK_INDEX + 1);
     }
 
     /**


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

Forge unit tests `PoolHelperTest::testPriceToIndex` and `PoolHelperTest::testIndexToPrice` do not revert on fail due to
incorrect `vm.expectRevert` checks on the top-level function calls.

See [https://github.com/foundry-rs/foundry/issues/3723](https://github.com/foundry-rs/foundry/issues/3723), [https://github.com/foundry-rs/foundry/issues/5820](https://github.com/foundry-rs/foundry/issues/5820)
for more context.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

Improve test coverage, split revert tests in different functions as suggested in https://github.com/foundry-rs/foundry/issues/5820#issuecomment-1715784297

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
