### PR TITLE
Reduce CRA interval to 5 days

### DIFF
--- a/src/RewardsManager.sol
+++ b/src/RewardsManager.sol
@@ -63,7 +63,7 @@ contract RewardsManager is IRewardsManager {
     /**
      * @notice Time period after a burn event in which buckets exchange rates can be updated.
      */
-    uint256 internal constant UPDATE_PERIOD = 2 weeks;
+    uint256 internal constant UPDATE_PERIOD = 5 days;
 
     /***********************/
     /*** State Variables ***/

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -394,7 +394,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
      *  @dev    increment `latestBurnEpoch` counter
      *  @dev    update `reserveAuction.latestBurnEventEpoch` and burn event `timestamp` state
      *  @dev    === Reverts on ===
-     *  @dev    2 weeks not passed `ReserveAuctionTooSoon()`
+     *  @dev    5 days not passed `ReserveAuctionTooSoon()`
      *  @dev    unsettled liquidation `AuctionActive()`
      *  @dev    === Emit events ===
      *  @dev    - `KickReserveAuction`

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -221,8 +221,8 @@ library KickerActions {
         // retrieve timestamp of latest burn event and last burn timestamp
         uint256 latestBurnEpoch = reserveAuction_.latestBurnEventEpoch;
 
-        // check that at least two weeks have passed since the last reserve auction completed
-        if (block.timestamp < reserveAuction_.kicked + 2 weeks + 72 hours) {
+        // check that at least five days have passed since the last reserve auction completed
+        if (block.timestamp < reserveAuction_.kicked + 5 days + 72 hours) {
             revert ReserveAuctionTooSoon();
         }
 

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -222,7 +222,7 @@ library KickerActions {
         uint256 latestBurnEpoch = reserveAuction_.latestBurnEventEpoch;
 
         // check that at least five days have passed since the last reserve auction completed
-        if (block.timestamp < reserveAuction_.kicked + 5 days + 72 hours) {
+        if (block.timestamp < reserveAuction_.kicked + 120 hours) {
             revert ReserveAuctionTooSoon();
         }
 

--- a/src/libraries/external/KickerActions.sol
+++ b/src/libraries/external/KickerActions.sol
@@ -221,7 +221,7 @@ library KickerActions {
         // retrieve timestamp of latest burn event and last burn timestamp
         uint256 latestBurnEpoch = reserveAuction_.latestBurnEventEpoch;
 
-        // check that at least five days have passed since the last reserve auction completed
+        // check that at least five days have passed since the last reserve auction was kicked
         if (block.timestamp < reserveAuction_.kicked + 120 hours) {
             revert ReserveAuctionTooSoon();
         }

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -173,19 +173,15 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // pass time to allow auction to complete
         skip(48 hours);
 
-        // check that you can't start a new auction immediately after the last one finished
-        _assertReserveAuctionTooSoon();
-
-        // check that you can't start a new auction five days after the last start...
-        skip(5 days - 72 hours);
+        // check that you can't start a new auction immediately after the last one finished...
         _assertReserveAuctionTooSoon();
 
         // ...or a day later...
-        skip(1 days);
+        skip(24 hours);
         _assertReserveAuctionTooSoon();
 
-        // ...but you can start another auction five days after the last one completed
-        skip(72 hours - 1 days);
+        // ...but you can start another auction five days after the last one was kicked
+        skip(24 hours);
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: 420.358577242054894754 * 1e18,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -176,15 +176,15 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // check that you can't start a new auction immediately after the last one finished
         _assertReserveAuctionTooSoon();
 
-        // check that you can't start a new auction two weeks after the last start...
-        skip(2 weeks - 72 hours);
+        // check that you can't start a new auction five days after the last start...
+        skip(5 days - 72 hours);
         _assertReserveAuctionTooSoon();
 
         // ...or a day later...
         skip(1 days);
         _assertReserveAuctionTooSoon();
 
-        // ...but you can start another auction 2 weeks after the last one completed
+        // ...but you can start another auction five days after the last one completed
         skip(72 hours - 1 days);
         _kickReserveAuction({
             from:              _bidder,

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -305,7 +305,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
 
         // ensure auction cannot be kicked when no reserves are claimable
-        skip(2 weeks);
+        skip(5 days);
         _assertKickReservesNoReservesRevert();
 
         _assertReserveAuction({

--- a/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
+++ b/tests/forge/unit/Rewards/RewardsDSTestPlus.sol
@@ -473,7 +473,7 @@ abstract contract RewardsHelperContract is RewardsDSTestPlus {
         _ajnaToken.approve(address(pool), type(uint256).max);
         poolContract.kickReserveAuction();
 
-        // Can't trigger reserve auction if less than two weeks have passed since last auction
+        // Can't trigger reserve auction if less than five days have passed since last auction
         vm.expectRevert(IPoolErrors.ReserveAuctionTooSoon.selector);
         poolContract.kickReserveAuction();
 
@@ -524,7 +524,7 @@ abstract contract RewardsHelperContract is RewardsDSTestPlus {
         _ajnaToken.approve(address(pool), type(uint256).max);
         poolContract.kickReserveAuction();
 
-        // Can't trigger reserve auction if less than two weeks have passed since last auction
+        // Can't trigger reserve auction if less than five days have passed since last auction
         vm.expectRevert(IPoolErrors.ReserveAuctionTooSoon.selector);
         poolContract.kickReserveAuction();
 

--- a/tests/forge/unit/Rewards/RewardsManager.t.sol
+++ b/tests/forge/unit/Rewards/RewardsManager.t.sol
@@ -1680,7 +1680,6 @@ contract RewardsManagerTest is RewardsHelperContract {
         uint256 rewardsEarned = _rewardsManager.calculateRewards(tokenIdOne, _pool.currentBurnEpoch());
         assertEq(rewardsEarned, 226.035173868192232711 * 1e18);
         assertLt(rewardsEarned, Maths.wmul(totalTokensBurned, 0.800000000000000000 * 1e18));
-        return;
 
         /******************************/
         /*** Second Reserve Auction ***/


### PR DESCRIPTION
## Description

Previously, Claimable Reserve Auctions (CRAs) could be kicked no sooner than 2 weeks after the last auction completed.  This change reduces that interval to 5 days (120 hours), measured from the kick of the previous CRA.

## Purpose

Reduce the profitability of attacks which aim to steal reserves by intentionally pushing bad debt onto the pool..

## Impact

No contract size or gas changes anticipated.

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [ ] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
