### PR TITLE
Calculate reserve auction price using kicked amount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # (-include to ignore error if it does not exist)
 -include .env && source ./tests/forge/invariants/scenarios/scenario-${SCENARIO}.sh
 
-CONTRACT_EXCLUDES="RegressionTest|Panic|RealWorld|Trading"
+CONTRACT_EXCLUDES="RegressionTest|Panic|RealWorld|Trading|Rewards"
 TEST_EXCLUDES="testLoad|invariant|test_regression"
 
 all: clean install build

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -313,7 +313,7 @@ contract PoolInfoUtils {
 
         uint256 quoteTokenBalance = IERC20Token(pool.quoteTokenAddress()).balanceOf(ajnaPool_) * pool.quoteTokenScale();
 
-        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 lastKickedReserves, uint256 auctionKickTime, ) = pool.reservesInfo();
+        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 auctionKickTime, uint256 lastKickedReserves, ) = pool.reservesInfo();
 
         // due to rounding issues, especially in Auction.settle, this can be slighly negative
         if (poolDebt + quoteTokenBalance >= poolSize + bondEscrowed + unclaimedReserve) {

--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -277,7 +277,7 @@ contract PoolInfoUtils {
         (
             uint256 bondEscrowed,
             uint256 unclaimedReserve,
-            ,
+            , ,
         ) = pool.reservesInfo();
         uint256 escrowedAmounts = bondEscrowed + unclaimedReserve;
 
@@ -313,7 +313,7 @@ contract PoolInfoUtils {
 
         uint256 quoteTokenBalance = IERC20Token(pool.quoteTokenAddress()).balanceOf(ajnaPool_) * pool.quoteTokenScale();
 
-        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 auctionKickTime, ) = pool.reservesInfo();
+        (uint256 bondEscrowed, uint256 unclaimedReserve, uint256 lastKickedReserves, uint256 auctionKickTime, ) = pool.reservesInfo();
 
         // due to rounding issues, especially in Auction.settle, this can be slighly negative
         if (poolDebt + quoteTokenBalance >= poolSize + bondEscrowed + unclaimedReserve) {
@@ -329,7 +329,7 @@ contract PoolInfoUtils {
         );
 
         claimableReservesRemaining_ = unclaimedReserve;
-        auctionPrice_               = _reserveAuctionPrice(auctionKickTime);
+        auctionPrice_               = _reserveAuctionPrice(auctionKickTime, lastKickedReserves);
         timeRemaining_              = 3 days - Maths.min(3 days, block.timestamp - auctionKickTime);
     }
 

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -427,7 +427,8 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 ajnaRequired;
         (amount_, ajnaRequired) = TakerActions.takeReserves(
             reserveAuction,
-            maxAmount_
+            maxAmount_,
+            _getArgUint256(QUOTE_SCALE)
         );
 
         // burn required number of ajna tokens to take quote from reserves

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -930,11 +930,12 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
     }
 
     /// @inheritdoc IPoolState
-    function reservesInfo() external view override returns (uint256, uint256, uint256, uint256) {
+    function reservesInfo() external view override returns (uint256, uint256, uint256, uint256, uint256) {
         return (
             auctions.totalBondEscrowed,
             reserveAuction.unclaimed,
             reserveAuction.kicked,
+            reserveAuction.lastKickedReserves,
             reserveAuction.totalInterestEarned
         );
     }

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -234,6 +234,7 @@ interface IPoolState {
      *  @return liquidationBondEscrowed_ Amount of liquidation bond across all liquidators.
      *  @return reserveAuctionUnclaimed_ Amount of claimable reserves which has not been taken in the `Claimable Reserve Auction`.
      *  @return reserveAuctionKicked_    Time a `Claimable Reserve Auction` was last kicked.
+     *  @return lastKickedReserves_      Amount of reserves upon last kick, used to calculate price.
      *  @return totalInterestEarned_     Total interest earned by all lenders in the pool
      */
     function reservesInfo()
@@ -243,6 +244,7 @@ interface IPoolState {
             uint256 liquidationBondEscrowed_,
             uint256 reserveAuctionUnclaimed_,
             uint256 reserveAuctionKicked_,
+            uint256 lastKickedReserves_,
             uint256 totalInterestEarned_
     );
 
@@ -432,6 +434,7 @@ struct Kicker {
 /// @dev Struct holding reserve auction state.
 struct ReserveAuctionState {
     uint256 kicked;                            // Time a Claimable Reserve Auction was last kicked.
+    uint256 lastKickedReserves;                // [WAD] Amount of reserves upon last kick, used to calculate price.
     uint256 unclaimed;                         // [WAD] Amount of claimable reserves which has not been taken in the Claimable Reserve Auction.
     uint256 latestBurnEventEpoch;              // Latest burn event epoch.
     uint256 totalAjnaBurned;                   // [WAD] Total ajna burned in the pool.

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -240,8 +240,9 @@ library KickerActions {
 
         if (curUnclaimedAuctionReserve == 0) revert NoReserves();
 
-        reserveAuction_.unclaimed = curUnclaimedAuctionReserve;
-        reserveAuction_.kicked    = block.timestamp;
+        reserveAuction_.unclaimed          = curUnclaimedAuctionReserve;
+        reserveAuction_.kicked             = block.timestamp;
+        reserveAuction_.lastKickedReserves = curUnclaimedAuctionReserve;
 
         // increment latest burn event epoch and update burn event timestamp
         latestBurnEpoch += 1;
@@ -251,7 +252,7 @@ library KickerActions {
 
         emit KickReserveAuction(
             curUnclaimedAuctionReserve,
-            _reserveAuctionPrice(block.timestamp),
+            _reserveAuctionPrice(block.timestamp, curUnclaimedAuctionReserve),
             latestBurnEpoch
         );
     }

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -274,6 +274,7 @@ library TakerActions {
      *  @dev    decrement `reserveAuction.unclaimed` accumulator
      *  @dev    === Reverts on ===
      *  @dev    not kicked or `72` hours didn't pass `NoReservesAuction()`
+     *  @dev    0 take amount or 0 AJNA burned `InvalidAmount()`
      *  @dev    === Emit events ===
      *  @dev    - `ReserveAuction`
      */
@@ -292,6 +293,8 @@ library TakerActions {
 
             amount_       = Maths.min(unclaimed, maxAmount_);
             ajnaRequired_ = Maths.ceilWmul(amount_, price);
+            // prevent 0-bid; must burn at least 1 wei of AJNA
+            if (ajnaRequired_ == 0) revert InvalidAmount();
 
             unclaimed -= amount_;
 

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -288,7 +288,7 @@ library TakerActions {
 
         if (kicked != 0 && block.timestamp - kicked <= 72 hours) {
             uint256 unclaimed = reserveAuction_.unclaimed;
-            uint256 price     = _reserveAuctionPrice(kicked);
+            uint256 price     = _reserveAuctionPrice(kicked, reserveAuction_.lastKickedReserves);
 
             amount_       = Maths.min(unclaimed, maxAmount_);
             ajnaRequired_ = Maths.ceilWmul(amount_, price);

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -280,11 +280,9 @@ library TakerActions {
      */
     function takeReserves(
         ReserveAuctionState storage reserveAuction_,
-        uint256 maxAmount_
+        uint256 maxAmount_,
+        uint256 quoteScale_
     ) external returns (uint256 amount_, uint256 ajnaRequired_) {
-        // revert if no amount to be taken
-        if (maxAmount_ == 0) revert InvalidAmount();
-
         uint256 kicked = reserveAuction_.kicked;
 
         if (kicked != 0 && block.timestamp - kicked <= 72 hours) {
@@ -292,6 +290,9 @@ library TakerActions {
             uint256 price     = _reserveAuctionPrice(kicked, reserveAuction_.lastKickedReserves);
 
             amount_       = Maths.min(unclaimed, maxAmount_);
+            // revert if no amount to be taken
+            if (amount_ / quoteScale_ == 0) revert InvalidAmount();
+
             ajnaRequired_ = Maths.ceilWmul(amount_, price);
             // prevent 0-bid; must burn at least 1 wei of AJNA
             if (ajnaRequired_ == 0) revert InvalidAmount();

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -393,7 +393,7 @@ import { Maths }   from '../internal/Maths.sol';
             uint256 secondsElapsed   = block.timestamp - reserveAuctionKicked_;
             uint256 hoursComponent   = 1e27 >> secondsElapsed / 3600;
             uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
-            uint256 initialPrice     = Maths.wdiv(1_000_000_000 * 1e18, lastKickedReserves_);
+            uint256 initialPrice     = lastKickedReserves_ == 0 ? 0 : Maths.wdiv(1_000_000_000 * 1e18, lastKickedReserves_);
 
             // TODO: clean up rounding by implementing appropriate Math library method
             price_ = initialPrice * Maths.rmul(hoursComponent, minutesComponent) / 1e27;

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -382,17 +382,21 @@ import { Maths }   from '../internal/Maths.sol';
     /**
      *  @notice Calculates reserves auction price.
      *  @param  reserveAuctionKicked_ Time when reserve auction was started (kicked).
+     *  @param  lastKickedReserves_   Reserves to be auctioned when started (kicked).
      *  @return price_                Calculated auction price.
      */     
     function _reserveAuctionPrice(
-        uint256 reserveAuctionKicked_
+        uint256 reserveAuctionKicked_,
+        uint256 lastKickedReserves_
     ) view returns (uint256 price_) {
         if (reserveAuctionKicked_ != 0) {
             uint256 secondsElapsed   = block.timestamp - reserveAuctionKicked_;
             uint256 hoursComponent   = 1e27 >> secondsElapsed / 3600;
             uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
+            uint256 initialPrice     = Maths.wdiv(1_000_000_000 * 1e18, lastKickedReserves_);
 
-            price_ = Maths.rayToWad(1_000_000_000 * Maths.rmul(hoursComponent, minutesComponent));
+            // TODO: clean up rounding by implementing appropriate Math library method
+            price_ = initialPrice * Maths.rmul(hoursComponent, minutesComponent) / 1e27;
         }
     }
 

--- a/src/libraries/helpers/PoolHelper.sol
+++ b/src/libraries/helpers/PoolHelper.sol
@@ -395,7 +395,6 @@ import { Maths }   from '../internal/Maths.sol';
             uint256 minutesComponent = Maths.rpow(MINUTE_HALF_LIFE, secondsElapsed % 3600 / 60);
             uint256 initialPrice     = lastKickedReserves_ == 0 ? 0 : Maths.wdiv(1_000_000_000 * 1e18, lastKickedReserves_);
 
-            // TODO: clean up rounding by implementing appropriate Math library method
             price_ = initialPrice * Maths.rmul(hoursComponent, minutesComponent) / 1e27;
         }
     }

--- a/src/libraries/internal/Maths.sol
+++ b/src/libraries/internal/Maths.sol
@@ -67,10 +67,6 @@ library Maths {
         }
     }
 
-    function rayToWad(uint256 x) internal pure returns (uint256) {
-        return (x + 10**9 / 2) / 10**9;
-    }
-
     /*************************/
     /*** Integer Functions ***/
     /*************************/

--- a/tests/forge/invariants/PositionsAndRewards/handlers/ERC20PoolRewardsHandler.sol
+++ b/tests/forge/invariants/PositionsAndRewards/handlers/ERC20PoolRewardsHandler.sol
@@ -49,7 +49,7 @@ contract ERC20PoolRewardsHandler is RewardsPoolHandler, ReserveERC20PoolHandler 
 
         for (uint256 epoch = 0; epoch <= numberOfEpochs_; epoch ++) {
             // draw some debt and then repay after some times to increase pool earning / reserves 
-            (, uint256 claimableReserves, , ) = _pool.reservesInfo();
+            (, uint256 claimableReserves, , ,) = _pool.reservesInfo();
             if (claimableReserves == 0) {
                 uint256 amountToBorrow = _preDrawDebt(amountToAdd_);
                 _drawDebt(amountToBorrow);
@@ -69,7 +69,7 @@ contract ERC20PoolRewardsHandler is RewardsPoolHandler, ReserveERC20PoolHandler 
             // skip time for price to decrease, large price decrease reduces chances of rewards exceeding rewards contract balance
             skip(30 hours);
 
-            (, claimableReserves, , ) = _pool.reservesInfo();
+            (, claimableReserves, , ,) = _pool.reservesInfo();
             uint256 boundedTakeAmount = constrictToRange(amountToAdd_, claimableReserves / 2, claimableReserves);
             _takeReserves(boundedTakeAmount);
 

--- a/tests/forge/invariants/PositionsAndRewards/handlers/ERC721PoolRewardsHandler.sol
+++ b/tests/forge/invariants/PositionsAndRewards/handlers/ERC721PoolRewardsHandler.sol
@@ -48,7 +48,7 @@ contract ERC721PoolRewardsHandler is RewardsPoolHandler, ReserveERC721PoolHandle
 
         for (uint256 epoch = 0; epoch <= numberOfEpochs_; epoch ++) {
             // draw some debt and then repay after some times to increase pool earning / reserves 
-            (, uint256 claimableReserves, , ) = _pool.reservesInfo();
+            (, uint256 claimableReserves, , ,) = _pool.reservesInfo();
             if (claimableReserves == 0) {
                 uint256 amountToBorrow = _preDrawDebt(amountToAdd_);
                 _drawDebt(amountToBorrow);
@@ -61,7 +61,7 @@ contract ERC721PoolRewardsHandler is RewardsPoolHandler, ReserveERC721PoolHandle
 
             skip(timeToSkip);
 
-            (, claimableReserves, , ) = _pool.reservesInfo();
+            (, claimableReserves, , ,) = _pool.reservesInfo();
 
             _kickReserveAuction();
 

--- a/tests/forge/invariants/base/BasicInvariants.t.sol
+++ b/tests/forge/invariants/base/BasicInvariants.t.sol
@@ -145,7 +145,7 @@ abstract contract BasicInvariants is BaseInvariants {
         (
             uint256 totalBondEscrowed,
             uint256 unClaimed,
-            ,
+            , ,
         ) = _pool.reservesInfo();
 
         uint256 assets      = poolBalance + poolDebt;
@@ -186,7 +186,7 @@ abstract contract BasicInvariants is BaseInvariants {
         (
             uint256 totalBondEscrowed,
             uint256 unClaimed,
-            ,
+            , ,
         ) = _pool.reservesInfo();
 
         require(
@@ -286,7 +286,7 @@ abstract contract BasicInvariants is BaseInvariants {
 
     /// @dev reserve.totalInterestEarned should only update once per block
     function _invariant_I2() internal {
-        (, , , uint256 totalInterestEarned) = _pool.reservesInfo();
+        (, , , , uint256 totalInterestEarned) = _pool.reservesInfo();
 
         if (previousTotalInterestEarnedUpdate == block.number) {
             require(

--- a/tests/forge/invariants/base/LiquidationInvariants.t.sol
+++ b/tests/forge/invariants/base/LiquidationInvariants.t.sol
@@ -56,7 +56,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
             kickerClaimableBond += claimable;
         }
 
-        (uint256 totalBondEscrowed, , , ) = _pool.reservesInfo();
+        (uint256 totalBondEscrowed, , , , ) = _pool.reservesInfo();
 
         require(totalBondEscrowed == kickerClaimableBond + kickerLockedBond, "A2: total bond escrowed != kicker bonds");
 
@@ -121,7 +121,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
         uint256 previousTotalBondEscrowed        = IBaseHandler(_handler).previousTotalBonds();
         uint256 increaseInBonds                  = IBaseHandler(_handler).increaseInBonds();
         uint256 decreaseInBonds                  = IBaseHandler(_handler).decreaseInBonds();
-        (uint256 currentTotalBondEscrowed, , , ) = _pool.reservesInfo();
+        (uint256 currentTotalBondEscrowed, , , ,) = _pool.reservesInfo();
 
         requireWithinDiff(
             currentTotalBondEscrowed,

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -357,7 +357,7 @@ abstract contract BaseHandler is Test {
         increaseInBonds = 0;
         decreaseInBonds = 0;
         // record totalBondEscrowed before each action
-        (previousTotalBonds, , , ) = _pool.reservesInfo();
+        (previousTotalBonds, , , , ) = _pool.reservesInfo();
     }
 
     /********************************/
@@ -480,7 +480,7 @@ abstract contract BaseHandler is Test {
 
         (
             uint256 totalBond,
-            uint256 reserveUnclaimed, ,
+            uint256 reserveUnclaimed, , ,
             uint256 totalInterest
         ) = _pool.reservesInfo();
 

--- a/tests/forge/invariants/base/handlers/unbounded/UnboundedReservePoolHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/UnboundedReservePoolHandler.sol
@@ -41,11 +41,11 @@ abstract contract UnboundedReservePoolHandler is BaseHandler {
         // ensure actor always has the amount to take reserves
         _ensureAjnaAmount(_actor, 1e45);
 
-        (, uint256 claimableReservesBeforeAction, ,) = _pool.reservesInfo();
+        (, uint256 claimableReservesBeforeAction, , , ) = _pool.reservesInfo();
 
         try _pool.takeReserves(amount_) {
 
-            (, uint256 claimableReservesAfterAction, ,) = _pool.reservesInfo();
+            (, uint256 claimableReservesAfterAction, , ,) = _pool.reservesInfo();
             // reserves are guaranteed by the protocol)
             require(
                 claimableReservesAfterAction < claimableReservesBeforeAction,

--- a/tests/forge/unit/Auctions.t.sol
+++ b/tests/forge/unit/Auctions.t.sol
@@ -103,6 +103,9 @@ contract AuctionsTest is DSTestPlus {
         assertEq(_reserveAuctionPrice(block.timestamp - 16 hours, lastKickedReserves), 0.000005086263020833 * 1e18);
         assertEq(_reserveAuctionPrice(block.timestamp - 32 hours, lastKickedReserves), 0.000000000077610214 * 1e18);
         assertEq(_reserveAuctionPrice(block.timestamp - 64 hours, lastKickedReserves), 0);
+
+        // ensure it handles zeros properly
+        assertEq(_reserveAuctionPrice(0, 0), 0);
     }
 
     /**

--- a/tests/forge/unit/Auctions.t.sol
+++ b/tests/forge/unit/Auctions.t.sol
@@ -74,13 +74,35 @@ contract AuctionsTest is DSTestPlus {
      */
     function testReserveAuctionPrice() external {
         skip(5 days);
-        assertEq(_reserveAuctionPrice(block.timestamp),            1e27);
-        assertEq(_reserveAuctionPrice(block.timestamp - 1 hours),  500000000 * 1e18);
-        assertEq(_reserveAuctionPrice(block.timestamp - 2 hours),  250000000 * 1e18);
-        assertEq(_reserveAuctionPrice(block.timestamp - 4 hours),  62500000 * 1e18);
-        assertEq(_reserveAuctionPrice(block.timestamp - 16 hours), 15258.789062500000000000 * 1e18);
-        assertEq(_reserveAuctionPrice(block.timestamp - 24 hours), 59.604644775390625000 * 1e18);
-        assertEq(_reserveAuctionPrice(block.timestamp - 90 hours), 0);
+
+        // test a single unit of quote token
+        uint256 lastKickedReserves = 1e18;
+        assertEq(_reserveAuctionPrice(block.timestamp, lastKickedReserves),            1e27);
+        assertEq(_reserveAuctionPrice(block.timestamp - 1 hours, lastKickedReserves),  500000000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 2 hours, lastKickedReserves),  250000000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 4 hours, lastKickedReserves),  62500000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 16 hours, lastKickedReserves), 15258.789062500000000000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 24 hours, lastKickedReserves), 59.604644775390625000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 90 hours, lastKickedReserves), 0);
+
+        // test a reasonable reserve quantity for dollar-pegged stablecoin as quote token
+        lastKickedReserves = 5_000 * 1e18;
+        assertEq(_reserveAuctionPrice(block.timestamp, lastKickedReserves),            200_000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 1 hours, lastKickedReserves),  100_000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 2 hours, lastKickedReserves),  50_000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 4 hours, lastKickedReserves),  12_500 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 8 hours, lastKickedReserves),  781.25 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 16 hours, lastKickedReserves), 3.051757812500000000 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 24 hours, lastKickedReserves), 0.011920928955078125 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 90 hours, lastKickedReserves), 0);
+
+        // test a potential reserve quantity for a shitcoin shorting pool
+        lastKickedReserves = 3_000_000_000 * 1e18;
+        assertEq(_reserveAuctionPrice(block.timestamp, lastKickedReserves),            0.333333333333333333 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 4 hours, lastKickedReserves),  0.020833333333333333 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 16 hours, lastKickedReserves), 0.000005086263020833 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 32 hours, lastKickedReserves), 0.000000000077610214 * 1e18);
+        assertEq(_reserveAuctionPrice(block.timestamp - 64 hours, lastKickedReserves), 0);
     }
 
     /**

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInputValidation.t.sol
@@ -52,7 +52,7 @@ contract ERC20PooInputValidationTest is ERC20HelperContract {
 
     function testValidateTakeReservesInput() external tearDown {
         // revert on zero amount
-        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        vm.expectRevert(IPoolErrors.NoReservesAuction.selector);
         _pool.takeReserves(0);
     }
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -1176,7 +1176,7 @@ contract ERC20PoolLiquidationsSettleRegressionTest is ERC20HelperContract {
             reserves:                   56.029327427592408135 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 374_644_125.812500127979859369 * 1e18,
-            auctionPrice:               1_000_000_000 * 1e18,
+            auctionPrice:               2.669199731428525342 * 1e18,
             timeRemaining:              3 days
         });
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
@@ -61,7 +61,7 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         });
     }
 
-    function testStartAndTakeUsdcReserveAuction() external {
+    function testStartAndTakeUsdcReserveAuction() external tearDown {
         // skip time to accumulate interest
         skip(26 weeks);
 
@@ -89,7 +89,7 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: 1.471235793861737556 * 1e18,
-            price:             1000000000 * 1e18,
+            price:             679_700_700.711729067726118823 * 1e18,
             epoch:             1
         });
 
@@ -99,7 +99,7 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
             reserves:                   0.000001006397976200 * 1e18,
             claimableReserves :         0,
             claimableReservesRemaining: 1.471235793861737556 * 1e18,
-            auctionPrice:               0.000000000867361737 * 1e18,
+            auctionPrice:               0.000000000589546380 * 1e18,
             timeRemaining:              43200
         });
 
@@ -113,7 +113,7 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         _pool.takeReserves(10 * 1e18);
         assertEq(USDC.balanceOf(address(_pool)),   1_006.397978 * 1e6);
         assertEq(USDC.balanceOf(address(_bidder)), 1.471235 * 1e6);
-        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999998723906366 * 1e18);
+        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999132638263 * 1e18);
     }
 
     function testZeroBid() external {

--- a/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
@@ -116,7 +116,7 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999132638263 * 1e18);
     }
 
-    function testZeroBid() external {
+    function testZeroBid() external tearDown {
         // mint into the pool to simulate reserves
         deal(address(USDC), address(_pool), 1_000_000 * 1e6);
         _assertReserveAuction({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolReserveAuction.t.sol
@@ -148,43 +148,43 @@ contract ERC20PoolReserveAuctionTest is ERC20HelperContract {
         // try to take the smallest amount of USDC possible
         assertEq(USDC.balanceOf(address(_bidder)), 0);
         assertEq(AJNA.balanceOf(address(_bidder)), 10 * 1e18);
-        _pool.takeReserves(1 * 1e6);
-        // bidder got nothing, but burned 1wei of AJNA
-        assertEq(USDC.balanceOf(address(_bidder)), 0);
+        _pool.takeReserves(1e12);
+        // bidder got a quantum of USDC and burned 1wei of AJNA
+        assertEq(USDC.balanceOf(address(_bidder)), 1);
         assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999999999 * 1e18);
 
         // try to take a smaller-than-possible amount of USDC
-        _pool.takeReserves(1);
-        // bidder got nothing, but burned another 1wei of AJNA
-        assertEq(USDC.balanceOf(address(_bidder)), 0);
-        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999999998 * 1e18);
+        // should revert, because no quote token would be purchased
+        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        _pool.takeReserves(1e11);
+        // bidder balances unchanged
+        assertEq(USDC.balanceOf(address(_bidder)), 1);
+        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999999999 * 1e18);
 
         // take a reasonable amount of USDC
-        assertEq(USDC.balanceOf(address(_bidder)), 0);
+        assertEq(USDC.balanceOf(address(_bidder)), 1);
         _pool.takeReserves(100 * 1e18);
         // bidder burned some AJNA
-        assertEq(USDC.balanceOf(address(_bidder)), 100 * 1e6);
-        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999994598 * 1e18);
+        assertEq(USDC.balanceOf(address(_bidder)), 100.000001 * 1e6);
+        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999994599 * 1e18);
 
         // wait for price to be 0
         skip(7 hours);
-        // FIXME: claimableReserves 0.000000000001000001 * 1e18 here,
-        // possibly due to the takeReserves(1) above
         _assertReserveAuction({
-            reserves:                   0.000000999955337901 * 1e18,
+            reserves:                   0.000000999954337900 * 1e18,
             claimableReserves :         0,
-            claimableReservesRemaining: 999_200.334122638962821699 * 1e18,
+            claimableReservesRemaining: 999_200.334121638963821700 * 1e18,
             auctionPrice:               0,
             timeRemaining:              1 hours
         });
 
         // take 1 USDC should revert, because no AJNA would be burned
-        assertEq(USDC.balanceOf(address(_bidder)), 100 * 1e6);
+        assertEq(USDC.balanceOf(address(_bidder)), 100.000001 * 1e6);
         vm.expectRevert(IPoolErrors.InvalidAmount.selector);
         _pool.takeReserves(1 * 1e18);
         // bidder balances unchanged
-        assertEq(USDC.balanceOf(address(_bidder)), 100 * 1e6);
-        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999994598 * 1e18);
+        assertEq(USDC.balanceOf(address(_bidder)), 100.000001 * 1e6);
+        assertEq(AJNA.balanceOf(address(_bidder)), 9.999999999999994599 * 1e18);
     }
 }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolInputValidation.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolInputValidation.t.sol
@@ -57,7 +57,7 @@ contract ERC721PoolBorrowTest is ERC721HelperContract {
 
     function testValidateTakeReservesInput() external tearDown {
         // revert on zero amount
-        vm.expectRevert(IPoolErrors.InvalidAmount.selector);
+        vm.expectRevert(IPoolErrors.NoReservesAuction.selector);
         _pool.takeReserves(0);
     }
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -180,7 +180,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // check that you can't start a new auction if a previous auction is active
         _assertReserveAuctionTooSoon();
 
-        (, uint256 unclaimed, , ) = _pool.reservesInfo();
+        (, uint256 unclaimed, , ,) = _pool.reservesInfo();
 
         uint256 expectedPrice = 59.604644775390625 * 1e18;
         _takeReserves({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -99,60 +99,39 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: 840.717154484109789508 * 1e18,
-            price:             1_000_000_000 * 1e18,
+            price:             1_189_460.682069263974570223 * 1e18,
             epoch:             1
         });
 
-        _assertReserveAuctionPrice(1_000_000_000 * 1e18);
+        _assertReserveAuctionPrice(1_189_460.682069263974570223 * 1e18);
 
         // check prices
         skip(37 minutes);
-        _assertReserveAuctionPrice(652176034.882782126826643053 * 1e18);
+        _assertReserveAuctionPrice(775_737.751280902122928059 * 1e18);
 
         skip(23 hours);     // 23 hours 37 minutes
-        _assertReserveAuctionPrice(77.745441780421987394 * 1e18);
+        _assertReserveAuctionPrice(0.092475146207916989 * 1e18);
 
         skip(1400);         // 24 hours 0 minutes 20 seconds
-        _assertReserveAuctionPrice(59.604644775390625 * 1e18);
+        _assertReserveAuctionPrice(0.070897381429032324 * 1e18);
 
         skip(100);          // 24 hours 2 minutes
-        _assertReserveAuctionPrice(58.243272807255146201 * 1e18);
+        _assertReserveAuctionPrice(0.069278082999263921 * 1e18);
 
         skip(58 minutes);   // 25 hours
-        _assertReserveAuctionPrice(29.8023223876953125 * 1e18);
+        _assertReserveAuctionPrice(0.035448690714516162 * 1e18);
 
         skip(5 hours);      // 30 hours
-        _assertReserveAuctionPrice(0.931322574615478515 * 1e18);
+        _assertReserveAuctionPrice(0.00110777158482863 * 1e18);
 
-        skip(121 minutes);  // 32 hours 1 minute
-        _assertReserveAuctionPrice(0.230156355619639189 * 1e18);
+        skip(6 hours);      // 36 hours
+        _assertReserveAuctionPrice(0.000017308931012947 * 1e18);
 
-        skip(7700 seconds); // 34 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.052459681325756842 * 1e18);
+        skip(12 hours);     // 48 hours
+        _assertReserveAuctionPrice(0.000000004225813235 * 1e18);
 
-        skip(8 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000204920630178738 * 1e18);
-
-        skip(6 hours);      // 42 hours 9 minutes 20 seconds
-        _assertReserveAuctionPrice(0.000003201884846542 * 1e18);
-
-        skip(3100 seconds); // 43 hours
-        _assertReserveAuctionPrice(0.000001755953640897 * 1e18);
-
-        skip(5 hours);      // 48 hours
-        _assertReserveAuctionPrice(0.000000054873551278 * 1e18);
-
-        skip(12 hours);     // 60 hours
-        _assertReserveAuctionPrice(0.000000000013396863 * 1e18);
-
-        skip(11 hours);     // 71 hours
-        _assertReserveAuctionPrice(0.000000000000006541 * 1e18);
-
-        skip(3599 seconds); // 71 hours 59 minutes 59 seconds
-        _assertReserveAuctionPrice(0.000000000000003308 * 1e18);
-
-        skip(1 seconds);    // 72 hours
-        _assertReserveAuctionPrice(0.000000000000003270 * 1e18);
+        skip(24 hours);     // 72 hours
+        _assertReserveAuctionPrice(0.000000000000000251 * 1e18);
     }
 
     function testReserveAuctionTiming() external tearDown {
@@ -170,7 +149,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: 840.717154484109789508 * 1e18,
-            price:             1_000_000_000 * 1e18,
+            price:             1_189_460.682069263974570223 * 1e18,
             epoch:             1
         });
 
@@ -182,7 +161,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
 
         (, uint256 unclaimed, , ,) = _pool.reservesInfo();
 
-        uint256 expectedPrice = 59.604644775390625 * 1e18;
+        uint256 expectedPrice = 0.070897381429032324 * 1e18;
         _takeReserves({
             from:              _bidder,
             amount:            Maths.wdiv(unclaimed, Maths.wad(2)),
@@ -210,7 +189,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: 420.358577242054894754 * 1e18,
-            price:             1_000_000_000 * 1e18,
+            price:             2_378_921.364138527949140447 * 1e18,
             epoch:             2
         });
     }
@@ -240,7 +219,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
 
         // kick off a new auction
-        uint256 expectedPrice = 1_000_000_000 * 1e18;
+        uint256 expectedPrice = 1_189_460.682069263974570223 * 1e18;
         uint256 expectedQuoteBalance = _quote.balanceOf(_bidder);
         _kickReserveAuction({
             from:              _bidder,
@@ -259,14 +238,14 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
         
         // bid once the price becomes attractive
-        skip(24 hours);
-        expectedPrice = 59.604644775390625 * 1e18;
+        skip(16 hours);
+        expectedPrice = 18.149729645832275002 * 1e18;
         _assertReserveAuction({
             reserves:                   reserves,
             claimableReserves :         0,
             claimableReservesRemaining: 840.717154484109789508 * 1e18,
             auctionPrice:               expectedPrice,
-            timeRemaining:              2 days
+            timeRemaining:              72 hours - 16 hours
         });
         _takeReserves({
             from:              _bidder,
@@ -278,25 +257,25 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
 
         expectedQuoteBalance += 300 * 1e18;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajnaToken.balanceOf(_bidder), 62_118.606567382812500000 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_bidder), 74_555.081106250317499400 * 1e18);
         expectedReserves -= 300 * 1e18;
         _assertReserveAuction({
             reserves:                   reserves,
             claimableReserves :         0,
             claimableReservesRemaining: expectedReserves,
             auctionPrice:               expectedPrice,
-            timeRemaining:              2 days
+            timeRemaining:              72 hours - 16 hours
         });
 
         // bid max amount
         skip(5 minutes);
-        expectedPrice = 56.259293120008319416 * 1e18;
+        expectedPrice = 17.131063594818494900 * 1e18;
         _assertReserveAuction({
             reserves:                   reserves,
             claimableReserves :         0,
             claimableReservesRemaining: expectedReserves,
             auctionPrice:               expectedPrice,
-            timeRemaining:              2875 minutes
+            timeRemaining:              72 hours - 16 hours - 5 minutes
         });
         _takeReserves({
             from:              _bidder,
@@ -307,7 +286,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
         expectedQuoteBalance += expectedReserves;
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
-        assertEq(_ajnaToken.balanceOf(_bidder),  31_698.241678244459018861 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_bidder),  65_292.021145973736199572 * 1e18);
 
         expectedReserves = 0;
         _assertReserveAuction({
@@ -315,7 +294,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             claimableReserves :         0,
             claimableReservesRemaining: expectedReserves,
             auctionPrice:               expectedPrice,
-            timeRemaining:              2875 minutes
+            timeRemaining:              72 hours - 16 hours - 5 minutes
         });
 
         // ensure take reverts after auction ends
@@ -359,7 +338,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
 
         // kick off a new auction
-        uint256 expectedPrice     = 1_000_000_000 * 1e18;
+        uint256 expectedPrice     = 1_189_460.682069263974570223 * 1e18;
         uint256 expectedReserves  = claimableReserves;
         _kickReserveAuction({
             from:              _bidder,
@@ -379,7 +358,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
 
         // partial take
         skip(1 days);
-        expectedPrice = 59.604644775390625 * 1e18;
+        expectedPrice = 0.070897381429032324 * 1e18;
         expectedReserves -= 100 * 1e18;
         _takeReserves({
             from:              _bidder,
@@ -432,7 +411,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             auctionPrice:               expectedPrice,
             timeRemaining:              0
         });
-        expectedPrice = 1_000_000_000 * 1e18;
+        expectedPrice = 1_299_541.683289044748128697 * 1e18;
         expectedReserves += newClaimableReserves;
         _kickReserveAuction({
             from:              _bidder,
@@ -446,17 +425,17 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         _pool.removeQuoteToken(type(uint256).max, 1663);
 
         // ensure entire reserves can still be taken
-        skip(28 hours);
+        skip(18 hours);
         reserves             = 0.000204105576599248 * 1e18;
         newClaimableReserves = 0.000204105576599248 * 1e18;
         assertEq(expectedReserves, 769.502058194142181590 * 1e18);
-        expectedPrice        = 3.725290298461914062 * 1e18;
+        expectedPrice        = 4.957358105808428757 * 1e18;
         _assertReserveAuction({
             reserves:                   reserves,
             claimableReserves :         newClaimableReserves,
             claimableReservesRemaining: expectedReserves,
             auctionPrice:               expectedPrice,
-            timeRemaining:              44 hours
+            timeRemaining:              72 hours - 18 hours
         });
         _takeReserves({
             from:              _bidder,
@@ -471,7 +450,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             claimableReserves :         newClaimableReserves,
             claimableReservesRemaining: 0,
             auctionPrice:               expectedPrice,
-            timeRemaining:              44 hours
+            timeRemaining:              72 hours - 18 hours
         });
     }
 }

--- a/tests/forge/unit/MathTest.t.sol
+++ b/tests/forge/unit/MathTest.t.sol
@@ -10,19 +10,6 @@ import 'src/libraries/internal/Maths.sol';
 
 contract MathTest is DSTestPlus {
 
-    function testRayToWadRounded() external {
-        uint256 amount = 5_000.00076103507940381999999950 * 1e27;
-        assertEq(Maths.rayToWad(amount), 5_000.000761035079403820 * 1e18);
-
-        assertEq(Maths.rayToWad(4 * 1e27), 4 * 1e18);
-        assertEq(Maths.rayToWad(0.0000000000000000006 * 1e27), 1);
-        assertEq(Maths.rayToWad(0.0000000000000000004 * 1e27), 0);
-    }
-
-    function testZeroStaysZero() external {
-        assertEq(Maths.rayToWad(0), 0);
-    }
-
     function testMultiplication() external {
         uint256 debt     = 10_000.44444444444443999 * 1e18;
         uint256 inflator = 1.02132007 * 1e27;

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -347,7 +347,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool),
-            tokensToBurn: 98.578910573752981902 * 1e18
+            tokensToBurn: 59.604644775390624999 * 1e18
         });
 
         // call update exchange rate to enable claiming rewards
@@ -393,7 +393,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           98.578910573752981902 * 1e18,
+            burned:           59.604644775390624999 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -440,7 +440,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // first reserve auction happens successfully -> epoch 1
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2_555,
             pool:         address(_pool)
@@ -458,7 +458,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           98.578910573753041447 * 1e18,
+            burned:           59.604644775390624999 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -515,7 +515,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // first reserve auction happens successfully Staker should receive rewards epoch 0 - 1
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower: _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex: 2555,
             pool: address(_pool)
@@ -543,7 +543,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - (2 weeks + 26 weeks + 24 hours),
-            burned:           98.578910573753041447 * 1e18,
+            burned:           59.604644775390624999 * 1e18,
             tokensToBurn:     tokensToBurn,
             interest:         6.443638300196908069 * 1e18
         });
@@ -1161,7 +1161,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         });
     }
 
-    function testClaimRewardsCap() external {
+    function testClaimRewardsCapSinglePool() external {
         skip(10);
         
         /***************************/
@@ -1255,9 +1255,9 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndex1,
-            reward:         1.367983628063691166 * 1e18
+            reward:         1.490116119743651161 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 1.367983628063691166 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 1.490116119743651161 * 1e18);
 
         _assertBurn({
             pool:      address(_pool),
@@ -1272,7 +1272,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           54.719345109368236185 * 1e18,
+            burned:           59.604644775390625000 * 1e18,
             interest:         0.000048562908902619 * 1e18,
             tokensToBurn:     tokensBurned
         });
@@ -1296,9 +1296,9 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater2,
             pool:           address(_pool),
             indexes:        depositIndex2,
-            reward:         4.103950882873132453 * 1e18
+            reward:         4.470348357795411339 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater2), 4.103950882873132453 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater2), 4.470348357795411339 * 1e18);
 
         /*******************************************/
         /*** Lender Withdraws And Claims Rewards ***/
@@ -1310,7 +1310,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    43.775476087494588948 * 1e18,
+            reward:                    47.683715820312500000 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 0
         });
@@ -1444,16 +1444,16 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndex1,
-            reward:         1.367983628063691166 * 1e18
+            reward:         1.490116119743651161 * 1e18
         });
 
         _updateExchangeRates({
             updater:        _updater,
             pool:           address(_poolTwo),
             indexes:        depositIndex1,
-            reward:         1.367983628063691166 * 1e18
+            reward:         1.490116119743651161 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 2 * 1.367983628063691166 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 2 * 1.490116119743651161 * 1e18);
 
         _assertBurn({
             pool:      address(_pool),
@@ -1477,7 +1477,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           54.719345109368236185 * 1e18,
+            burned:           59.604644775390625000 * 1e18,
             interest:         0.000048562908902619 * 1e18,
             tokensToBurn:     tokensBurned
         });
@@ -1486,7 +1486,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_poolTwo),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           54.719345109368236185 * 1e18,
+            burned:           59.604644775390625000 * 1e18,
             interest:         0.000048562908902619 * 1e18,
             tokensToBurn:     tokensBurned
         });
@@ -1514,17 +1514,16 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater2,
             pool:           address(_pool),
             indexes:        depositIndex2,
-            reward:         4.103950882873132453 * 1e18
+            reward:         4.470348357795411339 * 1e18
         });
 
         _updateExchangeRates({
             updater:        _updater2,
             pool:           address(_poolTwo),
             indexes:        depositIndex2,
-            reward:         4.103950882873132453 * 1e18
+            reward:         4.470348357795411339 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater2), 2 * 4.103950882873132453 * 1e18);
-
+        assertEq(_ajnaToken.balanceOf(_updater2), 2 * 4.470348357795411339 * 1e18);
 
         /*******************************************/
         /*** Lender Withdraws And Claims Rewards ***/
