### PR TITLE
Continuation of #1021 - clear TP naming and improved code descriptions

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -47,17 +47,17 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Exposes status of a liquidation auction.
-     *  @param  ajnaPool_                 Address of `Ajna` pool.
-     *  @param  borrower_                 Identifies the loan being liquidated.
-     *  @return kickTime_                 Time auction was kicked, implying end time.
-     *  @return collateral_               Remaining collateral available to be purchased.               (`WAD`)
-     *  @return debtToCover_              Borrower debt to be covered.                                  (`WAD`)
-     *  @return isCollateralized_         `True` if loan is collateralized.
-     *  @return price_                    Current price of the auction.                                 (`WAD`)
-     *  @return neutralPrice_             Price at which bond holder is neither rewarded nor penalized. (`WAD`)
-     *  @return referencePrice_           Price used to determine auction start price.                  (`WAD`)
-     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`).             (`WAD`)
-     *  @return bondFactor_               The factor used for calculating bond size.                    (`WAD`)
+     *  @param  ajnaPool_         Address of `Ajna` pool.
+     *  @param  borrower_         Identifies the loan being liquidated.
+     *  @return kickTime_         Time auction was kicked, implying end time.
+     *  @return collateral_       Remaining collateral available to be purchased.               (`WAD`)
+     *  @return debtToCover_      Borrower debt to be covered.                                  (`WAD`)
+     *  @return isCollateralized_ `True` if loan is collateralized.
+     *  @return price_            Current price of the auction.                                 (`WAD`)
+     *  @return neutralPrice_     Price at which bond holder is neither rewarded nor penalized. (`WAD`)
+     *  @return referencePrice_   Price used to determine auction start price.                  (`WAD`)
+     *  @return debtToCollateral_ Borrower debt to collateral at time of kick.                  (`WAD`)
+     *  @return bondFactor_       The factor used for calculating bond size.                    (`WAD`)
      */
     function auctionStatus(address ajnaPool_, address borrower_)
         external
@@ -70,7 +70,7 @@ contract PoolInfoUtils {
             uint256 price_,
             uint256 neutralPrice_,
             uint256 referencePrice_,
-            uint256 unadjustedThresholdPrice_,
+            uint256 debtToCollateral_,
             uint256 bondFactor_
         )
     {
@@ -81,7 +81,7 @@ contract PoolInfoUtils {
             kickTime_,
             referencePrice_,
             neutralPrice_,
-            unadjustedThresholdPrice_, , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
+            debtToCollateral_, , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
 
         if (kickTime_ != 0) {
             (debtToCover_, collateral_, ) = this.borrowerInfo(ajnaPool_, borrower_);
@@ -97,18 +97,18 @@ contract PoolInfoUtils {
     /**
      *  @notice Returns details of an auction for a given borrower address.
      *  @dev    Calls and returns all values from pool.auctionInfo().
-     *  @param  ajnaPool_                 Address of `Ajna` pool.
-     *  @param  borrower_                 Address of the borrower that is liquidated.
-     *  @return kicker_                   Address of the kicker that is kicking the auction.
-     *  @return bondFactor_               The factor used for calculating bond size.
-     *  @return bondSize_                 The bond amount in quote token terms.
-     *  @return kickTime_                 Time the liquidation was initiated.
-     *  @return referencePrice_           Price used to determine auction start price.
-     *  @return neutralPrice_             `Neutral Price` of auction.
-     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation.
-     *  @return head_                     Address of the head auction.
-     *  @return next_                     Address of the next auction in queue.
-     *  @return prev_                     Address of the prev auction in queue.
+     *  @param  ajnaPool_         Address of `Ajna` pool.
+     *  @param  borrower_         Address of the borrower that is liquidated.
+     *  @return kicker_           Address of the kicker that is kicking the auction.
+     *  @return bondFactor_       The factor used for calculating bond size.
+     *  @return bondSize_         The bond amount in quote token terms.
+     *  @return kickTime_         Time the liquidation was initiated.
+     *  @return referencePrice_   Price used to determine auction start price.
+     *  @return neutralPrice_     `Neutral Price` of auction.
+     *  @return debtToCollateral_ Borrower debt to collateral at time of kick, which is used in BPF for kicker's reward calculation.
+     *  @return head_             Address of the head auction.
+     *  @return next_             Address of the next auction in queue.
+     *  @return prev_             Address of the prev auction in queue.
      */
     function auctionInfo(address ajnaPool_, address borrower_) external view returns (
         address kicker_,
@@ -117,7 +117,7 @@ contract PoolInfoUtils {
         uint256 kickTime_,
         uint256 referencePrice_,
         uint256 neutralPrice_,
-        uint256 unadjustedThresholdPrice_,
+        uint256 debtToCollateral_,
         address head_,
         address next_,
         address prev_

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -47,17 +47,17 @@ contract PoolInfoUtils {
 
     /**
      *  @notice Exposes status of a liquidation auction.
-     *  @param  ajnaPool_         Address of `Ajna` pool.
-     *  @param  borrower_         Identifies the loan being liquidated.
-     *  @return kickTime_         Time auction was kicked, implying end time.
-     *  @return collateral_       Remaining collateral available to be purchased.               (`WAD`)
-     *  @return debtToCover_      Borrower debt to be covered.                                  (`WAD`)
-     *  @return isCollateralized_ `True` if loan is collateralized.
-     *  @return price_            Current price of the auction.                                 (`WAD`)
-     *  @return neutralPrice_     Price at which bond holder is neither rewarded nor penalized. (`WAD`)
-     *  @return referencePrice_   Price used to determine auction start price.                  (`WAD`)
-     *  @return thresholdPrice_   Threshold Price when liquidation was started.                 (`WAD`)
-     *  @return bondFactor_       The factor used for calculating bond size.                    (`WAD`)
+     *  @param  ajnaPool_                 Address of `Ajna` pool.
+     *  @param  borrower_                 Identifies the loan being liquidated.
+     *  @return kickTime_                 Time auction was kicked, implying end time.
+     *  @return collateral_               Remaining collateral available to be purchased.               (`WAD`)
+     *  @return debtToCover_              Borrower debt to be covered.                                  (`WAD`)
+     *  @return isCollateralized_         `True` if loan is collateralized.
+     *  @return price_                    Current price of the auction.                                 (`WAD`)
+     *  @return neutralPrice_             Price at which bond holder is neither rewarded nor penalized. (`WAD`)
+     *  @return referencePrice_           Price used to determine auction start price.                  (`WAD`)
+     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`).             (`WAD`)
+     *  @return bondFactor_               The factor used for calculating bond size.                    (`WAD`)
      */
     function auctionStatus(address ajnaPool_, address borrower_)
         external
