### PR TITLE
Kirill [M-07] | Prevent reserves auction kick until all pending auctions are fully settled

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -60,7 +60,8 @@ import {
     _revertIfAuctionDebtLocked,
     _revertIfAuctionClearable,
     _revertAfterExpiry,
-    _revertIfAuctionPriceBelow
+    _revertIfAuctionPriceBelow,
+    _revertIfActiveAuctions
 }                               from '../libraries/helpers/RevertsHelper.sol';
 
 import { Buckets }  from '../libraries/internal/Buckets.sol';
@@ -160,7 +161,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         _revertIfAuctionClearable(auctions, loans);
 
-        _revertIfAuctionPriceBelow(index_, auctions);
+        _revertIfAuctionPriceBelow(auctions, index_);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -196,7 +197,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
 
         _revertIfAuctionClearable(auctions, loans);
 
-        _revertIfAuctionPriceBelow(toIndex_, auctions);
+        _revertIfAuctionPriceBelow(auctions, toIndex_);
 
         PoolState memory poolState = _accruePoolInterest();
 
@@ -400,7 +401,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev    - `KickReserveAuction`
      */
     function kickReserveAuction() external override nonReentrant {
-        _revertIfAuctionClearable(auctions, loans);
+        _revertIfActiveAuctions(auctions);
 
         // start a new claimable reserve auction, passing in relevant parameters such as the current pool size, debt, balance, and inflator value
         KickerActions.kickReserveAuction(

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -76,22 +76,34 @@ import { Maths }    from '../internal/Maths.sol';
         if (newPrice_ < _priceAt(limitIndex_)) revert LimitIndexExceeded();
     }
 
-/**
+    /**
      *  @notice  Check if provided price is above current auction price.
      *  @notice  Prevents manipulative deposits and arbTakes.
      *  @dev     Reverts with `AddAboveAuctionPrice` if price is above head of auction queue.
-     *  @param index_    Identifies bucket price to be compared with current auction price.
      *  @param auctions_ Auctions data.
+     *  @param index_    Identifies bucket price to be compared with current auction price.
      */
     function _revertIfAuctionPriceBelow(
-        uint256 index_,
-        AuctionsState storage auctions_
+        AuctionsState storage auctions_,
+        uint256 index_
     ) view {
         address head = auctions_.head;
         if (head != address(0)) {
             uint256 auctionPrice = _auctionPrice(auctions_.liquidations[head].referencePrice, auctions_.liquidations[head].kickTime);
             if (_priceAt(index_) >= auctionPrice) revert AddAboveAuctionPrice();
         }
+    }
+
+    /**
+     *  @notice  Check if there are still active / non settled auctions in pool.
+     *  @notice  Prevents kicking reserves auctions until all pending auctions are fully settled.
+     *  @dev     Reverts with `AuctionNotCleared`.
+     *  @param auctions_ Auctions data.
+     */
+    function _revertIfActiveAuctions(
+        AuctionsState storage auctions_
+    ) view {
+        if (auctions_.noOfAuctions != 0) revert AuctionNotCleared();
     }
 
     /**

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -1151,6 +1151,10 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
         (reserves, claimableReserves, , ,) = _poolUtils.poolReservesInfo(address(_pool));
         assertEq(reserves, 294_613_974.051804158154633582 * 1e18);
         assertEq(claimableReserves, 294_613_859.916107852369559136 * 1e18);
+
+        // test reserves auction cannot be kicked until auction settled
+        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
+        _pool.kickReserveAuction();
  
         // settle auction with reserves
         changePrank(actor6);
@@ -1165,6 +1169,16 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
         (reserves, claimableReserves, , ,) = _poolUtils.poolReservesInfo(address(_pool));
         assertEq(reserves, 374_644_181.841827555572267504 * 1e18);
         assertEq(claimableReserves, 374_644_125.812500127979859369 * 1e18);
+
+        // test reserves auction can be kicked after auction settled
+        _pool.kickReserveAuction();
+        _assertReserveAuction({
+            reserves:                   56.029327427592408135 * 1e18,
+            claimableReserves :         0,
+            claimableReservesRemaining: 374_644_125.812500127979859369 * 1e18,
+            auctionPrice:               1_000_000_000 * 1e18,
+            timeRemaining:              3 days
+        });
     }
 }
 


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

Implement suggested resolution for `[M-07] | Liquidation of positions with bad debt can cause losses for `HPB` depositors`

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

- Don’t allow calls to `kickReserveAuction` until all pending auctions are fully settled - revert with `AuctionNotCleared` if so
- update unit test to cover scenario
- apply consistent style for `_revertIfAuctionPriceBelow` helper (storage param first)

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->
Slightly decrease in contracts size
```
| ERC20Pool                     | 23.637    | 0.939       |
| ERC721Pool                    | 24.372    | 0.204       |
```
vs develop
```
| ERC20Pool                     | 23.599    | 0.977       |
| ERC721Pool                    | 24.334    | 0.242       |
```

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