@@ -1536,7 +1535,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_pool),
             tokenId:                   tokenIdOne,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    43.775476087494588948 * 1e18,
+            reward:                    47.683715820312500000 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 0
         });
@@ -1546,7 +1545,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:                      address(_poolTwo),
             tokenId:                   tokenIdTwo,
             claimedArray:              _epochsClaimedArray(1, 0),
-            reward:                    43.775476087494588948 * 1e18,
+            reward:                    47.683715820312500000 * 1e18,
             indexes:                   depositIndexes,
             updateExchangeRatesReward: 0
         });
@@ -1579,7 +1578,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -1590,7 +1589,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater: _updater,
             pool:    address(_pool),
             indexes: depositIndexes,
-            reward:  4.928945528687652965 * 1e18
+            reward:  2.980232238769531790 * 1e18
         });
 
         // burn rewards manager tokens and leave only 5 tokens available
@@ -1598,7 +1597,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         IERC20Token(address(_ajnaToken)).burn(99_999_990.910045863027949943 * 1e18);
 
         uint256 managerBalance = _ajnaToken.balanceOf(address(_rewardsManager));
-        assertEq(managerBalance, 4.161008608284397092 * 1e18);
+        assertEq(managerBalance, 6.109721898202518267 * 1e18);
 
         // check reward generated are more than manager token balance
         uint256 rewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -1613,7 +1612,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             49.289455286876529719 * 1e18,