@@ -70,7 +70,7 @@ contract PoolInfoUtils {
             uint256 price_,
             uint256 neutralPrice_,
             uint256 referencePrice_,
-            uint256 thresholdPrice_,
+            uint256 unadjustedThresholdPrice_,
             uint256 bondFactor_
         )
     {
@@ -81,7 +81,7 @@ contract PoolInfoUtils {
             kickTime_,
             referencePrice_,
             neutralPrice_,
-            thresholdPrice_, , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
+            unadjustedThresholdPrice_, , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
 
         if (kickTime_ != 0) {
             (debtToCover_, collateral_, ) = this.borrowerInfo(ajnaPool_, borrower_);
@@ -97,18 +97,18 @@ contract PoolInfoUtils {
     /**
      *  @notice Returns details of an auction for a given borrower address.
      *  @dev    Calls and returns all values from pool.auctionInfo().
-     *  @param  ajnaPool_       Address of `Ajna` pool.
-     *  @param  borrower_       Address of the borrower that is liquidated.
-     *  @return kicker_         Address of the kicker that is kicking the auction.
-     *  @return bondFactor_     The factor used for calculating bond size.
-     *  @return bondSize_       The bond amount in quote token terms.
-     *  @return kickTime_       Time the liquidation was initiated.
-     *  @return referencePrice_ Price used to determine auction start price.
-     *  @return neutralPrice_   `Neutral Price` of auction.
-     *  @return thresholdPrice_ Threshold Price when liquidation was started.
-     *  @return head_           Address of the head auction.
-     *  @return next_           Address of the next auction in queue.
-     *  @return prev_           Address of the prev auction in queue.
+     *  @param  ajnaPool_                 Address of `Ajna` pool.
+     *  @param  borrower_                 Address of the borrower that is liquidated.
+     *  @return kicker_                   Address of the kicker that is kicking the auction.
+     *  @return bondFactor_               The factor used for calculating bond size.
+     *  @return bondSize_                 The bond amount in quote token terms.
+     *  @return kickTime_                 Time the liquidation was initiated.
+     *  @return referencePrice_           Price used to determine auction start price.
+     *  @return neutralPrice_             `Neutral Price` of auction.
+     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation.
+     *  @return head_                     Address of the head auction.
+     *  @return next_                     Address of the next auction in queue.
+     *  @return prev_                     Address of the prev auction in queue.
      */
     function auctionInfo(address ajnaPool_, address borrower_) external view returns (
         address kicker_,
@@ -117,7 +117,7 @@ contract PoolInfoUtils {
         uint256 kickTime_,
         uint256 referencePrice_,
         uint256 neutralPrice_,
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         address head_,
         address next_,
         address prev_

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -204,10 +204,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _revertIfAuctionDebtLocked(deposits, poolState.t0DebtInAuction, fromIndex_, poolState.inflator);
 
         MoveQuoteParams memory moveParams;
-        moveParams.maxAmountToMove  = maxAmount_;
-        moveParams.fromIndex        = fromIndex_;
-        moveParams.toIndex          = toIndex_;
-        moveParams.thresholdPrice   = Loans.getMax(loans).thresholdPrice;
+        moveParams.maxAmountToMove             = maxAmount_;
+        moveParams.fromIndex                   = fromIndex_;
+        moveParams.toIndex                     = toIndex_;
+        moveParams.maxUnadjustedThresholdPrice = Loans.getMax(loans).unadjustedThresholdPrice;
 
         uint256 newLup;
         (
@@ -247,9 +247,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             deposits,
             poolState,
             RemoveQuoteParams({
-                maxAmount:      Maths.min(maxAmount_, _availableQuoteToken()),
-                index:          index_,
-                thresholdPrice: Loans.getMax(loans).thresholdPrice
+                maxAmount:                   Maths.min(maxAmount_, _availableQuoteToken()),
+                index:                       index_,
+                maxUnadjustedThresholdPrice: Loans.getMax(loans).unadjustedThresholdPrice
             })
         );
 
@@ -559,7 +559,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                     emaState,
                     deposits,
                     poolState_,
-                    Loans.getMax(loans).thresholdPrice,
+                    Loans.getMax(loans).unadjustedThresholdPrice,
                     elapsed
                 ) returns (uint256 newInflator, uint256 newInterest) {
                     poolState_.inflator = newInflator;
@@ -739,7 +739,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 kickTime_,
         uint256 referencePrice_,
         uint256 neutralPrice_,
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         address head_,
         address next_,
         address prev_
@@ -752,7 +752,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             liquidation.kickTime,
             liquidation.referencePrice,
             liquidation.neutralPrice,
-            liquidation.thresholdPrice,
+            liquidation.unadjustedThresholdPrice,
             auctions.head,
             liquidation.next,
             liquidation.prev
@@ -911,7 +911,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory loan = Loans.getByIndex(loans, loanId_);
         return (
             loan.borrower,
-            Maths.wmul(loan.thresholdPrice, COLLATERALIZATION_FACTOR)
+            Maths.wmul(loan.unadjustedThresholdPrice, COLLATERALIZATION_FACTOR)
         );
     }
 
@@ -920,7 +920,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            _htp(maxLoan.thresholdPrice, inflatorState.inflator),
+            _htp(maxLoan.unadjustedThresholdPrice, inflatorState.inflator),
             Loans.noOfLoans(loans)
         );
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -204,10 +204,10 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         _revertIfAuctionDebtLocked(deposits, poolState.t0DebtInAuction, fromIndex_, poolState.inflator);
 
         MoveQuoteParams memory moveParams;
-        moveParams.maxAmountToMove             = maxAmount_;
-        moveParams.fromIndex                   = fromIndex_;
-        moveParams.toIndex                     = toIndex_;
-        moveParams.maxUnadjustedThresholdPrice = Loans.getMax(loans).unadjustedThresholdPrice;
+        moveParams.maxAmountToMove       = maxAmount_;
+        moveParams.fromIndex             = fromIndex_;
+        moveParams.toIndex               = toIndex_;
+        moveParams.maxT0DebtToCollateral = Loans.getMax(loans).t0DebtToCollateral;
 
         uint256 newLup;
         (
@@ -247,9 +247,9 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             deposits,
             poolState,
             RemoveQuoteParams({
-                maxAmount:                   Maths.min(maxAmount_, _availableQuoteToken()),
-                index:                       index_,
-                maxUnadjustedThresholdPrice: Loans.getMax(loans).unadjustedThresholdPrice
+                maxAmount:             Maths.min(maxAmount_, _availableQuoteToken()),
+                index:                 index_,
+                maxT0DebtToCollateral: Loans.getMax(loans).t0DebtToCollateral
             })
         );
 
@@ -559,7 +559,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
                     emaState,
                     deposits,
                     poolState_,
-                    Loans.getMax(loans).unadjustedThresholdPrice,
+                    Loans.getMax(loans).t0DebtToCollateral,
                     elapsed
                 ) returns (uint256 newInflator, uint256 newInterest) {
                     poolState_.inflator = newInflator;
@@ -739,7 +739,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 kickTime_,
         uint256 referencePrice_,
         uint256 neutralPrice_,
-        uint256 unadjustedThresholdPrice_,
+        uint256 debtToCollateral_,
         address head_,
         address next_,
         address prev_
@@ -752,7 +752,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             liquidation.kickTime,
             liquidation.referencePrice,
             liquidation.neutralPrice,
-            liquidation.unadjustedThresholdPrice,
+            liquidation.debtToCollateral,
             auctions.head,
             liquidation.next,
             liquidation.prev
@@ -911,7 +911,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory loan = Loans.getByIndex(loans, loanId_);
         return (
             loan.borrower,
-            Maths.wmul(loan.unadjustedThresholdPrice, COLLATERALIZATION_FACTOR)
+            Maths.wmul(loan.t0DebtToCollateral, COLLATERALIZATION_FACTOR)
         );
     }
 
@@ -920,7 +920,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            _htp(maxLoan.unadjustedThresholdPrice, inflatorState.inflator),
+            _htp(maxLoan.t0DebtToCollateral, inflatorState.inflator),
             Loans.noOfLoans(loans)
         );
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -911,7 +911,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory loan = Loans.getByIndex(loans, loanId_);
         return (
             loan.borrower,
-            Maths.wmul(loan.t0DebtToCollateral, COLLATERALIZATION_FACTOR)
+            loan.t0DebtToCollateral
         );
     }
 
@@ -920,7 +920,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         Loan memory maxLoan = Loans.getMax(loans);
         return (
             maxLoan.borrower,
-            _htp(maxLoan.t0DebtToCollateral, inflatorState.inflator),
+            maxLoan.t0DebtToCollateral,
             Loans.noOfLoans(loans)
         );
     }

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -52,7 +52,6 @@ import {
 import {
     COLLATERALIZATION_FACTOR,
     _determineInflatorState,
-    _htp,
     _priceAt,
     _roundToScale
 }                               from '../libraries/helpers/PoolHelper.sol';

--- a/src/interfaces/pool/commons/IPoolErrors.sol
+++ b/src/interfaces/pool/commons/IPoolErrors.sol
@@ -205,8 +205,8 @@ interface IPoolErrors {
     error TransferToSameOwner();
 
     /**
-     *  @notice The threshold price of the loan to be inserted in loans heap is zero.
+     *  @notice The DebtToCollateral of the loan to be inserted in loans heap is zero.
      */
-    error ZeroThresholdPrice();
+    error ZeroDebtToCollateral();
 
 }

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -74,17 +74,17 @@ struct AddQuoteParams {
 
 /// @dev Struct used to hold parameters for `LenderAction.moveQuoteToken` action.
 struct MoveQuoteParams {
-    uint256 fromIndex;        // the deposit index from where amount is moved
-    uint256 maxAmountToMove;  // [WAD] max amount to move between deposits
-    uint256 toIndex;          // the deposit index where amount is moved to
-    uint256 thresholdPrice;   // [WAD] max threshold price in pool
+    uint256 fromIndex;                   // the deposit index from where amount is moved
+    uint256 maxAmountToMove;             // [WAD] max amount to move between deposits
+    uint256 toIndex;                     // the deposit index where amount is moved to
+    uint256 maxUnadjustedThresholdPrice; // [WAD] max unadjusted threshold price in pool
 }
 
 /// @dev Struct used to hold parameters for `LenderAction.removeQuoteToken` action.
 struct RemoveQuoteParams {
-    uint256 index;           // the deposit index from where amount is removed
-    uint256 maxAmount;       // [WAD] max amount to be removed
-    uint256 thresholdPrice;  // [WAD] max threshold price in pool
+    uint256 index;                       // the deposit index from where amount is removed
+    uint256 maxAmount;                   // [WAD] max amount to be removed
+    uint256 maxUnadjustedThresholdPrice; // [WAD] max unadjusted threshold price in pool
 }
 
 /*************************************/

--- a/src/interfaces/pool/commons/IPoolInternals.sol
+++ b/src/interfaces/pool/commons/IPoolInternals.sol
@@ -74,17 +74,17 @@ struct AddQuoteParams {
 
 /// @dev Struct used to hold parameters for `LenderAction.moveQuoteToken` action.
 struct MoveQuoteParams {
-    uint256 fromIndex;                   // the deposit index from where amount is moved
-    uint256 maxAmountToMove;             // [WAD] max amount to move between deposits
-    uint256 toIndex;                     // the deposit index where amount is moved to
-    uint256 maxUnadjustedThresholdPrice; // [WAD] max unadjusted threshold price in pool
+    uint256 fromIndex;             // the deposit index from where amount is moved
+    uint256 maxAmountToMove;       // [WAD] max amount to move between deposits
+    uint256 toIndex;               // the deposit index where amount is moved to
+    uint256 maxT0DebtToCollateral; // [WAD] max t0 debt to collateral in pool
 }
 
 /// @dev Struct used to hold parameters for `LenderAction.removeQuoteToken` action.
 struct RemoveQuoteParams {
-    uint256 index;                       // the deposit index from where amount is removed
-    uint256 maxAmount;                   // [WAD] max amount to be removed
-    uint256 maxUnadjustedThresholdPrice; // [WAD] max unadjusted threshold price in pool
+    uint256 index;                 // the deposit index from where amount is removed
+    uint256 maxAmount;             // [WAD] max amount to be removed
+    uint256 maxT0DebtToCollateral; // [WAD] max t0 debt to collateral in pool
 }
 
 /*************************************/

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -216,7 +216,7 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about pool loans.
-     *  @return maxBorrower_           Borrower address with highest threshold price.
+     *  @return maxBorrower_           Borrower address with highest t0 debt to collateral.
      *  @return maxT0DebtToCollateral_ Highest t0 debt to collateral in pool.
      *  @return noOfLoans_             Total number of loans.
      */

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -200,9 +200,9 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about a loan in the pool.
-     *  @param  loanId_         Loan's id within loan heap. Max loan is position `1`.
-     *  @return borrower_       Borrower address at the given position.
-     *  @return thresholdPrice_ Borrower threshold price in pool (including the collateralization factor).
+     *  @param  loanId_             Loan's id within loan heap. Max loan is position `1`.
+     *  @return borrower_           Borrower address at the given position.
+     *  @return t0DebtToCollateral_ Borrower t0 debt to collateral.
      */
     function loanInfo(
         uint256 loanId_
@@ -211,21 +211,21 @@ interface IPoolState {
         view
         returns (
             address borrower_,
-            uint256 thresholdPrice_
+            uint256 t0DebtToCollateral_
     );
 
     /**
      *  @notice Returns information about pool loans.
-     *  @return maxBorrower_       Borrower address with highest threshold price.
-     *  @return maxThresholdPrice_ Highest threshold price in pool (including the collateralization factor).
-     *  @return noOfLoans_         Total number of loans.
+     *  @return maxBorrower_           Borrower address with highest threshold price.
+     *  @return maxT0DebtToCollateral_ Highest t0 debt to collateral in pool.
+     *  @return noOfLoans_             Total number of loans.
      */
     function loansInfo()
         external
         view
         returns (
             address maxBorrower_,
-            uint256 maxThresholdPrice_,
+            uint256 maxT0DebtToCollateral_,
             uint256 noOfLoans_
     );
 

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -9,17 +9,17 @@ interface IPoolState {
 
     /**
      *  @notice Returns details of an auction for a given borrower address.
-     *  @param  borrower_       Address of the borrower that is liquidated.
-     *  @return kicker_         Address of the kicker that is kicking the auction.
-     *  @return bondFactor_     The factor used for calculating bond size.
-     *  @return bondSize_       The bond amount in quote token terms.
-     *  @return kickTime_       Time the liquidation was initiated.
-     *  @return referencePrice_ Price used to determine auction start price.
-     *  @return neutralPrice_   `Neutral Price` of auction.
-     *  @return thresholdPrice_ Threshold Price when liquidation was started.
-     *  @return head_           Address of the head auction.
-     *  @return next_           Address of the next auction in queue.
-     *  @return prev_           Address of the prev auction in queue.
+     *  @param  borrower_                 Address of the borrower that is liquidated.
+     *  @return kicker_                   Address of the kicker that is kicking the auction.
+     *  @return bondFactor_               The factor used for calculating bond size.
+     *  @return bondSize_                 The bond amount in quote token terms.
+     *  @return kickTime_                 Time the liquidation was initiated.
+     *  @return referencePrice_           Price used to determine auction start price.
+     *  @return neutralPrice_             `Neutral Price` of auction.
+     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation.
+     *  @return head_                     Address of the head auction.
+     *  @return next_                     Address of the next auction in queue.
+     *  @return prev_                     Address of the prev auction in queue.
      */
     function auctionInfo(address borrower_)
         external
@@ -31,7 +31,7 @@ interface IPoolState {
             uint256 kickTime_,
             uint256 referencePrice_,
             uint256 neutralPrice_,
-            uint256 thresholdPrice_,
+            uint256 unadjustedThresholdPrice_,
             address head_,
             address next_,
             address prev_
@@ -200,9 +200,9 @@ interface IPoolState {
 
     /**
      *  @notice Returns information about a loan in the pool.
-     *  @param  loanId_           Loan's id within loan heap. Max loan is position `1`.
-     *  @return borrower_         Borrower address at the given position.
-     *  @return t0ThresholdPrice_ Borrower t0 threshold price in pool.
+     *  @param  loanId_         Loan's id within loan heap. Max loan is position `1`.
+     *  @return borrower_       Borrower address at the given position.
+     *  @return thresholdPrice_ Borrower threshold price in pool (including the collateralization factor).
      */
     function loanInfo(
         uint256 loanId_
@@ -211,13 +211,13 @@ interface IPoolState {
         view
         returns (
             address borrower_,
-            uint256 t0ThresholdPrice_
+            uint256 thresholdPrice_
     );
 
     /**
      *  @notice Returns information about pool loans.
      *  @return maxBorrower_       Borrower address with highest threshold price.
-     *  @return maxThresholdPrice_ Highest threshold price in pool.
+     *  @return maxThresholdPrice_ Highest threshold price in pool (including the collateralization factor).
      *  @return noOfLoans_         Total number of loans.
      */
     function loansInfo()
@@ -380,8 +380,8 @@ struct LoansState {
 
 /// @dev Struct holding loan state.
 struct Loan {
-    address borrower;       // borrower address
-    uint96  thresholdPrice; // [WAD] Loan's threshold price.
+    address borrower;                 // borrower address
+    uint96  unadjustedThresholdPrice; // [WAD] Loan's unadjusted threshold price (`debt / collateral`).
 }
 
 /// @dev Struct holding borrower state.
@@ -407,16 +407,16 @@ struct AuctionsState {
 
 /// @dev Struct holding liquidation state.
 struct Liquidation {
-    address kicker;                // address that initiated liquidation
-    uint96  bondFactor;            // [WAD] bond factor used to start liquidation
-    uint96  kickTime;              // timestamp when liquidation was started
-    address prev;                  // previous liquidated borrower in auctions queue
-    uint96  referencePrice;        // [WAD] used to calculate auction start price
-    address next;                  // next liquidated borrower in auctions queue
-    uint160 bondSize;              // [WAD] liquidation bond size
-    uint96  neutralPrice;          // [WAD] Neutral Price when liquidation was started
-    uint256 thresholdPrice;        // [WAD] Threshold Price when liquidation was started
-    uint256 t0ReserveSettleAmount; // [WAD] Amount of t0Debt that could be settled via reserves in this auction
+    address kicker;                   // address that initiated liquidation
+    uint96  bondFactor;               // [WAD] bond factor used to start liquidation
+    uint96  kickTime;                 // timestamp when liquidation was started
+    address prev;                     // previous liquidated borrower in auctions queue
+    uint96  referencePrice;           // [WAD] used to calculate auction start price
+    address next;                     // next liquidated borrower in auctions queue
+    uint160 bondSize;                 // [WAD] liquidation bond size
+    uint96  neutralPrice;             // [WAD] Neutral Price when liquidation was started
+    uint256 unadjustedThresholdPrice; // [WAD] Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation
+    uint256 t0ReserveSettleAmount;    // [WAD] Amount of t0Debt that could be settled via reserves in this auction
 }
 
 /// @dev Struct holding kicker state.

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -9,17 +9,17 @@ interface IPoolState {
 
     /**
      *  @notice Returns details of an auction for a given borrower address.
-     *  @param  borrower_                 Address of the borrower that is liquidated.
-     *  @return kicker_                   Address of the kicker that is kicking the auction.
-     *  @return bondFactor_               The factor used for calculating bond size.
-     *  @return bondSize_                 The bond amount in quote token terms.
-     *  @return kickTime_                 Time the liquidation was initiated.
-     *  @return referencePrice_           Price used to determine auction start price.
-     *  @return neutralPrice_             `Neutral Price` of auction.
-     *  @return unadjustedThresholdPrice_ Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation.
-     *  @return head_                     Address of the head auction.
-     *  @return next_                     Address of the next auction in queue.
-     *  @return prev_                     Address of the prev auction in queue.
+     *  @param  borrower_         Address of the borrower that is liquidated.
+     *  @return kicker_           Address of the kicker that is kicking the auction.
+     *  @return bondFactor_       The factor used for calculating bond size.
+     *  @return bondSize_         The bond amount in quote token terms.
+     *  @return kickTime_         Time the liquidation was initiated.
+     *  @return referencePrice_   Price used to determine auction start price.
+     *  @return neutralPrice_     `Neutral Price` of auction.
+     *  @return debtToCollateral_ Borrower debt to collateral, which is used in BPF for kicker's reward calculation.
+     *  @return head_             Address of the head auction.
+     *  @return next_             Address of the next auction in queue.
+     *  @return prev_             Address of the prev auction in queue.
      */
     function auctionInfo(address borrower_)
         external
@@ -31,7 +31,7 @@ interface IPoolState {
             uint256 kickTime_,
             uint256 referencePrice_,
             uint256 neutralPrice_,
-            uint256 unadjustedThresholdPrice_,
+            uint256 debtToCollateral_,
             address head_,
             address next_,
             address prev_
@@ -380,8 +380,8 @@ struct LoansState {
 
 /// @dev Struct holding loan state.
 struct Loan {
-    address borrower;                 // borrower address
-    uint96  unadjustedThresholdPrice; // [WAD] Loan's unadjusted threshold price (`debt / collateral`).
+    address borrower;           // borrower address
+    uint96  t0DebtToCollateral; // [WAD] Borrower t0 debt to collateral.
 }
 
 /// @dev Struct holding borrower state.
@@ -407,16 +407,16 @@ struct AuctionsState {
 
 /// @dev Struct holding liquidation state.
 struct Liquidation {
-    address kicker;                   // address that initiated liquidation
-    uint96  bondFactor;               // [WAD] bond factor used to start liquidation
-    uint96  kickTime;                 // timestamp when liquidation was started
-    address prev;                     // previous liquidated borrower in auctions queue
-    uint96  referencePrice;           // [WAD] used to calculate auction start price
-    address next;                     // next liquidated borrower in auctions queue
-    uint160 bondSize;                 // [WAD] liquidation bond size
-    uint96  neutralPrice;             // [WAD] Neutral Price when liquidation was started
-    uint256 unadjustedThresholdPrice; // [WAD] Unadjusted threshold Price (`debt / collateral`), which is used in BPF for kicker's reward calculation
-    uint256 t0ReserveSettleAmount;    // [WAD] Amount of t0Debt that could be settled via reserves in this auction
+    address kicker;                // address that initiated liquidation
+    uint96  bondFactor;            // [WAD] bond factor used to start liquidation
+    uint96  kickTime;              // timestamp when liquidation was started
+    address prev;                  // previous liquidated borrower in auctions queue
+    uint96  referencePrice;        // [WAD] used to calculate auction start price
+    address next;                  // next liquidated borrower in auctions queue
+    uint160 bondSize;              // [WAD] liquidation bond size
+    uint96  neutralPrice;          // [WAD] Neutral Price when liquidation was started
+    uint256 debtToCollateral;      // [WAD] Borrower debt to collateral, which is used in BPF for kicker's reward calculation
+    uint256 t0ReserveSettleAmount; // [WAD] Amount of t0Debt that could be settled via reserves in this auction
 }
 
 /// @dev Struct holding kicker state.

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -57,16 +57,16 @@ library KickerActions {
 
     /// @dev Struct used for `kick` function local vars.
     struct KickLocalVars {
-        uint256 borrowerDebt;          // [WAD] the accrued debt of kicked borrower
-        uint256 borrowerCollateral;    // [WAD] amount of kicked borrower collateral
-        uint256 t0ReserveSettleAmount; // [WAD] Amount of t0Debt that could be settled via reserves in an auction
-        uint256 borrowerNpTpRatio;     // [WAD] borrower NP to TP ratio
-        uint256 neutralPrice;          // [WAD] neutral price recorded in kick action
-        uint256 htp;                   // [WAD] highest threshold price in pool
-        uint256 referencePrice;        // [WAD] used to calculate auction start price
-        uint256 bondFactor;            // [WAD] bond factor of kicked auction
-        uint256 bondSize;              // [WAD] bond size of kicked auction
-        uint256 thresholdPrice;        // [WAD] borrower threshold price at kick time
+        uint256 borrowerDebt;             // [WAD] the accrued debt of kicked borrower
+        uint256 borrowerCollateral;       // [WAD] amount of kicked borrower collateral
+        uint256 t0ReserveSettleAmount;    // [WAD] Amount of t0Debt that could be settled via reserves in an auction
+        uint256 borrowerNpTpRatio;        // [WAD] borrower NP to TP ratio
+        uint256 neutralPrice;             // [WAD] neutral price recorded in kick action
+        uint256 htp;                      // [WAD] highest threshold price (including the collateralization factor) in pool
+        uint256 referencePrice;           // [WAD] used to calculate auction start price
+        uint256 bondFactor;               // [WAD] bond factor of kicked auction
+        uint256 bondSize;                 // [WAD] bond size of kicked auction
+        uint256 unadjustedThresholdPrice; // [WAD] borrower unadjusted threshold price at kick time
     }
 
     /// @dev Struct used for `lenderKick` function local vars.
@@ -346,7 +346,7 @@ library KickerActions {
         // which will make it harder for kicker to earn a reward and more likely that the kicker is penalized
         _revertIfPriceDroppedBelowLimit(vars.neutralPrice, limitIndex_);
 
-        vars.htp            = _htp(Loans.getMax(loans_).thresholdPrice, poolState_.inflator);
+        vars.htp            = _htp(Loans.getMax(loans_).unadjustedThresholdPrice, poolState_.inflator);
         vars.referencePrice = Maths.min(Maths.max(vars.htp, vars.neutralPrice), MAX_INFLATED_PRICE);
 
         (vars.bondFactor, vars.bondSize) = _bondParams(
@@ -354,7 +354,7 @@ library KickerActions {
             vars.borrowerNpTpRatio
         );
 
-        vars.thresholdPrice = Maths.wdiv(vars.borrowerDebt, vars.borrowerCollateral);
+        vars.unadjustedThresholdPrice = Maths.wdiv(vars.borrowerDebt, vars.borrowerCollateral);
 
         // record liquidation info
         _recordAuction(
@@ -365,7 +365,7 @@ library KickerActions {
             vars.bondFactor,
             vars.referencePrice,
             vars.neutralPrice,
-            vars.thresholdPrice,
+            vars.unadjustedThresholdPrice,
             vars.t0ReserveSettleAmount
         );
 
@@ -420,15 +420,15 @@ library KickerActions {
      *  @dev    `borrower -> liquidation` mapping update
      *  @dev    increment auctions count accumulator
      *  @dev    updates auction queue state
-     *  @param  auctions_              Struct for pool auctions state.
-     *  @param  liquidation_           Struct for current auction state.
-     *  @param  borrowerAddress_       Address of the borrower that is kicked.
-     *  @param  bondSize_              Bond size to cover newly kicked auction.
-     *  @param  bondFactor_            Bond factor of the newly kicked auction.
-     *  @param  referencePrice_        Used to calculate auction start price.
-     *  @param  neutralPrice_          Current pool `Neutral Price`.
-     *  @param  thresholdPrice_        Borrower threshold price.
-     *  @param  t0ReserveSettleAmount_ Amount of t0Debt that could be settled via reserves in auction
+     *  @param  auctions_                 Struct for pool auctions state.
+     *  @param  liquidation_              Struct for current auction state.
+     *  @param  borrowerAddress_          Address of the borrower that is kicked.
+     *  @param  bondSize_                 Bond size to cover newly kicked auction.
+     *  @param  bondFactor_               Bond factor of the newly kicked auction.
+     *  @param  referencePrice_           Used to calculate auction start price.
+     *  @param  neutralPrice_             Current pool `Neutral Price`.
+     *  @param  unadjustedThresholdPrice_ Borrower unadjusted threshold price.
+     *  @param  t0ReserveSettleAmount_    Amount of t0Debt that could be settled via reserves in auction
      */
     function _recordAuction(
         AuctionsState storage auctions_,
@@ -438,17 +438,17 @@ library KickerActions {
         uint256 bondFactor_,
         uint256 referencePrice_,
         uint256 neutralPrice_,
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         uint256 t0ReserveSettleAmount_
     ) internal {
         // record liquidation info
-        liquidation_.kicker                = msg.sender;
-        liquidation_.kickTime              = uint96(block.timestamp);
-        liquidation_.bondSize              = SafeCast.toUint160(bondSize_);
-        liquidation_.bondFactor            = SafeCast.toUint96(bondFactor_);
-        liquidation_.neutralPrice          = SafeCast.toUint96(neutralPrice_);
-        liquidation_.thresholdPrice        = thresholdPrice_;
-        liquidation_.t0ReserveSettleAmount = t0ReserveSettleAmount_;
+        liquidation_.kicker                   = msg.sender;
+        liquidation_.kickTime                 = uint96(block.timestamp);
+        liquidation_.bondSize                 = SafeCast.toUint160(bondSize_);
+        liquidation_.bondFactor               = SafeCast.toUint96(bondFactor_);
+        liquidation_.neutralPrice             = SafeCast.toUint96(neutralPrice_);
+        liquidation_.unadjustedThresholdPrice = unadjustedThresholdPrice_;
+        liquidation_.t0ReserveSettleAmount    = t0ReserveSettleAmount_;
 
         // increment number of active auctions
         ++auctions_.noOfAuctions;

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -303,7 +303,7 @@ library LenderActions {
 
         // recalculate LUP and HTP
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        vars.htp = _htp(params_.thresholdPrice, poolState_.inflator);
+        vars.htp = _htp(params_.maxUnadjustedThresholdPrice, poolState_.inflator);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (
@@ -420,7 +420,7 @@ library LenderActions {
 
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
-        uint256 htp = _htp(params_.thresholdPrice, poolState_.inflator);
+        uint256 htp = _htp(params_.maxUnadjustedThresholdPrice, poolState_.inflator);
 
         if (
             // check loan book's htp doesn't exceed new lup

--- a/src/libraries/external/LenderActions.sol
+++ b/src/libraries/external/LenderActions.sol
@@ -303,7 +303,7 @@ library LenderActions {
 
         // recalculate LUP and HTP
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
-        vars.htp = _htp(params_.maxUnadjustedThresholdPrice, poolState_.inflator);
+        vars.htp = _htp(params_.maxT0DebtToCollateral, poolState_.inflator);
 
         // check loan book's htp against new lup, revert if move drives LUP below HTP
         if (
@@ -420,7 +420,7 @@ library LenderActions {
 
         lup_ = Deposits.getLup(deposits_, poolState_.debt);
 
-        uint256 htp = _htp(params_.maxUnadjustedThresholdPrice, poolState_.inflator);
+        uint256 htp = _htp(params_.maxT0DebtToCollateral, poolState_.inflator);
 
         if (
             // check loan book's htp doesn't exceed new lup

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -239,19 +239,19 @@ library PoolCommons {
      *  @dev    === Write state ===
      *  @dev    - `Deposits.mult` (scale `Fenwick` tree with new interest accrued):
      *  @dev      update `scaling` array state
-     *  @param  emaParams_                Struct for pool `EMA`s state.
-     *  @param  deposits_                 Struct for pool deposits state.
-     *  @param  poolState_                Current state of the pool.
-     *  @param  unadjustedThresholdPrice_ Max Unadjusted Threshold Price in Pool.
-     *  @param  elapsed_                  Time elapsed since last inflator update.
-     *  @return newInflator_              The new value of pool inflator.
-     *  @return newInterest_              The new interest accrued.
+     *  @param  emaParams_             Struct for pool `EMA`s state.
+     *  @param  deposits_              Struct for pool deposits state.
+     *  @param  poolState_             Current state of the pool.
+     *  @param  maxT0DebtToCollateral_ Max t0 debt to collateral in Pool.
+     *  @param  elapsed_               Time elapsed since last inflator update.
+     *  @return newInflator_           The new value of pool inflator.
+     *  @return newInterest_           The new interest accrued.
      */
     function accrueInterest(
         EmaState      storage emaParams_,
         DepositsState storage deposits_,
         PoolState calldata poolState_,
-        uint256 unadjustedThresholdPrice_,
+        uint256 maxT0DebtToCollateral_,
         uint256 elapsed_
     ) external returns (uint256 newInflator_, uint256 newInterest_) {
         // Scale the borrower inflator to update amount of interest owed by borrowers
@@ -259,7 +259,7 @@ library PoolCommons {
 
         // calculate the highest threshold price
         newInflator_ = Maths.wmul(poolState_.inflator, pendingFactor);
-        uint256 htp  = _htp(unadjustedThresholdPrice_, poolState_.inflator);
+        uint256 htp  = _htp(maxT0DebtToCollateral_, poolState_.inflator);
 
         uint256 accrualIndex;
         if (htp > MAX_PRICE)      accrualIndex = 1;                 // if HTP is over the highest price bucket then no buckets earn interest

--- a/src/libraries/external/PoolCommons.sol
+++ b/src/libraries/external/PoolCommons.sol
@@ -239,19 +239,19 @@ library PoolCommons {
      *  @dev    === Write state ===
      *  @dev    - `Deposits.mult` (scale `Fenwick` tree with new interest accrued):
      *  @dev      update `scaling` array state
-     *  @param  emaParams_      Struct for pool `EMA`s state.
-     *  @param  deposits_       Struct for pool deposits state.
-     *  @param  poolState_      Current state of the pool.
-     *  @param  thresholdPrice_ Current Pool Threshold Price.
-     *  @param  elapsed_        Time elapsed since last inflator update.
-     *  @return newInflator_    The new value of pool inflator.
-     *  @return newInterest_    The new interest accrued.
+     *  @param  emaParams_                Struct for pool `EMA`s state.
+     *  @param  deposits_                 Struct for pool deposits state.
+     *  @param  poolState_                Current state of the pool.
+     *  @param  unadjustedThresholdPrice_ Max Unadjusted Threshold Price in Pool.
+     *  @param  elapsed_                  Time elapsed since last inflator update.
+     *  @return newInflator_              The new value of pool inflator.
+     *  @return newInterest_              The new interest accrued.
      */
     function accrueInterest(
         EmaState      storage emaParams_,
         DepositsState storage deposits_,
         PoolState calldata poolState_,
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         uint256 elapsed_
     ) external returns (uint256 newInflator_, uint256 newInterest_) {
         // Scale the borrower inflator to update amount of interest owed by borrowers
@@ -259,7 +259,7 @@ library PoolCommons {
 
         // calculate the highest threshold price
         newInflator_ = Maths.wmul(poolState_.inflator, pendingFactor);
-        uint256 htp  = _htp(thresholdPrice_, poolState_.inflator);
+        uint256 htp  = _htp(unadjustedThresholdPrice_, poolState_.inflator);
 
         uint256 accrualIndex;
         if (htp > MAX_PRICE)      accrualIndex = 1;                 // if HTP is over the highest price bucket then no buckets earn interest

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -699,7 +699,7 @@ library TakerActions {
         vars.bucketPrice = bucketPrice_;
         vars.bondFactor   = liquidation_.bondFactor;
         vars.bpf          = _bpf(
-            liquidation_.unadjustedThresholdPrice,
+            liquidation_.debtToCollateral,
             neutralPrice,
             liquidation_.bondFactor,
             bucketPrice_ == 0 ? vars.auctionPrice : bucketPrice_

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -699,7 +699,7 @@ library TakerActions {
         vars.bucketPrice = bucketPrice_;
         vars.bondFactor   = liquidation_.bondFactor;
         vars.bpf          = _bpf(
-            liquidation_.thresholdPrice,
+            liquidation_.unadjustedThresholdPrice,
             neutralPrice,
             liquidation_.bondFactor,
             bucketPrice_ == 0 ? vars.auctionPrice : bucketPrice_

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -169,15 +169,15 @@ import { Maths }   from '../internal/Maths.sol';
 
     /**
      *  @notice Calculates `HTP` price.
-     *  @param  thresholdPrice_ Threshold price.
-     *  @param  inflator_       Pool's inflator.
+     *  @param  unadjustedThresholdPrice_ Unadjusted Threshold price.
+     *  @param  inflator_                 Pool's inflator.
      */
     function _htp(
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         uint256 inflator_
     ) pure returns (uint256) {
         return Maths.wmul(
-            Maths.wmul(thresholdPrice_, inflator_),
+            Maths.wmul(unadjustedThresholdPrice_, inflator_),
             COLLATERALIZATION_FACTOR
         );
     }
@@ -400,10 +400,10 @@ import { Maths }   from '../internal/Maths.sol';
     /*** Auction Utilities ***/
     /*************************/
 
-    /// @dev max bond factor.
+    /// @dev min bond factor.
     uint256 constant MIN_BOND_FACTOR = 0.005 * 1e18;
-    /// @dev max NP / TP ratio.
-    uint256 constant MAX_NP_TP_RATIO = 0.03 * 1e18;
+    /// @dev max bond factor.
+    uint256 constant MAX_BOND_FACTOR = 0.03 * 1e18;
 
     /**
      *  @notice Calculates auction price.
@@ -433,28 +433,28 @@ import { Maths }   from '../internal/Maths.sol';
     /**
      *  @notice Calculates bond penalty factor.
      *  @dev    Called in kick and take.
-     *  @param thresholdPrice_ Borrower tp at time of kick.
-     *  @param neutralPrice_   `NP` of auction.
-     *  @param bondFactor_     Factor used to determine bondSize.
-     *  @param auctionPrice_   Auction price at the time of call or, for bucket takes, bucket price.
-     *  @return bpf_           Factor used in determining bond `reward` (positive) or `penalty` (negative).
+     *  @param unadjustedThresholdPrice_ Borrower unadjusted threshold price at time of kick.
+     *  @param neutralPrice_             `NP` of auction.
+     *  @param bondFactor_               Factor used to determine bondSize.
+     *  @param auctionPrice_             Auction price at the time of call or, for bucket takes, bucket price.
+     *  @return bpf_                     Factor used in determining bond `reward` (positive) or `penalty` (negative).
      */
     function _bpf(
-        uint256 thresholdPrice_,
+        uint256 unadjustedThresholdPrice_,
         uint256 neutralPrice_,
         uint256 bondFactor_,
         uint256 auctionPrice_
     ) pure returns (int256) {
         int256 sign;
-        if (thresholdPrice_ < neutralPrice_) {
-            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - thresholdPrice)))
+        if (unadjustedThresholdPrice_ < neutralPrice_) {
+            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - unadjustedThresholdPrice)))
             sign = Maths.minInt(
                 1e18,
                 Maths.maxInt(
                     -1 * 1e18,
                     PRBMathSD59x18.div(
                         int256(neutralPrice_) - int256(auctionPrice_),
-                        int256(neutralPrice_) - int256(thresholdPrice_)
+                        int256(neutralPrice_) - int256(unadjustedThresholdPrice_)
                     )
                 )
             );
@@ -476,10 +476,10 @@ import { Maths }   from '../internal/Maths.sol';
         uint256 borrowerDebt_,
         uint256 npTpRatio_
     ) pure returns (uint256 bondFactor_, uint256 bondSize_) {
-        // bondFactor = max(min(0.03,(((NP/TP_ratio)-1)/10)),0.005)
+        // bondFactor = max(min(MAX_BOND_FACTOR, (NP/TP_ratio - 1) / 10), MIN_BOND_FACTOR)
         bondFactor_ = Maths.max(
             Maths.min(
-                MAX_NP_TP_RATIO,
+                MAX_BOND_FACTOR,
                 (npTpRatio_ - 1e18) / 10
             ),
             MIN_BOND_FACTOR

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -169,15 +169,15 @@ import { Maths }   from '../internal/Maths.sol';
 
     /**
      *  @notice Calculates `HTP` price.
-     *  @param  unadjustedThresholdPrice_ Unadjusted Threshold price.
-     *  @param  inflator_                 Pool's inflator.
+     *  @param  maxT0DebtToCollateral_ Max t0 debt to collateral in pool.
+     *  @param  inflator_              Pool's inflator.
      */
     function _htp(
-        uint256 unadjustedThresholdPrice_,
+        uint256 maxT0DebtToCollateral_,
         uint256 inflator_
     ) pure returns (uint256) {
         return Maths.wmul(
-            Maths.wmul(unadjustedThresholdPrice_, inflator_),
+            Maths.wmul(maxT0DebtToCollateral_, inflator_),
             COLLATERALIZATION_FACTOR
         );
     }
@@ -433,28 +433,28 @@ import { Maths }   from '../internal/Maths.sol';
     /**
      *  @notice Calculates bond penalty factor.
      *  @dev    Called in kick and take.
-     *  @param unadjustedThresholdPrice_ Borrower unadjusted threshold price at time of kick.
-     *  @param neutralPrice_             `NP` of auction.
-     *  @param bondFactor_               Factor used to determine bondSize.
-     *  @param auctionPrice_             Auction price at the time of call or, for bucket takes, bucket price.
-     *  @return bpf_                     Factor used in determining bond `reward` (positive) or `penalty` (negative).
+     *  @param debtToCollateral_ Borrower debt to collateral at time of kick.
+     *  @param neutralPrice_     `NP` of auction.
+     *  @param bondFactor_       Factor used to determine bondSize.
+     *  @param auctionPrice_     Auction price at the time of call or, for bucket takes, bucket price.
+     *  @return bpf_             Factor used in determining bond `reward` (positive) or `penalty` (negative).
      */
     function _bpf(
-        uint256 unadjustedThresholdPrice_,
+        uint256 debtToCollateral_,
         uint256 neutralPrice_,
         uint256 bondFactor_,
         uint256 auctionPrice_
     ) pure returns (int256) {
         int256 sign;
-        if (unadjustedThresholdPrice_ < neutralPrice_) {
-            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - unadjustedThresholdPrice)))
+        if (debtToCollateral_ < neutralPrice_) {
+            // BPF = BondFactor * min(1, max(-1, (neutralPrice - price) / (neutralPrice - debtToCollateral)))
             sign = Maths.minInt(
                 1e18,
                 Maths.maxInt(
                     -1 * 1e18,
                     PRBMathSD59x18.div(
                         int256(neutralPrice_) - int256(auctionPrice_),
-                        int256(neutralPrice_) - int256(unadjustedThresholdPrice_)
+                        int256(neutralPrice_) - int256(debtToCollateral_)
                     )
                 )
             );

--- a/src/libraries/internal/Loans.sol
+++ b/src/libraries/internal/Loans.sol
@@ -35,7 +35,7 @@ library Loans {
     /**************/
 
     // See `IPoolErrors` for descriptions
-    error ZeroThresholdPrice();
+    error ZeroDebtToCollateral();
 
     /***********************/
     /***  Initialization ***/
@@ -88,7 +88,7 @@ library Loans {
             uint256 loanId = loans_.indices[borrowerAddress_];
             if (activeBorrower) {
                 // revert if t0 threshold price is zero
-                if (t0DebtToCollateral == 0) revert ZeroThresholdPrice();
+                if (t0DebtToCollateral == 0) revert ZeroDebtToCollateral();
 
                 // update heap, insert if a new loan, update loan if already in heap
                 _upsert(loans_, borrowerAddress_, loanId, uint96(t0DebtToCollateral));

--- a/src/libraries/internal/Loans.sol
+++ b/src/libraries/internal/Loans.sol
@@ -120,7 +120,7 @@ library Loans {
      */
     function _bubbleUp(LoansState storage loans_, Loan memory loan_, uint index_) private {
         uint256 count = loans_.loans.length;
-        if (index_ == ROOT_INDEX || loan_.thresholdPrice <= loans_.loans[index_ / 2].thresholdPrice){
+        if (index_ == ROOT_INDEX || loan_.unadjustedThresholdPrice <= loans_.loans[index_ / 2].unadjustedThresholdPrice){
           _insert(loans_, loan_, index_, count);
         } else {
           _insert(loans_, loans_.loans[index_ / 2], index_, count);
@@ -144,11 +144,11 @@ library Loans {
         } else {
             Loan memory largestChild = loans_.loans[cIndex];
 
-            if (count > cIndex + 1 && loans_.loans[cIndex + 1].thresholdPrice > largestChild.thresholdPrice) {
+            if (count > cIndex + 1 && loans_.loans[cIndex + 1].unadjustedThresholdPrice > largestChild.unadjustedThresholdPrice) {
                 largestChild = loans_.loans[++cIndex];
             }
 
-            if (largestChild.thresholdPrice <= loan_.thresholdPrice) {
+            if (largestChild.unadjustedThresholdPrice <= loan_.unadjustedThresholdPrice) {
               _insert(loans_, loan_, index_, count);
             } else {
               _insert(loans_, largestChild, index_, count);
@@ -190,31 +190,31 @@ library Loans {
 
     /**
      *  @notice Performs an insert or an update dependent on borrowers existance.
-     *  @param loans_          Holds loans heap data.
-     *  @param borrower_       Borrower address that is being updated or inserted.
-     *  @param index_          Index of `Loan` to be upserted.
-     *  @param thresholdPrice_ `Threshold Price` that is updated or inserted.
+     *  @param loans_                    Holds loans heap data.
+     *  @param borrower_                 Borrower address that is being updated or inserted.
+     *  @param index_                    Index of `Loan` to be upserted.
+     *  @param unadjustedThresholdPrice_ `Unadjusted Threshold Price` that is updated or inserted.
      */
     function _upsert(
         LoansState storage loans_,
         address borrower_,
         uint256 index_,
-        uint96 thresholdPrice_
+        uint96 unadjustedThresholdPrice_
     ) internal {
         // Loan exists, update in place.
         if (index_ != 0) {
             Loan memory currentLoan = loans_.loans[index_];
-            if (currentLoan.thresholdPrice > thresholdPrice_) {
-                currentLoan.thresholdPrice = thresholdPrice_;
+            if (currentLoan.unadjustedThresholdPrice > unadjustedThresholdPrice_) {
+                currentLoan.unadjustedThresholdPrice = unadjustedThresholdPrice_;
                 _bubbleDown(loans_, currentLoan, index_);
             } else {
-                currentLoan.thresholdPrice = thresholdPrice_;
+                currentLoan.unadjustedThresholdPrice = unadjustedThresholdPrice_;
                 _bubbleUp(loans_, currentLoan, index_);
             }
 
         // New loan, insert it
         } else {
-            _bubbleUp(loans_, Loan(borrower_, thresholdPrice_), loans_.loans.length);
+            _bubbleUp(loans_, Loan(borrower_, unadjustedThresholdPrice_), loans_.loans.length);
         }
     }
 

--- a/src/libraries/internal/Loans.sol
+++ b/src/libraries/internal/Loans.sol
@@ -20,10 +20,10 @@ import { Maths }    from './Maths.sol';
 /**
     @title  Loans library
     @notice Internal library containing common logic for loans management.
-    @dev    The `Loans` heap is a `Max Heap` data structure (complete binary tree), the root node is the loan with the highest threshold price (`TP`)
+    @dev    The `Loans` heap is a `Max Heap` data structure (complete binary tree), the root node is the loan with the highest t0 threshold price (`TP`)
             at a given time. The heap is represented as an array, where the first element is a dummy element (`Loan(address(0), 0)`) and the first
-            value of the heap starts at index `1`, `ROOT_INDEX`. The threshold price of a loan's parent is always greater than or equal to the
-            threshold price of the loan.
+            value of the heap starts at index `1`, `ROOT_INDEX`. The t0 threshold price of a loan's parent is always greater than or equal to the
+            t0 threshold price of the loan.
     @dev    This code was modified from the following source: https://github.com/zmitton/eth-heap/blob/master/contracts/Heap.sol
  */
 library Loans {
@@ -43,7 +43,7 @@ library Loans {
 
     /**
      *  @notice Initializes Loans Max Heap.
-     *  @dev    Organizes loans so `Highest Threshold Price` can be retrieved easily.
+     *  @dev    Organizes loans so `Highest t0 threshold price` can be retrieved easily.
      *  @param  loans_ Holds Loan heap data.
      */
     function init(LoansState storage loans_) internal {
@@ -82,12 +82,12 @@ library Loans {
 
         uint256 t0DebtToCollateral = activeBorrower ? Maths.wdiv(borrower_.t0Debt, borrower_.collateral) : 0;
 
-        // loan not in auction, update threshold price and position in heap
+        // loan not in auction, update t0 threshold price and position in heap
         if (!inAuction_ ) {
             // get the loan id inside the heap
             uint256 loanId = loans_.indices[borrowerAddress_];
             if (activeBorrower) {
-                // revert if threshold price is zero
+                // revert if t0 threshold price is zero
                 if (t0DebtToCollateral == 0) revert ZeroThresholdPrice();
 
                 // update heap, insert if a new loan, update loan if already in heap
@@ -234,7 +234,7 @@ library Loans {
     }
 
     /**
-     *  @notice Retreives `Loan` with the highest threshold price value.
+     *  @notice Retreives `Loan` with the highest t0 threshold price value.
      *  @param loans_ Holds loans heap data.
      *  @return `Max Loan` in the heap.
      */

--- a/src/libraries/internal/Loans.sol
+++ b/src/libraries/internal/Loans.sol
@@ -2,6 +2,7 @@
 
 pragma solidity 0.8.18;
 
+import { SafeCast }       from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { PRBMathSD59x18 } from "@prb-math/contracts/PRBMathSD59x18.sol";
 
 import {
@@ -91,7 +92,7 @@ library Loans {
                 if (t0DebtToCollateral == 0) revert ZeroDebtToCollateral();
 
                 // update heap, insert if a new loan, update loan if already in heap
-                _upsert(loans_, borrowerAddress_, loanId, uint96(t0DebtToCollateral));
+                _upsert(loans_, borrowerAddress_, loanId, SafeCast.toUint96(t0DebtToCollateral));
 
             // if loan is in heap and borrwer is no longer active (no debt, no collateral) then remove loan from heap
             } else if (loanId != 0) {

--- a/tests/INVARIANTS.md
+++ b/tests/INVARIANTS.md
@@ -28,8 +28,8 @@
 - **A9**: reference prices in liquidation queue shall not decrease
 
 ## Loans
-- **L1**: for each `Loan` in loans array (`LoansState.loans`) starting from index 1, the corresponding address (`Loan.borrower`) is not `0x`, the threshold price (`Loan.thresholdPrice`) is different than 0 and the id mapped in indices mapping (`LoansState.indices`) equals index of loan in loans array.  
-- **L2**: `Loan` in loans array (`LoansState.loans`) at index 0 has the corresponding address (`Loan.borrower`) equal with `0x` address and the threshold price (`Loan.thresholdPrice`) equal with 0
+- **L1**: for each `Loan` in loans array (`LoansState.loans`) starting from index 1, the corresponding address (`Loan.borrower`) is not `0x`, the unadjusted threshold price (`Loan.unadjustedThresholdPrice`) is different than 0 and the id mapped in indices mapping (`LoansState.indices`) equals index of loan in loans array.
+- **L2**: `Loan` in loans array (`LoansState.loans`) at index 0 has the corresponding address (`Loan.borrower`) equal with `0x` address and the unadjusted threshold price (`Loan.unadjustedThresholdPrice`) equal with 0
 - **L3**: Loans array (`LoansState.loans`) is a max-heap with respect to t0-threshold price: the t0TP of loan at index `i` is >= the t0-threshold price of the loans at index `2*i` and `2*i+1`
 
 ## Buckets

--- a/tests/INVARIANTS.md
+++ b/tests/INVARIANTS.md
@@ -28,8 +28,8 @@
 - **A9**: reference prices in liquidation queue shall not decrease
 
 ## Loans
-- **L1**: for each `Loan` in loans array (`LoansState.loans`) starting from index 1, the corresponding address (`Loan.borrower`) is not `0x`, the unadjusted threshold price (`Loan.unadjustedThresholdPrice`) is different than 0 and the id mapped in indices mapping (`LoansState.indices`) equals index of loan in loans array.
-- **L2**: `Loan` in loans array (`LoansState.loans`) at index 0 has the corresponding address (`Loan.borrower`) equal with `0x` address and the unadjusted threshold price (`Loan.unadjustedThresholdPrice`) equal with 0
+- **L1**: for each `Loan` in loans array (`LoansState.loans`) starting from index 1, the corresponding address (`Loan.borrower`) is not `0x`, the borrower t0 debt to collateral (`Loan.t0DebtToCollateral`) is different than 0 and the id mapped in indices mapping (`LoansState.indices`) equals index of loan in loans array.
+- **L2**: `Loan` in loans array (`LoansState.loans`) at index 0 has the corresponding address (`Loan.borrower`) equal with `0x` address and the borrower t0 debt to collateral (`Loan.t0DebtToCollateral`) equal with 0
 - **L3**: Loans array (`LoansState.loans`) is a max-heap with respect to t0-threshold price: the t0TP of loan at index `i` is >= the t0-threshold price of the loans at index `2*i` and `2*i+1`
 
 ## Buckets

--- a/tests/brownie/conftest.py
+++ b/tests/brownie/conftest.py
@@ -147,7 +147,7 @@ class PoolHelper:
 
     def loansInfo(self):
         # returns (poolSize, loansCount, maxBorrower, pendingInflator, pendingInterestFactor)
-        # Not to be confused with pool.loansInfo which returns (maxBorrower, maxThresholdPrice, noOfLoans)
+        # Not to be confused with pool.loansInfo which returns (maxBorrower, maxT0DebtToCollateral, noOfLoans)
         return self.pool_info_utils.poolLoansInfo(self.pool.address)
 
     def lup(self):

--- a/tests/forge/invariants/base/BasicInvariants.t.sol
+++ b/tests/forge/invariants/base/BasicInvariants.t.sol
@@ -252,7 +252,7 @@ abstract contract BasicInvariants is BaseInvariants {
         for (uint256 loanId = 1; loanId < totalLoans; loanId++) {
             (borrower, t0Tp) = _pool.loanInfo(loanId);
 
-            // borrower address and threshold price should not 0
+            // borrower address and t0 threshold price should not 0
             require(borrower != address(0), "Loan Invariant L1");
             require(t0Tp != 0,              "Loan Invariant L1");
 

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -318,7 +318,7 @@ abstract contract BaseHandler is Test {
             err == keccak256(abi.encodeWithSignature("AuctionNotClearable()")) ||
             err == keccak256(abi.encodeWithSignature("ReserveAuctionTooSoon()")) ||
             err == keccak256(abi.encodeWithSignature("NoReserves()")) ||
-            err == keccak256(abi.encodeWithSignature("ZeroThresholdPrice()")) ||
+            err == keccak256(abi.encodeWithSignature("DebtToCollateral()")) ||
             err == keccak256(abi.encodeWithSignature("NoReservesAuction()")) ||
             err == keccak256(abi.encodeWithSignature("AddAboveAuctionPrice()")),
             "Unexpected revert error"

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -380,8 +380,8 @@ abstract contract BaseHandler is Test {
         if (pendingFactor == 1e18) return;
 
         // get TP of worst loan
-        (, uint256 htp,) = _pool.loansInfo();
-
+        uint256 htp = _poolInfo.htp(address(_pool));
+        
         uint256 accrualIndex;
 
         if (htp > MAX_PRICE)      accrualIndex = 1;                          // if HTP is over the highest price bucket then no buckets earn interest

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -318,7 +318,7 @@ abstract contract BaseHandler is Test {
             err == keccak256(abi.encodeWithSignature("AuctionNotClearable()")) ||
             err == keccak256(abi.encodeWithSignature("ReserveAuctionTooSoon()")) ||
             err == keccak256(abi.encodeWithSignature("NoReserves()")) ||
-            err == keccak256(abi.encodeWithSignature("DebtToCollateral()")) ||
+            err == keccak256(abi.encodeWithSignature("ZeroDebtToCollateral()")) ||
             err == keccak256(abi.encodeWithSignature("NoReservesAuction()")) ||
             err == keccak256(abi.encodeWithSignature("AddAboveAuctionPrice()")),
             "Unexpected revert error"

--- a/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20BorrowerTpLessThanMinPrice.t.sol
@@ -36,16 +36,16 @@ contract ERC20PoolBorrowerTPLessThanMinPrice is ERC20HelperContract {
 
         _borrow({
             from:       _borrower,
-            amount:     990 * 1e9,
+            amount:     900 * 1e9,
             indexLimit: 2550,
             newLup:     3_010.892022197881557845 * 1e18
         });
 
         (uint256 debt, uint256 collateral, ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
-        uint256 thresholdPrice = Maths.wdiv(debt, collateral);
+        uint256 debtToCollateral = Maths.wdiv(debt, collateral);
 
         // Ensure borrower tp is less than min price
-        assertLt(thresholdPrice, MIN_PRICE);
+        assertLt(Maths.wmul(debtToCollateral, COLLATERALIZATION_FACTOR), MIN_PRICE);
 
         // Lender can kick borrower with tp less than min price
         changePrank(_lender);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -490,7 +490,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         expectedDebt = 21_179.004767688830766408 * 1e18;
         _assertPool(
             PoolParams({
-                htp:                  439.728847704586373630 * 1e18,
+                htp:                  440.523299167927679941 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             50_102.605614470717226695 * 1e18,
                 pledgedCollateral:    50 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolBorrow.t.sol
@@ -838,7 +838,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
      *          Reverts:
      *              Attempts to borrow with a TP of 0.
      */
-    function testZeroThresholdPriceLoanBeforeRepay() external tearDown {
+    function testZeroDebtToCollateralLoanBeforeRepay() external tearDown {
         // borrower 1 initiates a highly overcollateralized loan with a TP of 0 that won't be inserted into the Queue
         _pledgeCollateral({
             from:     _borrower,
@@ -846,7 +846,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
             amount:   50 * 1e18
         });
 
-        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
+        vm.expectRevert(abi.encodeWithSignature('ZeroDebtToCollateral()'));
         IERC20Pool(address(_pool)).drawDebt(_borrower, 0.00000000000000001 * 1e18, 3000, 0);
 
         // borrower 1 borrows 500 quote from the pool after using a non 0 TP
@@ -883,7 +883,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
      *          Reverts:
      *              Attempts to repay with a subsequent TP of 0.
      */
-    function testZeroThresholdPriceLoanAfterRepay() external tearDown {
+    function testZeroDebtToCollateralLoanAfterRepay() external tearDown {
 
         // borrower 1 borrows 500 quote from the pool
         _drawDebt({
@@ -924,7 +924,7 @@ contract ERC20PoolBorrowTest is ERC20HelperContract {
         deal(address(_quote), _borrower,  _quote.balanceOf(_borrower) + 10_000 * 1e18);
 
         // should revert if borrower repays most, but not all of their debt resulting in a 0 tp loan remaining on the book
-        vm.expectRevert(abi.encodeWithSignature('ZeroThresholdPrice()'));
+        vm.expectRevert(abi.encodeWithSignature('ZeroDebtToCollateral()'));
         IERC20Pool(address(_pool)).repayDebt(_borrower, 500.480769230769231000 * 1e18 - 1, 0, _borrower, MAX_FENWICK_INDEX);
 
         // should be able to pay back all pendingDebt

--- a/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
@@ -178,7 +178,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
                 totalBondEscrowed: 1.104560604152777078 * 1e18,
                 auctionPrice:      54.920254943840808688 * 1e18,
                 debtInAuction:     98.794903846153846199 * 1e18,
-                thresholdPrice:    94.995099852071005961 * 1e18,
+                debtToCollateral:  94.995099852071005961 * 1e18,
                 neutralPrice:      109.840509887681617373 * 1e18
             })
         );
@@ -364,7 +364,7 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
                 totalBondEscrowed: 11_179.675302295250711919 * 1e18,
                 auctionPrice:      52.467014501698027340 * 1e18,
                 debtInAuction:     999_940.55769230769276876 * 1e18,
-                thresholdPrice:    96.148130547337278151 * 1e18,
+                debtToCollateral:  96.148130547337278151 * 1e18,
                 neutralPrice:      111.173731071526020388 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -510,7 +510,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         // ensure pendingInflator increases as time passes
         _assertPool(
             PoolParams({
-                htp:                  312.300000000000000144 * 1e18,
+                htp:                  312.301782539333725867 * 1e18,
                 lup:                  2_981.007422784467321543 * 1e18,
                 poolSize:             29_998.63013698630137 * 1e18,
                 pledgedCollateral:    50 * 1e18,
@@ -913,7 +913,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  986_210_526.315789474138947369 * 1e18,
+                htp:                  999_813_215.945856302275851081 * 1e18,
                 lup:                  999969141.897027226245329498 * 1e18,
                 poolSize:             99_995_433_789_954_337.9 * 1e18,
                 pledgedCollateral:    95_000_000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInterestRateAndEMAs.t.sol
@@ -1273,7 +1273,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
         _updateInterest();
     }
 
-    function testUpdateInterestZeroThresholdPrice() external {
+    function testUpdateInterestZeroDebtToCollateral() external {
         _mintQuoteAndApproveTokens(_lender, 1_000_000_000 * 1e18);
         _mintCollateralAndApproveTokens(_borrower, 1_000_000_000 * 1e18);
 
@@ -1325,7 +1325,7 @@ contract ERC20PoolInterestRateTestAndEMAs is ERC20HelperContract {
                 uint256 collateralToPledge = requiredCollateral - collateralPledged;
                 _mintCollateralAndApproveTokens(_borrower, collateralToPledge);
 
-                // Pledge collateral reverts with `ZeroThresholdPrice()`
+                // Pledge collateral reverts with `ZeroDebtToCollateral()`
                 if (i == 103) {
                     vm.expectRevert();
                 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -150,7 +150,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -183,7 +183,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      2_786.004733495419094016 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -261,7 +261,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      9.151333567485071268 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -333,7 +333,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      9.151333567485071268 * 1e18,
                 debtInAuction:     0.744103746989137588 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -369,7 +369,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      15.390647183378366864 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -454,7 +454,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      15.390647183378366864 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -493,7 +493,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.042759438341664008 * 1e18,
                 auctionPrice:      15.390647183378366864 * 1e18,
                 debtInAuction:     4.076551853619286517 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -567,7 +567,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      30.781294366756733728 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );
@@ -628,7 +628,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -670,7 +670,7 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.210458053887159482 * 1e18,
                 auctionPrice:      36.605334269940285200 * 1e18,
                 debtInAuction:     18.823940596160099025 * 1e18,
-                thresholdPrice:    9.411970298080049512 * 1e18,
+                debtToCollateral:  9.411970298080049512 * 1e18,
                 neutralPrice:      10.882830990216480836 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -151,7 +151,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -184,7 +184,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      2_843.843606056533345792 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -261,7 +261,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      9.341319897949748632 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -326,7 +326,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      9.341319897949748632 * 1e18,
                 debtInAuction:     0.181604610561948914 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         ); 
@@ -369,7 +369,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      15.710164831848276420 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -461,7 +461,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      15.710164831848276420 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -500,7 +500,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.047128646698885500 * 1e18,
                 auctionPrice:      15.710164831848276420 * 1e18,
                 debtInAuction:     4.467355778582383914 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -574,7 +574,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      31.420329663696552836 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -636,7 +636,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -671,7 +671,7 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0.214827269923259784 * 1e18,
                 auctionPrice:      37.365279591798994668 * 1e18,
                 debtInAuction:     19.214735158764197054 * 1e18,
-                thresholdPrice:    9.607367579382098527 * 1e18,
+                debtToCollateral:  9.607367579382098527 * 1e18,
                 neutralPrice:      11.108764086158333382 * 1e18
             })
         );
@@ -767,7 +767,7 @@ contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
                 totalBondEscrowed: 13_799_909_500.935435603423349661 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     920_341_611_662.285708998644615657 * 1e18,
-                thresholdPrice:    2_758.083788017359002804 * 1e18,
+                debtToCollateral:  2_758.083788017359002804 * 1e18,
                 neutralPrice:      3_137.845063437099084063 * 1e18  // was 2_860.503207254858101199
             })
         );
@@ -795,7 +795,7 @@ contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
                 totalBondEscrowed: 13_799_909_500.935435603423349661 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     33_716_280_531.11637887639485531 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      3_137.845063437099084063 * 1e18  // was 2_860.503207254858101199
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -149,7 +149,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -226,7 +226,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0.211592598652049829 * 1e18,
                 auctionPrice:      2_801.023626937442916608 * 1e18,
                 debtInAuction:     18.925417364872552389 * 1e18,
-                thresholdPrice:    9.462708682436276194 * 1e18,
+                debtToCollateral:  9.462708682436276194 * 1e18,
                 neutralPrice:      10.941498542724386393 * 1e18
             })
         );
@@ -286,7 +286,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -319,7 +319,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0.211592598652049829 * 1e18,
                 auctionPrice:      2_801.023626937442916608 * 1e18,
                 debtInAuction:     18.925417364872552389 * 1e18,
-                thresholdPrice:    9.462708682436276194 * 1e18,
+                debtToCollateral:  9.462708682436276194 * 1e18,
                 neutralPrice:      10.941498542724386393 * 1e18
             })
         );
@@ -353,7 +353,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -428,9 +428,9 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
             borrowerCollateralization: 0.992604445165255887 * 1e18
         });
         _assertLoans({
-            noOfLoans:         2,
-            maxBorrower:       _borrower,
-            maxThresholdPrice: 9.333966346153846158 * 1e18
+            noOfLoans:             2,
+            maxBorrower:           _borrower,
+            maxT0DebtToCollateral: 9.333966346153846158 * 1e18
         });
 
         // kick first loan
@@ -444,9 +444,9 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         1,
-            maxBorrower:       _borrower,
-            maxThresholdPrice: 9.333966346153846158 * 1e18
+            noOfLoans:             1,
+            maxBorrower:           _borrower,
+            maxT0DebtToCollateral: 9.333966346153846158 * 1e18
         });
 
         // kick 2nd loan
@@ -460,9 +460,9 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         0,
-            maxBorrower:       address(0),
-            maxThresholdPrice: 0
+            noOfLoans:             0,
+            maxBorrower:           address(0),
+            maxT0DebtToCollateral: 0
         });
         _assertPool(
             PoolParams({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -430,7 +430,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         2,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 9.707325000000000004 * 1e18
+            maxThresholdPrice: 9.333966346153846158 * 1e18
         });
 
         // kick first loan
@@ -446,7 +446,7 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 9.841217029733727242 * 1e18
+            maxThresholdPrice: 9.333966346153846158 * 1e18
         });
 
         // kick 2nd loan

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -646,19 +646,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         uint256 t0DebtToCollateral;
         (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower1);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, _borrower4);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, _borrower5);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
 
         // kick borrower 1
         _lenderKick({
@@ -672,16 +672,16 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower5);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, _borrower4);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
@@ -708,13 +708,13 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower4);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
@@ -743,10 +743,10 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower3);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
@@ -782,7 +782,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower2);
-        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.019230769230769240 * 1e18);
         (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -643,22 +643,22 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
     function testLenderKickAuctionAllBorrowersAndSettle() external tearDown {
         // assert loans positions in heap
         address borrower;
-        uint256 t0ThresholdPrice;
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        uint256 t0DebtToCollateral;
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower1);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, _borrower4);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, _borrower5);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
 
         // kick borrower 1
         _lenderKick({
@@ -670,21 +670,21 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             bond:       223.821804286277016796 * 1e18
         });
 
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower5);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, _borrower4);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
+        assertEq(t0DebtToCollateral, 0);
 
         address head;
         address next;
@@ -706,21 +706,21 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             bond:       223.821804286277016796 * 1e18
         });
 
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower4);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, _borrower3);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
+        assertEq(t0DebtToCollateral, 0);
 
         (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
@@ -741,21 +741,21 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             bond:       223.821804286277016796 * 1e18
         });
 
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower3);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, _borrower2);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
+        assertEq(t0DebtToCollateral, 0);
 
         (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
@@ -780,21 +780,21 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             bond:       223.821804286277016796 * 1e18
         });
 
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, _borrower2);
-        assertEq(t0ThresholdPrice, 20.820000000000000010 * 1e18);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 20.820000000000000010 * 1e18);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
+        assertEq(t0DebtToCollateral, 0);
 
         (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
@@ -823,21 +823,21 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             bond:       223.821804286277016796 * 1e18
         });
 
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(1);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(1);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(2);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(2);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(3);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(3);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(4);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(4);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
-        (borrower, t0ThresholdPrice) = _pool.loanInfo(5);
+        assertEq(t0DebtToCollateral, 0);
+        (borrower, t0DebtToCollateral) = _pool.loanInfo(5);
         assertEq(borrower, address(0));
-        assertEq(t0ThresholdPrice, 0);
+        assertEq(t0DebtToCollateral, 0);
 
         (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -254,7 +254,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 223.821804286277016796 * 1e18,
                 auctionPrice:      5_925.823171731783953152 * 1e18,
                 debtInAuction:     20_019.230769230769240000 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -385,7 +385,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 324.541616215101674353 * 1e18,
                 auctionPrice:      8_592.443599011086732032 * 1e18,
                 debtInAuction:     29_027.884615384615398000 * 1e18,
-                thresholdPrice:    29.027884615384615398 * 1e18,
+                debtToCollateral:  29.027884615384615398 * 1e18,
                 neutralPrice:      33.564232808637057547 * 1e18
             })
         );
@@ -510,7 +510,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 391.688157500984779392 * 1e18,
                 auctionPrice:      10_370.190550530621918208 * 1e18,
                 debtInAuction:     35_033.653846153846170000 * 1e18,
-                thresholdPrice:    35.033653846153846170 * 1e18,
+                debtToCollateral:  35.033653846153846170 * 1e18,
                 neutralPrice:      40.508556838010241868 * 1e18
             })
         );
@@ -633,7 +633,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 223.821804286277016796 * 1e18,
                 auctionPrice:      5_925.823171731783953152 * 1e18,
                 debtInAuction:     20_019.230769230769240000 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -895,7 +895,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     100_096.153846153846200000 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -919,7 +919,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     80_113.496231380830061171 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -958,7 +958,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     80_113.496231380830061171 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -982,7 +982,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     60_085.122173535622545879 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1021,7 +1021,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     60_085.122173535622545879 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -1045,7 +1045,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     40_056.748115690415030586 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1084,7 +1084,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     40_056.748115690415030586 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -1108,7 +1108,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     20_028.374057845207515293 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1147,7 +1147,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     20_028.374057845207515293 * 1e18,
-                thresholdPrice:    20.019230769230769240 * 1e18,
+                debtToCollateral:  20.019230769230769240 * 1e18,
                 neutralPrice:      23.147746764577281067 * 1e18
             })
         );
@@ -1171,7 +1171,7 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
                 totalBondEscrowed: 1_119.109021431385083980 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -382,7 +382,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  8.325570479144230295 * 1e18,
+                htp:                  8.326532822441837927 * 1e18,
                 lup:                  9.529276179422528643 * 1e18,
                 poolSize:             8_998.990799733397644463 * 1e18,
                 pledgedCollateral:    1_001.378022329922220102 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -185,7 +185,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -225,7 +225,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0.209172983065585793 * 1e18,
                 auctionPrice:      2_768.993203997475837952 * 1e18,
                 debtInAuction:     18.709000367642488138 * 1e18,
-                thresholdPrice:    9.354500183821244069 * 1e18,
+                debtToCollateral:  9.354500183821244069 * 1e18,
                 neutralPrice:      10.816379703115139992 * 1e18
             })
         );
@@ -277,7 +277,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0.209172983065585793 * 1e18,
                 auctionPrice:      30.593341743845004656 * 1e18,
                 debtInAuction:     18.709000367642488138 * 1e18,
-                thresholdPrice:    9.354500183821244069 * 1e18,
+                debtToCollateral:  9.354500183821244069 * 1e18,
                 neutralPrice:      10.816379703115139992 * 1e18
             })
         );
@@ -312,7 +312,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -478,7 +478,7 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
                 totalBondEscrowed: 90.564949726435836850 * 1e18,
                 auctionPrice:      2.341566462547213020 * 1e18,
                 debtInAuction:     8_100.375358686460903420 * 1e18,
-                thresholdPrice:    8.100375358686460903 * 1e18,
+                debtToCollateral:  8.100375358686460903 * 1e18,
                 neutralPrice:      9.366265850188852076 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -154,7 +154,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -187,7 +187,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2_787.506622839621476352 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -242,7 +242,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2.722174436366817848 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -277,7 +277,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 129.633622527137778568 * 1e18,
                 auctionPrice:      2.722174436366817848 * 1e18,
                 debtInAuction:     7_264.136220460174790403 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -354,7 +354,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 129.633622527137778568 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -436,7 +436,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -469,7 +469,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2_787.506622839621476352 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -525,7 +525,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -556,7 +556,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -647,7 +647,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2_787.506622839621476352 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -697,7 +697,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      1.144533362618078976 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -940,7 +940,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2_787.506622839621476352 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );
@@ -975,7 +975,7 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
                 totalBondEscrowed: 105.285754181824258217 * 1e18,
                 auctionPrice:      2.722174436366817848 * 1e18,
                 debtInAuction:     9_417.044136515672180411 * 1e18,
-                thresholdPrice:    9.417044136515672180 * 1e18,
+                debtToCollateral:  9.417044136515672180 * 1e18,
                 neutralPrice:      10.888697745467271392 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -193,7 +193,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.689307692307692312 * 1e18,
+                htp:                  9.822951211365485637 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_082.000000000000000000 * 1e18,
@@ -265,7 +265,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.154879586252788825 * 1e18,
+                htp:                  9.155493589919282477 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_082.000000000000000000 * 1e18,
@@ -420,7 +420,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.689307692307692312 * 1e18,
+                htp:                  9.822951211365485637 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -492,7 +492,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.520343841193019916 * 1e18,
+                htp:                  9.520928012632416038 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -627,7 +627,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.689307692307692312 * 1e18,
+                htp:                  9.822951211365485637 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -699,7 +699,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.520343841193019916 * 1e18,
+                htp:                  9.520642715125814291 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -860,7 +860,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  10.025904748790392364 * 1e18,
+                htp:                  10.025973419606037281 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             73_110.486627166698360626 * 1e18,
                 pledgedCollateral:    1_042 * 1e18,
@@ -1013,7 +1013,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         
         _assertPool(
             PoolParams({
-                htp:                  9.689307692307692312 * 1e18,
+                htp:                  9.822951211365485637 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             82_996.210045662100457000 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,
@@ -1085,7 +1085,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  9.520343841193019916 * 1e18,
+                htp:                  9.520642715125814291 * 1e18,
                 lup:                  9.721295865031779605 * 1e18,
                 poolSize:             83_215.881747961316167813 * 1e18,
                 pledgedCollateral:    2_042.000000000000000000 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -220,7 +220,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -292,7 +292,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      0.946897685981543764 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -328,7 +328,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 120.834036728063952141 * 1e18,
                 auctionPrice:      0.946897685981543764 * 1e18,
                 debtInAuction:     8_849.846531632272862778 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -447,7 +447,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -519,7 +519,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      1.391688189743023672 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -555,7 +555,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.979528711173099975 * 1e18,
                 auctionPrice:      1.391688189743023672 * 1e18,
                 debtInAuction:     9_809.792664465320061476 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -654,7 +654,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -726,7 +726,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      10.508629868487414000 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -762,7 +762,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 128.772008590038867086 * 1e18,
                 auctionPrice:      10.508629868487414000 * 1e18,
                 debtInAuction:     3_839.782833371446802894 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -832,7 +832,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      2_795.824779207511593472 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -887,7 +887,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      174.739048700469474560 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -940,7 +940,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 90.287513680490847847 * 1e18,
                 auctionPrice:      174.739048700469474560 * 1e18,
                 debtInAuction:     8_104.932634420295318817 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -1040,7 +1040,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1112,7 +1112,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 109.823933241385648657 * 1e18,
                 auctionPrice:      10.508629868487414000 * 1e18,
                 debtInAuction:     9_822.951211365485636463 * 1e18,
-                thresholdPrice:    9.445145395543736189 * 1e18,
+                debtToCollateral:  9.445145395543736189 * 1e18,
                 neutralPrice:      10.921190543779342162 * 1e18
             })
         );
@@ -1148,7 +1148,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 140.931576925968603373 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1203,7 +1203,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_804.489525424063798784 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1242,7 +1242,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2.738759302171937304 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1278,7 +1278,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.776701868219386837 * 1e18,
                 auctionPrice:      2.738759302171937304 * 1e18,
                 debtInAuction:     9_799.737641646680470914 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1326,7 +1326,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 142.009366933917715582 * 1e18,
                 auctionPrice:      2.738759302171937304 * 1e18,
                 debtInAuction:     7_037.435818497002749734 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1388,7 +1388,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 142.009366933917715582 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1515,7 +1515,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 142.009366933917715582 * 1e18,
                 auctionPrice:      2.738759302171937304 * 1e18,
                 debtInAuction:     5_020.054078728300909793 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1552,7 +1552,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 142.009366933917715582 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1617,7 +1617,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_804.489525424063798784 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1656,7 +1656,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1689,7 +1689,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.382534258638046113 * 1e18,
                 auctionPrice:      2_888.988762209327582208 * 1e18,
                 debtInAuction:     9_995.146145767066608231 * 1e18,
-                thresholdPrice:    9.759881630669866665 * 1e18,
+                debtToCollateral:  9.759881630669866665 * 1e18,
                 neutralPrice:      11.285112352380185868 * 1e18
             })
         );
@@ -1754,7 +1754,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      2_804.489525424063798784 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1785,7 +1785,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      10.955037208687749216 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1804,7 +1804,7 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
                 totalBondEscrowed: 110.164296670852752941 * 1e18,
                 auctionPrice:      7.746381098414054648 * 1e18,
                 debtInAuction:     9_853.394241979221645667 * 1e18,
-                thresholdPrice:    9.474417540364636198 * 1e18,
+                debtToCollateral:  9.474417540364636198 * 1e18,
                 neutralPrice:      10.955037208687749214 * 1e18
             })
         );
@@ -1957,7 +1957,7 @@ contract ERC20PoolLiquidationsLowPriceCollateralTest is ERC20HelperContract {
                 totalBondEscrowed: 8.509085736677607076 * 1e18,
                 auctionPrice:      0.004602395808091136 * 1e18,
                 debtInAuction:     761.075765343400230098 * 1e18,
-                thresholdPrice:    0.000015548291115577 * 1e18,
+                debtToCollateral:  0.000015548291115577 * 1e18,
                 neutralPrice:      0.000017978108625356 * 1e18
             })
         );
@@ -1983,7 +1983,7 @@ contract ERC20PoolLiquidationsLowPriceCollateralTest is ERC20HelperContract {
                 totalBondEscrowed: 8.509085736677607076 * 1e18,
                 auctionPrice:      0 * 1e18,
                 debtInAuction:     761.075765343400230098 * 1e18,
-                thresholdPrice:    0.000015548291115577 * 1e18,
+                debtToCollateral:  0.000015548291115577 * 1e18,
                 neutralPrice:      0.000017978108625356 * 1e18
             })
         );

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -121,7 +121,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
             maxT0DebtToCollateral: 6.005769230769230772 * 1e18
         });
 
-        // borrower 4 draws debt and becomes loan with highest threshold price in heap
+        // borrower 4 draws debt and becomes loan with highest t0 debt to collateral in heap
         _drawDebt({
             from:               _borrower4,
             borrower:           _borrower4,
@@ -137,7 +137,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
             maxT0DebtToCollateral: 14.013461538461538468 * 1e18
         });
 
-        // borrower 4 repays debt, borrower 6 becomes loan with highest threshold price in heap
+        // borrower 4 repays debt, borrower 6 becomes loan with highest t0 debt to collateral in heap
         _repayDebt({
             from:             _borrower4,
             borrower:         _borrower4,
@@ -153,7 +153,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
             maxT0DebtToCollateral: 6.005769230769230772 * 1e18
         });
 
-        // borrower 6 repays debt, borrower 5 becomes loan with highest threshold price in heap
+        // borrower 6 repays debt, borrower 5 becomes loan with highest t0 debt to collateral in heap
         _repayDebt({
             from:             _borrower6,
             borrower:         _borrower6,
@@ -169,7 +169,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
             maxT0DebtToCollateral: 5.004807692307692310 * 1e18
         });
 
-        // borrower 6 draws more debt and becomes loan with highest threshold price in heap
+        // borrower 6 draws more debt and becomes loan with highest t0 debt to collateral in heap
         _drawDebt({
             from:               _borrower6,
             borrower:           _borrower6,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -118,7 +118,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.246000000000000003 * 1e18
+            maxThresholdPrice: 6.005769230769230772 * 1e18
         });
 
         // borrower 4 draws debt and becomes loan with highest threshold price in heap
@@ -134,7 +134,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower4,
-            maxThresholdPrice: 14.574000000000000007 * 1e18
+            maxThresholdPrice: 14.013461538461538468 * 1e18
         });
 
         // borrower 4 repays debt, borrower 6 becomes loan with highest threshold price in heap
@@ -150,7 +150,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.246000000000000003 * 1e18
+            maxThresholdPrice: 6.005769230769230772 * 1e18
         });
 
         // borrower 6 repays debt, borrower 5 becomes loan with highest threshold price in heap
@@ -166,7 +166,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower5,
-            maxThresholdPrice: 5.205000000000000002 * 1e18
+            maxThresholdPrice: 5.004807692307692310 * 1e18
         });
 
         // borrower 6 draws more debt and becomes loan with highest threshold price in heap
@@ -182,7 +182,7 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         _assertLoans({
             noOfLoans:         6,
             maxBorrower:       _borrower6,
-            maxThresholdPrice: 12.497000000000000008 * 1e18
+            maxThresholdPrice: 12.016346153846153854 * 1e18
         });
     }
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLoanHeap.t.sol
@@ -116,9 +116,9 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         6,
-            maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.005769230769230772 * 1e18
+            noOfLoans:             6,
+            maxBorrower:           _borrower6,
+            maxT0DebtToCollateral: 6.005769230769230772 * 1e18
         });
 
         // borrower 4 draws debt and becomes loan with highest threshold price in heap
@@ -132,9 +132,9 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         6,
-            maxBorrower:       _borrower4,
-            maxThresholdPrice: 14.013461538461538468 * 1e18
+            noOfLoans:             6,
+            maxBorrower:           _borrower4,
+            maxT0DebtToCollateral: 14.013461538461538468 * 1e18
         });
 
         // borrower 4 repays debt, borrower 6 becomes loan with highest threshold price in heap
@@ -148,9 +148,9 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         6,
-            maxBorrower:       _borrower6,
-            maxThresholdPrice: 6.005769230769230772 * 1e18
+            noOfLoans:             6,
+            maxBorrower:           _borrower6,
+            maxT0DebtToCollateral: 6.005769230769230772 * 1e18
         });
 
         // borrower 6 repays debt, borrower 5 becomes loan with highest threshold price in heap
