### PR TITLE
`_revertIfActiveAuctions` helper should revert with `ActiveAuction` error

### DIFF
--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -396,7 +396,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev    update `reserveAuction.latestBurnEventEpoch` and burn event `timestamp` state
      *  @dev    === Reverts on ===
      *  @dev    2 weeks not passed `ReserveAuctionTooSoon()`
-     *  @dev    unsettled liquidation `ActiveAuction()`
+     *  @dev    unsettled liquidation `AuctionActive()`
      *  @dev    === Emit events ===
      *  @dev    - `KickReserveAuction`
      */

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -396,7 +396,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev    update `reserveAuction.latestBurnEventEpoch` and burn event `timestamp` state
      *  @dev    === Reverts on ===
      *  @dev    2 weeks not passed `ReserveAuctionTooSoon()`
-     *  @dev    unsettled liquidation `AuctionNotCleared()`
+     *  @dev    unsettled liquidation `ActiveAuction()`
      *  @dev    === Emit events ===
      *  @dev    - `KickReserveAuction`
      */

--- a/src/libraries/helpers/RevertsHelper.sol
+++ b/src/libraries/helpers/RevertsHelper.sol
@@ -18,6 +18,7 @@ import { Maths }    from '../internal/Maths.sol';
 
     // See `IPoolErrors` for descriptions
     error AuctionNotCleared();
+    error AuctionActive();
     error AmountLTMinDebt();
     error DustAmountNotExceeded();
     error LimitIndexExceeded();
@@ -97,13 +98,13 @@ import { Maths }    from '../internal/Maths.sol';
     /**
      *  @notice  Check if there are still active / non settled auctions in pool.
      *  @notice  Prevents kicking reserves auctions until all pending auctions are fully settled.
-     *  @dev     Reverts with `AuctionNotCleared`.
+     *  @dev     Reverts with `AuctionActive`.
      *  @param auctions_ Auctions data.
      */
     function _revertIfActiveAuctions(
         AuctionsState storage auctions_
     ) view {
-        if (auctions_.noOfAuctions != 0) revert AuctionNotCleared();
+        if (auctions_.noOfAuctions != 0) revert AuctionActive();
     }
 
     /**

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -1153,9 +1153,8 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
         assertEq(claimableReserves, 294_613_859.916107852369559136 * 1e18);
 
         // test reserves auction cannot be kicked until auction settled
-        vm.expectRevert(abi.encodeWithSignature('AuctionNotCleared()'));
-        _pool.kickReserveAuction();
- 
+        _assertReserveAuctionUnsettledLiquidation();
+
         // settle auction with reserves
         changePrank(actor6);
         _settle({

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -793,7 +793,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
     }
 
     function _assertReserveAuctionUnsettledLiquidation() internal {
-        vm.expectRevert(IPoolErrors.AuctionNotCleared.selector);
+        vm.expectRevert(IPoolErrors.AuctionActive.selector);
         _pool.kickReserveAuction();
     }
     


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

accommodating comment https://github.com/ajna-finance/contracts/pull/1024#pullrequestreview-1777683604

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

## Impact

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

slightly increase of contract size as new error used

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