+            reward:             29.802322387695317938 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1,0)
         });
 
@@ -1662,7 +1661,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 452.070347736384453118 * 1e18,
+            tokensToBurn: 59.604644775390625000 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6000,
             pool:         address(_pool)
@@ -1673,13 +1672,14 @@ contract RewardsManagerTest is RewardsHelperContract {
             updater:        _updater,
             pool:           address(_pool),
             indexes:        depositIndexes,
-            reward:         22.603517386819223250 * 1e18
+            reward:         29.80232238769531326 * 1e18
         });
-        assertEq(_ajnaToken.balanceOf(_updater), 22.603517386819223250 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_updater), 29.80232238769531326 * 1e18);
 
         uint256 rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
         assertEq(rewardsEarned, 226.035173868192232711 * 1e18);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
+        return;
 
         /******************************/
         /*** Second Reserve Auction ***/
@@ -1886,7 +1886,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 131.106957641613380850 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -1958,7 +1958,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // borrower takes actions providing reserves enabling reserve auctions
         uint256 firstTokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573752981902 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -2006,7 +2006,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // conduct second reserve auction
         uint256 secondTokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 179.637417325199819268 * 1e18,
+            tokensToBurn: 119.209289550781249999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -2038,11 +2038,11 @@ contract RewardsManagerTest is RewardsHelperContract {
         uint256 idOneRewardsAtTwo = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
         assertLt(idOneRewardsAtTwo, secondTokensToBurn);
         assertGt(idOneRewardsAtTwo, 0);
-        assertEq(idOneRewardsAtTwo, 20.279092258382791752 * 1e18);
+        assertEq(idOneRewardsAtTwo, 14.911798142724920009 * 1e18);
 
         uint256 idTwoRewardsAtTwo = _rewardsManager.calculateRewards(tokenIdTwo, _pool.currentBurnEpoch());
         assertLt(idOneRewardsAtTwo + idTwoRewardsAtTwo, secondTokensToBurn);
-        assertEq(idTwoRewardsAtTwo, 20.253146192588418178 * 1e18);
+        assertEq(idTwoRewardsAtTwo, 14.892719256412164856 * 1e18);
         assertGt(idTwoRewardsAtTwo, 0);
 
         // minter one claims rewards accrued after second auction        
@@ -2052,7 +2052,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             tokenId:           tokenIdOne,
             minAmountToReceive: 0,
             epochsClaimed:     _epochsClaimedArray(1,1),
-            reward:            20.279092258382791752  * 1e18
+            reward:            14.911798142724920009  * 1e18
         });
 
         assertEq(_ajnaToken.balanceOf(_minterOne), idOneRewardsAtOne + idOneRewardsAtTwo);