@@ -164,9 +164,9 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         6,
-            maxBorrower:       _borrower5,
-            maxThresholdPrice: 5.004807692307692310 * 1e18
+            noOfLoans:             6,
+            maxBorrower:           _borrower5,
+            maxT0DebtToCollateral: 5.004807692307692310 * 1e18
         });
 
         // borrower 6 draws more debt and becomes loan with highest threshold price in heap
@@ -180,9 +180,9 @@ contract ERC20PoolLoanHeapTest is ERC20HelperContract {
         });
 
         _assertLoans({
-            noOfLoans:         6,
-            maxBorrower:       _borrower6,
-            maxThresholdPrice: 12.016346153846153854 * 1e18
+            noOfLoans:             6,
+            maxBorrower:           _borrower6,
+            maxT0DebtToCollateral: 12.016346153846153854 * 1e18
         });
     }
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -348,7 +348,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 208.200000000000000096 * 1e18
+            maxThresholdPrice: 200.192307692307692400 * 1e18
         });
 
         (uint256 poolDebt,,,) = _pool.debtInfo();
@@ -409,7 +409,7 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
         _assertLoans({
             noOfLoans:         1,
             maxBorrower:       _borrower,
-            maxThresholdPrice: 104.200000000000000096 * 1e18
+            maxThresholdPrice: 100.192307692307692400 * 1e18
         });
 
         (poolDebt,,,) = _pool.debtInfo();

