### PR TITLE
Remove unused vars (Kirill I-18)

### DIFF
--- a/src/PositionManager.sol
+++ b/src/PositionManager.sol
@@ -591,9 +591,7 @@ contract PositionManager is PermitERC721, IPositionManager, Multicall, Reentranc
             collateralTokenSymbol: tokenSymbol(collateralTokenAddress),
             quoteTokenSymbol:      tokenSymbol(quoteTokenAddress),
             tokenId:               tokenId_,
-            pool:                  pool,
-            owner:                 ownerOf(tokenId_),
-            indexes:               tokenInfo.positionIndexes.values()
+            owner:                 ownerOf(tokenId_)
         });
 
         return PositionNFTSVG.constructTokenURI(params);

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -15,7 +15,6 @@ struct KickResult {
     uint256 amountToCoverBond;    // [WAD] amount of bond that needs to be covered
     uint256 t0KickedDebt;         // [WAD] new t0 debt after kick
     uint256 collateralPreAction;  // [WAD] The amount of borrower collateral before kick, same as the one after kick
-    uint256 poolDebt;             // [WAD] current debt in pool after kick
     uint256 lup;                  // [WAD] current LUP in pool after kick
 }
 

--- a/src/libraries/external/BorrowerActions.sol
+++ b/src/libraries/external/BorrowerActions.sol
@@ -46,7 +46,6 @@ library BorrowerActions {
     struct DrawDebtLocalVars {
         bool    borrow;                // true if borrow action
         uint256 borrowerDebt;          // [WAD] borrower's accrued debt
-        uint256 compensatedCollateral; // [WAD] amount of borrower collateral that is compensated with LP (NFTs only)
         uint256 t0BorrowAmount;        // [WAD] t0 amount to borrow
         uint256 t0DebtChange;          // [WAD] additional t0 debt resulted from draw debt action
         bool    pledge;                // true if pledge action
@@ -56,7 +55,6 @@ library BorrowerActions {
     /// @dev Struct used for `repayDebt` function local vars.
     struct RepayDebtLocalVars {
         uint256 borrowerDebt;          // [WAD] borrower's accrued debt
-        uint256 compensatedCollateral; // [WAD] amount of borrower collateral that is compensated with LP (NFTs only)
         bool    pull;                  // true if pull action
         bool    repay;                 // true if repay action
         bool    stampNpTpRatio;        // true if loan's Np to Tp ratio should be restamped (when repay settles auction or pull collateral)

--- a/src/libraries/external/PositionNFTSVG.sol
+++ b/src/libraries/external/PositionNFTSVG.sol
@@ -21,9 +21,7 @@ library PositionNFTSVG {
         string collateralTokenSymbol; // the symbol of collateral token of the pool
         string quoteTokenSymbol;      // the symbol of quote token of the pool
         uint256 tokenId;              // the ID of positions NFT token
-        address pool;                 // the address of pool tracked in positions NFT token
         address owner;                // the owner of positions NFT token
-        uint256[] indexes;            // the array of price buckets index with LP to be tracked by the NFT
     }
 
     /*******************************/

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -84,7 +84,6 @@ library TakerActions {
         uint256 bucketScale;                 // [WAD] The bucket scale.
         uint256 collateralAmount;            // [WAD] The amount of collateral taken.
         uint256 excessQuoteToken;            // [WAD] Difference of quote token that borrower receives after take (for fractional NFT only)
-        uint256 factor;                      // The take factor, calculated based on bond penalty factor.
         bool    isRewarded;                  // True if kicker is rewarded (auction price lower than neutral price), false if penalized (auction price greater than neutral price).
         address kicker;                      // Address of auction kicker.
         uint256 quoteTokenAmount;            // [WAD] Scaled quantity in Fenwick tree and before 1-bpf factor, paid for collateral
@@ -705,7 +704,6 @@ library TakerActions {
             liquidation_.bondFactor,
             bucketPrice_ == 0 ? vars.auctionPrice : bucketPrice_
         );
-        vars.factor       = uint256(1e18 - Maths.maxInt(0, vars.bpf));
         vars.kicker       = liquidation_.kicker;
         vars.isRewarded   = (vars.bpf  >= 0);
     }


### PR DESCRIPTION
## Description

Remove unused varables to resolve Kirill I-18.

## Purpose

Improve maintainability of the code.

## Impact

No impact was expected on pool contracts, but it actually decreased size of `ERC20Pool` from 23,609B  (96.06%) to 23,599B  (96.02%).

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