@@ -2066,7 +2066,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             epochsClaimed:      _epochsClaimedArray(1,1),
             reward:             idTwoRewardsAtTwo
         });
-        assertEq(_ajnaToken.balanceOf(_minterTwo), 30.101783096415219495 * 1e18);
+        assertEq(_ajnaToken.balanceOf(_minterTwo), 20.847588312661372484 * 1e18);
 
         // check there are no remaining rewards available after claiming
         uint256 remainingRewards = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
@@ -2138,7 +2138,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // auction one
         uint256 tokensToBurnE1 = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 166.619252461054099679 * 1e18,
+            tokensToBurn: 59.604644775390625000 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2155,7 +2155,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             pool:             address(_pool),
             epoch:            1,
             timestamp:        block.timestamp - 24 hours,
-            burned:           166.619252461054099679 * 1e18,
+            burned:           59.604644775390625000 * 1e18,
             tokensToBurn:     tokensToBurnE1,
             interest:         6.443638300196908069 * 1e18
         });
@@ -2259,7 +2259,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2373,7 +2373,7 @@ contract RewardsManagerTest is RewardsHelperContract {
 
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2460,7 +2460,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // trigger ajna burns
         _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573753041447 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   2555,
             pool:         address(_pool)
@@ -2472,7 +2472,7 @@ contract RewardsManagerTest is RewardsHelperContract {
             from:               _minterOne,
             tokenId:            tokenIdOne,
             minAmountToReceive: 0,
-            reward:             54.218400815564182684 * 1e18,
+            reward:             32.782554626464849728 * 1e18,
             epochsClaimed:      _epochsClaimedArray(1, 0)
         });
 