--- a/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolPrecision.t.sol
@@ -123,9 +123,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             lupIndex: 0
         });
         _assertLoans({
-            noOfLoans:         0,
-            maxBorrower:       address(0),
-            maxThresholdPrice: 0
+            noOfLoans:             0,
+            maxBorrower:           address(0),
+            maxT0DebtToCollateral: 0
         });
         assertEq(_pool.depositSize(), 149_993.150684931506850000 * 1e18);
 
@@ -167,9 +167,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             lupIndex: 0
         });
         _assertLoans({
-            noOfLoans:         0,
-            maxBorrower:       address(0),
-            maxThresholdPrice: 0
+            noOfLoans:             0,
+            maxBorrower:           address(0),
+            maxT0DebtToCollateral: 0
         });
         assertEq(_pool.depositSize(), 124_993.150684931506850000 * 1e18);
 
@@ -289,9 +289,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             lupIndex: 0
         });
         _assertLoans({
-            noOfLoans:         0,
-            maxBorrower:       address(0),
-            maxThresholdPrice: 0
+            noOfLoans:             0,
+            maxBorrower:           address(0),
+            maxT0DebtToCollateral: 0
         });
         assertEq(_pool.depositSize(), 149_993.150684931506850000 * 1e18);
 
@@ -346,9 +346,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             lupIndex: 2549
         });
         _assertLoans({
-            noOfLoans:         1,
-            maxBorrower:       _borrower,
-            maxThresholdPrice: 200.192307692307692400 * 1e18
+            noOfLoans:             1,
+            maxBorrower:           _borrower,
+            maxT0DebtToCollateral: 200.192307692307692400 * 1e18
         });
 
         (uint256 poolDebt,,,) = _pool.debtInfo();
