### PR TITLE
Fixed Take event emit for ERC721 pools

### DIFF
--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -369,14 +369,6 @@ library TakerActions {
 
         _rewardTake(auctions_, liquidation, vars_);
 
-        emit Take(
-            params_.borrower,
-            vars_.quoteTokenAmount,
-            vars_.collateralAmount,
-            vars_.bondChange,
-            vars_.isRewarded
-        );
-
         if (params_.poolType == uint8(PoolType.ERC721)) {
             // slither-disable-next-line divide-before-multiply
             uint256 collateralTaken = (vars_.collateralAmount / 1e18) * 1e18; // solidity rounds down, so if 2.5 it will be 2.5 / 1 = 2
@@ -397,6 +389,14 @@ library TakerActions {
                 }
             }
         }
+
+        emit Take(
+            params_.borrower,
+            vars_.quoteTokenAmount,
+            vars_.collateralAmount,
+            vars_.bondChange,
+            vars_.isRewarded
+        );
     }
 
     /**

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -583,7 +583,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             borrowerCollateralization: 0.801361613336061264 * 1e18
         });
 
-  //      _assertCollateralInvariants();
+       _assertCollateralInvariants();
 
         assertEq(_quote.balanceOf(_borrower),      5_100 * 1e18);
         assertEq(_quote.balanceOf(address(_pool)), 4_225.052380000077218250 * 1e18);
@@ -595,7 +595,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             maxCollateral:   2,
             bondChange:      101.346184596990929201 * 1e18,
             givenAmount:     9_236.603649496932503519 * 1e18,
-            collateralTaken: 0.825440365375700217 * 1e18,
+            collateralTaken: 1.000000000000000000 * 1e18,
             isReward:        false
         });
 
@@ -627,7 +627,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             })
         );
 
-   //     _assertCollateralInvariants();
+       _assertCollateralInvariants();
 
         // remaining token is moved to pool claimable array
         assertEq(ERC721Pool(address(_pool)).bucketTokenIds(0), 1);
@@ -650,6 +650,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         // the 2 NFTs (one taken, one claimed) are owned by lender
         assertEq(_collateral.ownerOf(3), _lender);
+        assertEq(_collateral.ownerOf(1),address(_pool));
 
         // ensure no collateral in buckets
         _assertBucket({
@@ -728,6 +729,12 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             amount:  40_000 * 1e18,
             index:   2000
         });
+
+        // pool owns borrower2's collateral pre-merge and remove
+        assertEq(_collateral.ownerOf(51), address(_pool));
+        assertEq(_collateral.ownerOf(53), address(_pool));
+        assertEq(_collateral.ownerOf(73), address(_pool));
+
         uint256[] memory removalIndexes = new uint256[](2);
         removalIndexes[0] = 2000;
         removalIndexes[1] = 2286;
@@ -777,6 +784,11 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             removeCollateralAtIndex: removalIndexes,
             toIndexLps:              0 * 1e18
         });
+
+        // lender owns collateral post-merge and remove
+        assertEq(_collateral.ownerOf(51), _lender);
+        assertEq(_collateral.ownerOf(53), _lender);
+        assertEq(_collateral.ownerOf(73), _lender);
 
         _removeAllLiquidity({
             from:     _lender,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -652,7 +652,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(3), _lender);
         assertEq(_collateral.ownerOf(1),address(_pool));
 
-  //      _assertCollateralInvariants();
+       _assertCollateralInvariants();
 
         // borrower2 exits from auction by deposit take
         skip(3.2 hours);
@@ -676,7 +676,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
             lpAwardTaker:     0,
             lpAwardKicker:    2.032141649575679123 * 1e18
         });
-//        _assertCollateralInvariants();
+        _assertCollateralInvariants();
         _assertBorrower({
             borrower:                  _borrower2,
             borrowerDebt:              0,
@@ -719,7 +719,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         assertEq(_collateral.ownerOf(53), address(_pool));
         assertEq(_collateral.ownerOf(73), address(_pool));
 
-        uint256[] memory removalIndexes = new uint256[](2);
+        uint256[] memory removalIndexes = new uint256[](3);
         removalIndexes[0] = 2000;
         removalIndexes[1] = 2278;
         removalIndexes[2] = 2501;

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -359,7 +359,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
             maxCollateral:   2,
             bondChange:      0.243847547737474028 * 1e18,
             givenAmount:     22.183024574062103585 * 1e18,
-            collateralTaken: 1.538515492082238493 * 1e18, // not a rounded collateral, difference of 2 - 1.53 collateral should go to borrower in quote tokens at auction price
+            collateralTaken: 2.0 * 1e18, // not a rounded collateral, difference of 2 - 1.53 collateral should go to borrower in quote tokens at auction price
             isReward:        false
         });
 


### PR DESCRIPTION
## Description
<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
* Noticed in takes for ERC721 pools that the collateral event emitted from take calls is inaccurate due to the integral collateral amount required for takers. This PR resolves those rounding issues by moving the `Take` event after we adjust ERC721 collateral take balances.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->
* insignificant gas change

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
