### PR TITLE
Emit subset hash on pool creation

### DIFF
--- a/src/ERC20PoolFactory.sol
+++ b/src/ERC20PoolFactory.sol
@@ -75,7 +75,7 @@ contract ERC20PoolFactory is PoolDeployer, IERC20PoolFactory {
         deployedPools[ERC20_NON_SUBSET_HASH][collateral_][quote_] = pool_;
         deployedPoolsList.push(pool_);
 
-        emit PoolCreated(pool_);
+        emit PoolCreated(pool_, ERC20_NON_SUBSET_HASH);
 
         pool.initialize(interestRate_);
     }

--- a/src/ERC721PoolFactory.sol
+++ b/src/ERC721PoolFactory.sol
@@ -85,7 +85,7 @@ contract ERC721PoolFactory is PoolDeployer, IERC721PoolFactory {
         deployedPools[subsetHash][collateral_][quote_] = pool_;
         deployedPoolsList.push(pool_);
 
-        emit PoolCreated(pool_);
+        emit PoolCreated(pool_, subsetHash);
 
         pool.initialize(tokenIds_, interestRate_);
     }

--- a/src/interfaces/pool/IPoolFactory.sol
+++ b/src/interfaces/pool/IPoolFactory.sol
@@ -44,6 +44,7 @@ interface IPoolFactory {
     /**
      *  @notice Emitted when a new pool is created.
      *  @param  pool_ The address of the new pool.
+     *  @param  subsetHash_ The subset hash for the pool lookup
      */
-    event PoolCreated(address pool_);
+    event PoolCreated(address pool_, bytes32 subsetHash_);
 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolFactory.t.sol
@@ -13,6 +13,7 @@ import { IPoolFactory }     from 'src/interfaces/pool/IPoolFactory.sol';
 
 contract ERC20PoolFactoryTest is ERC20HelperContract {
     address immutable poolAddress = 0x9Fd7552Da37D2D296CB4a84d507c35Dcc926220a;
+    bytes32 constant ERC20_NON_SUBSET_HASH = keccak256("ERC20_NON_SUBSET_HASH");
 
     function setUp() external {
         // deploy new pool factory for factory tests
@@ -94,7 +95,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
             quote:        address(_quote),
             interestRate: 2 * 10**18
         });
-        
+
         // check tracking of deployed pools
         assertEq(_poolFactory.getDeployedPoolsList().length, 0);
     }
@@ -144,7 +145,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         skip(333);
 
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(address(_collateral), address(_quote), 0.0543 * 10**18));
 
         assertEq(address(pool),             poolAddress);
@@ -175,7 +176,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         address compAddress = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
         address daiAddress  = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(compAddress, daiAddress, 0.0543 * 10**18));
 
         assertEq(address(pool),             poolAddress);
@@ -200,7 +201,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         address wbtcAddress = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
         address daiAddress  = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(wbtcAddress, daiAddress, 0.0543 * 10**18));
 
         assertEq(address(pool),             poolAddress);
@@ -225,7 +226,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         address wbtcAddress = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
         address usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(wbtcAddress, usdcAddress, 0.0543 * 10**18));
 
         assertEq(address(pool),             poolAddress);
@@ -250,7 +251,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
         address compAddress = 0xc00e94Cb662C3520282E6f5717214004A7f26888;
         address usdcAddress = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         ERC20Pool pool = ERC20Pool(_poolFactory.deployPool(compAddress, usdcAddress, 0.0543 * 10**18));
 
         assertEq(address(pool),             poolAddress);