@@ -407,9 +407,9 @@ contract ERC20PoolPrecisionTest is ERC20DSTestPlus {
             lupIndex: 2549
         });
         _assertLoans({
-            noOfLoans:         1,
-            maxBorrower:       _borrower,
-            maxThresholdPrice: 100.192307692307692400 * 1e18
+            noOfLoans:             1,
+            maxBorrower:           _borrower,
+            maxT0DebtToCollateral: 100.192307692307692400 * 1e18
         });
 
         (poolDebt,,,) = _pool.debtInfo();

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1545,7 +1545,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertPool(
             PoolParams({
-                htp:                  0.000000031102107386 * 1e18,
+                htp:                  0.000000031966000026 * 1e18,
                 lup:                  14_343_926.246295999585280544 * 1e18,
                 poolSize:             0.000000059751560420 * 1e18,
                 pledgedCollateral:    1 * 1e18,

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1627,7 +1627,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -1660,7 +1660,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 totalBondEscrowed: 0.215563505329166046 * 1e18,
                 auctionPrice:      2_853.589753984526295552 * 1e18,
                 debtInAuction:     19.280586055366139163 * 1e18,
-                thresholdPrice:    9.640293027683069581 * 1e18,
+                debtToCollateral:  9.640293027683069581 * 1e18,
                 neutralPrice:      11.146834976502055842 * 1e18
             })
         );
