### PR TITLE
add ERC721PoolInfoUtils tests

### DIFF
--- a/tests/forge/unit/ERC721Pool/ERC721PoolInfoUtils.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolInfoUtils.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+import { Strings } from '@openzeppelin/contracts/utils/Strings.sol';
+
+import { ERC721HelperContract } from './ERC721DSTestPlus.sol';
+import { Token }               from '../../utils/Tokens.sol';
+
+import 'src/libraries/helpers/PoolHelper.sol';
+import 'src/interfaces/pool/erc721/IERC721Pool.sol';
+
+import 'src/ERC721Pool.sol';
+import 'src/PoolInfoUtilsMulticall.sol';
+
+contract ERC721PoolInfoUtilsTest is ERC721HelperContract {
+
+    address internal _borrower;
+    address internal _borrower2;
+    address internal _lender;
+    address internal _lender2;
+
+    function setUp() external {
+        _startTest();
+
+        _borrower  = makeAddr("borrower");
+        _borrower2 = makeAddr("borrower2");
+        _lender    = makeAddr("lender");
+        _lender2   = makeAddr("lender2");
+
+        // deploy collection pool
+        _pool = this.createPool();
+
+        _mintAndApproveQuoteTokens(_lender, 200_000 * 1e18);
+        _mintAndApproveCollateralTokens(_borrower, 52);
+        _mintAndApproveCollateralTokens(_borrower2, 10);
+
+        changePrank(_borrower);
+        _quote.approve(address(_pool), 200_000 * 1e18);
+
+        // lender deposits 10000 Quote into 3 buckets
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2550
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2551
+        });
+        _addInitialLiquidity({
+            from:   _lender,
+            amount: 10_000 * 1e18,
+            index:  2552
+        });
+
+        // borrower deposits three NFTs into the subset pool
+        uint256[] memory tokenIdsToAdd = new uint256[](3);
+        tokenIdsToAdd[0] = 1;
+        tokenIdsToAdd[1] = 3;
+        tokenIdsToAdd[2] = 5;
+
+        _drawDebt({
+            from:           _borrower,
+            borrower:       _borrower,
+            amountToBorrow: 3_000 * 1e18,
+            limitIndex:     2_551,
+            tokenIds:       tokenIdsToAdd,
+            newLup:         _priceAt(2550)
+        });
+    }
+
+    function createPool() external returns (ERC721Pool) {
+        // deploy subset pool
+        uint256[] memory subsetTokenIds = new uint256[](6);
+        subsetTokenIds[0] = 1;
+        subsetTokenIds[1] = 3;
+        subsetTokenIds[2] = 5;
+        subsetTokenIds[3] = 51;
+        subsetTokenIds[4] = 53;
+        subsetTokenIds[5] = 73;
+        return _deploySubsetPool(subsetTokenIds);
+    }
+
+    function testPoolInfoUtilsInvariantsFuzzed(uint256 depositIndex_, uint256 price_) external {
+        depositIndex_ = bound(depositIndex_, 0, 7388);
+        assertEq(_priceAt(depositIndex_), _poolUtils.indexToPrice(depositIndex_));
+
+        price_ = bound(price_, MIN_PRICE, MAX_PRICE);
+        assertEq(_indexOf(price_), _poolUtils.priceToIndex(price_));
+    }
+
+    function testPoolInfoUtilsMulticallPoolBalanceDetails() external {
+        PoolInfoUtilsMulticall poolUtilsMulticall = new PoolInfoUtilsMulticall(_poolUtils);
+
+        uint256 meaningfulIndex = 5000;
+        address quoteTokenAddress = IPool(_pool).quoteTokenAddress();
+        address collateralTokenAddress = IPool(_pool).collateralAddress();
+
+        PoolInfoUtilsMulticall.PoolBalanceDetails memory poolBalanceDetails = poolUtilsMulticall.poolBalanceDetails(address(_pool), meaningfulIndex, quoteTokenAddress, collateralTokenAddress, true);
+
+        assertEq(poolBalanceDetails.debt,        3_002.884615384615386000 * 1e18);
+        assertEq(poolBalanceDetails.quoteTokenBalance,  27_000 * 1e18);
+        assertEq(poolBalanceDetails.collateralTokenBalance,  3 * 1e18);
+    }
+
+
+}

--- a/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolReserveAuction.t.sol
@@ -58,6 +58,8 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
 
         (poolDebt,,,) = _pool.debtInfo();
         assertEq(poolDebt - 175_000 * 1e18, 4_590.373946590638353626 * 1e18);  // debt matches develop
+
+        assertEq(_pool.currentBurnEpoch(), 0);
     }
 
     function testClaimableReserveNoAuction() external tearDown {
@@ -104,6 +106,8 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         });
 
         _assertReserveAuctionPrice(1_189_460.682069263974570223 * 1e18);
+
+        assertEq(_pool.currentBurnEpoch(), 1);
 
         // check prices
         skip(37 minutes);
@@ -217,6 +221,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
         // kick off a new auction
         uint256 expectedPrice = 1_189_460.682069263974570223 * 1e18;
         uint256 expectedQuoteBalance = _quote.balanceOf(_bidder);
+        uint256 timestamp = block.timestamp;
         _kickReserveAuction({
             from:              _bidder,
             remainingReserves: expectedReserves,
@@ -232,6 +237,7 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             timeRemaining:              3 days
         });
         assertEq(_quote.balanceOf(_bidder), expectedQuoteBalance);
+        assertEq(_pool.currentBurnEpoch(), 1);
         
         // bid once the price becomes attractive
         skip(16 hours);
@@ -310,6 +316,13 @@ contract ERC721PoolReserveAuctionTest is ERC721HelperContract {
             claimableReservesRemaining: 0,
             auctionPrice:               0,
             timeRemaining:              0
+        });
+
+        _assertBurnInfo({
+            epoch: 1,
+            timestamp: timestamp,
+            totalInterest: 3_758.789008448196373660 * 1e18,
+            totalBurned: 14_707.978854026263800428 * 1e18
         });
     }
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -797,6 +797,18 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         _pool.kickReserveAuction();
     }
 
+    function _assertBurnInfo(
+        uint256 epoch,
+        uint256 timestamp,
+        uint256 totalInterest,
+        uint256 totalBurned
+    ) internal {
+        (uint256 curTimestamp, uint256 curTotalInterest, uint256 curTotalBurned) = _pool.burnInfo(epoch);
+        assertEq(curTimestamp, timestamp);
+        assertEq(curTotalInterest, totalInterest);
+        assertEq(curTotalBurned, totalBurned);
+    }
+
     /**********************/
     /*** Revert asserts ***/
     /**********************/


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->

- Expand code coverage by adding tests for 721 pool flow of  `testPoolInfoUtilsMulticallPoolBalanceDetails`.
- Cover `currentBurnEpoch` and `burnInfo`.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->