@@ -271,7 +272,7 @@ contract ERC20PoolFactoryTest is ERC20HelperContract {
 
     function testPoolAlreadyInitialized() external {
         vm.expectEmit(true, true, false, true);
-        emit PoolCreated(poolAddress);
+        emit PoolCreated(poolAddress, ERC20_NON_SUBSET_HASH);
         address pool = _poolFactory.deployPool(address(_collateral), address(_quote), 0.05 * 10**18);
 
         vm.expectRevert(IPoolErrors.AlreadyInitialized.selector);

--- a/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolFactory.t.sol
@@ -33,6 +33,8 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _factory = new ERC721PoolFactory(_ajna);
 
         // deploy NFT collection pool
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(0x8a2be84c82956B6DdA0c4D647Ae9357d845a086B, _factory.getNFTSubsetHash(tokenIds));
         _NFTCollectionPoolAddress = _factory.deployPool(address(_collateral), address(_quote), tokenIds, 0.05 * 10**18);
         _NFTCollectionPool        = ERC721Pool(_NFTCollectionPoolAddress);
 
@@ -43,6 +45,8 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _tokenIdsSubsetOne[2] = 50;
         _tokenIdsSubsetOne[3] = 61;
 
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(0x18D11C8Cf8dc292E647F0b324d10637a3A63F678, _factory.getNFTSubsetHash(_tokenIdsSubsetOne));
         _NFTSubsetOnePoolAddress = _factory.deployPool(address(_collateral), address(_quote), _tokenIdsSubsetOne, 0.05 * 10**18);
         _NFTSubsetOnePool        = ERC721Pool(_NFTSubsetOnePoolAddress);
 
@@ -56,6 +60,8 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         _tokenIdsSubsetTwo[5] = 61;
         _tokenIdsSubsetTwo[6] = 180;
 
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(0xf80F47F84F20d8aF58cC8e93634348491357323c, _factory.getNFTSubsetHash(_tokenIdsSubsetTwo));
         _NFTSubsetTwoPoolAddress = _factory.deployPool(address(_collateral), address(_quote), _tokenIdsSubsetTwo, 0.05 * 10**18);
         _NFTSubsetTwoPool        = ERC721Pool(_NFTSubsetTwoPoolAddress);
 
@@ -304,6 +310,8 @@ contract ERC721PoolFactoryTest is ERC721HelperContract {
         tokenIdsTestSubset[1] = 2;
         tokenIdsTestSubset[2] = 3;
 
+        vm.expectEmit(true, true, false, true);
+        emit PoolCreated(0xA8FBA534d7ebefEBB270cDC4814A1A25916A94d3, _factory.getNFTSubsetHash(tokenIdsTestSubset));
         address poolAddress = _factory.deployPool(address(_collateral), address(_quote), tokenIdsTestSubset, 0.05 * 10**18);
 
         // check tracking of deployed pools

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -417,7 +417,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         address to,
         uint256 amount
     ) internal virtual {
-        // to be overidden by ERC20 helper 
+        // to be overidden by ERC20 helper
     }
 
     function _assertQuoteTokenTransferEventRoundingDown(
@@ -425,7 +425,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         address to,
         uint256 amount
     ) internal virtual {
-        // to be overidden by ERC20 helper 
+        // to be overidden by ERC20 helper
     }
 
     function _assertCollateralTokenTransferEvent(
@@ -433,7 +433,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         address to,
         uint256 amount
     ) internal virtual {
-        // to be overidden by ERC20 helper 
+        // to be overidden by ERC20 helper
     }
 
     /*********************/
@@ -487,11 +487,11 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         assertEq(vars.borrowerThresholdPrice,   state_.thresholdPrice);
 
         (
-            uint256 kickTime, 
-            uint256 collateral, 
-            uint256 debtToCover, 
-            bool    isCollateralized,      
-            uint256 price,          
+            uint256 kickTime,
+            uint256 collateral,
+            uint256 debtToCover,
+            bool    isCollateralized,
+            uint256 price,
             uint256 neutralPrice,
             ,
             ,
@@ -506,9 +506,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             assertEq(collateral,       borrowerCollateral);
             assertEq(debtToCover,      borrowerDebt);
             assertEq(isCollateralized, _isCollateralized(
-                borrowerDebt, 
-                borrowerCollateral, 
-                _lup(), 
+                borrowerDebt,
+                borrowerCollateral,
+                _lup(),
                 _pool.poolType())
             );
             assertEq(price,            state_.auctionPrice);
@@ -516,12 +516,12 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     }
 
     function _assertPool(PoolParams memory state_) internal {
-        ( 
-            , 
-            , 
-            uint256 htp, 
-            , 
-            uint256 lup, 
+        (
+            ,
+            ,
+            uint256 htp,
+            ,
+            uint256 lup,
         ) = _poolUtils.poolPricesInfo(address(_pool));
         (
             uint256 poolSize,
@@ -530,9 +530,9 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             uint256 pendingInflator,
         ) = _poolUtils.poolLoansInfo(address(_pool));
         (
-            uint256 poolMinDebtAmount, 
-            , 
-            uint256 poolActualUtilization, 
+            uint256 poolMinDebtAmount,
+            ,
+            uint256 poolActualUtilization,
             uint256 poolTargetUtilization
         ) = _poolUtils.poolUtilizationInfo(address(_pool));
 
@@ -586,7 +586,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     ) internal {
         _assertBucketAssets(index, lpBalance, collateral, deposit, exchangeRate);
 
-        // validate bucket is healthy / LP consistent with assets 
+        // validate bucket is healthy / LP consistent with assets
         _validateBucketLp(index, lpBalance);
         _validateBucketQuantities(index);
     }
@@ -796,7 +796,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
         _pool.kickReserveAuction();
     }
-    
+
     /**********************/
     /*** Revert asserts ***/
     /**********************/
@@ -1012,7 +1012,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256,
         uint256
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertBorrowBorrowerNotSenderRevert(
@@ -1021,7 +1021,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256,
         uint256
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertBorrowLimitIndexRevert(
@@ -1029,7 +1029,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256,
         uint256
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertBorrowBorrowerUnderCollateralizedRevert(
@@ -1037,7 +1037,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256,
         uint256
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertBorrowMinDebtRevert(
@@ -1045,7 +1045,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256,
         uint256
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertFlashloanFeeRevertsForToken(
@@ -1346,7 +1346,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         address from,
         uint256 maxAmount
     ) internal virtual {
-        // to be overidden by ERC20/ERC721DSTestPlus 
+        // to be overidden by ERC20/ERC721DSTestPlus
     }
 
     function _assertTakeDebtUnderMinPoolDebtRevert(
@@ -1426,7 +1426,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     /********************/
 
     // Pool deployer events
-    event PoolCreated(address pool_);
+    event PoolCreated(address pool_, bytes32 subsetHash_);
 
 
     /************************/
@@ -1449,7 +1449,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         IPool pool = IPool(pool_);
 
         uint256 lupIndex = pool.depositIndex(debtAmount_);
-        lup_ = _priceAt(lupIndex); 
+        lup_ = _priceAt(lupIndex);
     }
 
     function setRandomSeed(uint256 seed) public {


### PR DESCRIPTION
## Description

Updated to target `develop` from #1012 

Adds subsetHash to PoolCreated event.

Adds tests of event emission to ERC721 pool creation.

## Purpose

`subsetHash` is a required parameter for pool lookup in the factory. For non-subset pools, this subsetHash can be obtained from the factory constant, but for ERC721 subset pools this value is calculated in the deploy function and not emitted or returned. Emitting the subsetHash in the event will allow integrators to get the hash from the event and use it for pool lookups without needing to inspect the transaction inputs and recalculating the value.

## Impact

Slight gas increase for the additional event parameter on pool deploy.

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