@@ -1693,7 +1693,7 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
                 totalBondEscrowed: 0.215563505329166046 * 1e18,
                 auctionPrice:      9.373333573165302108 * 1e18,
                 debtInAuction:     19.280586055366139163 * 1e18,
-                thresholdPrice:    9.640293027683069581 * 1e18,
+                debtToCollateral:  9.640293027683069581 * 1e18,
                 neutralPrice:      11.146834976502055842 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -491,7 +491,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         _assertLoans({
             noOfLoans: 1,
             maxBorrower: _borrower,
-            maxThresholdPrice: 347.000000000000000160 * 1e18
+            maxThresholdPrice: 333.653846153846154000 * 1e18
         });
 
         // should revert if LUP is below the limit
@@ -525,7 +525,7 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         _assertLoans({
             noOfLoans: 2,
             maxBorrower: _borrower2,
-            maxThresholdPrice: 2_966.850000000000001368 * 1e18
+            maxThresholdPrice: 2_852.740384615384616700 * 1e18
         });
 
         // should be able to repay loan if properly specified

--- a/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolBorrow.t.sol
@@ -489,9 +489,9 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         });
 
         _assertLoans({
-            noOfLoans: 1,
-            maxBorrower: _borrower,
-            maxThresholdPrice: 333.653846153846154000 * 1e18
+            noOfLoans:             1,
+            maxBorrower:           _borrower,
+            maxT0DebtToCollateral: 333.653846153846154000 * 1e18
         });
 
         // should revert if LUP is below the limit