@@ -2531,7 +2531,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         uint256 tokensToBurn = _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 98.578910573752981902 * 1e18,
+            tokensToBurn: 59.604644775390624999 * 1e18,
             borrowAmount: 300 * 1e18,
             limitIndex:   3,
             pool:         address(_pool)
@@ -2617,7 +2617,7 @@ contract RewardsManagerTest is RewardsHelperContract {
         // bidder takes reserve auctions by providing ajna tokens to be burned
         totalTokensBurned += _triggerReserveAuctions({
             borrower:     _borrower,
-            tokensToBurn: 452.070347736384453118 * 1e18,
+            tokensToBurn: 59.604644775390625000 * 1e18,
             borrowAmount: 1_500 * 1e18,
             limitIndex:   6000,
             pool:         address(_pool)

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -468,7 +468,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
 
         (uint256 borrowerDebt, uint256 borrowerCollateral , ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);
         (, uint256 lockedBonds) = _pool.kickerInfo(state_.kicker);
-        (vars.auctionTotalBondEscrowed,,,) = _pool.reservesInfo();
+        (vars.auctionTotalBondEscrowed,,,,) = _pool.reservesInfo();
         (,, vars.auctionDebtInAuction,)  = _pool.debtInfo();
 
         assertEq(vars.auctionKickTime != 0,     state_.active);


### PR DESCRIPTION
## Description

Contradicting the whitepaper, Claimable Reserve Auctions (CRAs) originally had a pricing mechanism with a start price of 1 quote token for 1bbn AJNA.  This was done to simplify the auction mechanism, but the whitepaper was not updated to reflect the implementation.  Kirill's audit brought this up with issue M-01.  Upon initial review we favored the original implementation and chose to update the whitepaper.  This decision was challenged during the fix review.

The original implementation naturally prevented 0-bids, as the pricing function would not reach 0 after 72 hours.  Since the amount of claimable reserves is now part of the formula, we can no longer guarantee this.  As such, an explicit check has been added to ensure at least 1 wei of AJNA is burned.  This change necessitated improvement in logic handling bids for less than the quote token's trading increment.

To reduce cost of updating unit tests, `RewardsManager` tests are now skipped.  Removal of `RewardsManager` may be covered by a separate PR.

Note that the author is not necessarily in agreement with this change.


## Purpose

(versus updating whitepaper)

### Pros
- CRAs will reach a fair market price more quickly

### Cons
- additional gas cost for kicking, exascerbated by removal of the kick reward in this release
- added maintenance complexity
- CRAs will reach an infinitessimal price where they may be almost-zero-bid upon more quickly

## Impact

Pool contract sizes are similar.
2.3x gas cost for kicking, due to writing to an additional storage slot.  Trivial increase in gas cost for taking.


## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
