### PR TITLE
Update `_assertAuction` to check borrower `t0ReserveSettleAmount` and add invariant A10

### DIFF
--- a/src/PoolInfoUtils.sol
+++ b/src/PoolInfoUtils.sol
@@ -83,7 +83,7 @@ contract PoolInfoUtils is Multicall {
             kickTime_,
             referencePrice_,
             neutralPrice_,
-            debtToCollateral_, , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
+            debtToCollateral_, , , , ) = IPool(ajnaPool_).auctionInfo(borrower_);
 
         if (kickTime_ != 0) {
             (debtToCover_, collateral_, , ) = this.borrowerInfo(ajnaPool_, borrower_);
@@ -99,18 +99,19 @@ contract PoolInfoUtils is Multicall {
     /**
      *  @notice Returns details of an auction for a given borrower address.
      *  @dev    Calls and returns all values from pool.auctionInfo().
-     *  @param  ajnaPool_         Address of `Ajna` pool.
-     *  @param  borrower_         Address of the borrower that is liquidated.
-     *  @return kicker_           Address of the kicker that is kicking the auction.
-     *  @return bondFactor_       The factor used for calculating bond size.
-     *  @return bondSize_         The bond amount in quote token terms.
-     *  @return kickTime_         Time the liquidation was initiated.
-     *  @return referencePrice_   Price used to determine auction start price.
-     *  @return neutralPrice_     `Neutral Price` of auction.
-     *  @return debtToCollateral_ Borrower debt to collateral at time of kick, which is used in BPF for kicker's reward calculation.
-     *  @return head_             Address of the head auction.
-     *  @return next_             Address of the next auction in queue.
-     *  @return prev_             Address of the prev auction in queue.
+     *  @param  ajnaPool_              Address of `Ajna` pool.
+     *  @param  borrower_              Address of the borrower that is liquidated.
+     *  @return kicker_                Address of the kicker that is kicking the auction.
+     *  @return bondFactor_            The factor used for calculating bond size.
+     *  @return bondSize_              The bond amount in quote token terms.
+     *  @return kickTime_              Time the liquidation was initiated.
+     *  @return referencePrice_        Price used to determine auction start price.
+     *  @return neutralPrice_          `Neutral Price` of auction.
+     *  @return debtToCollateral_      Borrower debt to collateral at time of kick, which is used in BPF for kicker's reward calculation.
+     *  @return t0ReserveSettleAmount_ Amount of t0Debt that could be settled via reserves in this auction
+     *  @return head_                  Address of the head auction.
+     *  @return next_                  Address of the next auction in queue.
+     *  @return prev_                  Address of the prev auction in queue.
      */
     function auctionInfo(address ajnaPool_, address borrower_) external view returns (
         address kicker_,
@@ -120,6 +121,7 @@ contract PoolInfoUtils is Multicall {
         uint256 referencePrice_,
         uint256 neutralPrice_,
         uint256 debtToCollateral_,
+        uint256 t0ReserveSettleAmount_,
         address head_,
         address next_,
         address prev_

--- a/src/base/Pool.sol
+++ b/src/base/Pool.sol
@@ -741,6 +741,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
         uint256 referencePrice_,
         uint256 neutralPrice_,
         uint256 debtToCollateral_,
+        uint256 t0ReserveSettleAmount_,
         address head_,
         address next_,
         address prev_
@@ -754,6 +755,7 @@ abstract contract Pool is Clone, ReentrancyGuard, Multicall, IPool {
             liquidation.referencePrice,
             liquidation.neutralPrice,
             liquidation.debtToCollateral,
+            liquidation.t0ReserveSettleAmount,
             auctions.head,
             liquidation.next,
             liquidation.prev

--- a/src/interfaces/pool/commons/IPoolState.sol
+++ b/src/interfaces/pool/commons/IPoolState.sol
@@ -9,17 +9,18 @@ interface IPoolState {
 
     /**
      *  @notice Returns details of an auction for a given borrower address.
-     *  @param  borrower_         Address of the borrower that is liquidated.
-     *  @return kicker_           Address of the kicker that is kicking the auction.
-     *  @return bondFactor_       The factor used for calculating bond size.
-     *  @return bondSize_         The bond amount in quote token terms.
-     *  @return kickTime_         Time the liquidation was initiated.
-     *  @return referencePrice_   Price used to determine auction start price.
-     *  @return neutralPrice_     `Neutral Price` of auction.
-     *  @return debtToCollateral_ Borrower debt to collateral, which is used in BPF for kicker's reward calculation.
-     *  @return head_             Address of the head auction.
-     *  @return next_             Address of the next auction in queue.
-     *  @return prev_             Address of the prev auction in queue.
+     *  @param  borrower_              Address of the borrower that is liquidated.
+     *  @return kicker_                Address of the kicker that is kicking the auction.
+     *  @return bondFactor_            The factor used for calculating bond size.
+     *  @return bondSize_              The bond amount in quote token terms.
+     *  @return kickTime_              Time the liquidation was initiated.
+     *  @return referencePrice_        Price used to determine auction start price.
+     *  @return neutralPrice_          `Neutral Price` of auction.
+     *  @return debtToCollateral_      Borrower debt to collateral, which is used in BPF for kicker's reward calculation.
+     *  @return t0ReserveSettleAmount_ Amount of t0Debt that could be settled via reserves in this auction
+     *  @return head_                  Address of the head auction.
+     *  @return next_                  Address of the next auction in queue.
+     *  @return prev_                  Address of the prev auction in queue.
      */
     function auctionInfo(address borrower_)
         external
@@ -32,6 +33,7 @@ interface IPoolState {
             uint256 referencePrice_,
             uint256 neutralPrice_,
             uint256 debtToCollateral_,
+            uint256 t0ReserveSettleAmount_,
             address head_,
             address next_,
             address prev_

--- a/tests/INVARIANTS.md
+++ b/tests/INVARIANTS.md
@@ -26,6 +26,7 @@
 - **A7**: total bond escrowed accumulator (`AuctionsState.totalBondEscrowed`) should increase when auction is kicked with the difference needed to cover the bond and should decrease only when kicker bonds withdrawn (`Pool.withdrawBonds`). Claimable bonds should be available for withdrawal from pool at any time.  
 - **A8**: Upon a take/arbtake/deposittake the kicker reward <= borrower penalty
 - **A9**: reference prices in liquidation queue shall not decrease
+- **A10**: Upon kick `t0ReserveSettleAmount` should be set to `BorrowerT0Debt * borrowFeeRate / 2` for the kicked borrower.
 
 ## Loans
 - **L1**: for each `Loan` in loans array (`LoansState.loans`) starting from index 1, the corresponding address (`Loan.borrower`) is not `0x`, the borrower t0 debt to collateral (`Loan.t0DebtToCollateral`) is different than 0 and the id mapped in indices mapping (`LoansState.indices`) equals index of loan in loans array.

--- a/tests/forge/interactions/PurchaseQuoteWithExternalLiquidity.t.sol
+++ b/tests/forge/interactions/PurchaseQuoteWithExternalLiquidity.t.sol
@@ -21,7 +21,7 @@ contract PurchaseQuoteWithExternalLiquidityTest is Test {
     address   internal _lender;
 
     function setUp() external {
-        vm.createSelectFork(vm.envString("ETH_RPC_URL"));
+        vm.createSelectFork(vm.envString("ETH_RPC_URL"), 18800000);
         _ajnaPool = ERC20Pool(new ERC20PoolFactory(AJNA).deployPool(WETH, USDC, 0.05 * 10**18));
         _lender   = makeAddr("lender");
 

--- a/tests/forge/invariants/PositionManager/handlers/ERC20PoolPositionHandler.sol
+++ b/tests/forge/invariants/PositionManager/handlers/ERC20PoolPositionHandler.sol
@@ -117,7 +117,7 @@ contract ERC20PoolPositionHandler is PositionPoolHandler, BaseERC20PoolHandler, 
     ) external useTimestamps useRandomActor(takerIndex_) skipTime(skippedTime_) writeLogs {
         address borrower = _borrowers[constrictToRange(borrowerIndex_, 0, _borrowers.length - 1)];
 
-        (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
+        (, , , uint256 kickTime, , , , , , , ) = _pool.auctionInfo(borrower);
 
         // Kick borrower if not already kicked
         if (kickTime == 0) {

--- a/tests/forge/invariants/PositionManager/handlers/ERC20PoolPositionHandler.sol
+++ b/tests/forge/invariants/PositionManager/handlers/ERC20PoolPositionHandler.sol
@@ -24,7 +24,7 @@ contract ERC20PoolPositionHandler is PositionPoolHandler, BaseERC20PoolHandler, 
     address[] internal _borrowers;
 
     uint16 internal constant LENDERS = 200;
-    uint16 internal constant LOANS_COUNT = 500;
+    uint16 internal constant LOANS_COUNT = 320;
     uint16 nonce;
     uint256 numberOfBuckets;
 

--- a/tests/forge/invariants/base/BasicInvariants.t.sol
+++ b/tests/forge/invariants/base/BasicInvariants.t.sol
@@ -321,7 +321,7 @@ abstract contract BasicInvariants is BaseInvariants {
         for (uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
 
-            (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
+            (, , , uint256 kickTime, , , , , , , ) = _pool.auctionInfo(borrower);
 
             if (kickTime == 0) {
                 (uint256 borrowerT0Debt, uint256 borrowerCollateral, ) = _pool.borrowerInfo(borrower);

--- a/tests/forge/invariants/base/LiquidationInvariants.t.sol
+++ b/tests/forge/invariants/base/LiquidationInvariants.t.sol
@@ -22,6 +22,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
         _invariant_A7();
         _invariant_A8();
         _invariant_A9();
+        _invariant_A10();
     }
 
     /// @dev checks sum of all borrower's t0debt is equals to total pool t0debtInAuction
@@ -150,6 +151,19 @@ abstract contract LiquidationInvariants is BasicInvariants {
             (,,,, referencePrice,,,,, nextBorrower,) = _pool.auctionInfo(nextBorrower);
             require(lastReferencePrice <= referencePrice, "Auction Invariant A9");
             lastReferencePrice = referencePrice;
+        }
+    }
+
+    /// @dev borrower t0 reserve settle amount should be set borrowerT0debt * borrowFeeRate / 2.
+    function _invariant_A10() internal view {
+        uint256 actorCount = IBaseHandler(_handler).getActorsCount();
+
+        for (uint256 i = 0; i < actorCount; i++) {
+            address borrower = IBaseHandler(_handler).actors(i);
+            uint256 borrowerT0ReserveSettleAmount = IBaseHandler(_handler).borrowerT0ReserveSettleAmount(borrower);
+            (,,,,,,,uint256 requiredT0ReserveSettleAmount,,,) = _pool.auctionInfo(borrower);
+
+            require(borrowerT0ReserveSettleAmount == requiredT0ReserveSettleAmount, "Auction Invariant A10");
         }
     }
     

--- a/tests/forge/invariants/base/LiquidationInvariants.t.sol
+++ b/tests/forge/invariants/base/LiquidationInvariants.t.sol
@@ -31,7 +31,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
 
         for (uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
+            (, , , uint256 kickTime, , , , , , , ) = _pool.auctionInfo(borrower);
 
             if (kickTime != 0) {
                 (uint256 t0debt, , ) = _pool.borrowerInfo(borrower);
@@ -63,7 +63,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
         uint256 lockedBonds;
         for (uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (, , uint256 bond, , , , , , , ) = _pool.auctionInfo(borrower);
+            (, , uint256 bond, , , , , , , , ) = _pool.auctionInfo(borrower);
             lockedBonds += bond;
         }
         require(lockedBonds == kickerLockedBond, "A2: bonds in auctions != than kicker locked bonds");
@@ -95,7 +95,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
         for (uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
 
-            (, , , uint256 kickTime, , , , , , ) = _pool.auctionInfo(borrower);
+            (, , , uint256 kickTime, , , , , , , ) = _pool.auctionInfo(borrower);
 
             if (kickTime != 0) borrowersKicked += 1;
         }
@@ -109,7 +109,7 @@ abstract contract LiquidationInvariants is BasicInvariants {
 
         for (uint256 i = 0; i < actorCount; i++) {
             address borrower = IBaseHandler(_handler).actors(i);
-            (address kicker, , uint256 bondSize, , , , , , , ) = _pool.auctionInfo(borrower);
+            (address kicker, , uint256 bondSize, , , , , , , , ) = _pool.auctionInfo(borrower);
             (, uint256 lockedAmount) = _pool.kickerInfo(kicker);
 
             require(lockedAmount >= bondSize, "Auction Invariant A5");
@@ -145,9 +145,9 @@ abstract contract LiquidationInvariants is BasicInvariants {
     /// @dev reference prices in liquidation queue shall not decrease
     function _invariant_A9() internal view {
         uint256 referencePrice;
-        (,,,, uint256 lastReferencePrice,,, address nextBorrower,,) = _pool.auctionInfo(address(0));
+        (,,,, uint256 lastReferencePrice,,,, address nextBorrower,,) = _pool.auctionInfo(address(0));
         while (nextBorrower != address(0)) {
-            (,,,, referencePrice,,,, nextBorrower,) = _pool.auctionInfo(nextBorrower);
+            (,,,, referencePrice,,,,, nextBorrower,) = _pool.auctionInfo(nextBorrower);
             require(lastReferencePrice <= referencePrice, "Auction Invariant A9");
             lastReferencePrice = referencePrice;
         }

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -50,12 +50,11 @@ abstract contract BaseHandler is Test {
 
     struct AuctionInfo {
         address kicker;
-        uint256 bondFactor;
-        uint256 bondSize;
         uint256 kickTime;
         uint256 referencePrice;
         uint256 neutralPrice;
         uint256 debtToCollateral;
+        uint256 t0ReserveSettleAmount;
         uint256 auctionPrice;
         uint256 auctionPriceIndex;
         address head;
@@ -331,12 +330,13 @@ abstract contract BaseHandler is Test {
     function _getAuctionInfo(address borrower_) internal view returns (AuctionInfo memory auctionInfo_) {
         (
             auctionInfo_.kicker,
-            auctionInfo_.bondFactor,
-            auctionInfo_.bondSize,
+            ,
+            ,
             auctionInfo_.kickTime,
             auctionInfo_.referencePrice,
             auctionInfo_.neutralPrice,
             auctionInfo_.debtToCollateral,
+            auctionInfo_.t0ReserveSettleAmount,
             auctionInfo_.head,
             ,
         ) = _pool.auctionInfo(borrower_);
@@ -662,7 +662,7 @@ abstract contract BaseHandler is Test {
         ) = _poolInfo.poolLoansInfo(address(_pool));
 
         (
-            , , , , , , ,
+            , , , , , , , ,
             address headAuction, ,
         ) = _pool.auctionInfo(address(0));
 
@@ -778,11 +778,11 @@ abstract contract BaseHandler is Test {
         uint256 bondFactor;
         uint256 bondSize;
         uint256 neutralPrice;
-        (,,,,,,, nextBorrower,,) = _pool.auctionInfo(address(0));
+        (,,,,,,,, nextBorrower,,) = _pool.auctionInfo(address(0));
         while (nextBorrower != address(0)) {
             data = string(abi.encodePacked("Borrower ", Strings.toHexString(uint160(nextBorrower), 20), " Auction Details :"));
             printInNextLine(data);
-            (, bondFactor, bondSize, kickTime, referencePrice, neutralPrice,,, nextBorrower,) = _pool.auctionInfo(nextBorrower);
+            (, bondFactor, bondSize, kickTime, referencePrice, neutralPrice,,,, nextBorrower,) = _pool.auctionInfo(nextBorrower);
 
             printLog("Bond Factor     = ", bondFactor);
             printLog("Bond Size       = ", bondSize);

--- a/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/BaseHandler.sol
@@ -143,6 +143,9 @@ abstract contract BaseHandler is Test {
     uint256 public borrowerPenalty; // Borrower penalty on take
     uint256 public kickerReward;    // Kicker reward on take
 
+    // Borrower reserve settlement state
+    mapping(address => uint256) public borrowerT0ReserveSettleAmount;
+
     // All Buckets used in invariant testing that also includes Buckets where collateral is added when a borrower is in auction and has partial NFT
     EnumerableSet.UintSet internal buckets;
 
@@ -527,6 +530,12 @@ abstract contract BaseHandler is Test {
         decreaseInBonds = 0;
         // record totalBondEscrowed before each action
         (previousTotalBonds, , , , ) = _pool.reservesInfo();
+
+        // Record borrower reserve settle amount
+        for(uint256 i = 0; i < actors.length; i++) {
+            address borrower = actors[i];
+            borrowerT0ReserveSettleAmount[borrower] = _getAuctionInfo(borrower).t0ReserveSettleAmount;
+        }
     }
 
     /********************************/

--- a/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
@@ -233,6 +233,9 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
                     auctionInfo.auctionPrice
                 );
             }
+
+            // **A10**: T0 reserve settle amount resets if borrower is out of auction
+            if (_getAuctionInfo(borrower_).kickTime == 0) borrowerT0ReserveSettleAmount[borrower_] = 0;
         } catch (bytes memory err) {
             _ensurePoolError(err);
         }
@@ -341,6 +344,9 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
 
             // assign value to fenwick tree to mitigate rounding error that could be created in a _fenwickRemove call
             fenwickDeposits[bucketIndex_] = afterTakeVars.deposit;
+
+            // **A10**: T0 reserve settle amount resets if borrower is out of auction
+            if (_getAuctionInfo(borrower_).kickTime == 0) borrowerT0ReserveSettleAmount[borrower_] = 0;
         } catch (bytes memory err) {
             // Reset event Logs
             vm.getRecordedLogs();
@@ -468,6 +474,10 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
                 buckets.add(7388);
                 lenderDepositTime[borrower_][7388] = block.timestamp;
             }
+
+            // **A10**: T0 reserve settle amount resets if borrower is out of auction
+            if (_getAuctionInfo(borrower_).kickTime == 0) borrowerT0ReserveSettleAmount[borrower_] = 0;
+            
         } catch (bytes memory err) {
             _ensurePoolError(err);
         }

--- a/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
+++ b/tests/forge/invariants/base/handlers/unbounded/UnboundedLiquidationPoolHandler.sol
@@ -4,12 +4,18 @@ pragma solidity 0.8.18;
 
 import '../../../../utils/DSTestPlus.sol';
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
-import { Math }           from '@openzeppelin/contracts/utils/math/Math.sol';
+import { Math }  from '@openzeppelin/contracts/utils/math/Math.sol';
 
-import { Maths }                                    from 'src/libraries/internal/Maths.sol';
-import { _priceAt, _indexOf, MIN_PRICE, MAX_PRICE } from 'src/libraries/helpers/PoolHelper.sol';
-import { MAX_FENWICK_INDEX }                        from 'src/libraries/helpers/PoolHelper.sol';
-import { Buckets }                                  from 'src/libraries/internal/Buckets.sol'; 
+import { Maths } from 'src/libraries/internal/Maths.sol';
+import {
+    _priceAt,
+    _indexOf,
+    _borrowFeeRate,
+    MIN_PRICE,
+    MAX_PRICE,
+    MAX_FENWICK_INDEX
+} from 'src/libraries/helpers/PoolHelper.sol';
+import { Buckets }     from 'src/libraries/internal/Buckets.sol'; 
 
 import { BaseHandler } from './BaseHandler.sol';
 import '@std/Vm.sol';
@@ -40,6 +46,8 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
         BorrowerInfo memory borrowerInfo = _getBorrowerInfo(borrower_);
         KickerInfo   memory kickerInfoBeforeKick = _getKickerInfo(_actor);
 
+        (uint256 interestRate, ) = _pool.interestRateInfo();
+
         // ensure actor always has the amount to pay for bond
         _ensureQuoteAmount(_actor, borrowerInfo.debt);
 
@@ -53,6 +61,9 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
 
             // **A7**: totalBondEscrowed should increase when auctioned kicked with the difference needed to cover the bond 
             increaseInBonds += kickerInfoAfterKick.totalBond - kickerInfoBeforeKick.totalBond;
+
+            // **A10**: toReserve should be set to borrowerT0debt * borrowerFeeRate / 2
+            borrowerT0ReserveSettleAmount[borrower_] = Maths.wmul(borrowerInfo.t0Debt, _borrowFeeRate(interestRate)) / 2;
         } catch (bytes memory err) {
             _ensurePoolError(err);
         }
@@ -71,6 +82,8 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
         BucketInfo memory bucketInfoBeforeKick = _getBucketInfo(bucketIndex_);
         KickerInfo memory kickerInfoBeforeKick = _getKickerInfo(_actor);
 
+        (uint256 interestRate, ) = _pool.interestRateInfo();
+
         // record fenwick tree state before action
         fenwickDeposits[bucketIndex_] = bucketInfoBeforeKick.deposit;
 
@@ -88,6 +101,9 @@ abstract contract UnboundedLiquidationPoolHandler is BaseHandler {
 
             // **A7**: totalBondEscrowed should increase when auctioned kicked with the difference needed to cover the bond 
             increaseInBonds += kickerInfoAfterKick.totalBond - kickerInfoBeforeKick.totalBond;
+
+            // **A10**: toReserve should be set to borrowerT0debt * borrowerFeeRate / 2
+            borrowerT0ReserveSettleAmount[maxBorrower] = Maths.wmul(borrowerInfo.t0Debt, _borrowFeeRate(interestRate)) / 2;
 
             _fenwickRemove(bucketInfoBeforeKick.deposit - bucketInfoAfterKick.deposit, bucketIndex_);
         } catch (bytes memory err) {

--- a/tests/forge/invariants/interfaces/IBaseHandler.sol
+++ b/tests/forge/invariants/interfaces/IBaseHandler.sol
@@ -38,5 +38,7 @@ interface IBaseHandler {
     
     function lenderDepositTime(address lender, uint256 bucketIndex) external view returns(uint256);
 
+    function borrowerT0ReserveSettleAmount(address borrower) external view returns(uint256);
+
     function getBuckets() external view returns(uint256[] memory);
 }

--- a/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20DSTestPlus.sol
@@ -177,13 +177,13 @@ abstract contract ERC20DSTestPlus is DSTestPlus, IERC20PoolEvents {
         // Settle any auctions and then repay debt
         for (uint i = 0; i < borrowers.length(); i++) {
             address borrower = borrowers.at(i);
-            (,,, uint256 kickTime,,,,,,) = _pool.auctionInfo(borrower);
+            (,,, uint256 kickTime,,,,,,,) = _pool.auctionInfo(borrower);
             if (kickTime != 0) {
                 changePrank(borrower);
                 _pool.settle(borrower, bucketsUsed.length() + 1);
 
                 // Settle again if not settled, this can happen when less reserves calculated with DEPOSIT_BUFFER and borrower is not fully settled
-                (,,, kickTime,,,,,,) = _pool.auctionInfo(borrower);
+                (,,, kickTime,,,,,,,) = _pool.auctionInfo(borrower);
                 if (kickTime != 0) {
                     _pool.settle(borrower, bucketsUsed.length() + 1);
                 }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolDebtExceedsDeposit.t.sol
@@ -168,18 +168,19 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
         skip(8 hours);
         _assertAuction(
             AuctionParams({
-                borrower:          _attacker,
-                active:            true,
-                kicker:            _attacker,
-                bondSize:          1.104560604152777078 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 8 hours,
-                referencePrice:    109.840509887681617373 * 1e18,
-                totalBondEscrowed: 1.104560604152777078 * 1e18,
-                auctionPrice:      54.920254943840808688 * 1e18,
-                debtInAuction:     98.794903846153846199 * 1e18,
-                debtToCollateral:  94.995099852071005961 * 1e18,
-                neutralPrice:      109.840509887681617373 * 1e18
+                borrower:              _attacker,
+                active:                true,
+                kicker:                _attacker,
+                bondSize:              1.104560604152777078 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 8 hours,
+                referencePrice:        109.840509887681617373 * 1e18,
+                totalBondEscrowed:     1.104560604152777078 * 1e18,
+                auctionPrice:          54.920254943840808688 * 1e18,
+                debtInAuction:         98.794903846153846199 * 1e18,
+                debtToCollateral:      94.995099852071005961 * 1e18,
+                neutralPrice:          109.840509887681617373 * 1e18,
+                t0ReserveSettleAmount: 0.047497549926035526 * 1e18
             })
         );
 
@@ -354,18 +355,19 @@ contract ERC20PoolDebtExceedsDepositTest is ERC20HelperContract {
         skip(8 hours + 10 minutes);
         _assertAuction(
             AuctionParams({
-                borrower:          _attacker,
-                active:            true,
-                kicker:            _attacker,
-                bondSize:          11_179.675302295250711919 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 8 hours - 10 minutes,
-                referencePrice:    111.173731071526020388 * 1e18,
-                totalBondEscrowed: 11_179.675302295250711919 * 1e18,
-                auctionPrice:      52.467014501698027340 * 1e18,
-                debtInAuction:     999_940.55769230769276876 * 1e18,
-                debtToCollateral:  96.148130547337278151 * 1e18,
-                neutralPrice:      111.173731071526020388 * 1e18
+                borrower:              _attacker,
+                active:                true,
+                kicker:                _attacker,
+                bondSize:              11_179.675302295250711919 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 8 hours - 10 minutes,
+                referencePrice:        111.173731071526020388 * 1e18,
+                totalBondEscrowed:     11_179.675302295250711919 * 1e18,
+                auctionPrice:          52.467014501698027340 * 1e18,
+                debtInAuction:         999_940.55769230769276876 * 1e18,
+                debtToCollateral:      96.148130547337278151 * 1e18,
+                neutralPrice:          111.173731071526020388 * 1e18,
+                t0ReserveSettleAmount: 480.740652736686621509 * 1e18
             })
         );
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolInfoUtils.t.sol
@@ -154,21 +154,23 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
             uint256 referencePrice,
             uint256 neutralPrice,
             uint256 debtToCollateral,
+            uint256 t0ReserveSettleAmount,
             address head,
             address next,
             address prev
         ) = _poolUtils.auctionInfo(address(_pool), _borrower);
         // since loan is not in auction values are 0
-        assertEq(kicker,            address(0));
-        assertEq(bondFactor,        0);
-        assertEq(bondSize,          0);
-        assertEq(kickTime,          0);
-        assertEq(referencePrice,    0);
-        assertEq(neutralPrice,      0);
-        assertEq(debtToCollateral,  0);
-        assertEq(head,              address(0));
-        assertEq(next,              address(0));
-        assertEq(prev,              address(0));
+        assertEq(kicker,                address(0));
+        assertEq(bondFactor,            0);
+        assertEq(bondSize,              0);
+        assertEq(kickTime,              0);
+        assertEq(referencePrice,        0);
+        assertEq(neutralPrice,          0);
+        assertEq(debtToCollateral,      0);
+        assertEq(t0ReserveSettleAmount, 0);
+        assertEq(head,                  address(0));
+        assertEq(next,                  address(0));
+        assertEq(prev,                  address(0));
     }
 
     function testPoolInfoUtilsAuctionInfoSingleLiquidation() external {
@@ -181,20 +183,22 @@ contract ERC20PoolInfoUtilsTest is ERC20HelperContract {
             uint256 referencePrice,
             uint256 neutralPrice,
             uint256 debtToCollateral,
+            uint256 t0ReserveSettleAmount,
             address head,
             address next,
             address prev
         ) = _poolUtils.auctionInfo(address(_pool), _borrower);
-        assertEq(kicker,            _lender);
-        assertEq(bondFactor,        0.011180339887498948 * 1e18);
-        assertEq(bondSize,          235.012894500590867635 * 1e18);
-        assertEq(kickTime,          _startTime);
-        assertEq(referencePrice,    243.051341028061451209 * 1e18);
-        assertEq(neutralPrice,      243.051341028061451209 * 1e18);
-        assertEq(debtToCollateral,  210.201923076923077020 * 1e18);
-        assertEq(head,              _borrower);
-        assertEq(next,              address(0));
-        assertEq(prev,              address(0));
+        assertEq(kicker,                 _lender);
+        assertEq(bondFactor,             0.011180339887498948 * 1e18);
+        assertEq(bondSize,               235.012894500590867635 * 1e18);
+        assertEq(kickTime,               _startTime);
+        assertEq(referencePrice,         243.051341028061451209 * 1e18);
+        assertEq(neutralPrice,           243.051341028061451209 * 1e18);
+        assertEq(debtToCollateral,       210.201923076923077020 * 1e18);
+        assertEq(t0ReserveSettleAmount,  10.105861686390537400 * 1e18);
+        assertEq(head,                   _borrower);
+        assertEq(next,                   address(0));
+        assertEq(prev,                   address(0));
     }
 
     function testPoolInfoUtilsBorrowerInfo() external {

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsArbTake.t.sol
@@ -140,18 +140,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -173,18 +174,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      2_786.004733495419094016 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          2_786.004733495419094016 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertKicker({
@@ -251,18 +253,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18, // should be the same after arb take, kicker will be rewarded with LP
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6.5 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      9.151333567485071268 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18, // should be the same after arb take, kicker will be rewarded with LP
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6.5 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          9.151333567485071268 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBorrower({
@@ -323,18 +326,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18, // bond size remains the same, kicker was rewarded with LP
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6.5 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      9.151333567485071268 * 1e18,
-                debtInAuction:     0.744103746989137588 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18, // bond size remains the same, kicker was rewarded with LP
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6.5 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          9.151333567485071268 * 1e18,
+                debtInAuction:         0.744103746989137588 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -359,18 +363,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      15.390647183378366864 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          15.390647183378366864 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -444,18 +449,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      15.390647183378366864 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          15.390647183378366864 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -483,18 +489,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.042759438341664008 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.042759438341664008 * 1e18,
-                auctionPrice:      15.390647183378366864 * 1e18,
-                debtInAuction:     4.076551853619286517 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.042759438341664008 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.042759438341664008 * 1e18,
+                auctionPrice:          15.390647183378366864 * 1e18,
+                debtInAuction:         4.076551853619286517 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBucket({
@@ -557,18 +564,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 3 hours,
-                referencePrice:    10.882830990216480836 * 1e18,
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      30.781294366756733728 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 3 hours,
+                referencePrice:        10.882830990216480836 * 1e18,
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          30.781294366756733728 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBorrower({
@@ -618,18 +626,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -660,18 +669,19 @@ contract ERC20PoolLiquidationsArbTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.210458053887159482 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 2.5 hours,
-                referencePrice:    10.882830990216480836 * 1e18, 
-                totalBondEscrowed: 0.210458053887159482 * 1e18,
-                auctionPrice:      36.605334269940285200 * 1e18,
-                debtInAuction:     18.823940596160099025 * 1e18,
-                debtToCollateral:  9.411970298080049512 * 1e18,
-                neutralPrice:      10.882830990216480836 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.210458053887159482 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 2.5 hours,
+                referencePrice:        10.882830990216480836 * 1e18, 
+                totalBondEscrowed:     0.210458053887159482 * 1e18,
+                auctionPrice:          36.605334269940285200 * 1e18,
+                debtInAuction:         18.823940596160099025 * 1e18,
+                debtToCollateral:      9.411970298080049512 * 1e18,
+                neutralPrice:          10.882830990216480836 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBorrower({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsDepositTake.t.sol
@@ -141,18 +141,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -174,18 +175,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      2_843.843606056533345792 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          2_843.843606056533345792 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertKicker({
@@ -251,18 +253,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6.5 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      9.341319897949748632 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6.5 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          9.341319897949748632 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBorrower({
@@ -316,18 +319,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6.5 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      9.341319897949748632 * 1e18,
-                debtInAuction:     0.181604610561948914 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6.5 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          9.341319897949748632 * 1e18,
+                debtInAuction:         0.181604610561948914 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         ); 
         _assertBorrower({
@@ -359,18 +363,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      15.710164831848276420 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          15.710164831848276420 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -451,18 +456,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      15.710164831848276420 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          15.710164831848276420 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -490,18 +496,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.047128646698885500 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.047128646698885500 * 1e18,
-                auctionPrice:      15.710164831848276420 * 1e18,
-                debtInAuction:     4.467355778582383914 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.047128646698885500 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.047128646698885500 * 1e18,
+                auctionPrice:          15.710164831848276420 * 1e18,
+                debtInAuction:         4.467355778582383914 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBucket({
@@ -564,18 +571,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 3 hours,
-                referencePrice:    11.108764086158333382 * 1e18,
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      31.420329663696552836 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 3 hours,
+                referencePrice:        11.108764086158333382 * 1e18,
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          31.420329663696552836 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         _assertBorrower({
@@ -626,18 +634,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -661,18 +670,19 @@ contract ERC20PoolLiquidationsDepositTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.214827269923259784 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 2.5 hours,
-                referencePrice:    11.108764086158333382 * 1e18, 
-                totalBondEscrowed: 0.214827269923259784 * 1e18,
-                auctionPrice:      37.365279591798994668 * 1e18,
-                debtInAuction:     19.214735158764197054 * 1e18,
-                debtToCollateral:  9.607367579382098527 * 1e18,
-                neutralPrice:      11.108764086158333382 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.214827269923259784 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 2.5 hours,
+                referencePrice:        11.108764086158333382 * 1e18, 
+                totalBondEscrowed:     0.214827269923259784 * 1e18,
+                auctionPrice:          37.365279591798994668 * 1e18,
+                debtInAuction:         19.214735158764197054 * 1e18,
+                debtToCollateral:      9.607367579382098527 * 1e18,
+                neutralPrice:          11.108764086158333382 * 1e18,
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -757,18 +767,19 @@ contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
         // assert auction before bucket take, enough time passed so auction price is zero
         _assertAuction(
             AuctionParams({
-                borrower:          actor2,
-                active:            true,
-                kicker:            actor1,
-                bondSize:          13_799_909_500.935435603423349661 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    3_137.845063437099084063 * 1e18,
-                totalBondEscrowed: 13_799_909_500.935435603423349661 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     920_341_611_662.285708998644615657 * 1e18,
-                debtToCollateral:  2_758.083788017359002804 * 1e18,
-                neutralPrice:      3_137.845063437099084063 * 1e18  // was 2_860.503207254858101199
+                borrower:              actor2,
+                active:                true,
+                kicker:                actor1,
+                bondSize:              13_799_909_500.935435603423349661 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        3_137.845063437099084063 * 1e18,
+                totalBondEscrowed:     13_799_909_500.935435603423349661 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         920_341_611_662.285708998644615657 * 1e18,
+                debtToCollateral:      2_758.083788017359002804 * 1e18,
+                neutralPrice:          3_137.845063437099084063 * 1e18,  // was 2_860.503207254858101199
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
 
@@ -785,18 +796,19 @@ contract ERC20PoolLiquidationsDepositTakeRegressionTest is ERC20HelperContract {
         // ensure some debt was covered by the take
         _assertAuction(
             AuctionParams({
-                borrower:          actor2,
-                active:            true,
-                kicker:            actor1,
-                bondSize:          13_799_909_500.935435603423349661 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    3_137.845063437099084063 * 1e18,
-                totalBondEscrowed: 13_799_909_500.935435603423349661 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     33_716_280_531.11637887639485531 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      3_137.845063437099084063 * 1e18  // was 2_860.503207254858101199
+                borrower:              actor2,
+                active:                true,
+                kicker:                actor1,
+                bondSize:              13_799_909_500.935435603423349661 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        3_137.845063437099084063 * 1e18,
+                totalBondEscrowed:     13_799_909_500.935435603423349661 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         33_716_280_531.11637887639485531 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          3_137.845063437099084063 * 1e18,  // was 2_860.503207254858101199
+                t0ReserveSettleAmount: 0.008926844489644974 * 1e18
             })
         );
         // ensure kicker was rewarded since bucket price taken was below the neutral price

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsKick.t.sol
@@ -139,18 +139,19 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -216,18 +217,19 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.211592598652049829 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.941498542724386393 * 1e18,
-                totalBondEscrowed: 0.211592598652049829 * 1e18,
-                auctionPrice:      2_801.023626937442916608 * 1e18,
-                debtInAuction:     18.925417364872552389 * 1e18,
-                debtToCollateral:  9.462708682436276194 * 1e18,
-                neutralPrice:      10.941498542724386393 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.211592598652049829 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.941498542724386393 * 1e18,
+                totalBondEscrowed:     0.211592598652049829 * 1e18,
+                auctionPrice:          2_801.023626937442916608 * 1e18,
+                debtInAuction:         18.925417364872552389 * 1e18,
+                debtToCollateral:      9.462708682436276194 * 1e18,
+                neutralPrice:          10.941498542724386393 * 1e18,
+                t0ReserveSettleAmount: 0.008974967640532548 * 1e18
             })
         );
         _assertKicker({
@@ -276,18 +278,19 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -309,18 +312,19 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.211592598652049829 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.941498542724386393 * 1e18,
-                totalBondEscrowed: 0.211592598652049829 * 1e18,
-                auctionPrice:      2_801.023626937442916608 * 1e18,
-                debtInAuction:     18.925417364872552389 * 1e18,
-                debtToCollateral:  9.462708682436276194 * 1e18,
-                neutralPrice:      10.941498542724386393 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.211592598652049829 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.941498542724386393 * 1e18,
+                totalBondEscrowed:     0.211592598652049829 * 1e18,
+                auctionPrice:          2_801.023626937442916608 * 1e18,
+                debtInAuction:         18.925417364872552389 * 1e18,
+                debtToCollateral:      9.462708682436276194 * 1e18,
+                neutralPrice:          10.941498542724386393 * 1e18,
+                t0ReserveSettleAmount: 0.008974967640532548 * 1e18
             })
         );
 
@@ -343,18 +347,19 @@ contract ERC20PoolLiquidationsKickTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -689,9 +689,9 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         address head;
         address next;
         address prev;
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(address(0));
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(address(0));
         assertEq(head, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -722,11 +722,11 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower1);
@@ -757,15 +757,15 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
@@ -796,19 +796,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower4);
@@ -839,23 +839,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         assertEq(borrower, address(0));
         assertEq(t0DebtToCollateral, 0);
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, _borrower2);
         assertEq(prev, _borrower4);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower3);
@@ -924,23 +924,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower4);
         assertEq(prev, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower5);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower4);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -987,23 +987,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower1);
         assertEq(next, _borrower5);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower1);
         assertEq(next, _borrower3);
         assertEq(prev, _borrower1);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower1);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1050,23 +1050,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower5);
         assertEq(next, _borrower3);
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, _borrower5);
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower5);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1113,23 +1113,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, _borrower3);
         assertEq(next, address(0));
         assertEq(prev, address(0));
@@ -1176,23 +1176,23 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
             })
         );
 
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower1);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower5);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower4);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower3);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));
-        (, , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
+        (, , , , , , , , head, next, prev) = _pool.auctionInfo(_borrower2);
         assertEq(head, address(0));
         assertEq(next, address(0));
         assertEq(prev, address(0));

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsLenderKick.t.sol
@@ -244,18 +244,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // assert kicked auction
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 223.821804286277016796 * 1e18,
-                auctionPrice:      5_925.823171731783953152 * 1e18,
-                debtInAuction:     20_019.230769230769240000 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower1,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     223.821804286277016796 * 1e18,
+                auctionPrice:          5_925.823171731783953152 * 1e18,
+                debtInAuction:         20_019.230769230769240000 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -375,18 +376,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // assert kicked auction
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            true,
-                kicker:            _lender3,
-                bondSize:          324.541616215101674353 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    33.564232808637057547 * 1e18,
-                totalBondEscrowed: 324.541616215101674353 * 1e18,
-                auctionPrice:      8_592.443599011086732032 * 1e18,
-                debtInAuction:     29_027.884615384615398000 * 1e18,
-                debtToCollateral:  29.027884615384615398 * 1e18,
-                neutralPrice:      33.564232808637057547 * 1e18
+                borrower:              _borrower1,
+                active:                true,
+                kicker:                _lender3,
+                bondSize:              324.541616215101674353 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        33.564232808637057547 * 1e18,
+                totalBondEscrowed:     324.541616215101674353 * 1e18,
+                auctionPrice:          8_592.443599011086732032 * 1e18,
+                debtInAuction:         29_027.884615384615398000 * 1e18,
+                debtToCollateral:      29.027884615384615398 * 1e18,
+                neutralPrice:          33.564232808637057547 * 1e18,
+                t0ReserveSettleAmount: 13.955713757396456409 * 1e18
             })
         );
     }
@@ -500,18 +502,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // assert kicked auction
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            true,
-                kicker:            _lender2,
-                bondSize:          391.688157500984779392 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    40.508556838010241868 * 1e18,
-                totalBondEscrowed: 391.688157500984779392 * 1e18,
-                auctionPrice:      10_370.190550530621918208 * 1e18,
-                debtInAuction:     35_033.653846153846170000 * 1e18,
-                debtToCollateral:  35.033653846153846170 * 1e18,
-                neutralPrice:      40.508556838010241868 * 1e18
+                borrower:              _borrower1,
+                active:                true,
+                kicker:                _lender2,
+                bondSize:              391.688157500984779392 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        40.508556838010241868 * 1e18,
+                totalBondEscrowed:     391.688157500984779392 * 1e18,
+                auctionPrice:          10_370.190550530621918208 * 1e18,
+                debtInAuction:         35_033.653846153846170000 * 1e18,
+                debtToCollateral:      35.033653846153846170 * 1e18,
+                neutralPrice:          40.508556838010241868 * 1e18,
+                t0ReserveSettleAmount: 16.843102810650895666 * 1e18
             })
         );
     }
@@ -623,18 +626,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // assert kicked auction
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 223.821804286277016796 * 1e18,
-                auctionPrice:      5_925.823171731783953152 * 1e18,
-                debtInAuction:     20_019.230769230769240000 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower1,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     223.821804286277016796 * 1e18,
+                auctionPrice:          5_925.823171731783953152 * 1e18,
+                debtInAuction:         20_019.230769230769240000 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -885,18 +889,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // settle borrower 2
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     100_096.153846153846200000 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         100_096.153846153846200000 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -909,18 +914,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     80_113.496231380830061171 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         80_113.496231380830061171 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -948,18 +954,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // settle borrower 4
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower4,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     80_113.496231380830061171 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower4,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         80_113.496231380830061171 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -972,18 +979,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower4,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     60_085.122173535622545879 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower4,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         60_085.122173535622545879 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1011,18 +1019,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // settle borrower 1
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     60_085.122173535622545879 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower1,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         60_085.122173535622545879 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -1035,18 +1044,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower1,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     40_056.748115690415030586 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower1,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         40_056.748115690415030586 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1074,18 +1084,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // settle borrower 5
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower5,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     40_056.748115690415030586 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower5,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         40_056.748115690415030586 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -1098,18 +1109,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower5,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     20_028.374057845207515293 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower5,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         20_028.374057845207515293 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1137,18 +1149,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
         // settle borrower 3
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower3,
-                active:            true,
-                kicker:            _lender1,
-                bondSize:          223.821804286277016796 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    23.147746764577281067 * 1e18,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     20_028.374057845207515293 * 1e18,
-                debtToCollateral:  20.019230769230769240 * 1e18,
-                neutralPrice:      23.147746764577281067 * 1e18
+                borrower:              _borrower3,
+                active:                true,
+                kicker:                _lender1,
+                bondSize:              223.821804286277016796 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        23.147746764577281067 * 1e18,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         20_028.374057845207515293 * 1e18,
+                debtToCollateral:      20.019230769230769240 * 1e18,
+                neutralPrice:          23.147746764577281067 * 1e18,
+                t0ReserveSettleAmount: 9.624630177514797523 * 1e18
             })
         );
 
@@ -1161,18 +1174,19 @@ contract ERC20PoolLiquidationsLenderKickAuctionTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower3,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 1_119.109021431385083980 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower3,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     1_119.109021431385083980 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsMisc.t.sol
@@ -175,18 +175,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -215,18 +216,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.209172983065585793 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.816379703115139992 * 1e18,
-                totalBondEscrowed: 0.209172983065585793 * 1e18,
-                auctionPrice:      2_768.993203997475837952 * 1e18,
-                debtInAuction:     18.709000367642488138 * 1e18,
-                debtToCollateral:  9.354500183821244069 * 1e18,
-                neutralPrice:      10.816379703115139992 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.209172983065585793 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.816379703115139992 * 1e18,
+                totalBondEscrowed:     0.209172983065585793 * 1e18,
+                auctionPrice:          2_768.993203997475837952 * 1e18,
+                debtInAuction:         18.709000367642488138 * 1e18,
+                debtToCollateral:      9.354500183821244069 * 1e18,
+                neutralPrice:          10.816379703115139992 * 1e18,
+                t0ReserveSettleAmount: 0.008077470876479286 * 1e18
             })
         );
 
@@ -267,18 +269,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.209172983065585793 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 3 hours,
-                referencePrice:    10.816379703115139992 * 1e18,
-                totalBondEscrowed: 0.209172983065585793 * 1e18,
-                auctionPrice:      30.593341743845004656 * 1e18,
-                debtInAuction:     18.709000367642488138 * 1e18,
-                debtToCollateral:  9.354500183821244069 * 1e18,
-                neutralPrice:      10.816379703115139992 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.209172983065585793 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 3 hours,
+                referencePrice:        10.816379703115139992 * 1e18,
+                totalBondEscrowed:     0.209172983065585793 * 1e18,
+                auctionPrice:          30.593341743845004656 * 1e18,
+                debtInAuction:         18.709000367642488138 * 1e18,
+                debtToCollateral:      9.354500183821244069 * 1e18,
+                neutralPrice:          10.816379703115139992 * 1e18,
+                t0ReserveSettleAmount: 0.008077470876479286 * 1e18
             })
         );
         _assertBorrower({
@@ -302,18 +305,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
         // Borrower is removed from auction, keeps collateral in system
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -468,18 +472,19 @@ contract ERC20PoolLiquidationsMiscTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          90.564949726435836850 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    9.366265850188852076 * 1e18,
-                totalBondEscrowed: 90.564949726435836850 * 1e18,
-                auctionPrice:      2.341566462547213020 * 1e18,
-                debtInAuction:     8_100.375358686460903420 * 1e18,
-                debtToCollateral:  8.100375358686460903 * 1e18,
-                neutralPrice:      9.366265850188852076 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              90.564949726435836850 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        9.366265850188852076 * 1e18,
+                totalBondEscrowed:     90.564949726435836850 * 1e18,
+                auctionPrice:          2.341566462547213020 * 1e18,
+                debtInAuction:         8_100.375358686460903420 * 1e18,
+                debtToCollateral:      8.100375358686460903 * 1e18,
+                neutralPrice:          9.366265850188852076 * 1e18,
+                t0ReserveSettleAmount: 2.799525804363903483 * 1e18
             })
         );
         _assertBorrower({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsScaled.t.sol
@@ -321,6 +321,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
             ,
             ,
             ,
+            ,
         ) = _pool.auctionInfo(_borrower);
 
         assertEq(auctionKicker,         kicker);
@@ -374,7 +375,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         }
 
         // confirm LP were awarded to the kicker
-        (address kicker, , , uint256 kickTime, uint256 referencePrice, uint256 neutralPrice, , , ,) = _pool.auctionInfo(_borrower);
+        (address kicker, , , uint256 kickTime, uint256 referencePrice, uint256 neutralPrice, , , , ,) = _pool.auctionInfo(_borrower);
         uint256 auctionPrice = _auctionPrice(referencePrice, kickTime);
         if (auctionPrice < neutralPrice) {
             uint256 kickerLP = _kickerLP(bucketId);
@@ -445,7 +446,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
         uint256 auctionDebt_,
         uint256 auctionCollateral_
     ){
-        (, , , uint256 kickTime, uint256 referencePrice, , , , , ) = _pool.auctionInfo(_borrower);
+        (, , , uint256 kickTime, uint256 referencePrice, , , , , , ) = _pool.auctionInfo(_borrower);
         uint256 lastAuctionPrice = _auctionPrice(referencePrice, kickTime);
         (uint256 lastAuctionDebt, uint256 lastAuctionCollateral, , ) = _poolUtils.borrowerInfo(address(_pool), _borrower);
         if (secondsToSkip != 0) {
@@ -471,7 +472,7 @@ contract ERC20PoolLiquidationsScaledTest is ERC20DSTestPlus {
     }
 
     function _kickerLP(uint256 bucketId) internal view returns (uint256) {
-        (address kicker, , , , , , , , , ) = _pool.auctionInfo(_borrower);
+        (address kicker, , , , , , , , , , ) = _pool.auctionInfo(_borrower);
         (uint256 kickerLP, ) = _pool.lenderInfo(bucketId, kicker);
         return kickerLP;
     }

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsSettle.t.sol
@@ -144,18 +144,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -177,18 +178,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2_787.506622839621476352 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2_787.506622839621476352 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -232,18 +234,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2.722174436366817848 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2.722174436366817848 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -267,18 +270,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          129.633622527137778568 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 129.633622527137778568 * 1e18,
-                auctionPrice:      2.722174436366817848 * 1e18,
-                debtInAuction:     7_264.136220460174790403 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              129.633622527137778568 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     129.633622527137778568 * 1e18,
+                auctionPrice:          2.722174436366817848 * 1e18,
+                debtInAuction:         7_264.136220460174790403 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -344,18 +348,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 129.633622527137778568 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     129.633622527137778568 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -426,18 +431,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -459,18 +465,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2_787.506622839621476352 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2_787.506622839621476352 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -515,18 +522,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 73 hours,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 73 hours,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -546,18 +554,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -637,18 +646,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          kickTime,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2_787.506622839621476352 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              kickTime,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2_787.506622839621476352 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -687,18 +697,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          kickTime,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      1.144533362618078976 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              kickTime,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          1.144533362618078976 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -930,18 +941,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          kickTime,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2_787.506622839621476352 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              kickTime,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2_787.506622839621476352 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({
@@ -965,18 +977,19 @@ contract ERC20PoolLiquidationsSettleTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          105.285754181824258217 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          kickTime,
-                referencePrice:    10.888697745467271392 * 1e18,
-                totalBondEscrowed: 105.285754181824258217 * 1e18,
-                auctionPrice:      2.722174436366817848 * 1e18,
-                debtInAuction:     9_417.044136515672180411 * 1e18,
-                debtToCollateral:  9.417044136515672180 * 1e18,
-                neutralPrice:      10.888697745467271392 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              105.285754181824258217 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              kickTime,
+                referencePrice:        10.888697745467271392 * 1e18,
+                totalBondEscrowed:     105.285754181824258217 * 1e18,
+                auctionPrice:          2.722174436366817848 * 1e18,
+                debtInAuction:         9_417.044136515672180411 * 1e18,
+                debtToCollateral:      9.417044136515672180 * 1e18,
+                neutralPrice:          10.888697745467271392 * 1e18,
+                t0ReserveSettleAmount: 4.465828402366866051 * 1e18
             })
         );
         _assertBorrower({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolLiquidationsTake.t.sol
@@ -210,18 +210,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -282,18 +283,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 47000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      0.946897685981543764 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 47000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          0.946897685981543764 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -318,18 +320,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // Residual is not collateralized, auction is active
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
-                bondSize:          120.834036728063952141 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 47000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 120.834036728063952141 * 1e18,
-                auctionPrice:      0.946897685981543764 * 1e18,
-                debtInAuction:     8_849.846531632272862778 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
+                bondSize:              120.834036728063952141 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 47000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     120.834036728063952141 * 1e18,
+                auctionPrice:          0.946897685981543764 * 1e18,
+                debtInAuction:         8_849.846531632272862778 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         // Bad debt remains
@@ -437,18 +440,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -509,18 +513,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 43000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      1.391688189743023672 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 43000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          1.391688189743023672 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -545,18 +550,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // Residual is not collateralized, auction is active
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
-                bondSize:          109.979528711173099975 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 43000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.979528711173099975 * 1e18,
-                auctionPrice:      1.391688189743023672 * 1e18,
-                debtInAuction:     9_809.792664465320061476 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                address(0xb012341CA6E91C00A290F658fbaA5211F2559fB1),
+                bondSize:              109.979528711173099975 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 43000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.979528711173099975 * 1e18,
+                auctionPrice:          1.391688189743023672 * 1e18,
+                debtInAuction:         9_809.792664465320061476 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -644,18 +650,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -716,18 +723,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 22000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      10.508629868487414000 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 22000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          10.508629868487414000 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -752,18 +760,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // Residual is collateralized, auction remains active.
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          128.772008590038867086 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 22000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 128.772008590038867086 * 1e18,
-                auctionPrice:      10.508629868487414000 * 1e18,
-                debtInAuction:     3_839.782833371446802894 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              128.772008590038867086 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 22000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     128.772008590038867086 * 1e18,
+                auctionPrice:          10.508629868487414000 * 1e18,
+                debtInAuction:         3_839.782833371446802894 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -822,18 +831,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      2_795.824779207511593472 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          2_795.824779207511593472 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertKicker({
@@ -877,18 +887,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 80 minutes,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      174.739048700469474560 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 80 minutes,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          174.739048700469474560 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -930,18 +941,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // take recollateralized borrower however once in auction, always in auction...
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          90.287513680490847847 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 80 minutes,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 90.287513680490847847 * 1e18,
-                auctionPrice:      174.739048700469474560 * 1e18,
-                debtInAuction:     8_104.932634420295318817 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              90.287513680490847847 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 80 minutes,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     90.287513680490847847 * 1e18,
+                auctionPrice:          174.739048700469474560 * 1e18,
+                debtInAuction:         8_104.932634420295318817 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -1030,18 +1042,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1102,18 +1115,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          109.823933241385648657 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 22000 seconds,
-                referencePrice:    10.921190543779342162 * 1e18,
-                totalBondEscrowed: 109.823933241385648657 * 1e18,
-                auctionPrice:      10.508629868487414000 * 1e18,
-                debtInAuction:     9_822.951211365485636463 * 1e18,
-                debtToCollateral:  9.445145395543736189 * 1e18,
-                neutralPrice:      10.921190543779342162 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              109.823933241385648657 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 22000 seconds,
+                referencePrice:        10.921190543779342162 * 1e18,
+                totalBondEscrowed:     109.823933241385648657 * 1e18,
+                auctionPrice:          10.508629868487414000 * 1e18,
+                debtInAuction:         9_822.951211365485636463 * 1e18,
+                debtToCollateral:      9.445145395543736189 * 1e18,
+                neutralPrice:          10.921190543779342162 * 1e18,
+                t0ReserveSettleAmount: 4.658321005917162001 * 1e18
             })
         );
         _assertBorrower({
@@ -1138,18 +1152,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         // Residual is collateralized, auction is not active
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 140.931576925968603373 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     140.931576925968603373 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1193,18 +1208,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      2_804.489525424063798784 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          2_804.489525424063798784 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertKicker({
@@ -1232,18 +1248,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      2.738759302171937304 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          2.738759302171937304 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertBorrower({
@@ -1268,18 +1285,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.776701868219386837 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.776701868219386837 * 1e18,
-                auctionPrice:      2.738759302171937304 * 1e18,
-                debtInAuction:     9_799.737641646680470914 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.776701868219386837 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.776701868219386837 * 1e18,
+                auctionPrice:          2.738759302171937304 * 1e18,
+                debtInAuction:         9_799.737641646680470914 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertBorrower({
@@ -1316,18 +1334,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          142.009366933917715582 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 142.009366933917715582 * 1e18,
-                auctionPrice:      2.738759302171937304 * 1e18,
-                debtInAuction:     7_037.435818497002749734 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              142.009366933917715582 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     142.009366933917715582 * 1e18,
+                auctionPrice:          2.738759302171937304 * 1e18,
+                debtInAuction:         7_037.435818497002749734 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertBorrower({
@@ -1378,18 +1397,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 142.009366933917715582 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     142.009366933917715582 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1505,18 +1525,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          142.009366933917715582 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 142.009366933917715582 * 1e18,
-                auctionPrice:      2.738759302171937304 * 1e18,
-                debtInAuction:     5_020.054078728300909793 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              142.009366933917715582 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     142.009366933917715582 * 1e18,
+                auctionPrice:          2.738759302171937304 * 1e18,
+                debtInAuction:         5_020.054078728300909793 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1542,18 +1563,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 142.009366933917715582 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     142.009366933917715582 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1607,18 +1629,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      2_804.489525424063798784 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          2_804.489525424063798784 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertBorrower({
@@ -1646,18 +1669,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1679,18 +1703,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.218237587785293172 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    11.285112352380185868 * 1e18,
-                totalBondEscrowed: 110.382534258638046113 * 1e18,
-                auctionPrice:      2_888.988762209327582208 * 1e18,
-                debtInAuction:     9_995.146145767066608231 * 1e18,
-                debtToCollateral:  9.759881630669866665 * 1e18,
-                neutralPrice:      11.285112352380185868 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.218237587785293172 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        11.285112352380185868 * 1e18,
+                totalBondEscrowed:     110.382534258638046113 * 1e18,
+                auctionPrice:          2_888.988762209327582208 * 1e18,
+                debtInAuction:         9_995.146145767066608231 * 1e18,
+                debtToCollateral:      9.759881630669866665 * 1e18,
+                neutralPrice:          11.285112352380185868 * 1e18,
+                t0ReserveSettleAmount: 0.008229058801775144 * 1e18
             })
         );
         _assertKicker({
@@ -1744,18 +1769,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      2_804.489525424063798784 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          2_804.489525424063798784 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
         _assertBorrower({
@@ -1775,18 +1801,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         skip(6 hours);
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6 hours,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      10.955037208687749216 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6 hours,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          10.955037208687749216 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
 
@@ -1794,18 +1821,19 @@ contract ERC20PoolLiquidationsTakeTest is ERC20HelperContract {
         skip(1 hours);
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          110.164296670852752941 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 7 hours,
-                referencePrice:    10.955037208687749214 * 1e18,
-                totalBondEscrowed: 110.164296670852752941 * 1e18,
-                auctionPrice:      7.746381098414054648 * 1e18,
-                debtInAuction:     9_853.394241979221645667 * 1e18,
-                debtToCollateral:  9.474417540364636198 * 1e18,
-                neutralPrice:      10.955037208687749214 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              110.164296670852752941 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 7 hours,
+                referencePrice:        10.955037208687749214 * 1e18,
+                totalBondEscrowed:     110.164296670852752941 * 1e18,
+                auctionPrice:          7.746381098414054648 * 1e18,
+                debtInAuction:         9_853.394241979221645667 * 1e18,
+                debtToCollateral:      9.474417540364636198 * 1e18,
+                neutralPrice:          10.955037208687749214 * 1e18,
+                t0ReserveSettleAmount: 4.672757951183434197 * 1e18
             })
         );
 
@@ -1947,18 +1975,19 @@ contract ERC20PoolLiquidationsLowPriceCollateralTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          8.509085736677607076 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    0.000017978108625356 * 1e18,
-                totalBondEscrowed: 8.509085736677607076 * 1e18,
-                auctionPrice:      0.004602395808091136 * 1e18,
-                debtInAuction:     761.075765343400230098 * 1e18,
-                debtToCollateral:  0.000015548291115577 * 1e18,
-                neutralPrice:      0.000017978108625356 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              8.509085736677607076 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        0.000017978108625356 * 1e18,
+                totalBondEscrowed:     8.509085736677607076 * 1e18,
+                auctionPrice:          0.004602395808091136 * 1e18,
+                debtInAuction:         761.075765343400230098 * 1e18,
+                debtToCollateral:      0.000015548291115577 * 1e18,
+                neutralPrice:          0.000017978108625356 * 1e18,
+                t0ReserveSettleAmount: 0.360923631656804907 * 1e18
             })
         );
         _assertBorrower({
@@ -1973,18 +2002,19 @@ contract ERC20PoolLiquidationsLowPriceCollateralTest is ERC20HelperContract {
         skip(71 hours);
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          8.509085736677607076 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime + 100 days,
-                referencePrice:    0.000017978108625356 * 1e18,
-                totalBondEscrowed: 8.509085736677607076 * 1e18,
-                auctionPrice:      0 * 1e18,
-                debtInAuction:     761.075765343400230098 * 1e18,
-                debtToCollateral:  0.000015548291115577 * 1e18,
-                neutralPrice:      0.000017978108625356 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              8.509085736677607076 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime + 100 days,
+                referencePrice:        0.000017978108625356 * 1e18,
+                totalBondEscrowed:     8.509085736677607076 * 1e18,
+                auctionPrice:          0 * 1e18,
+                debtInAuction:         761.075765343400230098 * 1e18,
+                debtToCollateral:      0.000015548291115577 * 1e18,
+                neutralPrice:          0.000017978108625356 * 1e18,
+                t0ReserveSettleAmount: 0.360923631656804907 * 1e18
             })
         );
         _assertTakeZeroBidRevert({

--- a/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
+++ b/tests/forge/unit/ERC20Pool/ERC20PoolQuoteToken.t.sol
@@ -1617,18 +1617,19 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -1650,18 +1651,19 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.215563505329166046 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    11.146834976502055842 * 1e18,
-                totalBondEscrowed: 0.215563505329166046 * 1e18,
-                auctionPrice:      2_853.589753984526295552 * 1e18,
-                debtInAuction:     19.280586055366139163 * 1e18,
-                debtToCollateral:  9.640293027683069581 * 1e18,
-                neutralPrice:      11.146834976502055842 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.215563505329166046 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        11.146834976502055842 * 1e18,
+                totalBondEscrowed:     0.215563505329166046 * 1e18,
+                auctionPrice:          2_853.589753984526295552 * 1e18,
+                debtInAuction:         19.280586055366139163 * 1e18,
+                debtToCollateral:      9.640293027683069581 * 1e18,
+                neutralPrice:          11.146834976502055842 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertKicker({
@@ -1683,18 +1685,19 @@ contract ERC20PoolQuoteTokenTest is ERC20HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.215563505329166046 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6.5 hours,
-                referencePrice:    11.146834976502055842 * 1e18,
-                totalBondEscrowed: 0.215563505329166046 * 1e18,
-                auctionPrice:      9.373333573165302108 * 1e18,
-                debtInAuction:     19.280586055366139163 * 1e18,
-                debtToCollateral:  9.640293027683069581 * 1e18,
-                neutralPrice:      11.146834976502055842 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.215563505329166046 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6.5 hours,
+                referencePrice:        11.146834976502055842 * 1e18,
+                totalBondEscrowed:     0.215563505329166046 * 1e18,
+                auctionPrice:          9.373333573165302108 * 1e18,
+                debtInAuction:         19.280586055366139163 * 1e18,
+                debtToCollateral:      9.640293027683069581 * 1e18,
+                neutralPrice:          11.146834976502055842 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
 

--- a/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721DSTestPlus.sol
@@ -163,13 +163,13 @@ abstract contract ERC721DSTestPlus is DSTestPlus, IERC721PoolEvents {
         
         for (uint i = 0; i < borrowers.length(); i++) {
             address borrower = borrowers.at(i);
-            (,,, uint256 kickTime,,,,,,) = _pool.auctionInfo(borrower);
+            (,,, uint256 kickTime,,,,,,,) = _pool.auctionInfo(borrower);
             if (kickTime != 0) {
                 changePrank(borrower);
                 _pool.settle(borrower, bucketsUsed.length() + 1);
 
                 // Settle again if not settled, this can happen when less reserves calculated with DEPOSIT_BUFFER and borrower is not fully settled
-                (,,, kickTime,,,,,,) = _pool.auctionInfo(borrower);
+                (,,, kickTime,,,,,,,) = _pool.auctionInfo(borrower);
                 if (kickTime != 0) {
                     _pool.settle(borrower, bucketsUsed.length() + 1);
                 }

--- a/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolCollateral.t.sol
@@ -673,18 +673,19 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          6.605224811402125309 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 32 hours,
-                referencePrice:    341.557588066529373749 * 1e18,
-                totalBondEscrowed: 6.605224811402125309 * 1e18,
-                auctionPrice:      0.000081433674828178 * 1e18,
-                debtInAuction:     590.789267398535232527 * 1e18,
-                debtToCollateral:  295.394633699267616263 * 1e18,
-                neutralPrice:      341.557588066529373749 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                address(_lender),
+                bondSize:              6.605224811402125309 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 32 hours,
+                referencePrice:        341.557588066529373749 * 1e18,
+                totalBondEscrowed:     6.605224811402125309 * 1e18,
+                auctionPrice:          0.000081433674828178 * 1e18,
+                debtInAuction:         590.789267398535232527 * 1e18,
+                debtToCollateral:      295.394633699267616263 * 1e18,
+                neutralPrice:          341.557588066529373749 * 1e18,
+                t0ReserveSettleAmount: 0.072184726331360981 * 1e18
             })
         );
 
@@ -835,18 +836,19 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          6.605224811402125309 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 32 hours,
-                referencePrice:    341.557588066529373749 * 1e18,
-                totalBondEscrowed: 6.605224811402125309 * 1e18,
-                auctionPrice:      0.000081433674828178 * 1e18,
-                debtInAuction:     418.513981107458710209 * 1e18,
-                debtToCollateral:  295.394633699267616263 * 1e18,
-                neutralPrice:      341.557588066529373749 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                address(_lender),
+                bondSize:              6.605224811402125309 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 32 hours,
+                referencePrice:        341.557588066529373749 * 1e18,
+                totalBondEscrowed:     6.605224811402125309 * 1e18,
+                auctionPrice:          0.000081433674828178 * 1e18,
+                debtInAuction:         418.513981107458710209 * 1e18,
+                debtToCollateral:      295.394633699267616263 * 1e18,
+                neutralPrice:          341.557588066529373749 * 1e18,
+                t0ReserveSettleAmount: 0.072184726331360981 * 1e18
             })
         );
 
@@ -923,18 +925,19 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          6.605225721858288176 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - (32 hours + 4210 minutes),
-                referencePrice:    341.557588066529373749 * 1e18,
-                totalBondEscrowed: 6.605225721858288176 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     418.513900584240044901 * 1e18,
-                debtToCollateral:  295.394633699267616263 * 1e18,
-                neutralPrice:      341.557588066529373749 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                address(_lender),
+                bondSize:              6.605225721858288176 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - (32 hours + 4210 minutes),
+                referencePrice:        341.557588066529373749 * 1e18,
+                totalBondEscrowed:     6.605225721858288176 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         418.513900584240044901 * 1e18,
+                debtToCollateral:      295.394633699267616263 * 1e18,
+                neutralPrice:          341.557588066529373749 * 1e18,
+                t0ReserveSettleAmount: 0.072184726331360981 * 1e18
             })
         );
 
@@ -967,18 +970,19 @@ contract ERC721PoolCollateralTest is ERC721HelperContract {
 
         _assertAuction(
              AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 6.605225721858288176 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     6.605225721858288176 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsDepositTake.t.sol
@@ -203,18 +203,19 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      12.609408860297298412 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          12.609408860297298412 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
 
@@ -245,18 +246,19 @@ contract ERC721PoolLiquidationsDepositTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.076149339066797765 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 6 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.076149339066797765 * 1e18,
-                auctionPrice:      12.609408860297298412 * 1e18,
-                debtInAuction:     7.063223505145093670 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.076149339066797765 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 6 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.076149339066797765 * 1e18,
+                auctionPrice:          12.609408860297298412 * 1e18,
+                debtInAuction:         7.063223505145093670 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         // borrower is compensated LP for fractional collateral

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsKick.t.sol
@@ -142,18 +142,19 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
 
          _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -196,18 +197,19 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3_228.008668236108393472 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3_228.008668236108393472 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertBorrower({
@@ -265,18 +267,19 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -298,18 +301,19 @@ contract ERC721PoolLiquidationsKickTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3_228.008668236108393472 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3_228.008668236108393472 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
 

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettle.t.sol
@@ -182,18 +182,19 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         // settle borrower 2, whose neutral price has been carried from borrower 1
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          55.955451071569254199 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          _startTime,
-                referencePrice:    2_893.468345572160133444 * 1e18,
-                totalBondEscrowed: 111.910902143138508398 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     10_009.615384615384620000 * 1e18,
-                debtToCollateral:  1_668.269230769230770000 * 1e18,
-                neutralPrice:      1_928.978897048106755629 * 1e18
+                borrower:              _borrower2,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              55.955451071569254199 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              _startTime,
+                referencePrice:        2_893.468345572160133444 * 1e18,
+                totalBondEscrowed:     111.910902143138508398 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         10_009.615384615384620000 * 1e18,
+                debtToCollateral:      1_668.269230769230770000 * 1e18,
+                neutralPrice:          1_928.978897048106755629 * 1e18,
+                t0ReserveSettleAmount: 2.406157544378699381 * 1e18
             })
         );
 
@@ -214,18 +215,19 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 111.910902143138508398 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     5_007.093514461301878824 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     111.910902143138508398 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         5_007.093514461301878824 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -264,18 +266,19 @@ contract ERC721PoolLiquidationsSettleTest is ERC721HelperContract {
         );
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 111.910902143138508398 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     111.910902143138508398 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsSettleAuction.t.sol
@@ -612,18 +612,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         // auction 2 still ongoing
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 112.526190000038609125 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     10_064.901171882309537906 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     112.526190000038609125 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         10_064.901171882309537906 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -687,18 +688,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 112.526190000038609125 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     112.526190000038609125 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -908,18 +910,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 148.374406222773030563 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     10_066.670727855240484714 * 1e18,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     148.374406222773030563 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         10_066.670727855240484714 * 1e18,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBucket({
@@ -953,18 +956,19 @@ contract ERC721PoolLiquidationsSettleAuctionTest is ERC721HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower2,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 35.848216222734421438 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower2,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     35.848216222734421438 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBucket({

--- a/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
+++ b/tests/forge/unit/ERC721Pool/ERC721PoolLiquidationsTake.t.sol
@@ -146,18 +146,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -218,18 +219,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3_228.008668236108393472 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3_228.008668236108393472 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertKicker({
@@ -251,18 +253,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         // debt to collateral increases slightly due to interest
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5.5 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      14.995198732643899296 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5.5 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          14.995198732643899296 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
 
@@ -319,18 +322,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.076196129225921767 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 5.5 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.076196129225921767 * 1e18,
-                auctionPrice:      14.995198732643899296 * 1e18,
-                debtInAuction:     7.067282337479398835 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.076196129225921767 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 5.5 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.076196129225921767 * 1e18,
+                auctionPrice:          14.995198732643899296 * 1e18,
+                debtInAuction:         7.067282337479398835 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertKicker({
@@ -391,18 +395,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertKicker({
@@ -426,18 +431,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -497,18 +503,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3_228.008668236108393472 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3_228.008668236108393472 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertKicker({
@@ -528,18 +535,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3.152352215074324604 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3.152352215074324604 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertBorrower({
@@ -599,18 +607,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.314336286156756295 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 10 hours,
-                referencePrice:    12.609408860297298412 * 1e18, 
-                totalBondEscrowed: 0.314336286156756295 * 1e18,
-                auctionPrice:      3.152352215074324604 * 1e18,
-                debtInAuction:     15.577292449182337291 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.314336286156756295 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 10 hours,
+                referencePrice:        12.609408860297298412 * 1e18, 
+                totalBondEscrowed:     0.314336286156756295 * 1e18,
+                auctionPrice:          3.152352215074324604 * 1e18,
+                debtInAuction:         15.577292449182337291 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         // kicker bond is locked as auction is not cleared
@@ -630,18 +639,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0.314336286156756295 * 1e18,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0.314336286156756295 * 1e18,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertKicker({
@@ -667,18 +677,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
         _assertBorrower({
@@ -707,18 +718,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         });
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737474028 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737474028 * 1e18,
-                auctionPrice:      3_228.008668236108393472 * 1e18,
-                debtInAuction:     21.810387715504679661 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737474028 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737474028 * 1e18,
+                auctionPrice:          3_228.008668236108393472 * 1e18,
+                debtInAuction:         21.810387715504679661 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
 
@@ -737,18 +749,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737602246 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 50 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737602246 * 1e18,
-                auctionPrice:      0.000000000011468190 * 1e18,
-                debtInAuction:     21.815990418133811604 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737602246 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 50 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737602246 * 1e18,
+                auctionPrice:          0.000000000011468190 * 1e18,
+                debtInAuction:         21.815990418133811604 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertBorrower({
@@ -770,18 +783,19 @@ contract ERC721PoolLiquidationsTakeTest is ERC721HelperContract {
         // ensure auction state did not change
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          0.243847547737602246 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 50 hours,
-                referencePrice:    12.609408860297298412 * 1e18,
-                totalBondEscrowed: 0.243847547737602246 * 1e18,
-                auctionPrice:      0.000000000011468190 * 1e18,
-                debtInAuction:     21.815990418133811604 * 1e18,
-                debtToCollateral:  10.905193857752339830 * 1e18,
-                neutralPrice:      12.609408860297298412 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              0.243847547737602246 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 50 hours,
+                referencePrice:        12.609408860297298412 * 1e18,
+                totalBondEscrowed:     0.243847547737602246 * 1e18,
+                auctionPrice:          0.000000000011468190 * 1e18,
+                debtInAuction:         21.815990418133811604 * 1e18,
+                debtToCollateral:      10.905193857752339830 * 1e18,
+                neutralPrice:          12.609408860297298412 * 1e18,
+                t0ReserveSettleAmount: 0.009143398668639057 * 1e18
             })
         );
         _assertBorrower({
@@ -905,18 +919,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -933,18 +948,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          10_897_869.739154233968795067 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 1 minutes,
-                referencePrice:    1_127_062_351.229373656878717077 * 1e18,
-                totalBondEscrowed: 10_897_869.739154233968795067 * 1e18,
-                auctionPrice:      278_699_640_324.071955737458053632 * 1e18, // auction price exceeds top bucket
-                debtInAuction:     974_735_101.867470788027259956 * 1e18,
-                debtToCollateral:  974_735_101.867470788027259955 * 1e18,
-                neutralPrice:      1_127_062_351.229373656878717077 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                address(_lender),
+                bondSize:              10_897_869.739154233968795067 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 1 minutes,
+                referencePrice:        1_127_062_351.229373656878717077 * 1e18,
+                totalBondEscrowed:     10_897_869.739154233968795067 * 1e18,
+                auctionPrice:          278_699_640_324.071955737458053632 * 1e18, // auction price exceeds top bucket
+                debtInAuction:         974_735_101.867470788027259956 * 1e18,
+                debtToCollateral:      974_735_101.867470788027259955 * 1e18,
+                neutralPrice:          1_127_062_351.229373656878717077 * 1e18,
+                t0ReserveSettleAmount: 462_246.925850591938067995 * 1e18
             })
         );
 
@@ -963,18 +979,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1026,18 +1043,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1072,18 +1090,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            address(_lender),
-                bondSize:          21_502_134.795353695767188920 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp - 1 minutes,
-                referencePrice:    1_111_879_990.262346637742836677 * 1e18,
-                totalBondEscrowed: 21_502_134.795353695767188920 * 1e18,
-                auctionPrice:      274_945_350_655.745057322116218624 * 1e18, // auction price exceeds top bucket
-                debtInAuction:     1_923_209_402.550975799525343721 * 1e18,
-                debtToCollateral:  961_604_701.275487899762671860 * 1e18,
-                neutralPrice:      1_111_879_990.262346637742836677 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                address(_lender),
+                bondSize:              21_502_134.795353695767188920 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp - 1 minutes,
+                referencePrice:        1_111_879_990.262346637742836677 * 1e18,
+                totalBondEscrowed:     21_502_134.795353695767188920 * 1e18,
+                auctionPrice:          274_945_350_655.745057322116218624 * 1e18, // auction price exceeds top bucket
+                debtInAuction:         1_923_209_402.550975799525343721 * 1e18,
+                debtToCollateral:      961_604_701.275487899762671860 * 1e18,
+                neutralPrice:          1_111_879_990.262346637742836677 * 1e18,
+                t0ReserveSettleAmount: 911_915.309334910242883819 * 1e18
             })
         );
 
@@ -1113,18 +1132,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1174,18 +1194,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 
@@ -1240,18 +1261,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            true,
-                kicker:            _lender,
-                bondSize:          21_502_134.795353695767188920 * 1e18,
-                bondFactor:        0.011180339887498948 * 1e18,
-                kickTime:          block.timestamp,
-                referencePrice:    1111879990.262346637742836677 * 1e18,
-                totalBondEscrowed: 21_502_134.795353695767188920 * 1e18,
-                auctionPrice:      284_641_277_507.160739262166189312 * 1e18, // auction price exceeds top bucket
-                debtInAuction:     1_923_209_402.550975799525343721 * 1e18,
-                debtToCollateral:  961_604_701.275487899762671860 * 1e18,
-                neutralPrice:      1111879990.262346637742836677 * 1e18
+                borrower:              _borrower,
+                active:                true,
+                kicker:                _lender,
+                bondSize:              21_502_134.795353695767188920 * 1e18,
+                bondFactor:            0.011180339887498948 * 1e18,
+                kickTime:              block.timestamp,
+                referencePrice:        1111879990.262346637742836677 * 1e18,
+                totalBondEscrowed:     21_502_134.795353695767188920 * 1e18,
+                auctionPrice:          284_641_277_507.160739262166189312 * 1e18, // auction price exceeds top bucket
+                debtInAuction:         1_923_209_402.550975799525343721 * 1e18,
+                debtToCollateral:      961_604_701.275487899762671860 * 1e18,
+                neutralPrice:          1111879990.262346637742836677 * 1e18,
+                t0ReserveSettleAmount: 911_915.309334910242883819 * 1e18
             })
         );
 
@@ -1275,18 +1297,19 @@ contract ERC721PoolLiquidationsHighTakeTest is ERC721HelperContract {
 
         _assertAuction(
             AuctionParams({
-                borrower:          _borrower,
-                active:            false,
-                kicker:            address(0),
-                bondSize:          0,
-                bondFactor:        0,
-                kickTime:          0,
-                referencePrice:    0,
-                totalBondEscrowed: 0,
-                auctionPrice:      0,
-                debtInAuction:     0,
-                debtToCollateral:  0,
-                neutralPrice:      0
+                borrower:              _borrower,
+                active:                false,
+                kicker:                address(0),
+                bondSize:              0,
+                bondFactor:            0,
+                kickTime:              0,
+                referencePrice:        0,
+                totalBondEscrowed:     0,
+                auctionPrice:          0,
+                debtInAuction:         0,
+                debtToCollateral:      0,
+                neutralPrice:          0,
+                t0ReserveSettleAmount: 0
             })
         );
 

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -84,6 +84,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 debtInAuction;
         uint256 debtToCollateral;
         uint256 neutralPrice;
+        uint256 t0ReserveSettleAmount;
     }
 
     mapping(address => EnumerableSet.UintSet) lendersDepositedIndex;
@@ -450,6 +451,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         uint256 auctionTotalBondEscrowed;
         uint256 auctionDebtInAuction;
         uint256 borrowerDebtToCollateral;
+        uint256 borrowerT0ReserveSettleAmount;
     }
 
     function _assertAuction(AuctionParams memory state_) internal {
@@ -462,7 +464,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             vars.auctionReferencePrice,
             vars.auctionNeutralPrice,
             vars.borrowerDebtToCollateral,
-            ,
+            vars.borrowerT0ReserveSettleAmount,
             ,
             ,
         ) = _pool.auctionInfo(state_.borrower);
@@ -472,20 +474,21 @@ abstract contract DSTestPlus is Test, IPoolEvents {
         (vars.auctionTotalBondEscrowed,,,,) = _pool.reservesInfo();
         (,, vars.auctionDebtInAuction,)  = _pool.debtInfo();
 
-        assertEq(vars.auctionKickTime != 0,     state_.active);
-        assertEq(vars.auctionKicker,            state_.kicker);
-        assertGe(lockedBonds,                   vars.auctionBondSize);
-        assertEq(vars.auctionBondSize,          state_.bondSize);
-        assertEq(vars.auctionBondFactor,        state_.bondFactor);
-        assertEq(vars.auctionKickTime,          state_.kickTime);
-        assertEq(vars.auctionReferencePrice,    state_.referencePrice);
-        assertEq(vars.auctionTotalBondEscrowed, state_.totalBondEscrowed);
+        assertEq(vars.auctionKickTime != 0,          state_.active);
+        assertEq(vars.auctionKicker,                 state_.kicker);
+        assertGe(lockedBonds,                        vars.auctionBondSize);
+        assertEq(vars.auctionBondSize,               state_.bondSize);
+        assertEq(vars.auctionBondFactor,             state_.bondFactor);
+        assertEq(vars.auctionKickTime,               state_.kickTime);
+        assertEq(vars.auctionReferencePrice,         state_.referencePrice);
+        assertEq(vars.auctionTotalBondEscrowed,      state_.totalBondEscrowed);
         assertEq(_auctionPrice(
             vars.auctionReferencePrice,
-            vars.auctionKickTime),              state_.auctionPrice);
-        assertEq(vars.auctionDebtInAuction,     state_.debtInAuction);
-        assertEq(vars.auctionNeutralPrice,      state_.neutralPrice);
-        assertEq(vars.borrowerDebtToCollateral,   state_.debtToCollateral);
+            vars.auctionKickTime),                   state_.auctionPrice);
+        assertEq(vars.auctionDebtInAuction,          state_.debtInAuction);
+        assertEq(vars.auctionNeutralPrice,           state_.neutralPrice);
+        assertEq(vars.borrowerDebtToCollateral,      state_.debtToCollateral);
+        assertEq(vars.borrowerT0ReserveSettleAmount, state_.t0ReserveSettleAmount);
 
         (
             uint256 kickTime,

--- a/tests/forge/utils/DSTestPlus.sol
+++ b/tests/forge/utils/DSTestPlus.sol
@@ -464,6 +464,7 @@ abstract contract DSTestPlus is Test, IPoolEvents {
             vars.borrowerDebtToCollateral,
             ,
             ,
+            ,
         ) = _pool.auctionInfo(state_.borrower);
 
         (uint256 borrowerDebt, uint256 borrowerCollateral , , ) = _poolUtils.borrowerInfo(address(_pool), state_.borrower);


### PR DESCRIPTION
## Description

<!-- Explain what was changed.  For example:
_Updated rounding in `removeQuoteToken` to round to token precision._ -->
- Update `auctionInfo`  to return borrower `t0ReserveSettleAmount` from the pool.
- Update `_assertAuction` to check borrower `t0ReserveSettleAmount`.
- Add invariant A10: Upon kick `t0ReserveSettleAmount` should be set to `BorrowerT0Debt * borrowFeeRate / 2` for the kicked borrower
- Update `LOANS_COUNT` in  `ERC20PoolPositionsInvariants` from `500` to `320` to resolve the `EvmError: MemoryLimitOOG` error while running tests. This started to fail because `auctionInfo` updated to return `t0ReserveSettleAmount` now.

## Purpose

<!-- Explain why the change was made, citing any issues where appropriate.  For example:
_Resolves audit issue M-333: Removal of quote token may leave dust amounts._
Or, if the change does not affect deployed contracts: _Resolve rounding issue with invariant E9 to handle tokens with less than 8 decimals._ -->

## Impact
- This PR includes src changes to return `t0ReserveSettleAmount`. This PR can be used for testing only to avoid contracts redeployment as there is no real need for user to know how much bad debt can be settled through reserves at the time of settlement.

<!-- State technical consequences of the change, whether beneficial or detrimental.  For example:
_Small increase in `removeQuoteToken` gas cost._
If the change does not affect deployed contracts, feel free to leave _none_. -->

## Tasks

- [x] Changes to protocol contracts are covered by unit tests executed by CI.
- [x] Protocol contract size limits have not been exceeded.
- [x] Gas consumption for impacted transactions have been compared with the target branch, and nontrivial changes cited in the _Impact_ section above.
- [x] Scope labels have been assigned as appropriate.
- [x] Invariant tests have been manually executed as appropriate for the nature of the change.