@@ -523,9 +523,9 @@ contract ERC721SubsetPoolBorrowTest is ERC721PoolBorrowTest {
         });
 
         _assertLoans({
-            noOfLoans: 2,
-            maxBorrower: _borrower2,
-            maxThresholdPrice: 2_852.740384615384616700 * 1e18
+            noOfLoans:             2,
+            maxBorrower:           _borrower2,
+            maxT0DebtToCollateral: 2_852.740384615384616700 * 1e18
         });
 
         // should be able to repay loan if properly specified

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -664,7 +664,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
         skip(10_000 days);
         _assertPool(
             PoolParams({
-                htp:                  78.075000000000000036 * 1e18,
+                htp:                  307.210419047238320914 * 1e18,
                 lup:                  0.000000099836282890 * 1e18,
                 poolSize:             199.990867579908675800 * 1e18,
                 pledgedCollateral:    2 * 1e18,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -711,7 +711,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605224811402125309 * 1e18,
                 auctionPrice:      0.000081433674828178 * 1e18,
                 debtInAuction:     590.789267398535232527 * 1e18,
-                thresholdPrice:    295.394633699267616263 * 1e18,
+                debtToCollateral:  295.394633699267616263 * 1e18,
                 neutralPrice:      341.557588066529373749 * 1e18
             })
         );
@@ -873,7 +873,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605224811402125309 * 1e18,
                 auctionPrice:      0.000081433674828178 * 1e18,
                 debtInAuction:     418.513981107458710209 * 1e18,
-                thresholdPrice:    295.394633699267616263 * 1e18,
+                debtToCollateral:  295.394633699267616263 * 1e18,
                 neutralPrice:      341.557588066529373749 * 1e18
             })
         );
@@ -961,7 +961,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605225721858288176 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     418.513900584240044901 * 1e18,
-                thresholdPrice:    295.394633699267616263 * 1e18,
+                debtToCollateral:  295.394633699267616263 * 1e18,
                 neutralPrice:      341.557588066529373749 * 1e18
             })
         );
@@ -1005,7 +1005,7 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
                 totalBondEscrowed: 6.605225721858288176 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolEMAs.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolEMAs.t.sol
@@ -104,7 +104,7 @@ contract ERC721PoolEMAsTest is ERC721HelperContract {
         // debtColEma / lupt0DebtEma ~= 8_059_788.6 / 10_467_670.6 ~= 0.77 expected target utilization
         _assertPool(
             PoolParams({
-                htp:                  1_205.367672582122068119 * 1e18,
+                htp:                  1_205.388312616241411607 * 1e18,
                 lup:                  _p1505_26,
                 poolSize:             14_999.315068493150685000 * 1e18,
                 pledgedCollateral:    6 * 1e18,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -213,7 +213,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      12.609408860297298412 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -255,7 +255,7 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.076149339066797765 * 1e18,
                 auctionPrice:      12.609408860297298412 * 1e18,
                 debtInAuction:     7.063223505145093670 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -152,7 +152,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -206,7 +206,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3_228.008668236108393472 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -275,7 +275,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -308,7 +308,7 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3_228.008668236108393472 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -192,7 +192,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 totalBondEscrowed: 111.910902143138508398 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     10_009.615384615384620000 * 1e18,
-                thresholdPrice:    1_668.269230769230770000 * 1e18,
+                debtToCollateral:  1_668.269230769230770000 * 1e18,
                 neutralPrice:      1_928.978897048106755629 * 1e18
             })
         );
@@ -224,7 +224,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 totalBondEscrowed: 111.910902143138508398 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     5_007.093514461301878824 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -274,7 +274,7 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
                 totalBondEscrowed: 111.910902143138508398 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -622,7 +622,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 totalBondEscrowed: 112.526190000038609125 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     10_064.901171882309537906 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -696,7 +696,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 totalBondEscrowed: 112.526190000038609125 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -906,7 +906,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 totalBondEscrowed: 148.374406222773030669 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     10_066.670727855240484714 * 1e18,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -951,7 +951,7 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
                 totalBondEscrowed: 35.848216222734421544 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -156,7 +156,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -228,7 +228,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3_228.008668236108393472 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -248,7 +248,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_lender), 46_999.756152452262525972 * 1e18);
         assertEq(_quote.balanceOf(_borrower), 119 * 1e18);
 
-        // threshold price increases slightly due to interest
+        // debt to collateral increases slightly due to interest
         _assertAuction(
             AuctionParams({
                 borrower:          _borrower,
@@ -261,7 +261,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      14.995198732643899296 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -329,7 +329,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.076196129225921767 * 1e18,
                 auctionPrice:      14.995198732643899296 * 1e18,
                 debtInAuction:     7.067282337479398835 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -401,7 +401,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -436,7 +436,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -507,7 +507,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3_228.008668236108393472 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -538,7 +538,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3.152352215074324604 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -609,7 +609,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.314336286156756295 * 1e18,
                 auctionPrice:      3.152352215074324604 * 1e18,
                 debtInAuction:     15.577292449182337291 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -640,7 +640,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.314336286156756295 * 1e18,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -677,7 +677,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0,
                 auctionPrice:      0,
                 debtInAuction:     0,
-                thresholdPrice:    0,
+                debtToCollateral:  0,
                 neutralPrice:      0
             })
         );
@@ -717,7 +717,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737474028 * 1e18,
                 auctionPrice:      3_228.008668236108393472 * 1e18,
                 debtInAuction:     21.810387715504679661 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -747,7 +747,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737602246 * 1e18,
                 auctionPrice:      0.000000000011468190 * 1e18,
                 debtInAuction:     21.815990418133811604 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );
@@ -780,7 +780,7 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
                 totalBondEscrowed: 0.243847547737602246 * 1e18,
                 auctionPrice:      0.000000000011468190 * 1e18,
                 debtInAuction:     21.815990418133811604 * 1e18,
-                thresholdPrice:    10.905193857752339830 * 1e18,
+                debtToCollateral:  10.905193857752339830 * 1e18,
                 neutralPrice:      12.609408860297298412 * 1e18
             })
         );

--- a/tests/forge/unit/Heap.t.sol
+++ b/tests/forge/unit/Heap.t.sol
@@ -14,7 +14,7 @@ contract HeapTest is DSTestPlus {
     function testHeapInsertAndRandomlyRemoveTps() public {
         // assert initial state
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(), 0);
+        assertEq(_loans.getMaxT0DebtToCollateral(), 0);
 
         address b1 = makeAddr("b1");
         address b2 = makeAddr("b2");
@@ -22,46 +22,46 @@ contract HeapTest is DSTestPlus {
         address b4 = makeAddr("b4");
         address b5 = makeAddr("b5");
 
-        _loans.upsertTp(b1, 100 * 1e18);
-        _loans.upsertTp(b5, 500 * 1e18);
-        _loans.upsertTp(b2, 200 * 1e18);
-        _loans.upsertTp(b4, 400 * 1e18);
-        _loans.upsertTp(b3, 300 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 100 * 1e18);
+        _loans.upsertT0DebtToCollateral(b5, 500 * 1e18);
+        _loans.upsertT0DebtToCollateral(b2, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b3, 300 * 1e18);
 
-        assertEq(_loans.getMaxTp(),       500 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       500 * 1e18);
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getTotalTps(),    6);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    6);
 
-        _loans.removeTp(b2);
-        assertEq(_loans.getMaxTp(),       500 * 1e18);
+        _loans.removeT0DebtToCollateral(b2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       500 * 1e18);
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getTotalTps(),    5);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    5);
 
-        _loans.removeTp(b5);
-        assertEq(_loans.getMaxTp(),       400 * 1e18);
+        _loans.removeT0DebtToCollateral(b5);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       400 * 1e18);
         assertEq(_loans.getMaxBorrower(), b4);
-        assertEq(_loans.getTotalTps(),    4);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    4);
 
-        _loans.removeTp(b4);
+        _loans.removeT0DebtToCollateral(b4);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getMaxTp(),       300 * 1e18);
-        assertEq(_loans.getTotalTps(),    3);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       300 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    3);
 
-        _loans.removeTp(b1);
+        _loans.removeT0DebtToCollateral(b1);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getMaxTp(),       300 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       300 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.removeTp(b3);
+        _loans.removeT0DebtToCollateral(b3);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
     }
 
     function testHeapInsertMultipleLoansWithSameTp() public {
         // assert initial state
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(), 0);
+        assertEq(_loans.getMaxT0DebtToCollateral(), 0);
 
         address b1 = makeAddr("b1");
         address b2 = makeAddr("b2");
@@ -70,64 +70,64 @@ contract HeapTest is DSTestPlus {
         address b5 = makeAddr("b5");
         address b6 = makeAddr("b6");
 
-        _loans.upsertTp(b1, 100 * 1e18);
-        _loans.upsertTp(b2, 200 * 1e18);
-        _loans.upsertTp(b3, 200 * 1e18);
-        _loans.upsertTp(b4, 300 * 1e18);
-        _loans.upsertTp(b5, 400 * 1e18);
-        _loans.upsertTp(b6, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 100 * 1e18);
+        _loans.upsertT0DebtToCollateral(b2, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b3, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 300 * 1e18);
+        _loans.upsertT0DebtToCollateral(b5, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b6, 400 * 1e18);
 
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getMaxTp(),       400 * 1e18);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       400 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        assertEq(_loans.getTp(b1), 100 * 1e18);
-        assertEq(_loans.getTp(b2), 200 * 1e18);
-        assertEq(_loans.getTp(b3), 200 * 1e18);
-        assertEq(_loans.getTp(b4), 300 * 1e18);
-        assertEq(_loans.getTp(b5), 400 * 1e18);
-        assertEq(_loans.getTp(b6), 400 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b1), 100 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b2), 200 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b3), 200 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b4), 300 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b5), 400 * 1e18);
+        assertEq(_loans.getT0DebtToCollateral(b6), 400 * 1e18);
 
-        _loans.removeTp(b5);
+        _loans.removeT0DebtToCollateral(b5);
         assertEq(_loans.getMaxBorrower(), b6);
-        assertEq(_loans.getMaxTp(),       400 * 1e18);
-        assertEq(_loans.getTotalTps(),    6);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       400 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    6);
 
-        _loans.removeTp(b6);
+        _loans.removeT0DebtToCollateral(b6);
         assertEq(_loans.getMaxBorrower(), b4);
-        assertEq(_loans.getMaxTp(),       300 * 1e18);
-        assertEq(_loans.getTotalTps(),    5);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       300 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    5);
 
-        _loans.removeTp(b4);
+        _loans.removeT0DebtToCollateral(b4);
         assertEq(_loans.getMaxBorrower(), b2);
-        assertEq(_loans.getMaxTp(),       200 * 1e18);
-        assertEq(_loans.getTotalTps(),    4);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       200 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    4);
 
-        _loans.upsertTp(b1, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 200 * 1e18);
         assertEq(_loans.getMaxBorrower(), b2);
-        assertEq(_loans.getMaxTp(),       200 * 1e18);
-        assertEq(_loans.getTotalTps(),    4);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       200 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    4);
 
-        _loans.removeTp(b2);
+        _loans.removeT0DebtToCollateral(b2);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getMaxTp(),       200 * 1e18);
-        assertEq(_loans.getTotalTps(),    3);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       200 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    3);
 
-        _loans.removeTp(b3);
+        _loans.removeT0DebtToCollateral(b3);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getMaxTp(),       200 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       200 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.removeTp(b1);
+        _loans.removeT0DebtToCollateral(b1);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
     }
 
     function testHeapInsertAndRemoveHeadByMaxTp() public {
         // assert initial state
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(), 0);
+        assertEq(_loans.getMaxT0DebtToCollateral(), 0);
 
         address b1 = makeAddr("b1");
         address b2 = makeAddr("b2");
@@ -135,60 +135,60 @@ contract HeapTest is DSTestPlus {
         address b4 = makeAddr("b4");
         address b5 = makeAddr("b5");
 
-        _loans.upsertTp(b1, 100 * 1e18);
-        _loans.upsertTp(b2, 200 * 1e18);
-        _loans.upsertTp(b3, 300 * 1e18);
-        _loans.upsertTp(b4, 400 * 1e18);
-        _loans.upsertTp(b5, 500 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 100 * 1e18);
+        _loans.upsertT0DebtToCollateral(b2, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b3, 300 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b5, 500 * 1e18);
 
-        assertEq(_loans.getMaxTp(),       500 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       500 * 1e18);
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getTotalTps(),    6);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    6);
 
-        _loans.removeTp(b5);
-        assertEq(_loans.getMaxTp(),       400 * 1e18);
+        _loans.removeT0DebtToCollateral(b5);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       400 * 1e18);
         assertEq(_loans.getMaxBorrower(), b4);
-        assertEq(_loans.getTotalTps(),    5);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    5);
 
-        _loans.removeTp(b4);
+        _loans.removeT0DebtToCollateral(b4);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getMaxTp(),       300 * 1e18);
-        assertEq(_loans.getTotalTps(),    4);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       300 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    4);
 
-        _loans.removeTp(b3);
+        _loans.removeT0DebtToCollateral(b3);
         assertEq(_loans.getMaxBorrower(), b2);
-        assertEq(_loans.getMaxTp(),       200 * 1e18);
-        assertEq(_loans.getTotalTps(),    3);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       200 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    3);
 
