### PR TITLE
added min protection to restrict underflow on `bucketTake`

### DIFF
--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -167,7 +167,7 @@ library TakerActions {
 
         // update borrower after take
         borrower.collateral -= vars.collateralAmount;
-        borrower.t0Debt     =  vars.t0BorrowerDebt - Maths.min(vars.t0RepayAmount, vars.t0BorrowerDebt);
+        borrower.t0Debt     =  vars.t0BorrowerDebt - vars.t0RepayAmount;
         // update pool params after take
         poolState_.t0Debt -= vars.t0RepayAmount;
         poolState_.debt   =  Maths.wmul(poolState_.t0Debt, poolState_.inflator);
@@ -766,6 +766,9 @@ library TakerActions {
 
             vars.quoteTokenAmount         = Maths.wmul(vars.collateralAmount, vars.auctionPrice);
         }
+
+        // repaid amount cannot exceed the borrower owned debt
+        vars.t0RepayAmount = Maths.min(vars.t0RepayAmount, vars.t0BorrowerDebt);
 
         if (vars.isRewarded) {
             // take is below neutralPrice, Kicker is rewarded

--- a/src/libraries/external/TakerActions.sol
+++ b/src/libraries/external/TakerActions.sol
@@ -167,10 +167,10 @@ library TakerActions {
 
         // update borrower after take
         borrower.collateral -= vars.collateralAmount;
-        borrower.t0Debt     = vars.t0BorrowerDebt - vars.t0RepayAmount;
+        borrower.t0Debt     =  vars.t0BorrowerDebt - Maths.min(vars.t0RepayAmount, vars.t0BorrowerDebt);
         // update pool params after take
         poolState_.t0Debt -= vars.t0RepayAmount;
-        poolState_.debt   = Maths.wmul(poolState_.t0Debt, poolState_.inflator);
+        poolState_.debt   =  Maths.wmul(poolState_.t0Debt, poolState_.inflator);
 
         // update loan after take
         (
@@ -239,10 +239,10 @@ library TakerActions {
 
         // update borrower after take
         borrower.collateral -= vars.collateralAmount;
-        borrower.t0Debt     = vars.t0BorrowerDebt - vars.t0RepayAmount;
+        borrower.t0Debt     =  vars.t0BorrowerDebt - vars.t0RepayAmount;
         // update pool params after take
         poolState_.t0Debt -= vars.t0RepayAmount;
-        poolState_.debt   = Maths.wmul(poolState_.t0Debt, poolState_.inflator);
+        poolState_.debt   =  Maths.wmul(poolState_.t0Debt, poolState_.inflator);
 
         // update loan after take
         (


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
* removed possible underflow that could occur when repaying a loans debt in `bucketTake` flow by adding a `min(t0RepayAmount, t0Debt)`

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->
* This change was suggested in our Certora audit `L1` here is a lengthier description of their issue:

This points to the repayAmount that can underflow -> https://github.com/ajna-finance/ajna-core/blob/main/src/libraries/external/TakerActions.sol#L756 which points to the quote token constraint. Certora states the "round-down which computes repayAmount together with the computation of the debt collateral constraint can lead to a higher value than intended, since the later rounds up."

Here is the code:
```
// Collateral taken in bucket takes is constrained by the deposit available at the price including the reward.  This is moot in the case of takes.
vars.depositCollateralConstraint = (vars.unscaledDeposit != type(uint256).max) ? _roundToScale(Math.mulDiv(vars.unscaledDeposit, vars.bucketScale, netRewardedPrice), collateralScale_) : type(uint256).max;
...
vars.collateralAmount         = vars.depositCollateralConstraint;
...
vars.t0RepayAmount            = Math.mulDiv(vars.collateralAmount, borrowerPrice, inflator_);
```
Certora says that the repayAmount rounds down, I believe this is due to the `a * b / c` which can truncate any fractional part if it exceeds uint256, makes sense to me.

Then they are saying `debtcollateralConstraint` rounds up... well that could cause the first if to execute when the deposit in the bucket actually exceeded debt -> https://github.com/ajna-finance/ajna-core/blob/14e8655948efdb84af1a7eb96083cf9bec09d98b/src/libraries/external/TakerActions.sol#L752-L753
If that occurs then the `depositCollateralConstraint` -> https://github.com/ajna-finance/ajna-core/blob/14e8655948efdb84af1a7eb96083cf9bec09d98b/src/libraries/external/TakerActions.sol#L747-L748 could actually be larger than what is in the bucket. I think this is what results in the underflow since then repayAmount would exceed the debt.

## Impact
Increase of a 100 gas on `bucketTake`

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [ ] Changes to protocol contracts are covered by unit tests executed by CI.
- [ ] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [ ] Scope labels have been assigned as appropriate.
- [ ] Invariant tests have been manually executed as appropriate for the nature of the change.