-        _loans.removeTp(b2);
+        _loans.removeT0DebtToCollateral(b2);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getMaxTp(),       100 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       100 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.removeTp(b1);
+        _loans.removeT0DebtToCollateral(b1);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
     }
 
     function testHeapRemoveLastTp() public {
         // assert initial state
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
 
         address b1 = makeAddr("b1");
-        _loans.upsertTp(b1, 100 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 100 * 1e18);
 
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getMaxTp(),       100 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       100 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
         // remove last TP
-        _loans.removeTp(b1);
+        _loans.removeT0DebtToCollateral(b1);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
     }
 
     function testHeapUpdateTp() public {
@@ -199,36 +199,36 @@ contract HeapTest is DSTestPlus {
         address b5 = makeAddr("b5");
         address b6 = makeAddr("b6");
 
-        _loans.upsertTp(b1, 100 * 1e18);
-        _loans.upsertTp(b2, 200 * 1e18);
-        _loans.upsertTp(b3, 300 * 1e18);
-        _loans.upsertTp(b4, 400 * 1e18);
-        _loans.upsertTp(b5, 500 * 1e18);
-        _loans.upsertTp(b6, 600 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 100 * 1e18);
+        _loans.upsertT0DebtToCollateral(b2, 200 * 1e18);
+        _loans.upsertT0DebtToCollateral(b3, 300 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b5, 500 * 1e18);
+        _loans.upsertT0DebtToCollateral(b6, 600 * 1e18);
 
-        assertEq(_loans.getMaxTp(),       600 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       600 * 1e18);
         assertEq(_loans.getMaxBorrower(), b6);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        _loans.upsertTp(b4, 1_000 * 1e18);
-        assertEq(_loans.getMaxTp(),       1_000 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 1_000 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       1_000 * 1e18);
         assertEq(_loans.getMaxBorrower(), b4);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        _loans.upsertTp(b4, 10 * 1e18);
-        assertEq(_loans.getMaxTp(),       600 * 1e18);
+        _loans.upsertT0DebtToCollateral(b4, 10 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       600 * 1e18);
         assertEq(_loans.getMaxBorrower(), b6);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        _loans.upsertTp(b6, 100 * 1e18);
-        assertEq(_loans.getMaxTp(),       500 * 1e18);
+        _loans.upsertT0DebtToCollateral(b6, 100 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       500 * 1e18);
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        _loans.upsertTp(b6, 3_000 * 1e18);
-        assertEq(_loans.getMaxTp(),       3_000 * 1e18);
+        _loans.upsertT0DebtToCollateral(b6, 3_000 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       3_000 * 1e18);
         assertEq(_loans.getMaxBorrower(), b6);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
     }
 
     function testHeapZeroInsertion() public {
@@ -236,35 +236,35 @@ contract HeapTest is DSTestPlus {
         address b2 = makeAddr("b2");
         address b3 = makeAddr("b3");
 
-        _loans.upsertTp(b1, 0);
-        assertEq(_loans.getMaxTp(),       0);
+        _loans.upsertT0DebtToCollateral(b1, 0);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.upsertTp(b2, 153 * 1e18);
-        assertEq(_loans.getMaxTp(),       153 * 1e18);
+        _loans.upsertT0DebtToCollateral(b2, 153 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       153 * 1e18);
         assertEq(_loans.getMaxBorrower(), b2);
-        assertEq(_loans.getTotalTps(),    3);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    3);
 
-        _loans.removeTp(b2);
-        assertEq(_loans.getMaxTp(),       0);
+        _loans.removeT0DebtToCollateral(b2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.upsertTp(b3, 2_007 * 1e18);
-        assertEq(_loans.getMaxTp(),       2_007 * 1e18);
+        _loans.upsertT0DebtToCollateral(b3, 2_007 * 1e18);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       2_007 * 1e18);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getTotalTps(),    3);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    3);
 
-        _loans.removeTp(b1);
-        assertEq(_loans.getMaxTp(),       2_007 * 1e18);
+        _loans.removeT0DebtToCollateral(b1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       2_007 * 1e18);
         assertEq(_loans.getMaxBorrower(), b3);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.removeTp(b3);
+        _loans.removeT0DebtToCollateral(b3);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
     }
 
     function testLoadHeapFuzzy(uint256 inserts_, uint256 seed_) public {
@@ -274,33 +274,33 @@ contract HeapTest is DSTestPlus {
 
         // test adding different TPs
         address removeAddress = _loans.getIdByInsertIndex(randomInRange(1, _loans.numInserts() - 1, true));
-        uint256 tp = _loans.getTp(removeAddress);
+        uint256 tp = _loans.getT0DebtToCollateral(removeAddress);
         uint256 length = _loans.getCount() - 1;
 
-        _loans.removeTp(removeAddress);
+        _loans.removeT0DebtToCollateral(removeAddress);
         
         assertEq(length - 1, _loans.getCount() - 1);
-        assertEq(_loans.getTp(removeAddress), 0);
-        assertTrue(_loans.getTp(removeAddress) != tp);
+        assertEq(_loans.getT0DebtToCollateral(removeAddress), 0);
+        assertTrue(_loans.getT0DebtToCollateral(removeAddress) != tp);
     }
 
     function testHeapBorrowRepayBorrow() public {
         address b1 = makeAddr("b1");
 
-        _loans.upsertTp(b1, 300 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 300 * 1e18);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getMaxTp(),       300 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       300 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
 
-        _loans.removeTp(b1);
+        _loans.removeT0DebtToCollateral(b1);
         assertEq(_loans.getMaxBorrower(), address(0));
-        assertEq(_loans.getMaxTp(),       0);
-        assertEq(_loans.getTotalTps(),    1);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       0);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    1);
 
-        _loans.upsertTp(b1, 400 * 1e18);
+        _loans.upsertT0DebtToCollateral(b1, 400 * 1e18);
         assertEq(_loans.getMaxBorrower(), b1);
-        assertEq(_loans.getMaxTp(),       400 * 1e18);
-        assertEq(_loans.getTotalTps(),    2);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       400 * 1e18);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    2);
     }
 
     function testHeapRemoveMiddleAndHead() public {
@@ -312,31 +312,31 @@ contract HeapTest is DSTestPlus {
         address b6 = makeAddr("b6");
         address b7 = makeAddr("b7");
 
-        _loans.upsertTp(b7, 7);
-        _loans.upsertTp(b4, 4);
-        _loans.upsertTp(b6, 6);
-        _loans.upsertTp(b2, 2);
-        _loans.upsertTp(b3, 3);
-        _loans.upsertTp(b1, 1);
-        _loans.upsertTp(b5, 5);
+        _loans.upsertT0DebtToCollateral(b7, 7);
+        _loans.upsertT0DebtToCollateral(b4, 4);
+        _loans.upsertT0DebtToCollateral(b6, 6);
+        _loans.upsertT0DebtToCollateral(b2, 2);
+        _loans.upsertT0DebtToCollateral(b3, 3);
+        _loans.upsertT0DebtToCollateral(b1, 1);
+        _loans.upsertT0DebtToCollateral(b5, 5);
         assertEq(_loans.getMaxBorrower(), b7);
-        assertEq(_loans.getMaxTp(),       7);
-        assertEq(_loans.getTotalTps(),    8);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    8);
 
-        _loans.removeTp(b2);
+        _loans.removeT0DebtToCollateral(b2);
         assertEq(_loans.getMaxBorrower(), b7);
-        assertEq(_loans.getMaxTp(),       7);
-        assertEq(_loans.getTotalTps(),    7);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       7);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    7);
 
-        _loans.removeTp(b7);
+        _loans.removeT0DebtToCollateral(b7);
         assertEq(_loans.getMaxBorrower(), b6);
-        assertEq(_loans.getMaxTp(),       6);
-        assertEq(_loans.getTotalTps(),    6);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       6);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    6);
 
-        _loans.removeTp(b6);
+        _loans.removeT0DebtToCollateral(b6);
         assertEq(_loans.getMaxBorrower(), b5);
-        assertEq(_loans.getMaxTp(),       5);
-        assertEq(_loans.getTotalTps(),    5);
+        assertEq(_loans.getMaxT0DebtToCollateral(),       5);
+        assertEq(_loans.getTotalT0DebtToCollaterals(),    5);
     }
 }
 
@@ -349,40 +349,40 @@ contract HeapGasLoadTest is DSTestPlus {
         _loans = new HeapInstance();
         for (uint256 i; i < NODES_COUNT; i++) {
                 address borrower = makeAddr(vm.toString(i));
-            _loans.upsertTp(borrower, 1 * 1e18 + i * 1e18);
+            _loans.upsertT0DebtToCollateral(borrower, 1 * 1e18 + i * 1e18);
             _borrowers.push(borrower);
         }
     }
 
     function testLoadHeapGasExerciseDeleteOnAllNodes() public {
-        assertEq(_loans.getTotalTps(), NODES_COUNT + 1); // account node 0 too
+        assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1); // account node 0 too
 
         for (uint256 i; i < NODES_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
-            assertEq(_loans.getTotalTps(), NODES_COUNT + 1);
+            assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1);
 
-            _loans.removeTp(_borrowers[i]);
+            _loans.removeT0DebtToCollateral(_borrowers[i]);
 
-            assertEq(_loans.getTotalTps(), NODES_COUNT);
+            assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_loans.getTotalTps(), NODES_COUNT + 1);
+        assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1);
     }
 
     function testLoadHeapGasExerciseUpsertOnAllNodes() public {
-        assertEq(_loans.getTotalTps(), NODES_COUNT + 1); // account node 0 too
+        assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1); // account node 0 too
 
         for (uint256 i; i < NODES_COUNT; i++) {
             uint256 snapshot = vm.snapshot();
-            assertEq(_loans.getTotalTps(), NODES_COUNT + 1);
+            assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1);
 
-            _loans.upsertTp(_borrowers[i], 1_000_000 * 1e18 + i * 1e18);
+            _loans.upsertT0DebtToCollateral(_borrowers[i], 1_000_000 * 1e18 + i * 1e18);
 
-            assertEq(_loans.getTotalTps(), NODES_COUNT + 1);
+            assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1);
             vm.revertTo(snapshot);
         }
 
-        assertEq(_loans.getTotalTps(), NODES_COUNT + 1);
+        assertEq(_loans.getTotalT0DebtToCollaterals(), NODES_COUNT + 1);
     }
 }

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -727,12 +727,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     function _assertLoans(
         uint256 noOfLoans,
         address maxBorrower,
-        uint256 maxThresholdPrice
+        uint256 maxT0DebtToCollateral
     ) internal {
         (address curMaxBorrower, uint256 curTpPrice, uint256 curNoOfLoans) = _pool.loansInfo();
         assertEq(curNoOfLoans,   noOfLoans);
         assertEq(curMaxBorrower, maxBorrower);
-        assertEq(curTpPrice,     maxThresholdPrice);
+        assertEq(curTpPrice,     maxT0DebtToCollateral);
     }
 
     function _assertPoolPrices(

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -82,7 +82,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 totalBondEscrowed;
         uint256 auctionPrice;
         uint256 debtInAuction;
-        uint256 thresholdPrice;
+        uint256 debtToCollateral;
         uint256 neutralPrice;
     }
 
@@ -449,7 +449,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 auctionNeutralPrice;
         uint256 auctionTotalBondEscrowed;
         uint256 auctionDebtInAuction;
-        uint256 borrowerThresholdPrice;
+        uint256 borrowerDebtToCollateral;
     }
 
     function _assertAuction(AuctionParams memory state_) internal {
@@ -461,7 +461,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             vars.auctionKickTime,
             vars.auctionReferencePrice,
             vars.auctionNeutralPrice,
-            vars.borrowerThresholdPrice,
+            vars.borrowerDebtToCollateral,
             ,
             ,
         ) = _pool.auctionInfo(state_.borrower);
@@ -484,7 +484,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             vars.auctionKickTime),              state_.auctionPrice);
         assertEq(vars.auctionDebtInAuction,     state_.debtInAuction);
         assertEq(vars.auctionNeutralPrice,      state_.neutralPrice);
-        assertEq(vars.borrowerThresholdPrice,   state_.thresholdPrice);
+        assertEq(vars.borrowerDebtToCollateral,   state_.debtToCollateral);
 
         (
             uint256 kickTime, 

--- a/tests/forge/utils/HeapInstance.sol
+++ b/tests/forge/utils/HeapInstance.sol
@@ -40,11 +40,11 @@ contract HeapInstance is DSTestPlus {
     }
 
     function getTp(address borrower_) public view returns (uint256) {
-        return _heap.getByIndex(_heap.indices[borrower_]).thresholdPrice;
+        return _heap.getByIndex(_heap.indices[borrower_]).unadjustedThresholdPrice;
     }
 
     function getMaxTp() external view returns (uint256) {
-        return _heap.getMax().thresholdPrice;
+        return _heap.getMax().unadjustedThresholdPrice;
     }
 
     function getMaxBorrower() external view returns (address) {

--- a/tests/forge/utils/HeapInstance.sol
+++ b/tests/forge/utils/HeapInstance.sol
@@ -31,27 +31,27 @@ contract HeapInstance is DSTestPlus {
         return inserts[i_];
     }
 
-    function upsertTp(address borrower_, uint256 tp_) public {
+    function upsertT0DebtToCollateral(address borrower_, uint256 tp_) public {
         _heap._upsert(borrower_, _heap.indices[borrower_], uint96(tp_));
     }
 
-    function removeTp(address borrower_) external {
+    function removeT0DebtToCollateral(address borrower_) external {
         _heap.remove(borrower_, _heap.indices[borrower_]);
     }
 
-    function getTp(address borrower_) public view returns (uint256) {
-        return _heap.getByIndex(_heap.indices[borrower_]).unadjustedThresholdPrice;
+    function getT0DebtToCollateral(address borrower_) public view returns (uint256) {
+        return _heap.getByIndex(_heap.indices[borrower_]).t0DebtToCollateral;
     }
 
-    function getMaxTp() external view returns (uint256) {
-        return _heap.getMax().unadjustedThresholdPrice;
+    function getMaxT0DebtToCollateral() external view returns (uint256) {
+        return _heap.getMax().t0DebtToCollateral;
     }
 
     function getMaxBorrower() external view returns (address) {
         return _heap.getMax().borrower;
     }
 
-    function getTotalTps() external view returns (uint256) {
+    function getTotalT0DebtToCollaterals() external view returns (uint256) {
         return _heap.loans.length;
     }
 
@@ -81,12 +81,12 @@ contract HeapInstance is DSTestPlus {
             tp = randomInRange(99_836_282_890, 1_004_968_987.606512354182109771 * 10**18, true);
 
             // Insert TP
-            upsertTp(borrower, tp);
+            upsertT0DebtToCollateral(borrower, tp);
             insertsDec  -=  1;
 
             // Verify amount of Heap TPs
             assertEq(_heap.loans.length - 1, totalInserts - insertsDec);
-            assertEq(getTp(borrower), tp);
+            assertEq(getT0DebtToCollateral(borrower), tp);
 
             if (trackInserts_)  inserts.push(borrower);
         }


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

PR to address comments https://github.com/ajna-finance/contracts/pull/1021#pullrequestreview-1776012397 and https://github.com/ajna-finance/contracts/pull/1021#pullrequestreview-1776380121

- Change Tp naming as:
        - t0DebtToCollateral : ( t0Debt / collateral )
        - debtToCollateral :   ( debt / collateral )
        - t0ThresholdPrice :   ( t0Debt / collateral ) * collateralization factor
        - thresholdPrice :     ( debt / collateral ) * collateralization factor
- natspec update
- rename `MAX_NP_TP_RATIO` to `MAX_BOND_FACTOR`
- Update `LoansInfo` and `LoanInfo` methods to return `maxT0DebtToCollateral` and `t0DebtToCollateral` respectively to maintain consistency in `Pool` contract of returning `t0` values.
- `Htp` in `PoolInfoUtils` is now calculated with `pendingInflator` rather than `inflator` (updated at last pool interaction).
- renamed borrower's `ZeroThresholdPrice` error to `ZeroDebtToCollateral` error
- removed unused `_htp` import in `pool.sol`

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

code clarity

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

None

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
